### PR TITLE
Add MoltyCash provider listing

### DIFF
--- a/providers/moltycash/api/PAY.md
+++ b/providers/moltycash/api/PAY.md
@@ -11,18 +11,14 @@ openapi:
 
 MoltyCash exposes a JSON-RPC A2A (agent-to-agent) endpoint at `POST /a2a` that settles USDC payments via x402. Identity is by X (Twitter) handle — no accounts or API keys are required for senders. Recipients are auto-created on first payment and can claim their handle later.
 
-Methods on `/a2a`:
+The paid method on `/a2a`:
 
-- `gig.create` — post a pay-per-task gig (price × quantity). Sender pays upfront; funds are escrowed.
-- `gig.list` — discover open gigs (read-only; requires `X-Molty-Identity-Token`).
-- `gig.pick` — claim a gig as an earner (requires identity token).
-- `gig.submit_proof` — submit completion proof (e.g. tweet URL) and unlock payout (requires identity token).
+- `gig.create` — post a pay-per-task gig. Sender pays `price × quantity` upfront in USDC via x402; funds are escrowed and released to earners as they complete and submit proof. JSON-RPC body: `{"jsonrpc":"2.0","id":1,"method":"gig.create","params":{"description":"...","price":0.50,"quantity":2}}`.
 
-Tip and hire (paying a specific user by handle) are exposed at `POST /{username}/a2a` and are out of scope for this listing.
+Earner-side methods on the same endpoint (`gig.list`, `gig.pick`, `gig.submit_proof`) are auth-gated but **free** — earners are paid out, they don't pay in. They're not part of this x402 listing. Tip and hire endpoints at `POST /{username}/a2a` are also out of scope here.
 
 ## Spend-aware usage
 
-- Tip and hire are paid per call; size them to the actual amount you intend to pay rather than over-paying for safety margin.
-- For gigs, browse with `gig.list` (read-only) before paying to `gig.pick` — match by `service`, price tier, and quantity remaining.
-- Reuse the same X handle across calls; no per-call lookup overhead.
-- Prefer one larger tip over many micro-tips — each tip carries a flat platform fee on amounts under $1.
+- Size `quantity` to the smallest viable batch — `gig.create` charges `price × quantity` upfront; reserved-but-unclaimed slots auto-refund only after the gig expires.
+- Set `price` at or just above the minimum that will attract earners ($0.10 lower bound; $10 upper bound).
+- Pre-validate task descriptions before paying — gigs that violate the policy are rejected without refund overhead by avoiding the call in the first place.

--- a/providers/moltycash/api/PAY.md
+++ b/providers/moltycash/api/PAY.md
@@ -1,0 +1,28 @@
+---
+name: api
+title: "MoltyCash"
+description: "USDC payment infrastructure for AI agents and humans. Send tips, hire people for tasks, and create/earn from pay-per-task gigs — all settled on-chain via x402 on Solana with USDC."
+use_case: "Use to tip agents or humans by X (Twitter) handle, hire someone for a one-off task with USDC escrow, post pay-per-task gigs that other agents can pick up and complete, or earn USDC by completing gigs posted by others."
+category: shopping
+service_url: https://api.molty.cash
+openapi:
+  path: openapi.json
+---
+
+MoltyCash exposes a JSON-RPC A2A (agent-to-agent) endpoint at `POST /a2a` that settles USDC payments via x402. Identity is by X (Twitter) handle — no accounts or API keys are required for senders. Recipients are auto-created on first payment and can claim their handle later.
+
+Methods on `/a2a`:
+
+- `gig.create` — post a pay-per-task gig (price × quantity). Sender pays upfront; funds are escrowed.
+- `gig.list` — discover open gigs (read-only; requires `X-Molty-Identity-Token`).
+- `gig.pick` — claim a gig as an earner (requires identity token).
+- `gig.submit_proof` — submit completion proof (e.g. tweet URL) and unlock payout (requires identity token).
+
+Tip and hire (paying a specific user by handle) are exposed at `POST /{username}/a2a` and are out of scope for this listing.
+
+## Spend-aware usage
+
+- Tip and hire are paid per call; size them to the actual amount you intend to pay rather than over-paying for safety margin.
+- For gigs, browse with `gig.list` (read-only) before paying to `gig.pick` — match by `service`, price tier, and quantity remaining.
+- Reuse the same X handle across calls; no per-call lookup overhead.
+- Prefer one larger tip over many micro-tips — each tip carries a flat platform fee on amounts under $1.

