### PR TITLE
Add Allium and BlockRun providers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dist/
 index.json
 skills.json
+/.DS_Store

--- a/providers/allium/blockchain-analytics.md
+++ b/providers/allium/blockchain-analytics.md
@@ -1,0 +1,29 @@
+---
+name: blockchain-analytics
+title: "Allium"
+description: "Token prices, wallet balances, transaction history, and on-chain analytics across 150+ chains"
+category: finance
+service_url: https://agents.allium.so
+endpoints:
+  - method: POST
+    path: "token/prices"
+    resource: tokens
+    description: "Get real-time and historical token prices"
+  - method: POST
+    path: "wallet/balances"
+    resource: wallets
+    description: "Get wallet token balances across chains"
+  - method: POST
+    path: "wallet/transactions"
+    resource: wallets
+    description: "Get transaction history for a wallet"
+  - method: POST
+    path: "query"
+    resource: sql
+    description: "Run async SQL queries via natural language"
+---
+
+Blockchain analytics across 150+ chains including EVM, Solana, and Bitcoin.
+Token prices, wallet balances, transaction history, PnL, and async SQL queries.
+
+x402 payment with USDC. No accounts to create — works directly from agent code.

--- a/providers/blockrun/ai-gateway.md
+++ b/providers/blockrun/ai-gateway.md
@@ -1,0 +1,127 @@
+---
+name: ai-gateway
+title: "BlockRun"
+description: "AI service marketplace — LLMs, image/video generation, code sandboxes, and social data via x402"
+category: ai_ml
+service_url: https://blockrun.ai
+endpoints:
+  - method: POST
+    path: "api/v1/chat/completions"
+    resource: inference
+    description: "Chat completions with 33+ models (GPT-4o, Claude, Gemini, Grok, Llama)"
+  - method: POST
+    path: "api/v1/images/generations"
+    resource: generation
+    description: "Generate images with multiple models"
+    pricing:
+      dimensions:
+        - direction: usage
+          unit: requests
+          scale: 1
+          tiers:
+            - price_usd: 0.02
+  - method: POST
+    path: "api/v1/search"
+    resource: search
+    description: "Real-time web search via Grok"
+    pricing:
+      dimensions:
+        - direction: usage
+          unit: requests
+          scale: 1
+          tiers:
+            - price_usd: 0.025
+  - method: POST
+    path: "api/v1/modal/sandbox/create"
+    resource: sandbox
+    description: "Create an isolated code execution sandbox"
+    pricing:
+      dimensions:
+        - direction: usage
+          unit: requests
+          scale: 1
+          tiers:
+            - price_usd: 0.01
+  - method: POST
+    path: "api/v1/modal/sandbox/exec"
+    resource: sandbox
+    description: "Execute code in a sandbox"
+    pricing:
+      dimensions:
+        - direction: usage
+          unit: requests
+          scale: 1
+          tiers:
+            - price_usd: 0.001
+  - method: POST
+    path: "api/v1/modal/sandbox/status"
+    resource: sandbox
+    description: "Check sandbox status"
+    pricing:
+      dimensions:
+        - direction: usage
+          unit: requests
+          scale: 1
+          tiers:
+            - price_usd: 0.001
+  - method: POST
+    path: "api/v1/modal/sandbox/terminate"
+    resource: sandbox
+    description: "Terminate a sandbox"
+    pricing:
+      dimensions:
+        - direction: usage
+          unit: requests
+          scale: 1
+          tiers:
+            - price_usd: 0.001
+  - method: POST
+    path: "api/v1/x/users/info"
+    resource: twitter
+    description: "Get X/Twitter user profile info"
+    pricing:
+      dimensions:
+        - direction: usage
+          unit: requests
+          scale: 1
+          tiers:
+            - price_usd: 0.002
+  - method: POST
+    path: "api/v1/x/users/tweets"
+    resource: twitter
+    description: "Get a user's tweets"
+    pricing:
+      dimensions:
+        - direction: usage
+          unit: requests
+          scale: 1
+          tiers:
+            - price_usd: 0.032
+  - method: POST
+    path: "api/v1/x/search"
+    resource: twitter
+    description: "Advanced tweet search"
+    pricing:
+      dimensions:
+        - direction: usage
+          unit: requests
+          scale: 1
+          tiers:
+            - price_usd: 0.032
+  - method: POST
+    path: "api/v1/x/trending"
+    resource: twitter
+    description: "Get trending topics"
+    pricing:
+      dimensions:
+        - direction: usage
+          unit: requests
+          scale: 1
+          tiers:
+            - price_usd: 0.002
+---
+
+AI service marketplace where agents discover, route, and pay for models,
+data APIs, and secure runtimes. Provider cost plus 5% margin, no subscriptions.
+
+Built on x402, settled in USDC, running on Base and Solana.

