### PR TITLE
feat: add b402/paysh-send — private USDC transfers via x402

### DIFF
--- a/providers/b402/paysh-send/PAY.md
+++ b/providers/b402/paysh-send/PAY.md
@@ -9,7 +9,7 @@ openapi:
   url: https://paysh-shield-production.up.railway.app/openapi.json
 ---
 
-Private USDC transfer service. The payer settles `principal + fee` USDC over x402; the recipient receives `principal` at the wallet you specify. The unshield is signed by the b402 hosted relayer, so the operator wallet does not appear on the spend tx and the on-chain edge from payer to recipient is broken at the cryptographic level.
+Private USDC transfer service. The payer settles `principal + fee` USDC over x402; the recipient receives `principal` at the wallet you specify. The unshield is signed by the b402 hosted relayer, so the operator wallet does not appear on the recipient-side tx — there is no graph-traversal edge from the payer to the recipient.
 
 Single endpoint: `POST /send` with body `{ "to": "<base58>", "amount": "<u64-string smallest units>" }`. First call returns 402 with the total price (principal + fee); retry with `X-PAYMENT` to settle. Response on success: `{ paymentSig, shieldSig, unshieldSig, recipient, principal, fee }`.
 

--- a/providers/b402/paysh-send/PAY.md
+++ b/providers/b402/paysh-send/PAY.md
@@ -1,0 +1,24 @@
+---
+name: paysh-send
+title: "paysh-send"
+description: "Pay-per-call private USDC transfer over x402. Sender pays principal plus a tiered fee; recipient receives principal at any wallet, signed by the b402 hosted relayer. Routed through the b402 shielded pool on Solana."
+use_case: "Use for sending USDC privately to any Solana wallet, paying contractors, grant recipients or vendors without doxing the payer, donations, agent-to-agent settlement, and any USDC transfer where the on-chain link from payer to recipient should be broken."
+category: finance
+service_url: https://paysh-shield-production.up.railway.app
+openapi:
+  url: https://paysh-shield-production.up.railway.app/openapi.json
+---
+
+Private USDC transfer service. The payer settles `principal + fee` USDC over x402; the recipient receives `principal` at the wallet you specify. The unshield is signed by the b402 hosted relayer, so the operator wallet does not appear on the spend tx and the on-chain edge from payer to recipient is broken at the cryptographic level.
+
+Single endpoint: `POST /send` with body `{ "to": "<base58>", "amount": "<u64-string smallest units>" }`. First call returns 402 with the total price (principal + fee); retry with `X-PAYMENT` to settle. Response on success: `{ paymentSig, shieldSig, unshieldSig, recipient, principal, fee }`.
+
+Fees: 0.05 USDC base plus 0.05% (principal < $1k), 0.08% (< $10k), or 0.10% (>= $10k). Min principal 0.01 USDC, max 100,000 USDC per call.
+
+## Spend-aware usage
+
+- Call `POST /send` exactly once per intended transfer; the body is the same on the 402 and on the X-PAYMENT retry. Do not retry on 200 — the transfer has already settled.
+- For amounts under $1, the 0.05 USDC base dominates the fee — batch small payouts into fewer larger transfers when the destination is the same.
+- Single-payment flows are subject to amount + timing correlation under chain analysis. Anonymity grows with concurrent volume in the b402 pool. For higher per-transfer privacy, schedule transfers in batches with random delays rather than sending immediately.
+- Recipient must accept USDC at a Solana wallet. The service auto-creates the recipient's USDC ATA if it does not exist; the ATA rent is paid by the relayer.
+- 502 with a `paymentSig` field means the payment landed but the shield-or-unshield step failed; surface the `paymentSig` for manual recovery rather than retrying the same request.


### PR DESCRIPTION
## Summary

Adds [paysh-send](https://paysh-shield-production.up.railway.app) — pay-per-call private USDC transfer over x402 on Solana — as `b402/paysh-send`.

Pay `principal + fee` USDC; the recipient receives `principal` at the wallet they specify, with no on-chain link back to the payer. Routed through the b402 shielded pool; the unshield is signed by the hosted relayer.

Single endpoint: `POST /send` with `{ to, amount }`. Returns 402 with the total price; retry with `X-PAYMENT`. Response: `{ paymentSig, shieldSig, unshieldSig, recipient, principal, fee }`.

## Payment

- **Protocol:** x402 v1, scheme `exact`
- **Network:** Solana mainnet
- **Asset:** USDC
- **Fee schedule:** 0.05 USDC base plus 0.05% (<$1k), 0.08% (<$10k), 0.10% (>=$10k)
- **Settlement:** server shields the principal into the b402 pool and unshields to the recipient via the [b402 hosted relayer](https://b402-solana-relayer-mainnet-62092339396.us-central1.run.app/health)

## OpenAPI source

Live at `https://paysh-shield-production.up.railway.app/openapi.json`. The `POST /send` route includes a request-body example so the probe settles a 402 instead of bouncing on `{}`.

## Architecture

Built on [b402-solana](https://github.com/mmchougule/b402-solana) — Anchor program, Groth16 prover, Light Protocol nullifier set, all live on mainnet. paysh-send composes shield + unshield behind a single x402 endpoint.

Source: https://github.com/mmchougule/b402-solana/tree/main/apps/paysh-demo-server

## Validation

```
$ pay catalog check providers/b402/paysh-send/PAY.md --verbose

Probe results
providers/b402/paysh-send OK
  POST   send                                               OK 402 x402         USDC (138ms)

Solana-compat verdict
PASS   providers/b402/paysh-send (1/1)
  OK  POST send  paid via x402 (ok)
PAY.md check successful
1 endpoint tested across 1 provider
1/1 gates compatible with Solana
```

## Test plan

- [x] `pay catalog check` green locally with probe (1/1 Solana-compatible)
- [x] `name:` matches parent directory (`paysh-send`)
- [x] `description` 214 chars, `use_case` 252 chars
- [x] `service_url` is production HTTPS
- [x] `category: finance`
- [x] `POST /send` returns 402 with USDC accepts entry on Solana mainnet
- [x] OpenAPI request body example included so probe can settle
- [x] Mainnet round trip end-to-end:
  - payment: [3JKFZ23S…](https://explorer.solana.com/tx/3JKFZ23SRG4mirKjAkGvB6XjT6atpprwvNrQhWnKVKe2ZzHiMUwoZTwEnS1Z9MmNC9uzzApExDEgfxZWgZ3VTRj?cluster=mainnet)
  - shield: [4Xumk4zs…](https://explorer.solana.com/tx/4Xumk4zsmXm1k98CpKqXmDQQoMqf7RmFg49GsYa1oK3oCHSog3TenwNXWtP4SD3rHWQubc7Bs6NnpBLn9STpfD5E?cluster=mainnet)
  - unshield (signer: hosted relayer `7f6gRiX5…iNM`): [TtSyd8hd…](https://explorer.solana.com/tx/TtSyd8hd5ucNaLRvAdNEBBH7Z1PvANoUY4BHzytN6uErAPHLbU1WEjkuSKjjjYP2q5WB3JAw3Sob8paZwQfqYbx?cluster=mainnet)
