### PR TITLE
feat: add algovoi/compliance-gate provider — pre-payment compliance screen for agents

### DIFF
--- a/providers/algovoi/compliance-gate/PAY.md
+++ b/providers/algovoi/compliance-gate/PAY.md
@@ -1,0 +1,104 @@
+---
+name: compliance-gate
+title: "AlgoVoi Compliance Gate"
+description: "Pre-payment compliance screen for autonomous agents. Returns a SAMLA-2018-tipping-off-compliant verdict (allow / block / flag) for a proposed recipient address against UK / EU / US / UN sanctions lists, AlgoVoi-tenant KYB status, and risk-tier classification — before the agent transmits funds. Pairs with a free /attestation endpoint exposing the gateway's full compliance posture."
+use_case: "Use before sending stablecoin payments to recipients you have not vetted. Particularly relevant for autonomous agents whose principals carry liability for payments to sanctioned entities, restricted jurisdictions, or high-risk counterparties — UK MLRs 2017, SAMLA 2018, OFAC SDN."
+category: identity
+service_url: https://api.algovoi.co.uk
+openapi:
+  path: openapi.json
+---
+
+# AlgoVoi Compliance Gate
+
+A public, no-auth, agent-callable compliance surface. Two endpoints that expose AlgoVoi's existing compliance machinery — KYB gating, sanctions screening, audit-chain shipping, risk-tier classification — to any agent making payment decisions.
+
+## Why this exists
+
+Every other production-running x402 service ships without sanctions screening, recipient KYB checks, or tipping-off-compliant disclosure handling. Autonomous-payment agents using those services have no protective layer between "model decides to pay" and "funds leave the wallet". An agent that accidentally pays a sanctioned entity exposes its principal to MLRs / OFAC / SAMLA liability. The Compliance Gate is the protective check.
+
+This is the productisation of [AlgoVoi's "compliance from day one" thesis](https://algovoi.co.uk/AlgoVoi/compliance.html) — the same screening AlgoVoi runs against every payer wallet on its own gateway, exposed publicly so any agent can call it.
+
+## Endpoints
+
+### `GET /compliance/attestation`
+
+Free, no-auth, no rate limit. Returns the gateway's full compliance posture as a verifiable transparency surface:
+
+- Frameworks asserted (UK MLRs 2017, SAMLA 2018 s.20, UK GDPR / DPA 2018, FCA PS19/22 self-assessment, ICO data-controller, SOC 2 targets)
+- Active sanctions sources (OFSI, OFAC, UN, EU)
+- URL / IP threat-intel feeds (Tor, SpamHaus DROP/EDROP, URLhaus, ThreatFox, OpenPhish, PhishTank, MaxMind GeoLite2)
+- Audit-chain head positions per chain + last shipment manifest
+- KYB classes + risk-tier definitions
+
+Use it to verify what AlgoVoi screens against, before relying on `/compliance/screen` verdicts.
+
+### `POST /compliance/screen`
+
+Free in v1, rate-limited. Pre-payment recipient screen. Body:
+
+```json
+{
+  "recipient_address": "<destination wallet address>",
+  "network": "base-mainnet | algorand-mainnet | stellar-mainnet | ...",
+  "amount_microunits": 10000,
+  "asset": "USDC"
+}
+```
+
+Returns:
+
+```json
+{
+  "verdict": "allow" | "block" | "flag",
+  "sanctions_clear": true,
+  "recipient_kyb_status": "unknown" | "trial" | "approved" | "rejected",
+  "risk_tier": "low" | "medium" | "high" | "restricted" | "unknown",
+  "reasons": ["<generic reason codes>"],
+  "screened_at": "<ISO timestamp>",
+  "verdict_id": "<UUID for audit>",
+  "network_normalised": "<internal network name>",
+  "tipping_off_notice": "..."
+}
+```
+
+Verdict semantics:
+
+- `allow` — no sanctions hit, no flagged risk-tier, no rejected KYB. Safe to proceed.
+- `block` — sanctions hit and `block_on_hit` policy active, OR recipient is on AlgoVoi's `restricted` risk tier. Do not transmit.
+- `flag` — sanctions hit but blocking is policy-disabled, OR recipient KYB status is `rejected`, OR our screen infrastructure was unavailable, OR the network is unsupported. Human-in-the-loop review recommended.
+
+`reasons` is intentionally generic. **We never reveal which sanctions list (if any) matched.** SAMLA 2018 s.20 makes such disclosure a criminal offence in the UK; tipping-off compliance is bedrock.
+
+## Spend-aware usage
+
+- **Call `/compliance/screen` once per unique recipient.** The verdict is stable for the lifetime of the sanctions cache (refreshed every 24h). Cache verdicts client-side; don't re-screen the same address every payment.
+- **`/compliance/attestation` is free and cacheable** (`Cache-Control: public, max-age=300`). Fetch once at agent startup; re-fetch on schema-version change.
+- **Treat `flag` as "ask the user"**, not "guess and proceed". The whole point of this surface is to surface ambiguity to the human-in-the-loop before funds move.
+- **Don't store raw `reasons` strings as user-facing copy** — they're machine codes. Humanise them before display.
+- **Honour `screen_unavailable` gracefully** — it means our infrastructure couldn't reach the sanctions cache during your call. Re-try with backoff or fall back to manual review.
+
+## Networks supported
+
+`algorand`, `voi`, `hedera`, `stellar`, `base`, `solana`, `tempo` (mainnets). Both CAIP-2 (`eip155:8453`, `solana:5eyk...`) and dash/underscore styles accepted on input. Testnets are intentionally rejected — production-only verdicts.
+
+## Privacy + audit
+
+- Every screen is logged with a `verdict_id` UUID for cross-system audit trail correlation.
+- The `recipient_address` is normalised before the cache lookup (lowercase + trim) but not retained beyond the audit row.
+- The caller's source IP is captured in the audit log via the standard CF / nginx / gateway proxy chain headers — used to drive rate-limiting and abuse handling, not published.
+
+## What this is NOT
+
+- **Not a sanctions-list publisher.** We screen against canonical sources (OFSI, OFAC, UN, EU) on a 24h refresh cadence. We do not maintain our own sanctions list, and we do not expose the cache contents.
+- **Not a KYC service.** AlgoVoi's KYB tier is only knowable for AlgoVoi-onboarded merchant tenants. For non-tenant recipients, `recipient_kyb_status` returns `unknown`.
+- **Not a substitute for full transaction monitoring.** `/compliance/screen` is a pre-payment check. Post-payment monitoring, suspicious-activity reporting (SAR), and ongoing customer due diligence are separate workflows requiring AlgoVoi's full tenant-onboarded gateway path.
+
+## Contact
+
+- Operator: `chopmob@gmail.com`
+- Docs: `https://docs.algovoi.co.uk/compliance`
+- Compliance hub: `https://algovoi.co.uk/AlgoVoi/compliance.html`
+- Incident protocol: `https://docs.algovoi.co.uk/incident-protocol`
+- Security policy: `https://api.algovoi.co.uk/.well-known/security.txt`
+- A2A discovery: `https://api.algovoi.co.uk/.well-known/agent-card.json`

--- a/providers/algovoi/compliance-gate/PAY.md
+++ b/providers/algovoi/compliance-gate/PAY.md
@@ -11,7 +11,7 @@ openapi:
 
 # AlgoVoi Compliance Gate
 
-A public, no-auth, agent-callable compliance surface. Two endpoints that expose AlgoVoi's existing compliance machinery — KYB gating, sanctions screening, audit-chain shipping, risk-tier classification — to any agent making payment decisions.
+A public, no-auth, agent-callable compliance surface. Two endpoints that expose AlgoVoi's existing compliance machinery — KYB gating, sanctions screening, in-DB SHA-256 hash chain across `audit_log` / `screening_hits` / `compliance_events`, risk-tier classification — to any agent making payment decisions. Off-VM Object Lock shipping (FCA / UK MLRs Reg 40(3) 7-year) is on the roadmap; current `/compliance/attestation` reports the off-VM shipment status as `planned` until a bucket is provisioned.
 
 ## Why this exists
 

--- a/providers/algovoi/compliance-gate/PAY.md
+++ b/providers/algovoi/compliance-gate/PAY.md
@@ -35,7 +35,7 @@ Use it to verify what AlgoVoi screens against, before relying on `/compliance/sc
 
 ### `POST /compliance/screen`
 
-Free in v1, rate-limited. Pre-payment recipient screen. Body:
+**Free and no-auth in v1, rate-limited.** Pre-payment recipient screen. Body:
 
 ```json
 {
@@ -44,6 +44,23 @@ Free in v1, rate-limited. Pre-payment recipient screen. Body:
   "amount_microunits": 10000,
   "asset": "USDC"
 }
+```
+
+**Clear-address example** (expect `verdict: allow`):
+
+```bash
+curl -s -X POST https://api.algovoi.co.uk/compliance/screen \
+  -H 'Content-Type: application/json' \
+  -d '{"recipient_address":"0x7D01d268636c835d9E56164A24A9587D82B8B186","network":"base-mainnet","amount_microunits":10000,"asset":"USDC"}' | jq
+```
+
+**Unsupported-network example** (expect `verdict: flag`, `reasons: ["unsupported_network"]`).
+Use a syntactically valid address; an invalid address (`"x"`) triggers a 422 validation error before the network check fires:
+
+```bash
+curl -s -X POST https://api.algovoi.co.uk/compliance/screen \
+  -H 'Content-Type: application/json' \
+  -d '{"recipient_address":"0x7D01d268636c835d9E56164A24A9587D82B8B186","network":"polygon-mainnet","amount_microunits":10000,"asset":"USDC"}' | jq
 ```
 
 Returns:
@@ -69,6 +86,14 @@ Verdict semantics:
 - `flag` — sanctions hit but blocking is policy-disabled, OR recipient KYB status is `rejected`, OR our screen infrastructure was unavailable, OR the network is unsupported. Human-in-the-loop review recommended.
 
 `reasons` is intentionally generic. **We never reveal which sanctions list (if any) matched.** SAMLA 2018 s.20 makes such disclosure a criminal offence in the UK; tipping-off compliance is bedrock.
+
+## Browser / cross-origin usage
+
+Both endpoints support CORS preflight from the allowed origins (`algovoi.co.uk`, `dashboard.algovoi.co.uk`, `recurr.algovoi.co.uk`). The following request headers are accepted in OPTIONS preflights:
+
+`Authorization`, `Content-Type`, `X-Tenant-Id`, `Idempotency-Key`, `X-PAYMENT`, `X-PAYMENT-REQUIRED`, `X-PAYMENT-RECEIPT`, `PAYMENT-REQUIRED`, `PAYMENT-SIGNATURE`
+
+The x402 payment headers (`X-PAYMENT` etc.) are included now so no config change will be needed if `/compliance/screen` moves to a metered/paid tier in a future version.
 
 ## Spend-aware usage
 

--- a/providers/algovoi/compliance-gate/openapi.json
+++ b/providers/algovoi/compliance-gate/openapi.json
@@ -1,0 +1,141 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "AlgoVoi Compliance Gate",
+    "version": "1.0.0",
+    "description": "Public, no-auth, agent-callable compliance surface. Pre-payment recipient screening with SAMLA-2018-tipping-off-compliant verdicts, plus a free transparency-attestation endpoint. Productisation of AlgoVoi's compliance-from-day-one thesis.",
+    "contact": {
+      "name": "AlgoVoi",
+      "email": "chopmob@gmail.com",
+      "url": "https://algovoi.co.uk"
+    },
+    "license": {
+      "name": "Public — free in v1",
+      "url": "https://docs.algovoi.co.uk/compliance"
+    }
+  },
+  "servers": [
+    {
+      "url": "https://api.algovoi.co.uk",
+      "description": "Production gateway"
+    }
+  ],
+  "paths": {
+    "/compliance/attestation": {
+      "get": {
+        "summary": "Gateway compliance posture",
+        "description": "Returns AlgoVoi's verifiable compliance posture: frameworks asserted (UK MLRs 2017, SAMLA 2018 s.20, UK GDPR, FCA PS19/22 self-assessment, SOC 2 targets), active sanctions sources, URL/IP threat-intel feeds, audit-chain head + last shipment, KYB classes, risk-tier definitions, tipping-off policy statement.",
+        "operationId": "compliance_attestation",
+        "responses": {
+          "200": {
+            "description": "Compliance posture JSON",
+            "headers": {
+              "Cache-Control": {
+                "schema": { "type": "string" },
+                "description": "public, max-age=300"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/AttestationResponse" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/compliance/screen": {
+      "post": {
+        "summary": "Pre-payment recipient screen",
+        "description": "Returns a SAMLA-compliant verdict (allow / block / flag) for a proposed recipient address against UK / EU / US / UN sanctions lists, AlgoVoi-tenant KYB status, and risk-tier classification. Reasons are intentionally generic — we never disclose which sanctions list (if any) matched. SAMLA 2018 s.20 tipping-off compliance.",
+        "operationId": "compliance_screen",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/ScreenRequest" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Screen verdict",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ScreenResponse" }
+              }
+            }
+          },
+          "422": { "description": "Malformed request body" },
+          "429": { "description": "Rate limit exceeded — defaults to 60 requests / minute / IP" }
+        },
+        "x-x402": {
+          "scheme": "free-with-rate-limit",
+          "limit": "60/minute/IP",
+          "future_paid_tier": "USDC on Base — subject to demand"
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "AttestationResponse": {
+        "type": "object",
+        "properties": {
+          "operator":         { "type": "object" },
+          "frameworks":       { "type": "object" },
+          "active_screening": { "type": "object" },
+          "audit_chain":      { "type": "object" },
+          "kyb_classes":      { "type": "object" },
+          "risk_tiers":       { "type": "object" },
+          "version":          { "type": "integer" },
+          "as_of":            { "type": "string", "format": "date-time" },
+          "tipping_off_policy": { "type": "string" }
+        }
+      },
+      "ScreenRequest": {
+        "type": "object",
+        "required": ["recipient_address", "network"],
+        "properties": {
+          "recipient_address": {
+            "type": "string", "minLength": 4, "maxLength": 128,
+            "description": "Destination wallet address. Format depends on network."
+          },
+          "network": {
+            "type": "string", "minLength": 4, "maxLength": 64,
+            "description": "CAIP-2, dash, or underscore style. e.g. 'base-mainnet', 'eip155:8453', 'algorand-mainnet', 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp'.",
+            "examples": [
+              "base-mainnet",
+              "eip155:8453",
+              "algorand-mainnet",
+              "stellar-mainnet"
+            ]
+          },
+          "amount_microunits": { "type": "integer", "minimum": 0, "nullable": true },
+          "asset": { "type": "string", "maxLength": 128, "nullable": true }
+        }
+      },
+      "ScreenResponse": {
+        "type": "object",
+        "required": ["verdict", "sanctions_clear", "recipient_kyb_status", "risk_tier", "reasons", "screened_at", "verdict_id", "network_normalised"],
+        "properties": {
+          "verdict": {
+            "type": "string", "enum": ["allow", "block", "flag"],
+            "description": "Aggregate verdict. `allow`: safe to proceed. `block`: do not transmit. `flag`: human-in-the-loop review."
+          },
+          "sanctions_clear":      { "type": "boolean" },
+          "recipient_kyb_status": { "type": "string", "enum": ["unknown", "trial", "approved", "rejected"] },
+          "risk_tier":            { "type": "string", "enum": ["low", "medium", "high", "restricted", "unknown"] },
+          "reasons": {
+            "type": "array", "items": { "type": "string" },
+            "description": "Generic machine-readable reason codes. Never names a sanctions list (SAMLA 2018 s.20 tipping-off compliance)."
+          },
+          "screened_at":          { "type": "string", "format": "date-time" },
+          "verdict_id":           { "type": "string", "format": "uuid" },
+          "network_normalised":   { "type": "string" },
+          "tipping_off_notice":   { "type": "string" }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What this adds

A second AlgoVoi provider - `providers/algovoi/compliance-gate/PAY.md` - exposing **AlgoVoi's compliance machinery** as a public agent-callable surface. This is the headline AlgoVoi entry; the existing `providers/algovoi/agent-trust-bench/` (PR #23) is the paired research instrument that demonstrates *what can go wrong without compliance* - the compliance-gate is *what to do about it*.

## Why this is a unique entry in pay-skills

Every other production-running x402 service in the directory ships without sanctions screening, without recipient KYB checks, without tipping-off-compliant disclosure handling. Autonomous agents using those services have no protective layer between "model decides to pay" and "funds leave the wallet". An agent that accidentally pays a sanctioned entity exposes its principal to UK MLRs / OFAC / SAMLA liability.

The Compliance Gate is the protective check, productised. It's the same screening AlgoVoi runs against every payer wallet on its own facilitator, exposed publicly so any agent can call it.

## Endpoints

| Endpoint | Purpose | Price |
|---|---|---|
| `GET /compliance/attestation` | Returns full compliance posture: frameworks asserted (UK MLRs 2017, SAMLA 2018 s.20, UK GDPR / DPA 2018, FCA PS19/22 self-assessment, SOC 2 targets), active sanctions sources (OFSI, OFAC, UN, EU), URL/IP threat-intel feeds (Tor, SpamHaus, URLhaus, ThreatFox, OpenPhish, PhishTank, MaxMind), audit-chain head positions, KYB classes, risk-tier definitions. | Free |
| `POST /compliance/screen` | Pre-payment recipient screen. Returns SAMLA-compliant verdict (`allow` / `block` / `flag`), `sanctions_clear`, `recipient_kyb_status`, `risk_tier`, generic `reasons`. Never reveals which sanctions list matched. | Free in v1 (rate-limited) |

## SAMLA 2018 s.20 compliance baked in

`POST /compliance/screen` returns generic reason codes - never names a sanctions list, never discloses which entity matched. UK SAMLA 2018 s.20 makes such disclosure a criminal offence. Every other compliance-as-a-service surface in the agentic-commerce ecosystem either doesn't ship this protection or ships it incorrectly. AlgoVoi gets this right because the same machinery already runs on tenant payments today.

## Verify live

```sh
# Compliance posture
curl -s https://api.algovoi.co.uk/compliance/attestation | jq

# Pre-payment screen - clear address (returns allow + clear reasons)
curl -s -X POST https://api.algovoi.co.uk/compliance/screen \
  -H 'Content-Type: application/json' \
  -d '{
        "recipient_address": "0x7D01d268636c835d9E56164A24A9587D82B8B186",
        "network": "base-mainnet",
        "amount_microunits": 10000,
        "asset": "USDC"
      }' | jq