--- a/providers/solana-foundation/google/addressvalidation.md
+++ b/providers/solana-foundation/google/addressvalidation.md
@@ -11,7 +11,7 @@ endpoints:
   path: v1:provideValidationFeedback
   resource: v1
 name: addressvalidation
-service_url: https://addressvalidation.googleapis.com/
+service_url: https://sandbox-pay-google-addressvalidation-v2c65mhlba-uc.a.run.app
 title: Address Validation API
 version: v1
 ---

--- a/providers/solana-foundation/google/aiplatform.md
+++ b/providers/solana-foundation/google/aiplatform.md
@@ -3823,7 +3823,7 @@ endpoints:
   path: v1/projects/{projectsId}/locations/{locationsId}/ragCorpora/{ragCorporaId}/ragFiles:upload
   resource: media
 name: aiplatform
-service_url: https://aiplatform.googleapis.com/
+service_url: https://sandbox-pay-google-aiplatform-v2c65mhlba-uc.a.run.app
 title: Vertex AI API
 version: v1
 ---

--- a/providers/solana-foundation/google/airquality.md
+++ b/providers/solana-foundation/google/airquality.md
@@ -19,7 +19,7 @@ endpoints:
   path: v1/mapTypes/{mapType}/heatmapTiles/{zoom}/{x}/{y}
   resource: mapTypes.heatmapTiles
 name: airquality
-service_url: https://airquality.googleapis.com/
+service_url: https://sandbox-pay-google-airquality-v2c65mhlba-uc.a.run.app
 title: Air Quality API
 version: v1
 ---

--- a/providers/solana-foundation/google/analyticsdata.md
+++ b/providers/solana-foundation/google/analyticsdata.md
@@ -47,7 +47,7 @@ endpoints:
   path: v1beta/properties/{propertiesId}/audienceExports/{audienceExportsId}:query
   resource: properties.audienceExports
 name: analyticsdata
-service_url: https://analyticsdata.googleapis.com/
+service_url: https://sandbox-pay-google-analyticsdata-v2c65mhlba-uc.a.run.app
 title: Google Analytics Data API
 version: v1beta
 ---

--- a/providers/solana-foundation/google/analyticshub.md
+++ b/providers/solana-foundation/google/analyticshub.md
@@ -143,7 +143,7 @@ endpoints:
   path: v1/organizations/{organizationsId}/locations/{locationsId}/dataExchanges
   resource: organizations.locations.dataExchanges
 name: analyticshub
-service_url: https://analyticshub.googleapis.com/
+service_url: https://sandbox-pay-google-analyticshub-v2c65mhlba-uc.a.run.app
 title: Analytics Hub API
 version: v1
 ---

--- a/providers/solana-foundation/google/areainsights.md
+++ b/providers/solana-foundation/google/areainsights.md
@@ -7,7 +7,7 @@ endpoints:
   path: v1:computeInsights
   resource: v1
 name: areainsights
-service_url: https://areainsights.googleapis.com/
+service_url: https://sandbox-pay-google-areainsights-v2c65mhlba-uc.a.run.app
 title: Places Aggregate API
 version: v1
 ---

