### PR TITLE
docs(purch/marketplace): tighten listing for agent routing

### DIFF
--- a/providers/purch/marketplace/PAY.md
+++ b/providers/purch/marketplace/PAY.md
@@ -2,21 +2,26 @@
 name: marketplace
 title: "Purch"
 description: "Search and buy products from Amazon and Shopify with USDC on Solana. Includes an AI shopping assistant, dynamic-priced product purchase flow, and Purch Vault for digital goods (skills, knowledge, personas) with downloadable artifacts."
-use_case: "Use for product search, Amazon and Shopify shopping, AI shopping assistance, price and review comparison, agent-initiated purchases with shipping address, and buying or downloading Purch Vault digital items like skills, knowledge bases, and personas."
+use_case: "Use for product search, Amazon and Shopify shopping, AI shopping assistance, price and review comparison, product purchase and checkout with shipping address, and buying or downloading Purch Vault digital items like skills, knowledge bases, and personas."
 category: shopping
 service_url: https://api.purch.xyz
 openapi:
   url: https://api.purch.xyz/openapi.json
 ---
 
-E-commerce API for AI agents. Search and buy from Amazon and Shopify, or trade
-digital goods through Purch Vault. All endpoints accept Solana USDC via x402.
+E-commerce API for AI agents. Two product surfaces share one checkout flow: a
+unified Amazon+Shopify catalog, and Purch Vault, a marketplace for
+agent-consumable digital goods (skills, knowledge bases, personas) with
+post-purchase artifact download. All paid endpoints accept Solana USDC via
+x402; the charged amount equals the cart total (product price + shipping +
+tax for physical items, item price for vault items).
 
 Search returns titles, prices, ratings, image URLs, vendors, and product URLs
 mixed across Amazon and Shopify. The `x402/shop` endpoint takes a
-natural-language `message` and returns curated recommendations. Purchases use
-dynamic pricing — the paid amount equals the product total (including shipping
-and tax).
+natural-language `message` and returns curated recommendations in the same
+shape as `x402/search`. Vault search filters by category, product type, and
+price range, and is cursor-paginated; product search is page-based (`page` +
+`hasMore`).
 
 Identifiers: Amazon products use `asin` (e.g. `B0CXYZ1234`) or `productUrl`;
 Shopify products use `productUrl` plus `variantId`; vault items use `slug`.
@@ -27,10 +32,15 @@ Solana mainnet.
 
 ## Spend-aware usage
 
-- Search or use `x402/shop` for recommendations before any purchase. A purchase
-  endpoint must only be called after the user confirms the exact item, variant,
+- Resolve products through `x402/search` or `x402/shop` before any buy call.
+  Purchase endpoints are not safe for price discovery — they charge the cart
+  total on success.
+- Pass exact identifiers to buy endpoints (`asin` / `productUrl` /
+  `variantId` / `slug`) — don't re-search what a prior call already returned.
+- For natural-language requests, prefer one well-formed `x402/shop` call over
+  iterative refinements; the assistant batches across both marketplaces.
+- Use the smallest result count that answers the task. Paginate via `cursor`
+  on `x402/vault/search` and via `page` + `hasMore` on `x402/search` rather
+  than over-requesting.
+- Always confirm before `x402/buy` or `x402/vault/buy`: exact item + variant,
   shipping destination, and total expected cost.
-- Use exact identifiers when available: `asin` or `productUrl` for Amazon,
-  `productUrl` plus `variantId` for Shopify, and `slug` for vault items.
-- Do not call purchase endpoints for price discovery. Use search results first,
-  then ask the user to pick one item.


### PR DESCRIPTION
Tightens the existing `purch/marketplace` listing so agents route to it more reliably and the body matches the convention used across the rest of the registry.

## Changes

**Frontmatter — `use_case` only**
- Swap `agent-initiated purchases with shipping address` → `product purchase and checkout with shipping address`. Adds the `product purchase` and `checkout` nouns that agents actually search on, while keeping the same length and intent. `description` is unchanged.

**Body — narrative refinements (no structural change)**
- Detail paragraph adds the vault search filters and the pagination model, distinguishing cursor-paginated vault search from page-based product search.
- `## Spend-aware usage` expanded from 3 → 5 rules:
  - separate the "don't use buy for price discovery" rule from the "pass exact identifiers" rule (they were collapsed before),
  - add a "prefer one well-formed `x402/shop` call over iterative refinements" rule,
  - add a pagination rule that names the correct mechanism for each search endpoint (`cursor` for vault, `page` + `hasMore` for product).

## Validation

```
$ pay catalog check providers/purch/marketplace/PAY.md
PAY.md check successful
6 endpoints tested across 1 provider
5/5 gates compatible with Solana
```

Whole-registry static check (`pay catalog check . --no-probe`) still passes.

## Verification

Endpoint claims, parameters, response shapes, and pagination model verified against the live OpenAPI at `https://api.purch.xyz/openapi.json`.