# Unsupported network (returns flag + unsupported_network)
curl -s -X POST https://api.algovoi.co.uk/compliance/screen \
  -H 'Content-Type: application/json' \
  -d '{"recipient_address":"x", "network":"polkadot-mainnet"}' | jq
```

## Files

- `providers/algovoi/compliance-gate/PAY.md` - frontmatter + spend-aware-usage prose + privacy/audit notes + what-it-isn't disclaimers
- `providers/algovoi/compliance-gate/openapi.json` - OpenAPI 3.1 spec for both endpoints, with `x-x402` extension noting current free-with-rate-limit pricing and future paid-tier intent

## Relationship to PR #23

The bench (`providers/algovoi/agent-trust-bench/`) and this compliance-gate are paired surfaces:

- **Bench** demonstrates the risk: "agents will pay anyone, anywhere, for anything, without checking"
- **Compliance Gate** is the answer: "here's the protective screen agents should call before paying"

Both are real, both are live, both honestly disclose what they are. Listing both under `providers/algovoi/` mirrors the pattern Solana Foundation, paysponge, and merit-systems use for multi-API operators.

## Networks supported

`algorand`, `voi`, `hedera`, `stellar`, `base`, `solana`, `tempo` mainnets. Both CAIP-2 (`eip155:8453`, `solana:5eykt4...`) and dash/underscore styles accepted. Testnets are intentionally rejected - production-only verdicts.

## Contact

- Operator: chopmob@gmail.com
- Compliance hub: https://algovoi.co.uk/AlgoVoi/compliance.html
- Docs: https://docs.algovoi.co.uk/compliance
- Incident protocol: https://docs.algovoi.co.uk/incident-protocol

**IETF Internet-Draft:** [`draft-hopley-x402-compliance-receipt-00`](https://datatracker.ietf.org/doc/draft-hopley-x402-compliance-receipt/) (Independent Submission, Informational, sole AlgoVoi authorship, live on IETF datatracker 2026-05-24)

---

*AlgoVoi (chopmob-cloud) - chopmob@gmail.com - Acquisition enquiries: https://docs.algovoi.co.uk/acquisition*