### PR TITLE
fix: update quicknode title casing

### DIFF
--- a/providers/quicknode/rpc/PAY.md
+++ b/providers/quicknode/rpc/PAY.md
@@ -1,6 +1,6 @@
 ---
 name: rpc
-title: "QuickNode"
+title: "Quicknode"
 description: "Pay-per-request JSON-RPC endpoints for 140+ blockchain networks. Each chain is its own path (e.g. solana-mainnet, ethereum-mainnet). Supports SIWX session auth, x402 micropayments, dynamic per-method pricing, and direct node access without infrastructure."
 use_case: "Use for blockchain JSON-RPC, querying account or contract state, submitting transactions, Solana RPC, EVM RPC, multi-chain dapps, block and transaction lookups, devnet/testnet access, and scalable chain reads with pay-per-request billing."
 category: compute


### PR DESCRIPTION
Updates the `title` field in `providers/quicknode/rpc/PAY.md` from `"QuickNode"` to `"Quicknode"` to match the official Quicknode brand casing.