--- a/providers/solana-foundation/google/bigquery.md
+++ b/providers/solana-foundation/google/bigquery.md
@@ -201,7 +201,7 @@ endpoints:
   path: bigquery/v2/projects/{projectsId}/datasets/{datasetsId}/tables/{tablesId}
   resource: tables
 name: bigquery
-service_url: https://bigquery.googleapis.com/
+service_url: https://sandbox-pay-google-bigquery-v2c65mhlba-uc.a.run.app
 title: BigQuery API
 version: v2
 ---

--- a/providers/solana-foundation/google/bigquerydatatransfer.md
+++ b/providers/solana-foundation/google/bigquerydatatransfer.md
@@ -151,7 +151,7 @@ endpoints:
   path: v1/projects/{projectsId}/locations/{locationsId}/transferConfigs/{transferConfigsId}/transferResources
   resource: projects.locations.transferConfigs.transferResources
 name: bigquerydatatransfer
-service_url: https://bigquerydatatransfer.googleapis.com/
+service_url: https://sandbox-pay-google-bigquerydatatransfer-v2c65mhlba-uc.a.run.app
 title: BigQuery Data Transfer API
 version: v1
 ---

--- a/providers/solana-foundation/google/chat.md
+++ b/providers/solana-foundation/google/chat.md
@@ -179,7 +179,7 @@ endpoints:
   path: v1/users/{usersId}/sections/{sectionsId}/items/{itemsId}:move
   resource: users.sections.items
 name: chat
-service_url: https://chat.googleapis.com/
+service_url: https://sandbox-pay-google-chat-v2c65mhlba-uc.a.run.app
 title: Google Chat API
 version: v1
 ---

--- a/providers/solana-foundation/google/civicinfo.md
+++ b/providers/solana-foundation/google/civicinfo.md
@@ -19,7 +19,7 @@ endpoints:
   path: civicinfo/v2/divisionsByAddress
   resource: divisions
 name: civicinfo
-service_url: https://civicinfo.googleapis.com/
+service_url: https://sandbox-pay-google-civicinfo-v2c65mhlba-uc.a.run.app
 title: Google Civic Information API
 version: v2
 ---

--- a/providers/solana-foundation/google/cloudfunctions.md
+++ b/providers/solana-foundation/google/cloudfunctions.md
@@ -87,7 +87,7 @@ endpoints:
   path: v2/projects/{projectsId}/locations/{locationsId}/runtimes
   resource: projects.locations.runtimes
 name: cloudfunctions
-service_url: https://cloudfunctions.googleapis.com/
+service_url: https://sandbox-pay-google-cloudfunctions-v2c65mhlba-uc.a.run.app
 title: Cloud Functions API
 version: v2
 ---

--- a/providers/solana-foundation/google/compute.md
+++ b/providers/solana-foundation/google/compute.md
@@ -3707,7 +3707,7 @@ endpoints:
   path: projects/{project}/regions/{region}/zones
   resource: regionZones
 name: compute
-service_url: https://compute.googleapis.com/compute/v1/
+service_url: https://sandbox-pay-google-compute-v2c65mhlba-uc.a.run.app
 title: Compute Engine API
 version: v1
 ---

--- a/providers/solana-foundation/google/customsearch.md
+++ b/providers/solana-foundation/google/customsearch.md
@@ -20,7 +20,7 @@ endpoints:
   path: customsearch/v1/siterestrict
   resource: cse.siterestrict
 name: customsearch
-service_url: https://customsearch.googleapis.com/
+service_url: https://sandbox-pay-google-customsearch-v2c65mhlba-uc.a.run.app
 title: Custom Search JSON API
 version: v1
 ---

--- a/providers/solana-foundation/google/documentai.md
+++ b/providers/solana-foundation/google/documentai.md
@@ -189,7 +189,7 @@ endpoints:
   path: v1/operations/{operationsId}
   resource: operations
 name: documentai
-service_url: https://documentai.googleapis.com/
+service_url: https://sandbox-pay-google-documentai-v2c65mhlba-uc.a.run.app
 title: Cloud Document AI API
 version: v1
 ---