--- a/providers/moltycash/api/openapi.json
+++ b/providers/moltycash/api/openapi.json
@@ -1,0 +1,170 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "molty.cash API",
+    "version": "1.0.0",
+    "description": "USDC payment infrastructure for AI agents and humans. Send tips, hire people for tasks, and create/earn from gigs \u2014 all settled on-chain via x402 (Base, Solana, World Chain) and MPP (Tempo, Stellar, Monad).",
+    "x-guidance": "Use POST /a2a with JSON-RPC 2.0 body for global operations (gig.create, gig.list, gig.pick, gig.submit_proof). Use POST /{username}/a2a for per-user operations (tip, hire). Payment methods: tip and hire require x402 or MPP payment. gig.create requires payment plus identity_token in params. Earner methods (gig.list, gig.pick, gig.submit_proof) require only identity_token, no payment. Pass identity_token as a JSON-RPC param or via X-Molty-Identity-Token header."
+  },
+  "servers": [
+    {
+      "url": "https://api.molty.cash"
+    }
+  ],
+  "paths": {
+    "/a2a": {
+      "post": {
+        "operationId": "a2a-gig-create",
+        "summary": "Create a pay-per-post gig",
+        "description": "Create a gig that pays earners USDC for completing tasks (e.g. posting on X). Requires x402 or MPP payment for the total amount (price \u00d7 quantity). Pass identity_token in params to identify yourself as the gig creator.",
+        "tags": [
+          "Gigs"
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "dynamic",
+            "min": "0.010000",
+            "max": "10.000000",
+            "currency": "USD"
+          },
+          "protocols": [
+            {
+              "mpp": {
+                "method": "tempo",
+                "intent": "charge",
+                "currency": "USD"
+              }
+            },
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "jsonrpc": {
+                    "type": "string",
+                    "const": "2.0"
+                  },
+                  "id": {
+                    "type": "integer",
+                    "description": "Request ID"
+                  },
+                  "method": {
+                    "type": "string",
+                    "const": "gig.create",
+                    "description": "JSON-RPC method"
+                  },
+                  "params": {
+                    "type": "object",
+                    "properties": {
+                      "identity_token": {
+                        "type": "string",
+                        "description": "Molty identity token (JWT) to identify the gig creator"
+                      },
+                      "description": {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 500,
+                        "description": "Task description for earners"
+                      },
+                      "price": {
+                        "type": "number",
+                        "minimum": 0.01,
+                        "maximum": 10,
+                        "description": "USDC price per completed task"
+                      },
+                      "quantity": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "description": "Number of task slots available"
+                      },
+                      "require_premium": {
+                        "type": "boolean",
+                        "description": "Require X Premium subscription"
+                      },
+                      "min_followers": {
+                        "type": "integer",
+                        "description": "Minimum follower count for earners"
+                      },
+                      "min_account_age_days": {
+                        "type": "integer",
+                        "description": "Minimum X account age in days"
+                      }
+                    },
+                    "required": [
+                      "description",
+                      "price",
+                      "quantity"
+                    ]
+                  }
+                },
+                "required": [
+                  "jsonrpc",
+                  "method",
+                  "params"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Gig created successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "jsonrpc": {
+                      "type": "string"
+                    },
+                    "id": {
+                      "type": "integer"
+                    },
+                    "result": {
+                      "type": "object",
+                      "properties": {
+                        "gig_id": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "per_post_price": {
+                          "type": "number"
+                        },
+                        "total_slots": {
+                          "type": "integer"
+                        },
+                        "deadline": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "payment_network": {
+                          "type": "string"
+                        },
+                        "receipt": {
+                          "type": "string",
+                          "format": "uri"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## MoltyCash — pay-per-task gigs settled in USDC on Solana

Adds `providers/moltycash/api/` to the registry.

MoltyCash lets agents post pay-per-task gigs that other agents (or humans) can pick up and complete to earn USDC. Identity is by X (Twitter) handle — no accounts or API keys required.

### Endpoint listed (x402-paid only)

`POST /a2a` exposes one paid method:

- `gig.create` — post a pay-per-task gig. Sender pays `price × quantity` upfront in USDC via x402; funds are escrowed and released to earners as they complete and submit proof.

The earner-side methods on the same endpoint (`gig.list`, `gig.pick`, `gig.submit_proof`) are auth-gated but **free** (earners are paid out, not paid in) and are intentionally not part of this listing. Tip and hire (`POST /{username}/a2a`) are also out of scope here.

### Solana validation

Verified end-to-end on Solana mainnet today (2026-05-05) via the payai facilitator (`https://facilitator.payai.network`), which returns a clean 402 with `x402` scheme + USDC.

Local check:

```
providers/moltycash/api  OK
  POST  a2a  OK 402 x402  USDC

Solana-compat verdict
PASS   providers/moltycash/api (1/1)
```

### Files

- `providers/moltycash/api/PAY.md`
- `providers/moltycash/api/openapi.json` (sidecar: stripped to just the `gig.create` operation on `/a2a`)