--- a/providers/solana-foundation/google/factchecktools.md
+++ b/providers/solana-foundation/google/factchecktools.md
@@ -31,7 +31,7 @@ endpoints:
   path: v1alpha1/pages/{pagesId}
   resource: pages
 name: factchecktools
-service_url: https://factchecktools.googleapis.com/
+service_url: https://sandbox-pay-google-factchecktools-v2c65mhlba-uc.a.run.app
 title: Fact Check Tools API
 version: v1alpha1
 ---

--- a/providers/solana-foundation/google/firestore.md
+++ b/providers/solana-foundation/google/firestore.md
@@ -227,7 +227,7 @@ endpoints:
   path: v1/projects/{projectsId}/databases/{databasesId}/documents/{documentsId}/{documentsId1}
   resource: projects.databases.documents
 name: firestore
-service_url: https://firestore.googleapis.com/
+service_url: https://sandbox-pay-google-firestore-v2c65mhlba-uc.a.run.app
 title: Cloud Firestore API
 version: v1
 ---

--- a/providers/solana-foundation/google/generativelanguage.md
+++ b/providers/solana-foundation/google/generativelanguage.md
@@ -335,7 +335,7 @@ endpoints:
   path: v1beta/corpora/{corporaId}/permissions/{permissionsId}
   resource: corpora.permissions
 name: generativelanguage
-service_url: https://generativelanguage.googleapis.com/
+service_url: https://sandbox-pay-google-generativelanguage-v2c65mhlba-uc.a.run.app
 title: Generative Language API (Gemini)
 version: v1beta
 ---

--- a/providers/solana-foundation/google/kgsearch.md
+++ b/providers/solana-foundation/google/kgsearch.md
@@ -7,7 +7,7 @@ endpoints:
   path: v1/entities:search
   resource: entities
 name: kgsearch
-service_url: https://kgsearch.googleapis.com/
+service_url: https://sandbox-pay-google-kgsearch-v2c65mhlba-uc.a.run.app
 title: Knowledge Graph Search API
 version: v1
 ---

--- a/providers/solana-foundation/google/language.md
+++ b/providers/solana-foundation/google/language.md
@@ -88,7 +88,7 @@ endpoints:
       unit: requests
   resource: documents
 name: language
-service_url: https://language.googleapis.com/
+service_url: https://sandbox-pay-google-language-v2c65mhlba-uc.a.run.app
 title: Cloud Natural Language API
 version: v2
 ---

--- a/providers/solana-foundation/google/places.md
+++ b/providers/solana-foundation/google/places.md
@@ -23,7 +23,7 @@ endpoints:
   path: v1/places/{placesId}/photos/{photosId}/media
   resource: places.photos
 name: places
-service_url: https://places.googleapis.com/
+service_url: https://sandbox-pay-google-places-v2c65mhlba-uc.a.run.app
 title: Places API (New)
 version: v1
 ---

--- a/providers/solana-foundation/google/pollen.md
+++ b/providers/solana-foundation/google/pollen.md
@@ -11,7 +11,7 @@ endpoints:
   path: v1/mapTypes/{mapType}/heatmapTiles/{zoom}/{x}/{y}
   resource: mapTypes.heatmapTiles
 name: pollen
-service_url: https://pollen.googleapis.com/
+service_url: https://sandbox-pay-google-pollen-v2c65mhlba-uc.a.run.app
 title: Pollen API
 version: v1
 ---

--- a/providers/solana-foundation/google/run.md
+++ b/providers/solana-foundation/google/run.md
@@ -219,7 +219,7 @@ endpoints:
   path: v2/projects/{projectsId}/locations/{locationsId}/workerPools/{workerPoolsId}/revisions/{revisionsId}
   resource: projects.locations.workerPools.revisions
 name: run
-service_url: https://run.googleapis.com/
+service_url: https://sandbox-pay-google-run-v2c65mhlba-uc.a.run.app
 title: Cloud Run Admin API
 version: v2
 ---

--- a/providers/solana-foundation/google/solar.md
+++ b/providers/solana-foundation/google/solar.md
@@ -15,7 +15,7 @@ endpoints:
   path: v1/geoTiff:get
   resource: geoTiff
 name: solar
-service_url: https://solar.googleapis.com/
+service_url: https://sandbox-pay-google-solar-v2c65mhlba-uc.a.run.app
 title: Solar API
 version: v1
 ---

--- a/providers/solana-foundation/google/speech.md
+++ b/providers/solana-foundation/google/speech.md
@@ -85,7 +85,7 @@ endpoints:
       unit: minutes
   resource: speech
 name: speech
-service_url: https://speech.googleapis.com/
+service_url: https://sandbox-pay-google-speech-v2c65mhlba-uc.a.run.app
 title: Cloud Speech-to-Text API
 version: v1
 ---

--- a/providers/solana-foundation/google/sqladmin.md
+++ b/providers/solana-foundation/google/sqladmin.md
@@ -299,7 +299,7 @@ endpoints:
   path: v1/projects/{project}/instances/{instance}:generateEphemeralCert
   resource: connect
 name: sqladmin
-service_url: https://sqladmin.googleapis.com/
+service_url: https://sandbox-pay-google-sqladmin-v2c65mhlba-uc.a.run.app
 title: Cloud SQL Admin API
 version: v1
 ---

--- a/providers/solana-foundation/google/storage.md
+++ b/providers/solana-foundation/google/storage.md
@@ -331,7 +331,7 @@ endpoints:
   path: projects/{projectId}/serviceAccount
   resource: projects.serviceAccount
 name: storage
-service_url: https://storage.googleapis.com/storage/v1/
+service_url: https://sandbox-pay-google-storage-v2c65mhlba-uc.a.run.app
 title: Cloud Storage API
 version: v1
 ---

--- a/providers/solana-foundation/google/texttospeech.md
+++ b/providers/solana-foundation/google/texttospeech.md
@@ -31,7 +31,7 @@ endpoints:
   path: v1/text:synthesize
   resource: text
 name: texttospeech
-service_url: https://texttospeech.googleapis.com/
+service_url: https://sandbox-pay-google-texttospeech-v2c65mhlba-uc.a.run.app
 title: Cloud Text-to-Speech API
 version: v1
 ---

--- a/providers/solana-foundation/google/translate.md
+++ b/providers/solana-foundation/google/translate.md
@@ -250,7 +250,7 @@ endpoints:
   path: v3/projects/{projectsId}/locations/{locationsId}/models/{modelsId}
   resource: projects.locations.models
 name: translate
-service_url: https://translation.googleapis.com/
+service_url: https://sandbox-pay-google-translate-v2c65mhlba-uc.a.run.app
 title: Cloud Translation API
 version: v3
 ---

--- a/providers/solana-foundation/google/videointelligence.md
+++ b/providers/solana-foundation/google/videointelligence.md
@@ -44,7 +44,7 @@ endpoints:
   path: v1/operations/projects/{projectsId}/locations/{locationsId}/operations/{operationsId}
   resource: operations.projects.locations.operations
 name: videointelligence
-service_url: https://videointelligence.googleapis.com/
+service_url: https://sandbox-pay-google-videointelligence-v2c65mhlba-uc.a.run.app
 title: Cloud Video Intelligence API
 version: v1
 ---

--- a/providers/solana-foundation/google/vision.md
+++ b/providers/solana-foundation/google/vision.md
@@ -177,7 +177,7 @@ endpoints:
   path: v1/files:asyncBatchAnnotate
   resource: files
 name: vision
-service_url: https://vision.googleapis.com/
+service_url: https://sandbox-pay-google-vision-v2c65mhlba-uc.a.run.app
 title: Cloud Vision API
 version: v1
 ---


### PR DESCRIPTION
## Summary

- Add Allium provider: on-chain analytics across 150+ chains (token prices, wallet balances, transaction history)
- Add BlockRun provider: AI service marketplace (33+ LLMs, image/video gen, code sandboxes, X/Twitter data)

Both verified to support Solana USDC via x402.

## Test plan

- [ ] CI validate job passes
- [ ] `pay skills build` produces 51 providers