### PR TITLE
add WURK provider listings

### DIFF
--- a/providers/wurk/human-feedback/PAY.md
+++ b/providers/wurk/human-feedback/PAY.md
@@ -1,0 +1,32 @@
+---
+name: human-feedback
+title: "WURK Human Feedback"
+description: "Hire humans through x402-paid Solana endpoints for agent feedback, opinions, reviews, tagging, lightweight research, submissions, and creator-selected winners."
+use_case: "Use for asking real people to review content, answer questions, tag data, give opinions, submit proof, or complete microtasks for an AI agent."
+category: productivity
+service_url: https://wurkapi.fun
+openapi:
+ url: https://wurkapi.fun/openapi-x402-solana-human-feedback.json
+---
+
+WURK Human Feedback lets agents hire real people for microtasks using x402
+payments on Solana USDC. Agents can create simple agent-help jobs, custom
+agent-to-human jobs, and advanced jobs with winner selection, entry limits,
+attachment requirements, and profile-quality requirements.
+
+Paid create and utility routes follow the public x402 v2 flow: call without
+`PAYMENT-SIGNATURE` to receive a 402 payment requirement, sign it, then retry
+the same URL with `PAYMENT-SIGNATURE`. Some follow-up routes use job secrets for
+viewing submissions or selecting winners after a paid job is created.
+
+## Spend-aware usage
+
+- Use tier routes for simple jobs when the requested winner count matches a
+  preset. Use custom routes when the user needs explicit `winners` and
+  `perUser` values.
+- Keep task descriptions specific and short enough for humans to execute
+  reliably. Include required proof or attachment instructions in the job text.
+- Use stricter requirements such as profile scores or verified accounts only
+  when needed; they can reduce eligible participants and slow fill time.
+- Reuse the returned `statusUrl` or job secret to view submissions. Do not pay
+  to recreate the same job just because submissions are still pending.

--- a/providers/wurk/human-feedback/PAY.md
+++ b/providers/wurk/human-feedback/PAY.md
@@ -6,7 +6,7 @@ use_case: "Use for asking real people to review content, answer questions, tag d
 category: productivity
 service_url: https://wurkapi.fun
 openapi:
- url: https://wurkapi.fun/openapi-x402-solana-human-feedback.json
+ path: openapi.json
 ---
 
 WURK Human Feedback lets agents hire real people for microtasks using x402

--- a/providers/wurk/human-feedback/openapi.json
+++ b/providers/wurk/human-feedback/openapi.json
@@ -1,0 +1,1300 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "WURK x402 Solana Human Feedback Endpoints",
+    "version": "1.1.0",
+    "description": "Category-specific x402 listing surface for WURK Solana human-feedback endpoints: hire humans for reviews, opinions, tagging, lightweight research, submission workflows, and creator winner selection. Public v2 flow uses `PAYMENT-SIGNATURE`."
+  },
+  "servers": [
+    {
+      "url": "https://wurkapi.fun"
+    }
+  ],
+  "tags": [
+    {
+      "name": "Agent Help"
+    }
+  ],
+  "paths": {
+    "/solana/agenttohuman": {
+      "post": {
+        "operationId": "post_solana_agenttohuman",
+        "tags": [
+          "Agent Help"
+        ],
+        "summary": "Agent-to-human (create, view, recover via action) (POST)",
+        "description": "Public x402 endpoint: `/solana/agenttohuman`.\n\nFlow kind: **paid** endpoint.\n\nFlow: call once **without** `PAYMENT-SIGNATURE` to receive `402 Payment-Required`; sign the requirement; retry the same URL **with** `PAYMENT-SIGNATURE` for `200`.\n\nUse `PAYMENT-SIGNATURE` for public routes (`/solana/*`, `/base/*`). `X-PAYMENT` is legacy/test context.\n\nAgent-help fallback context: tier routes commonly price at `0.02 USDC` per winner; custom defaults are often `winners=10` and `perUser=0.025` (about `0.25 USDC`).\n\nWhen action=create, total price is computed from winners × perUser.\n\nAliases exist under `/agenthelp` and dedicated view/recover routes.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PaymentSignature"
+          },
+          {
+            "$ref": "#/components/parameters/Action"
+          },
+          {
+            "$ref": "#/components/parameters/Description"
+          },
+          {
+            "$ref": "#/components/parameters/Winners"
+          },
+          {
+            "$ref": "#/components/parameters/PerUser"
+          },
+          {
+            "$ref": "#/components/parameters/Secret"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/PaidSuccess"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      }
+    },
+    "/solana/agenttohumanadvanced": {
+      "post": {
+        "operationId": "post_solana_agenttohumanadvanced",
+        "tags": [
+          "Agent Help"
+        ],
+        "summary": "Agent-to-human Advanced (create, view, recover via action) (POST)",
+        "description": "Public x402 endpoint: `/solana/agenttohumanadvanced`.\n\nFlow kind: **paid** endpoint.\n\nFlow: call once **without** `PAYMENT-SIGNATURE` to receive `402 Payment-Required`; sign the requirement; retry the same URL **with** `PAYMENT-SIGNATURE` for `200`.\n\nUse `PAYMENT-SIGNATURE` for public routes (`/solana/*`, `/base/*`). `X-PAYMENT` is legacy/test context.\n\nAgent-help fallback context: tier routes commonly price at `0.02 USDC` per winner; custom defaults are often `winners=10` and `perUser=0.025` (about `0.25 USDC`).\n\nAdvanced variant with winner selection mode, extended selection time, attachment requirement toggle, and requirement-tier validation.\n\nUse the single `requirement` field when gating by profile requirements (Sorsa score, WURK X metric score, Seeker ecosystem user, or X blue-verified account).\n\nFor creator-selection jobs, choose winners through the chain-agnostic route `POST /api/agenttohumanadvanced/choose-winners` using `secret` + `submissionIds`; requests cannot exceed remaining winner slots.\n\nSubmission speed/volume is variable: simple broad tasks can fill in minutes, while strict requirements or complex tasks may take hours to days; poll status/view endpoints accordingly.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PaymentSignature"
+          },
+          {
+            "$ref": "#/components/parameters/Action"
+          },
+          {
+            "$ref": "#/components/parameters/Description"
+          },
+          {
+            "$ref": "#/components/parameters/Winners"
+          },
+          {
+            "$ref": "#/components/parameters/PerUser"
+          },
+          {
+            "$ref": "#/components/parameters/Secret"
+          },
+          {
+            "$ref": "#/components/parameters/Requirement"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/PaidSuccess"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      }
+    },
+    "/solana/agenthelp": {
+      "post": {
+        "operationId": "post_solana_agenthelp",
+        "tags": [
+          "Agent Help"
+        ],
+        "summary": "Agent Help (custom create) (POST)",
+        "description": "Public x402 endpoint: `/solana/agenthelp`.\n\nFlow kind: **paid** endpoint.\n\nFlow: call once **without** `PAYMENT-SIGNATURE` to receive `402 Payment-Required`; sign the requirement; retry the same URL **with** `PAYMENT-SIGNATURE` for `200`.\n\nUse `PAYMENT-SIGNATURE` for public routes (`/solana/*`, `/base/*`). `X-PAYMENT` is legacy/test context.\n\nAgent-help fallback context: tier routes commonly price at `0.02 USDC` per winner; custom defaults are often `winners=10` and `perUser=0.025` (about `0.25 USDC`).",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PaymentSignature"
+          },
+          {
+            "$ref": "#/components/parameters/Description"
+          },
+          {
+            "$ref": "#/components/parameters/Winners"
+          },
+          {
+            "$ref": "#/components/parameters/PerUser"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/PaidSuccess"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      }
+    },
+    "/solana/agenttohuman/custom": {
+      "post": {
+        "operationId": "post_solana_agenttohuman_custom",
+        "tags": [
+          "Agent Help"
+        ],
+        "summary": "Agent Help (custom mode path) (POST)",
+        "description": "Public x402 endpoint: `/solana/agenttohuman/custom`.\n\nFlow kind: **paid** endpoint.\n\nFlow: call once **without** `PAYMENT-SIGNATURE` to receive `402 Payment-Required`; sign the requirement; retry the same URL **with** `PAYMENT-SIGNATURE` for `200`.\n\nUse `PAYMENT-SIGNATURE` for public routes (`/solana/*`, `/base/*`). `X-PAYMENT` is legacy/test context.\n\nAgent-help fallback context: tier routes commonly price at `0.02 USDC` per winner; custom defaults are often `winners=10` and `perUser=0.025` (about `0.25 USDC`).",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PaymentSignature"
+          },
+          {
+            "$ref": "#/components/parameters/Description"
+          },
+          {
+            "$ref": "#/components/parameters/Winners"
+          },
+          {
+            "$ref": "#/components/parameters/PerUser"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/PaidSuccess"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      }
+    },
+    "/solana/agenttohuman/recover": {
+      "post": {
+        "operationId": "post_solana_agenttohuman_recover",
+        "tags": [
+          "Agent Help"
+        ],
+        "summary": "Agent-to-human Recover (POST)",
+        "description": "Public x402 endpoint: `/solana/agenttohuman/recover`.\n\nFlow kind: **paid** endpoint.\n\nFlow: call once **without** `PAYMENT-SIGNATURE` to receive `402 Payment-Required`; sign the requirement; retry the same URL **with** `PAYMENT-SIGNATURE` for `200`.\n\nUse `PAYMENT-SIGNATURE` for public routes (`/solana/*`, `/base/*`). `X-PAYMENT` is legacy/test context.\n\nAgent-help fallback context: paid utility endpoint; typical fee is about `0.001 USDC` to recover recent jobs or view submissions.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PaymentSignature"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/PaidSuccess"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      }
+    },
+    "/solana/agenthelp/view": {
+      "post": {
+        "operationId": "post_solana_agenthelp_view",
+        "tags": [
+          "Agent Help"
+        ],
+        "summary": "Agent Help View (paid secret view) (POST)",
+        "description": "Public x402 endpoint: `/solana/agenthelp/view`.\n\nFlow kind: **paid** endpoint.\n\nFlow: call once **without** `PAYMENT-SIGNATURE` to receive `402 Payment-Required`; sign the requirement; retry the same URL **with** `PAYMENT-SIGNATURE` for `200`.\n\nUse `PAYMENT-SIGNATURE` for public routes (`/solana/*`, `/base/*`). `X-PAYMENT` is legacy/test context.\n\nAgent-help fallback context: paid utility endpoint; typical fee is about `0.001 USDC` to recover recent jobs or view submissions.\n\nThis alias requires `PAYMENT-SIGNATURE` before submissions are returned.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PaymentSignature"
+          },
+          {
+            "$ref": "#/components/parameters/Secret"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/PaidSuccess"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      }
+    },
+    "/solana/agenthelp/view/{secret}": {
+      "post": {
+        "operationId": "post_solana_agenthelp_view_secret",
+        "tags": [
+          "Agent Help"
+        ],
+        "summary": "Agent Help View (paid path secret) (POST)",
+        "description": "Public x402 endpoint: `/solana/agenthelp/view/{secret}`.\n\nFlow kind: **paid** endpoint.\n\nFlow: call once **without** `PAYMENT-SIGNATURE` to receive `402 Payment-Required`; sign the requirement; retry the same URL **with** `PAYMENT-SIGNATURE` for `200`.\n\nUse `PAYMENT-SIGNATURE` for public routes (`/solana/*`, `/base/*`). `X-PAYMENT` is legacy/test context.\n\nAgent-help fallback context: paid utility endpoint; typical fee is about `0.001 USDC` to recover recent jobs or view submissions.\n\nPath-based paid variant of `/agenthelp/view`.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PaymentSignature"
+          },
+          {
+            "$ref": "#/components/parameters/SecretPath"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/PaidSuccess"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      }
+    },
+    "/solana/agenthelp/recover": {
+      "post": {
+        "operationId": "post_solana_agenthelp_recover",
+        "tags": [
+          "Agent Help"
+        ],
+        "summary": "Agent Help Recover (POST)",
+        "description": "Public x402 endpoint: `/solana/agenthelp/recover`.\n\nFlow kind: **paid** endpoint.\n\nFlow: call once **without** `PAYMENT-SIGNATURE` to receive `402 Payment-Required`; sign the requirement; retry the same URL **with** `PAYMENT-SIGNATURE` for `200`.\n\nUse `PAYMENT-SIGNATURE` for public routes (`/solana/*`, `/base/*`). `X-PAYMENT` is legacy/test context.\n\nAgent-help fallback context: paid utility endpoint; typical fee is about `0.001 USDC` to recover recent jobs or view submissions.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PaymentSignature"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/PaidSuccess"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      }
+    },
+    "/solana/agenthelp-1": {
+      "post": {
+        "operationId": "post_solana_agenthelp_1",
+        "tags": [
+          "Agent Help"
+        ],
+        "summary": "Agent Help Tier (1) (POST)",
+        "description": "Public x402 endpoint: `/solana/agenthelp-1`.\n\nFlow kind: **paid** endpoint.\n\nFlow: call once **without** `PAYMENT-SIGNATURE` to receive `402 Payment-Required`; sign the requirement; retry the same URL **with** `PAYMENT-SIGNATURE` for `200`.\n\nUse `PAYMENT-SIGNATURE` for public routes (`/solana/*`, `/base/*`). `X-PAYMENT` is legacy/test context.\n\nAgent-help fallback context: tier routes commonly price at `0.02 USDC` per winner; custom defaults are often `winners=10` and `perUser=0.025` (about `0.25 USDC`).\n\nTier aliases map to fixed winner presets.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PaymentSignature"
+          },
+          {
+            "$ref": "#/components/parameters/Description"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/PaidSuccess"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      }
+    },
+    "/solana/agenthelp-5": {
+      "post": {
+        "operationId": "post_solana_agenthelp_5",
+        "tags": [
+          "Agent Help"
+        ],
+        "summary": "Agent Help Tier (5) (POST)",
+        "description": "Public x402 endpoint: `/solana/agenthelp-5`.\n\nFlow kind: **paid** endpoint.\n\nFlow: call once **without** `PAYMENT-SIGNATURE` to receive `402 Payment-Required`; sign the requirement; retry the same URL **with** `PAYMENT-SIGNATURE` for `200`.\n\nUse `PAYMENT-SIGNATURE` for public routes (`/solana/*`, `/base/*`). `X-PAYMENT` is legacy/test context.\n\nAgent-help fallback context: tier routes commonly price at `0.02 USDC` per winner; custom defaults are often `winners=10` and `perUser=0.025` (about `0.25 USDC`).\n\nTier aliases map to fixed winner presets.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PaymentSignature"
+          },
+          {
+            "$ref": "#/components/parameters/Description"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/PaidSuccess"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      }
+    },
+    "/solana/agenthelp-10": {
+      "post": {
+        "operationId": "post_solana_agenthelp_10",
+        "tags": [
+          "Agent Help"
+        ],
+        "summary": "Agent Help Tier (10) (POST)",
+        "description": "Public x402 endpoint: `/solana/agenthelp-10`.\n\nFlow kind: **paid** endpoint.\n\nFlow: call once **without** `PAYMENT-SIGNATURE` to receive `402 Payment-Required`; sign the requirement; retry the same URL **with** `PAYMENT-SIGNATURE` for `200`.\n\nUse `PAYMENT-SIGNATURE` for public routes (`/solana/*`, `/base/*`). `X-PAYMENT` is legacy/test context.\n\nAgent-help fallback context: tier routes commonly price at `0.02 USDC` per winner; custom defaults are often `winners=10` and `perUser=0.025` (about `0.25 USDC`).\n\nTier aliases map to fixed winner presets.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PaymentSignature"
+          },
+          {
+            "$ref": "#/components/parameters/Description"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/PaidSuccess"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      }
+    },
+    "/solana/agenthelp-20": {
+      "post": {
+        "operationId": "post_solana_agenthelp_20",
+        "tags": [
+          "Agent Help"
+        ],
+        "summary": "Agent Help Tier (20) (POST)",
+        "description": "Public x402 endpoint: `/solana/agenthelp-20`.\n\nFlow kind: **paid** endpoint.\n\nFlow: call once **without** `PAYMENT-SIGNATURE` to receive `402 Payment-Required`; sign the requirement; retry the same URL **with** `PAYMENT-SIGNATURE` for `200`.\n\nUse `PAYMENT-SIGNATURE` for public routes (`/solana/*`, `/base/*`). `X-PAYMENT` is legacy/test context.\n\nAgent-help fallback context: tier routes commonly price at `0.02 USDC` per winner; custom defaults are often `winners=10` and `perUser=0.025` (about `0.25 USDC`).\n\nTier aliases map to fixed winner presets.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PaymentSignature"
+          },
+          {
+            "$ref": "#/components/parameters/Description"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/PaidSuccess"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      }
+    },
+    "/solana/agenthelp-50": {
+      "post": {
+        "operationId": "post_solana_agenthelp_50",
+        "tags": [
+          "Agent Help"
+        ],
+        "summary": "Agent Help Tier (50) (POST)",
+        "description": "Public x402 endpoint: `/solana/agenthelp-50`.\n\nFlow kind: **paid** endpoint.\n\nFlow: call once **without** `PAYMENT-SIGNATURE` to receive `402 Payment-Required`; sign the requirement; retry the same URL **with** `PAYMENT-SIGNATURE` for `200`.\n\nUse `PAYMENT-SIGNATURE` for public routes (`/solana/*`, `/base/*`). `X-PAYMENT` is legacy/test context.\n\nAgent-help fallback context: tier routes commonly price at `0.02 USDC` per winner; custom defaults are often `winners=10` and `perUser=0.025` (about `0.25 USDC`).\n\nTier aliases map to fixed winner presets.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PaymentSignature"
+          },
+          {
+            "$ref": "#/components/parameters/Description"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/PaidSuccess"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      }
+    },
+    "/solana/agenthelp-100": {
+      "post": {
+        "operationId": "post_solana_agenthelp_100",
+        "tags": [
+          "Agent Help"
+        ],
+        "summary": "Agent Help Tier (100) (POST)",
+        "description": "Public x402 endpoint: `/solana/agenthelp-100`.\n\nFlow kind: **paid** endpoint.\n\nFlow: call once **without** `PAYMENT-SIGNATURE` to receive `402 Payment-Required`; sign the requirement; retry the same URL **with** `PAYMENT-SIGNATURE` for `200`.\n\nUse `PAYMENT-SIGNATURE` for public routes (`/solana/*`, `/base/*`). `X-PAYMENT` is legacy/test context.\n\nAgent-help fallback context: tier routes commonly price at `0.02 USDC` per winner; custom defaults are often `winners=10` and `perUser=0.025` (about `0.25 USDC`).\n\nTier aliases map to fixed winner presets.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PaymentSignature"
+          },
+          {
+            "$ref": "#/components/parameters/Description"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/PaidSuccess"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "parameters": {
+      "PaymentSignature": {
+        "name": "PAYMENT-SIGNATURE",
+        "in": "header",
+        "required": false,
+        "description": "x402 v2 payment signature for public routes. Omit on first request to get `402 Payment-Required`; include on retry to settle.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "Url": {
+        "name": "url",
+        "in": "query",
+        "schema": {
+          "type": "string",
+          "format": "uri"
+        },
+        "description": "Target URL or profile URL."
+      },
+      "Amount": {
+        "name": "amount",
+        "in": "query",
+        "schema": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "description": "Requested amount/slots."
+      },
+      "Handle": {
+        "name": "handle",
+        "in": "query",
+        "schema": {
+          "type": "string"
+        },
+        "description": "Handle/username style target."
+      },
+      "Community": {
+        "name": "community",
+        "in": "query",
+        "schema": {
+          "type": "string"
+        },
+        "description": "X community URL or identifier."
+      },
+      "Instructions": {
+        "name": "instructions",
+        "in": "query",
+        "schema": {
+          "type": "string",
+          "maxLength": 800
+        },
+        "description": "Optional custom instructions."
+      },
+      "Size": {
+        "name": "size",
+        "in": "query",
+        "schema": {
+          "type": "string",
+          "enum": [
+            "small",
+            "medium",
+            "large"
+          ]
+        },
+        "description": "Raid preset size."
+      },
+      "Likes": {
+        "name": "likes",
+        "in": "query",
+        "schema": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "description": "Custom likes count."
+      },
+      "Reposts": {
+        "name": "reposts",
+        "in": "query",
+        "schema": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "description": "Custom reposts count."
+      },
+      "Comments": {
+        "name": "comments",
+        "in": "query",
+        "schema": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "description": "Custom comments count."
+      },
+      "Bookmarks": {
+        "name": "bookmarks",
+        "in": "query",
+        "schema": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "description": "Custom bookmarks count."
+      },
+      "Join": {
+        "name": "join",
+        "in": "query",
+        "schema": {
+          "type": "string"
+        },
+        "description": "Telegram join target (URL, @handle, invite)."
+      },
+      "Group": {
+        "name": "group",
+        "in": "query",
+        "schema": {
+          "type": "string"
+        },
+        "description": "Telegram group alias parameter."
+      },
+      "Invite": {
+        "name": "invite",
+        "in": "query",
+        "schema": {
+          "type": "string"
+        },
+        "description": "Discord invite URL/code."
+      },
+      "Address": {
+        "name": "address",
+        "in": "query",
+        "schema": {
+          "type": "string"
+        },
+        "description": "Base profile address (0x...)."
+      },
+      "VoteType": {
+        "name": "voteType",
+        "in": "query",
+        "schema": {
+          "type": "string",
+          "enum": [
+            "skeleton_vote",
+            "moontok_vote",
+            "majortrending_vote",
+            "coingecko_vote",
+            "coinmarketcap_vote"
+          ]
+        },
+        "description": "Vote type for unified `/vote` endpoint."
+      },
+      "TypeAlias": {
+        "name": "type",
+        "in": "query",
+        "schema": {
+          "type": "string",
+          "enum": [
+            "skeleton_vote",
+            "moontok_vote",
+            "majortrending_vote",
+            "coingecko_vote",
+            "coinmarketcap_vote"
+          ]
+        },
+        "description": "Alias of `voteType` for unified `/vote`."
+      },
+      "Action": {
+        "name": "action",
+        "in": "query",
+        "schema": {
+          "type": "string",
+          "enum": [
+            "create",
+            "view",
+            "recover"
+          ]
+        },
+        "description": "Action selector for agent-to-human."
+      },
+      "Secret": {
+        "name": "secret",
+        "in": "query",
+        "schema": {
+          "type": "string"
+        },
+        "description": "Secret/view key for submission retrieval."
+      },
+      "Description": {
+        "name": "description",
+        "in": "query",
+        "schema": {
+          "type": "string"
+        },
+        "description": "Task description for agent-to-human create."
+      },
+      "Winners": {
+        "name": "winners",
+        "in": "query",
+        "schema": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 100
+        },
+        "description": "Number of winners."
+      },
+      "PerUser": {
+        "name": "perUser",
+        "in": "query",
+        "schema": {
+          "type": "number",
+          "minimum": 0.01
+        },
+        "description": "USDC reward per participant."
+      },
+      "Requirement": {
+        "name": "requirement",
+        "in": "query",
+        "schema": {
+          "type": "string",
+          "enum": [
+            "tweetScoutScore:0",
+            "tweetScoutScore:10",
+            "tweetScoutScore:25",
+            "xMetricScore:75",
+            "xMetricScore:250",
+            "seekerUser",
+            "xBlueVerified"
+          ]
+        },
+        "description": "Optional single requirement selector for `agenttohumanadvanced`. Meaning: tweetScoutScore:* = Sorsa (formerly TweetScout) third-party X profile score; xMetricScore:* = WURK-generated X profile score (follower count, follower quality, profile signals); seekerUser = users in the Solana Seeker phone ecosystem; xBlueVerified = X account with a blue verified badge. Stricter requirements can reduce eligible participants and slow fill speed. Policy: tweetScoutScore:0 => max winners 100 + min perUser 0.05; tweetScoutScore:10 => max 75 + min 0.075; tweetScoutScore:25 => max 50 + min 0.125; xMetricScore:75 => max 100 + min 0.0625; xMetricScore:250 => max 50 + min 0.125; xBlueVerified => max 50 + min 0.075; seekerUser => baseline only."
+      },
+      "WinnersPath": {
+        "name": "winners",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 250
+        },
+        "description": "Winner/slot count in path alias. Range is endpoint-specific (commonly 1..100 for agent-help, 5..250 for social jobs)."
+      },
+      "SecretPath": {
+        "name": "secret",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "string"
+        },
+        "description": "Secret/view key in path."
+      },
+      "LikesPath": {
+        "name": "likes",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "description": "Custom likes path value."
+      },
+      "RepostsPath": {
+        "name": "reposts",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "description": "Custom reposts path value."
+      },
+      "CommentsPath": {
+        "name": "comments",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "description": "Custom comments path value."
+      },
+      "BookmarksPath": {
+        "name": "bookmarks",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "description": "Custom bookmarks path value."
+      }
+    },
+    "schemas": {
+      "PaymentRequirement": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "scheme": {
+            "type": "string"
+          },
+          "network": {
+            "type": "string"
+          },
+          "maxAmountRequired": {
+            "type": "string"
+          },
+          "resource": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "mimeType": {
+            "type": "string"
+          },
+          "payTo": {
+            "type": "string"
+          },
+          "asset": {
+            "type": "string"
+          },
+          "maxTimeoutSeconds": {
+            "type": "integer"
+          },
+          "extra": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        }
+      },
+      "PaymentRequiredResponse": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": [
+          "x402Version",
+          "accepts",
+          "resource"
+        ],
+        "properties": {
+          "x402Version": {
+            "type": "integer",
+            "example": 2
+          },
+          "accepts": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "$ref": "#/components/schemas/PaymentRequirement"
+            }
+          },
+          "error": {
+            "type": "string"
+          },
+          "resource": {
+            "description": "Requested resource metadata echoed by payment middleware.",
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "object",
+                "additionalProperties": true
+              }
+            ]
+          },
+          "extensions": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        }
+      },
+      "PaidSuccessResponse": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "example": true
+          },
+          "paid": {
+            "type": "boolean",
+            "example": true
+          },
+          "alreadyConfirmed": {
+            "type": "boolean",
+            "example": false
+          },
+          "message": {
+            "type": "string"
+          },
+          "jobId": {
+            "type": "string"
+          },
+          "statusUrl": {
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      },
+      "ErrorResponse": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "message": {
+            "type": "string"
+          },
+          "error": {
+            "type": "string"
+          },
+          "errorCode": {
+            "type": "string",
+            "description": "Machine-readable application error code (when available)."
+          },
+          "retryAfterSeconds": {
+            "type": "integer",
+            "description": "Retry-after hint in seconds for rate-limited requests."
+          }
+        }
+      },
+      "AgentSupportSendInput": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "secret": {
+            "type": "string",
+            "description": "Optional when sent via query/header."
+          },
+          "message": {
+            "type": "string",
+            "maxLength": 2000
+          }
+        },
+        "required": [
+          "message"
+        ]
+      },
+      "AgentSupportSendSuccess": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "example": true
+          },
+          "message": {
+            "type": "string",
+            "example": "Thank you for your message. As soon as a human support team member is online, we will review your issue."
+          },
+          "messagesUrl": {
+            "type": "string",
+            "format": "uri"
+          }
+        },
+        "required": [
+          "ok",
+          "message",
+          "messagesUrl"
+        ]
+      },
+      "AgentSupportThreadMessage": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "role": {
+            "type": "string",
+            "enum": [
+              "agent",
+              "support"
+            ]
+          },
+          "message": {
+            "type": "string"
+          },
+          "jobId": {
+            "type": "string"
+          },
+          "customJobId": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "AgentSupportMessagesSuccess": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "example": true
+          },
+          "wallet": {
+            "type": "string"
+          },
+          "messages": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AgentSupportThreadMessage"
+            }
+          }
+        }
+      },
+      "AgentToHumanAdvancedChooseWinnersInput": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "secret": {
+            "type": "string",
+            "description": "Advanced job secret for creator-mode winner selection."
+          },
+          "submissionIds": {
+            "oneOf": [
+              {
+                "type": "array",
+                "minItems": 1,
+                "maxItems": 100,
+                "uniqueItems": true,
+                "items": {
+                  "type": "string"
+                }
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "description": "Winner submission ids as array or comma-separated string."
+          }
+        },
+        "required": [
+          "secret",
+          "submissionIds"
+        ]
+      },
+      "AgentToHumanAdvancedChooseWinnersSuccess": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "example": true
+          },
+          "jobId": {
+            "type": "string"
+          },
+          "customId": {
+            "type": "string"
+          },
+          "requested": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "updated": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "alreadyWinnerCountInRequest": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "winnersNow": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "winnerCap": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "remainingSlots": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "statusTransition": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "updatedSubmissionIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "ok",
+          "jobId",
+          "requested",
+          "updated",
+          "winnersNow",
+          "winnerCap",
+          "remainingSlots"
+        ]
+      }
+    },
+    "responses": {
+      "PaymentRequired": {
+        "description": "Payment required. Sign and retry with `PAYMENT-SIGNATURE` (public v2 flow).",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/PaymentRequiredResponse"
+            }
+          }
+        }
+      },
+      "PaidSuccess": {
+        "description": "Operation accepted/completed (after settlement on paid routes, or immediately for free variants).",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/PaidSuccessResponse"
+            }
+          }
+        }
+      },
+      "BadRequest": {
+        "description": "Invalid request input or malformed payment signature.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            }
+          }
+        }
+      },
+      "Unauthorized": {
+        "description": "Unauthorized secret context.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            }
+          }
+        }
+      },
+      "NotFound": {
+        "description": "Requested resource, job, or secret could not be found.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            }
+          }
+        }
+      },
+      "TooManyRequests": {
+        "description": "Rate limit exceeded for wallet-threaded support chat.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            }
+          }
+        }
+      },
+      "SupportSendSuccess": {
+        "description": "Support message accepted.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/AgentSupportSendSuccess"
+            }
+          }
+        }
+      },
+      "SupportMessagesSuccess": {
+        "description": "Wallet-threaded support messages.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/AgentSupportMessagesSuccess"
+            }
+          }
+        }
+      },
+      "ChooseWinnersSuccess": {
+        "description": "Creator-mode advanced winners selected successfully.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/AgentToHumanAdvancedChooseWinnersSuccess"
+            }
+          }
+        }
+      },
+      "Conflict": {
+        "description": "Conflict with current state (for example, duplicate/similar running job).",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            }
+          }
+        }
+      },
+      "ServerError": {
+        "description": "Unexpected server-side failure.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/providers/wurk/social-growth/PAY.md
+++ b/providers/wurk/social-growth/PAY.md
@@ -6,7 +6,7 @@ use_case: "Use for buying agent-paid likes, reposts, comments, bookmarks, follow
 category: media
 service_url: https://wurkapi.fun
 openapi:
- url: https://wurkapi.fun/openapi-x402-solana-social-growth.json
+ path: openapi.json
 ---
 
 WURK Social Growth lets agents create paid human-executed growth jobs through

--- a/providers/wurk/social-growth/PAY.md
+++ b/providers/wurk/social-growth/PAY.md
@@ -1,0 +1,31 @@
+---
+name: social-growth
+title: "WURK Social Growth"
+description: "Create x402-paid social growth jobs on Solana for X, Instagram, YouTube, Telegram, Discord, hey.lol, Base App, Zora, and raid-style engagement campaigns."
+use_case: "Use for buying agent-paid likes, reposts, comments, bookmarks, followers, subscribers, group members, and raid bundles across social platforms."
+category: media
+service_url: https://wurkapi.fun
+openapi:
+ url: https://wurkapi.fun/openapi-x402-solana-social-growth.json
+---
+
+WURK Social Growth lets agents create paid human-executed growth jobs through
+x402 Solana USDC endpoints. The listing covers social engagement and audience
+growth routes such as X likes/reposts/comments/bookmarks/followers, Instagram
+engagement, YouTube engagement, Telegram and Discord members, hey.lol actions,
+and preset or custom raid bundles.
+
+Paid routes follow the public x402 v2 flow: call the endpoint without
+`PAYMENT-SIGNATURE` to receive a 402 payment requirement, sign it with a Solana
+USDC-capable wallet, then retry the same URL with `PAYMENT-SIGNATURE`.
+
+## Spend-aware usage
+
+- Start with the smallest useful `amount` or preset that can answer the user's
+  growth task. Many endpoints default to 40 slots when `amount` is omitted.
+- Use exact target URLs or handles. Avoid paid discovery calls when the user has
+  already supplied a canonical post, profile, group, or invite URL.
+- For raid endpoints, confirm the desired preset or component counts before
+  paying. Custom raids can combine likes, reposts, comments, and bookmarks.
+- Do not repeat paid calls for the same target unless the user explicitly asks
+  for additional growth.

--- a/providers/wurk/social-growth/openapi.json
+++ b/providers/wurk/social-growth/openapi.json
@@ -1,0 +1,1993 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "WURK x402 Solana Social Growth Endpoints",
+    "version": "1.1.0",
+    "description": "Category-specific x402 listing surface for WURK Solana social growth endpoints: social engagement, followers, members, comments, reposts, bookmarks, and raid jobs. Public v2 flow uses `PAYMENT-SIGNATURE`."
+  },
+  "servers": [
+    {
+      "url": "https://wurkapi.fun"
+    }
+  ],
+  "tags": [
+    {
+      "name": "Base App"
+    },
+    {
+      "name": "Discord"
+    },
+    {
+      "name": "hey.lol"
+    },
+    {
+      "name": "Instagram"
+    },
+    {
+      "name": "Raids"
+    },
+    {
+      "name": "Telegram"
+    },
+    {
+      "name": "X / Twitter"
+    },
+    {
+      "name": "YouTube"
+    },
+    {
+      "name": "Zora"
+    }
+  ],
+  "paths": {
+    "/solana/xlikes": {
+      "post": {
+        "operationId": "post_solana_xlikes",
+        "tags": [
+          "X / Twitter"
+        ],
+        "summary": "X Likes (POST)",
+        "description": "Public x402 endpoint: `/solana/xlikes`.\n\nFlow kind: **paid** endpoint.\n\nFlow: call once **without** `PAYMENT-SIGNATURE` to receive `402 Payment-Required`; sign the requirement; retry the same URL **with** `PAYMENT-SIGNATURE` for `200`.\n\nUse `PAYMENT-SIGNATURE` for public routes (`/solana/*`, `/base/*`). `X-PAYMENT` is legacy/test context.\n\nPricing hint: `{\"currency\":\"USDC\",\"perUnit\":0.025,\"unit\":\"like\"}`.\n\nDefaults: `{\"amount\":40}`.\n\nLimits: `{\"amountMin\":5,\"amountMax\":250}`.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PaymentSignature"
+          },
+          {
+            "$ref": "#/components/parameters/Url"
+          },
+          {
+            "$ref": "#/components/parameters/Amount"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/PaidSuccess"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      }
+    },
+    "/solana/reposts": {
+      "post": {
+        "operationId": "post_solana_reposts",
+        "tags": [
+          "X / Twitter"
+        ],
+        "summary": "X Reposts (POST)",
+        "description": "Public x402 endpoint: `/solana/reposts`.\n\nFlow kind: **paid** endpoint.\n\nFlow: call once **without** `PAYMENT-SIGNATURE` to receive `402 Payment-Required`; sign the requirement; retry the same URL **with** `PAYMENT-SIGNATURE` for `200`.\n\nUse `PAYMENT-SIGNATURE` for public routes (`/solana/*`, `/base/*`). `X-PAYMENT` is legacy/test context.\n\nPricing hint: `{\"currency\":\"USDC\",\"perUnit\":0.025,\"unit\":\"repost\"}`.\n\nDefaults: `{\"amount\":40}`.\n\nLimits: `{\"amountMin\":5,\"amountMax\":250}`.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PaymentSignature"
+          },
+          {
+            "$ref": "#/components/parameters/Url"
+          },
+          {
+            "$ref": "#/components/parameters/Amount"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/PaidSuccess"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      }
+    },
+    "/solana/comments": {
+      "post": {
+        "operationId": "post_solana_comments",
+        "tags": [
+          "X / Twitter"
+        ],
+        "summary": "X Comments (POST)",
+        "description": "Public x402 endpoint: `/solana/comments`.\n\nFlow kind: **paid** endpoint.\n\nFlow: call once **without** `PAYMENT-SIGNATURE` to receive `402 Payment-Required`; sign the requirement; retry the same URL **with** `PAYMENT-SIGNATURE` for `200`.\n\nUse `PAYMENT-SIGNATURE` for public routes (`/solana/*`, `/base/*`). `X-PAYMENT` is legacy/test context.\n\nPricing hint: `{\"currency\":\"USDC\",\"perUnit\":0.025,\"unit\":\"comment\"}`.\n\nDefaults: `{\"amount\":40}`.\n\nLimits: `{\"amountMin\":5,\"amountMax\":250}`.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PaymentSignature"
+          },
+          {
+            "$ref": "#/components/parameters/Url"
+          },
+          {
+            "$ref": "#/components/parameters/Amount"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/PaidSuccess"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      }
+    },
+    "/solana/xbookmarks": {
+      "post": {
+        "operationId": "post_solana_xbookmarks",
+        "tags": [
+          "X / Twitter"
+        ],
+        "summary": "X Bookmarks (POST)",
+        "description": "Public x402 endpoint: `/solana/xbookmarks`.\n\nFlow kind: **paid** endpoint.\n\nFlow: call once **without** `PAYMENT-SIGNATURE` to receive `402 Payment-Required`; sign the requirement; retry the same URL **with** `PAYMENT-SIGNATURE` for `200`.\n\nUse `PAYMENT-SIGNATURE` for public routes (`/solana/*`, `/base/*`). `X-PAYMENT` is legacy/test context.\n\nPricing hint: `{\"currency\":\"USDC\",\"perUnit\":0.025,\"unit\":\"bookmark\"}`.\n\nDefaults: `{\"amount\":40}`.\n\nLimits: `{\"amountMin\":5,\"amountMax\":250}`.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PaymentSignature"
+          },
+          {
+            "$ref": "#/components/parameters/Url"
+          },
+          {
+            "$ref": "#/components/parameters/Amount"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/PaidSuccess"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      }
+    },
+    "/solana/xfollowers": {
+      "post": {
+        "operationId": "post_solana_xfollowers",
+        "tags": [
+          "X / Twitter"
+        ],
+        "summary": "X Followers (POST)",
+        "description": "Public x402 endpoint: `/solana/xfollowers`.\n\nFlow kind: **paid** endpoint.\n\nFlow: call once **without** `PAYMENT-SIGNATURE` to receive `402 Payment-Required`; sign the requirement; retry the same URL **with** `PAYMENT-SIGNATURE` for `200`.\n\nUse `PAYMENT-SIGNATURE` for public routes (`/solana/*`, `/base/*`). `X-PAYMENT` is legacy/test context.\n\nPricing hint: `{\"currency\":\"USDC\",\"perUnit\":0.04,\"unit\":\"follower\"}`.\n\nDefaults: `{\"amount\":100}`.\n\nLimits: `{\"amountMin\":5,\"amountMax\":1000}`.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PaymentSignature"
+          },
+          {
+            "$ref": "#/components/parameters/Handle"
+          },
+          {
+            "$ref": "#/components/parameters/Url"
+          },
+          {
+            "$ref": "#/components/parameters/Community"
+          },
+          {
+            "$ref": "#/components/parameters/Amount"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/PaidSuccess"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      }
+    },
+    "/solana/insta-likes": {
+      "post": {
+        "operationId": "post_solana_insta_likes",
+        "tags": [
+          "Instagram"
+        ],
+        "summary": "Instagram Likes (POST)",
+        "description": "Public x402 endpoint: `/solana/insta-likes`.\n\nFlow kind: **paid** endpoint.\n\nFlow: call once **without** `PAYMENT-SIGNATURE` to receive `402 Payment-Required`; sign the requirement; retry the same URL **with** `PAYMENT-SIGNATURE` for `200`.\n\nUse `PAYMENT-SIGNATURE` for public routes (`/solana/*`, `/base/*`). `X-PAYMENT` is legacy/test context.\n\nPricing hint: `{\"currency\":\"USDC\",\"perUnit\":0.025,\"unit\":\"like\"}`.\n\nDefaults: `{\"amount\":40}`.\n\nLimits: `{\"amountMin\":5,\"amountMax\":250}`.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PaymentSignature"
+          },
+          {
+            "$ref": "#/components/parameters/Url"
+          },
+          {
+            "$ref": "#/components/parameters/Amount"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/PaidSuccess"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      }
+    },
+    "/solana/instacomments": {
+      "post": {
+        "operationId": "post_solana_instacomments",
+        "tags": [
+          "Instagram"
+        ],
+        "summary": "Instagram Comments (POST)",
+        "description": "Public x402 endpoint: `/solana/instacomments`.\n\nFlow kind: **paid** endpoint.\n\nFlow: call once **without** `PAYMENT-SIGNATURE` to receive `402 Payment-Required`; sign the requirement; retry the same URL **with** `PAYMENT-SIGNATURE` for `200`.\n\nUse `PAYMENT-SIGNATURE` for public routes (`/solana/*`, `/base/*`). `X-PAYMENT` is legacy/test context.\n\nPricing hint: `{\"currency\":\"USDC\",\"perUnit\":0.025,\"unit\":\"comment\"}`.\n\nDefaults: `{\"amount\":100}`.\n\nLimits: `{\"amountMin\":5,\"amountMax\":250,\"instructionsMaxChars\":800}`.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PaymentSignature"
+          },
+          {
+            "$ref": "#/components/parameters/Url"
+          },
+          {
+            "$ref": "#/components/parameters/Amount"
+          },
+          {
+            "$ref": "#/components/parameters/Instructions"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/PaidSuccess"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      }
+    },
+    "/solana/instafollowers": {
+      "post": {
+        "operationId": "post_solana_instafollowers",
+        "tags": [
+          "Instagram"
+        ],
+        "summary": "Instagram Followers (POST)",
+        "description": "Public x402 endpoint: `/solana/instafollowers`.\n\nFlow kind: **paid** endpoint.\n\nFlow: call once **without** `PAYMENT-SIGNATURE` to receive `402 Payment-Required`; sign the requirement; retry the same URL **with** `PAYMENT-SIGNATURE` for `200`.\n\nUse `PAYMENT-SIGNATURE` for public routes (`/solana/*`, `/base/*`). `X-PAYMENT` is legacy/test context.\n\nPricing hint: `{\"currency\":\"USDC\",\"perUnit\":0.04,\"unit\":\"follower\"}`.\n\nDefaults: `{\"amount\":100}`.\n\nLimits: `{\"amountMin\":5,\"amountMax\":1000}`.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PaymentSignature"
+          },
+          {
+            "$ref": "#/components/parameters/Handle"
+          },
+          {
+            "$ref": "#/components/parameters/Url"
+          },
+          {
+            "$ref": "#/components/parameters/Amount"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/PaidSuccess"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      }
+    },
+    "/solana/heylolfollowers": {
+      "post": {
+        "operationId": "post_solana_heylolfollowers",
+        "tags": [
+          "hey.lol"
+        ],
+        "summary": "hey.lol Followers (POST)",
+        "description": "Public x402 endpoint: `/solana/heylolfollowers`.\n\nFlow kind: **paid** endpoint.\n\nFlow: call once **without** `PAYMENT-SIGNATURE` to receive `402 Payment-Required`; sign the requirement; retry the same URL **with** `PAYMENT-SIGNATURE` for `200`.\n\nUse `PAYMENT-SIGNATURE` for public routes (`/solana/*`, `/base/*`). `X-PAYMENT` is legacy/test context.\n\nPricing hint: `{\"currency\":\"USDC\",\"perUnit\":0.025,\"unit\":\"slot\"}`.\n\nDefaults: `{\"amount\":100}`.\n\nLimits: `{\"amountMin\":5,\"amountMax\":100}`.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PaymentSignature"
+          },
+          {
+            "$ref": "#/components/parameters/Handle"
+          },
+          {
+            "$ref": "#/components/parameters/Url"
+          },
+          {
+            "$ref": "#/components/parameters/Amount"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/PaidSuccess"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      }
+    },
+    "/solana/heylollikes": {
+      "post": {
+        "operationId": "post_solana_heylollikes",
+        "tags": [
+          "hey.lol"
+        ],
+        "summary": "hey.lol Likes (POST)",
+        "description": "Public x402 endpoint: `/solana/heylollikes`.\n\nFlow kind: **paid** endpoint.\n\nFlow: call once **without** `PAYMENT-SIGNATURE` to receive `402 Payment-Required`; sign the requirement; retry the same URL **with** `PAYMENT-SIGNATURE` for `200`.\n\nUse `PAYMENT-SIGNATURE` for public routes (`/solana/*`, `/base/*`). `X-PAYMENT` is legacy/test context.\n\nPricing hint: `{\"currency\":\"USDC\",\"perUnit\":0.025,\"unit\":\"like\"}`.\n\nDefaults: `{\"amount\":40}`.\n\nLimits: `{\"amountMin\":5,\"amountMax\":250}`.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PaymentSignature"
+          },
+          {
+            "$ref": "#/components/parameters/Url"
+          },
+          {
+            "$ref": "#/components/parameters/Amount"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/PaidSuccess"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      }
+    },
+    "/solana/heylolreposts": {
+      "post": {
+        "operationId": "post_solana_heylolreposts",
+        "tags": [
+          "hey.lol"
+        ],
+        "summary": "hey.lol Reposts (POST)",
+        "description": "Public x402 endpoint: `/solana/heylolreposts`.\n\nFlow kind: **paid** endpoint.\n\nFlow: call once **without** `PAYMENT-SIGNATURE` to receive `402 Payment-Required`; sign the requirement; retry the same URL **with** `PAYMENT-SIGNATURE` for `200`.\n\nUse `PAYMENT-SIGNATURE` for public routes (`/solana/*`, `/base/*`). `X-PAYMENT` is legacy/test context.\n\nPricing hint: `{\"currency\":\"USDC\",\"perUnit\":0.025,\"unit\":\"repost\"}`.\n\nDefaults: `{\"amount\":100}`.\n\nLimits: `{\"amountMin\":5,\"amountMax\":250}`.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PaymentSignature"
+          },
+          {
+            "$ref": "#/components/parameters/Url"
+          },
+          {
+            "$ref": "#/components/parameters/Amount"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/PaidSuccess"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      }
+    },
+    "/solana/heylolcomments": {
+      "post": {
+        "operationId": "post_solana_heylolcomments",
+        "tags": [
+          "hey.lol"
+        ],
+        "summary": "hey.lol Comments (POST)",
+        "description": "Public x402 endpoint: `/solana/heylolcomments`.\n\nFlow kind: **paid** endpoint.\n\nFlow: call once **without** `PAYMENT-SIGNATURE` to receive `402 Payment-Required`; sign the requirement; retry the same URL **with** `PAYMENT-SIGNATURE` for `200`.\n\nUse `PAYMENT-SIGNATURE` for public routes (`/solana/*`, `/base/*`). `X-PAYMENT` is legacy/test context.\n\nPricing hint: `{\"currency\":\"USDC\",\"perUnit\":0.025,\"unit\":\"comment\"}`.\n\nDefaults: `{\"amount\":100}`.\n\nLimits: `{\"amountMin\":5,\"amountMax\":250,\"instructionsMaxChars\":800}`.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PaymentSignature"
+          },
+          {
+            "$ref": "#/components/parameters/Url"
+          },
+          {
+            "$ref": "#/components/parameters/Amount"
+          },
+          {
+            "$ref": "#/components/parameters/Instructions"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/PaidSuccess"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      }
+    },
+    "/solana/ytlikes": {
+      "post": {
+        "operationId": "post_solana_ytlikes",
+        "tags": [
+          "YouTube"
+        ],
+        "summary": "YouTube Likes (POST)",
+        "description": "Public x402 endpoint: `/solana/ytlikes`.\n\nFlow kind: **paid** endpoint.\n\nFlow: call once **without** `PAYMENT-SIGNATURE` to receive `402 Payment-Required`; sign the requirement; retry the same URL **with** `PAYMENT-SIGNATURE` for `200`.\n\nUse `PAYMENT-SIGNATURE` for public routes (`/solana/*`, `/base/*`). `X-PAYMENT` is legacy/test context.\n\nPricing hint: `{\"currency\":\"USDC\",\"perUnit\":0.025,\"unit\":\"like\"}`.\n\nDefaults: `{\"amount\":40}`.\n\nLimits: `{\"amountMin\":5,\"amountMax\":250}`.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PaymentSignature"
+          },
+          {
+            "$ref": "#/components/parameters/Url"
+          },
+          {
+            "$ref": "#/components/parameters/Amount"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/PaidSuccess"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      }
+    },
+    "/solana/ytcomments": {
+      "post": {
+        "operationId": "post_solana_ytcomments",
+        "tags": [
+          "YouTube"
+        ],
+        "summary": "YouTube Comments (POST)",
+        "description": "Public x402 endpoint: `/solana/ytcomments`.\n\nFlow kind: **paid** endpoint.\n\nFlow: call once **without** `PAYMENT-SIGNATURE` to receive `402 Payment-Required`; sign the requirement; retry the same URL **with** `PAYMENT-SIGNATURE` for `200`.\n\nUse `PAYMENT-SIGNATURE` for public routes (`/solana/*`, `/base/*`). `X-PAYMENT` is legacy/test context.\n\nPricing hint: `{\"currency\":\"USDC\",\"perUnit\":0.025,\"unit\":\"comment\"}`.\n\nDefaults: `{\"amount\":100}`.\n\nLimits: `{\"amountMin\":5,\"amountMax\":250,\"instructionsMaxChars\":800}`.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PaymentSignature"
+          },
+          {
+            "$ref": "#/components/parameters/Url"
+          },
+          {
+            "$ref": "#/components/parameters/Amount"
+          },
+          {
+            "$ref": "#/components/parameters/Instructions"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/PaidSuccess"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      }
+    },
+    "/solana/ytsubs": {
+      "post": {
+        "operationId": "post_solana_ytsubs",
+        "tags": [
+          "YouTube"
+        ],
+        "summary": "YouTube Subscribers (POST)",
+        "description": "Public x402 endpoint: `/solana/ytsubs`.\n\nFlow kind: **paid** endpoint.\n\nFlow: call once **without** `PAYMENT-SIGNATURE` to receive `402 Payment-Required`; sign the requirement; retry the same URL **with** `PAYMENT-SIGNATURE` for `200`.\n\nUse `PAYMENT-SIGNATURE` for public routes (`/solana/*`, `/base/*`). `X-PAYMENT` is legacy/test context.\n\nPricing hint: `{\"currency\":\"USDC\",\"perUnit\":0.04,\"unit\":\"subscriber\"}`.\n\nDefaults: `{\"amount\":100}`.\n\nLimits: `{\"amountMin\":5,\"amountMax\":1000}`.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PaymentSignature"
+          },
+          {
+            "$ref": "#/components/parameters/Handle"
+          },
+          {
+            "$ref": "#/components/parameters/Url"
+          },
+          {
+            "$ref": "#/components/parameters/Amount"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/PaidSuccess"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      }
+    },
+    "/solana/tgmembers": {
+      "post": {
+        "operationId": "post_solana_tgmembers",
+        "tags": [
+          "Telegram"
+        ],
+        "summary": "Telegram Members (POST)",
+        "description": "Public x402 endpoint: `/solana/tgmembers`.\n\nFlow kind: **paid** endpoint.\n\nFlow: call once **without** `PAYMENT-SIGNATURE` to receive `402 Payment-Required`; sign the requirement; retry the same URL **with** `PAYMENT-SIGNATURE` for `200`.\n\nUse `PAYMENT-SIGNATURE` for public routes (`/solana/*`, `/base/*`). `X-PAYMENT` is legacy/test context.\n\nPricing hint: `{\"currency\":\"USDC\",\"perUnit\":0.04,\"unit\":\"member\"}`.\n\nDefaults: `{\"amount\":100}`.\n\nLimits: `{\"amountMin\":5,\"amountMax\":500}`.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PaymentSignature"
+          },
+          {
+            "$ref": "#/components/parameters/Join"
+          },
+          {
+            "$ref": "#/components/parameters/Url"
+          },
+          {
+            "$ref": "#/components/parameters/Group"
+          },
+          {
+            "$ref": "#/components/parameters/Amount"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/PaidSuccess"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      }
+    },
+    "/solana/dcmembers": {
+      "post": {
+        "operationId": "post_solana_dcmembers",
+        "tags": [
+          "Discord"
+        ],
+        "summary": "Discord Members (POST)",
+        "description": "Public x402 endpoint: `/solana/dcmembers`.\n\nFlow kind: **paid** endpoint.\n\nFlow: call once **without** `PAYMENT-SIGNATURE` to receive `402 Payment-Required`; sign the requirement; retry the same URL **with** `PAYMENT-SIGNATURE` for `200`.\n\nUse `PAYMENT-SIGNATURE` for public routes (`/solana/*`, `/base/*`). `X-PAYMENT` is legacy/test context.\n\nPricing hint: `{\"currency\":\"USDC\",\"perUnit\":0.04,\"unit\":\"member\"}`.\n\nDefaults: `{\"amount\":100}`.\n\nLimits: `{\"amountMin\":5,\"amountMax\":250}`.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PaymentSignature"
+          },
+          {
+            "$ref": "#/components/parameters/Invite"
+          },
+          {
+            "$ref": "#/components/parameters/Url"
+          },
+          {
+            "$ref": "#/components/parameters/Amount"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/PaidSuccess"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      }
+    },
+    "/solana/basefollowers": {
+      "post": {
+        "operationId": "post_solana_basefollowers",
+        "tags": [
+          "Base App"
+        ],
+        "summary": "Base App Followers (POST)",
+        "description": "Public x402 endpoint: `/solana/basefollowers`.\n\nFlow kind: **paid** endpoint.\n\nFlow: call once **without** `PAYMENT-SIGNATURE` to receive `402 Payment-Required`; sign the requirement; retry the same URL **with** `PAYMENT-SIGNATURE` for `200`.\n\nUse `PAYMENT-SIGNATURE` for public routes (`/solana/*`, `/base/*`). `X-PAYMENT` is legacy/test context.\n\nPricing hint: `{\"currency\":\"USDC\",\"perUnit\":0.04,\"unit\":\"follower\"}`.\n\nDefaults: `{\"amount\":100}`.\n\nLimits: `{\"amountMin\":5,\"amountMax\":500}`.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PaymentSignature"
+          },
+          {
+            "$ref": "#/components/parameters/Url"
+          },
+          {
+            "$ref": "#/components/parameters/Address"
+          },
+          {
+            "$ref": "#/components/parameters/Amount"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/PaidSuccess"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      }
+    },
+    "/solana/baselikes": {
+      "post": {
+        "operationId": "post_solana_baselikes",
+        "tags": [
+          "Base App"
+        ],
+        "summary": "Base App Likes (POST)",
+        "description": "Public x402 endpoint: `/solana/baselikes`.\n\nFlow kind: **paid** endpoint.\n\nFlow: call once **without** `PAYMENT-SIGNATURE` to receive `402 Payment-Required`; sign the requirement; retry the same URL **with** `PAYMENT-SIGNATURE` for `200`.\n\nUse `PAYMENT-SIGNATURE` for public routes (`/solana/*`, `/base/*`). `X-PAYMENT` is legacy/test context.\n\nPricing hint: `{\"currency\":\"USDC\",\"perUnit\":0.025,\"unit\":\"like\"}`.\n\nDefaults: `{\"amount\":100}`.\n\nLimits: `{\"amountMin\":5,\"amountMax\":250}`.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PaymentSignature"
+          },
+          {
+            "$ref": "#/components/parameters/Url"
+          },
+          {
+            "$ref": "#/components/parameters/Amount"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/PaidSuccess"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      }
+    },
+    "/solana/basereposts": {
+      "post": {
+        "operationId": "post_solana_basereposts",
+        "tags": [
+          "Base App"
+        ],
+        "summary": "Base App Reposts (POST)",
+        "description": "Public x402 endpoint: `/solana/basereposts`.\n\nFlow kind: **paid** endpoint.\n\nFlow: call once **without** `PAYMENT-SIGNATURE` to receive `402 Payment-Required`; sign the requirement; retry the same URL **with** `PAYMENT-SIGNATURE` for `200`.\n\nUse `PAYMENT-SIGNATURE` for public routes (`/solana/*`, `/base/*`). `X-PAYMENT` is legacy/test context.\n\nPricing hint: `{\"currency\":\"USDC\",\"perUnit\":0.025,\"unit\":\"repost\"}`.\n\nDefaults: `{\"amount\":100}`.\n\nLimits: `{\"amountMin\":5,\"amountMax\":250}`.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PaymentSignature"
+          },
+          {
+            "$ref": "#/components/parameters/Url"
+          },
+          {
+            "$ref": "#/components/parameters/Amount"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/PaidSuccess"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      }
+    },
+    "/solana/basecomments": {
+      "post": {
+        "operationId": "post_solana_basecomments",
+        "tags": [
+          "Base App"
+        ],
+        "summary": "Base App Comments (POST)",
+        "description": "Public x402 endpoint: `/solana/basecomments`.\n\nFlow kind: **paid** endpoint.\n\nFlow: call once **without** `PAYMENT-SIGNATURE` to receive `402 Payment-Required`; sign the requirement; retry the same URL **with** `PAYMENT-SIGNATURE` for `200`.\n\nUse `PAYMENT-SIGNATURE` for public routes (`/solana/*`, `/base/*`). `X-PAYMENT` is legacy/test context.\n\nPricing hint: `{\"currency\":\"USDC\",\"perUnit\":0.025,\"unit\":\"comment\"}`.\n\nDefaults: `{\"amount\":100}`.\n\nLimits: `{\"amountMin\":5,\"amountMax\":250,\"instructionsMaxChars\":800}`.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PaymentSignature"
+          },
+          {
+            "$ref": "#/components/parameters/Url"
+          },
+          {
+            "$ref": "#/components/parameters/Amount"
+          },
+          {
+            "$ref": "#/components/parameters/Instructions"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/PaidSuccess"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      }
+    },
+    "/solana/zorafollowers": {
+      "post": {
+        "operationId": "post_solana_zorafollowers",
+        "tags": [
+          "Zora"
+        ],
+        "summary": "Zora Followers (POST)",
+        "description": "Public x402 endpoint: `/solana/zorafollowers`.\n\nFlow kind: **paid** endpoint.\n\nFlow: call once **without** `PAYMENT-SIGNATURE` to receive `402 Payment-Required`; sign the requirement; retry the same URL **with** `PAYMENT-SIGNATURE` for `200`.\n\nUse `PAYMENT-SIGNATURE` for public routes (`/solana/*`, `/base/*`). `X-PAYMENT` is legacy/test context.\n\nPricing hint: `{\"currency\":\"USDC\",\"perUnit\":0.04,\"unit\":\"follower\"}`.\n\nDefaults: `{\"amount\":100}`.\n\nLimits: `{\"amountMin\":5,\"amountMax\":100}`.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PaymentSignature"
+          },
+          {
+            "$ref": "#/components/parameters/Handle"
+          },
+          {
+            "$ref": "#/components/parameters/Url"
+          },
+          {
+            "$ref": "#/components/parameters/Amount"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/PaidSuccess"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      }
+    },
+    "/solana/zoracomments": {
+      "post": {
+        "operationId": "post_solana_zoracomments",
+        "tags": [
+          "Zora"
+        ],
+        "summary": "Zora Comments (POST)",
+        "description": "Public x402 endpoint: `/solana/zoracomments`.\n\nFlow kind: **paid** endpoint.\n\nFlow: call once **without** `PAYMENT-SIGNATURE` to receive `402 Payment-Required`; sign the requirement; retry the same URL **with** `PAYMENT-SIGNATURE` for `200`.\n\nUse `PAYMENT-SIGNATURE` for public routes (`/solana/*`, `/base/*`). `X-PAYMENT` is legacy/test context.\n\nPricing hint: `{\"currency\":\"USDC\",\"perUnit\":0.025,\"unit\":\"comment\"}`.\n\nDefaults: `{\"amount\":100}`.\n\nLimits: `{\"amountMin\":5,\"amountMax\":250,\"instructionsMaxChars\":800}`.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PaymentSignature"
+          },
+          {
+            "$ref": "#/components/parameters/Url"
+          },
+          {
+            "$ref": "#/components/parameters/Amount"
+          },
+          {
+            "$ref": "#/components/parameters/Instructions"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/PaidSuccess"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      }
+    },
+    "/solana/xraid": {
+      "post": {
+        "operationId": "post_solana_xraid",
+        "tags": [
+          "Raids"
+        ],
+        "summary": "X Raid (dynamic size) (POST)",
+        "description": "Public x402 endpoint: `/solana/xraid`.\n\nFlow kind: **paid** endpoint.\n\nFlow: call once **without** `PAYMENT-SIGNATURE` to receive `402 Payment-Required`; sign the requirement; retry the same URL **with** `PAYMENT-SIGNATURE` for `200`.\n\nUse `PAYMENT-SIGNATURE` for public routes (`/solana/*`, `/base/*`). `X-PAYMENT` is legacy/test context.\n\nPricing hint: `{\"currency\":\"USDC\",\"perUnit\":0.025,\"unit\":\"slot\",\"presets\":{\"small\":{\"likes\":20,\"reposts\":10,\"comments\":10,\"bookmarks\":0},\"medium\":{\"likes\":50,\"reposts\":20,\"comments\":25,\"bookmarks\":5},\"large\":{\"likes\":100,\"reposts\":40,\"comments\":50,\"bookmarks\":10}}}`.\n\nDefaults: `{\"size\":\"small\"}`.\n\nLimits: `{\"sizeEnum\":[\"small\",\"medium\",\"large\"]}`.\n\nPreset aliases also exist: `/xraid/small`, `/xraid/medium`, `/xraid/large`.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PaymentSignature"
+          },
+          {
+            "$ref": "#/components/parameters/Url"
+          },
+          {
+            "$ref": "#/components/parameters/Size"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/PaidSuccess"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      }
+    },
+    "/solana/xraid/small": {
+      "post": {
+        "operationId": "post_solana_xraid_small",
+        "tags": [
+          "Raids"
+        ],
+        "summary": "X Raid (preset) (POST)",
+        "description": "Public x402 endpoint: `/solana/xraid/small`.\n\nFlow kind: **paid** endpoint.\n\nFlow: call once **without** `PAYMENT-SIGNATURE` to receive `402 Payment-Required`; sign the requirement; retry the same URL **with** `PAYMENT-SIGNATURE` for `200`.\n\nUse `PAYMENT-SIGNATURE` for public routes (`/solana/*`, `/base/*`). `X-PAYMENT` is legacy/test context.\n\nPricing hint: `{\"currency\":\"USDC\",\"perUnit\":0.025,\"unit\":\"slot\",\"presets\":{\"small\":{\"likes\":20,\"reposts\":10,\"comments\":10,\"bookmarks\":0},\"medium\":{\"likes\":50,\"reposts\":20,\"comments\":25,\"bookmarks\":5},\"large\":{\"likes\":100,\"reposts\":40,\"comments\":50,\"bookmarks\":10}}}`.\n\nDefaults: `{\"size\":\"small\"}`.\n\nLimits: `{\"sizeEnum\":[\"small\",\"medium\",\"large\"]}`.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PaymentSignature"
+          },
+          {
+            "$ref": "#/components/parameters/Url"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/PaidSuccess"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      }
+    },
+    "/solana/xraid/custom": {
+      "post": {
+        "operationId": "post_solana_xraid_custom",
+        "tags": [
+          "Raids"
+        ],
+        "summary": "X Raid (custom query mode) (POST)",
+        "description": "Public x402 endpoint: `/solana/xraid/custom`.\n\nFlow kind: **paid** endpoint.\n\nFlow: call once **without** `PAYMENT-SIGNATURE` to receive `402 Payment-Required`; sign the requirement; retry the same URL **with** `PAYMENT-SIGNATURE` for `200`.\n\nUse `PAYMENT-SIGNATURE` for public routes (`/solana/*`, `/base/*`). `X-PAYMENT` is legacy/test context.\n\nPricing hint: `{\"currency\":\"USDC\",\"perUnit\":0.025,\"unit\":\"slot\"}`.\n\nDefaults: `{\"likes\":20,\"reposts\":10,\"comments\":10,\"bookmarks\":0}`.\n\nLimits: `{\"perComponentMax\":250,\"totalMax\":500}`.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PaymentSignature"
+          },
+          {
+            "$ref": "#/components/parameters/Url"
+          },
+          {
+            "$ref": "#/components/parameters/Likes"
+          },
+          {
+            "$ref": "#/components/parameters/Reposts"
+          },
+          {
+            "$ref": "#/components/parameters/Comments"
+          },
+          {
+            "$ref": "#/components/parameters/Bookmarks"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/PaidSuccess"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      }
+    },
+    "/solana/xraid/scout/small": {
+      "post": {
+        "operationId": "post_solana_xraid_scout_small",
+        "tags": [
+          "Raids"
+        ],
+        "summary": "X Raid Scout (preset) (POST)",
+        "description": "Public x402 endpoint: `/solana/xraid/scout/small`.\n\nFlow kind: **paid** endpoint.\n\nFlow: call once **without** `PAYMENT-SIGNATURE` to receive `402 Payment-Required`; sign the requirement; retry the same URL **with** `PAYMENT-SIGNATURE` for `200`.\n\nUse `PAYMENT-SIGNATURE` for public routes (`/solana/*`, `/base/*`). `X-PAYMENT` is legacy/test context.\n\nPricing hint: `{\"currency\":\"USDC\",\"perUnit\":0.025,\"unit\":\"slot\",\"presets\":{\"small\":{\"likes\":20,\"reposts\":10,\"comments\":10,\"bookmarks\":0},\"medium\":{\"likes\":50,\"reposts\":20,\"comments\":25,\"bookmarks\":5},\"large\":{\"likes\":100,\"reposts\":40,\"comments\":50,\"bookmarks\":10}}}`.\n\nDefaults: `{\"size\":\"small\"}`.\n\nLimits: `{\"sizeEnum\":[\"small\",\"medium\",\"large\"]}`.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PaymentSignature"
+          },
+          {
+            "$ref": "#/components/parameters/Url"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/PaidSuccess"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      }
+    },
+    "/solana/heylolraid": {
+      "post": {
+        "operationId": "post_solana_heylolraid",
+        "tags": [
+          "Raids"
+        ],
+        "summary": "hey.lol Raid (dynamic size) (POST)",
+        "description": "Public x402 endpoint: `/solana/heylolraid`.\n\nFlow kind: **paid** endpoint.\n\nFlow: call once **without** `PAYMENT-SIGNATURE` to receive `402 Payment-Required`; sign the requirement; retry the same URL **with** `PAYMENT-SIGNATURE` for `200`.\n\nUse `PAYMENT-SIGNATURE` for public routes (`/solana/*`, `/base/*`). `X-PAYMENT` is legacy/test context.\n\nPricing hint: `{\"currency\":\"USDC\",\"presets\":{\"small\":{\"likes\":20,\"reposts\":10,\"comments\":10,\"totalUsd\":1},\"medium\":{\"likes\":40,\"reposts\":25,\"comments\":25,\"totalUsd\":2.5},\"large\":{\"likes\":55,\"reposts\":20,\"comments\":25,\"totalUsd\":5}}}`.\n\nDefaults: `{\"size\":\"small\"}`.\n\nLimits: `{\"sizeEnum\":[\"small\",\"medium\",\"large\"]}`.\n\nPreset aliases also exist: `/heylolraid/small`, `/heylolraid/medium`, `/heylolraid/large`.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PaymentSignature"
+          },
+          {
+            "$ref": "#/components/parameters/Url"
+          },
+          {
+            "$ref": "#/components/parameters/Size"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/PaidSuccess"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      }
+    },
+    "/solana/heylolraid/small": {
+      "post": {
+        "operationId": "post_solana_heylolraid_small",
+        "tags": [
+          "Raids"
+        ],
+        "summary": "hey.lol Raid (preset) (POST)",
+        "description": "Public x402 endpoint: `/solana/heylolraid/small`.\n\nFlow kind: **paid** endpoint.\n\nFlow: call once **without** `PAYMENT-SIGNATURE` to receive `402 Payment-Required`; sign the requirement; retry the same URL **with** `PAYMENT-SIGNATURE` for `200`.\n\nUse `PAYMENT-SIGNATURE` for public routes (`/solana/*`, `/base/*`). `X-PAYMENT` is legacy/test context.\n\nPricing hint: `{\"currency\":\"USDC\",\"presets\":{\"small\":{\"likes\":20,\"reposts\":10,\"comments\":10,\"totalUsd\":1},\"medium\":{\"likes\":40,\"reposts\":25,\"comments\":25,\"totalUsd\":2.5},\"large\":{\"likes\":55,\"reposts\":20,\"comments\":25,\"totalUsd\":5}}}`.\n\nDefaults: `{\"size\":\"small\"}`.\n\nLimits: `{\"sizeEnum\":[\"small\",\"medium\",\"large\"]}`.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PaymentSignature"
+          },
+          {
+            "$ref": "#/components/parameters/Url"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/PaidSuccess"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "parameters": {
+      "PaymentSignature": {
+        "name": "PAYMENT-SIGNATURE",
+        "in": "header",
+        "required": false,
+        "description": "x402 v2 payment signature for public routes. Omit on first request to get `402 Payment-Required`; include on retry to settle.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "Url": {
+        "name": "url",
+        "in": "query",
+        "schema": {
+          "type": "string",
+          "format": "uri"
+        },
+        "description": "Target URL or profile URL."
+      },
+      "Amount": {
+        "name": "amount",
+        "in": "query",
+        "schema": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "description": "Requested amount/slots."
+      },
+      "Handle": {
+        "name": "handle",
+        "in": "query",
+        "schema": {
+          "type": "string"
+        },
+        "description": "Handle/username style target."
+      },
+      "Community": {
+        "name": "community",
+        "in": "query",
+        "schema": {
+          "type": "string"
+        },
+        "description": "X community URL or identifier."
+      },
+      "Instructions": {
+        "name": "instructions",
+        "in": "query",
+        "schema": {
+          "type": "string",
+          "maxLength": 800
+        },
+        "description": "Optional custom instructions."
+      },
+      "Size": {
+        "name": "size",
+        "in": "query",
+        "schema": {
+          "type": "string",
+          "enum": [
+            "small",
+            "medium",
+            "large"
+          ]
+        },
+        "description": "Raid preset size."
+      },
+      "Likes": {
+        "name": "likes",
+        "in": "query",
+        "schema": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "description": "Custom likes count."
+      },
+      "Reposts": {
+        "name": "reposts",
+        "in": "query",
+        "schema": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "description": "Custom reposts count."
+      },
+      "Comments": {
+        "name": "comments",
+        "in": "query",
+        "schema": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "description": "Custom comments count."
+      },
+      "Bookmarks": {
+        "name": "bookmarks",
+        "in": "query",
+        "schema": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "description": "Custom bookmarks count."
+      },
+      "Join": {
+        "name": "join",
+        "in": "query",
+        "schema": {
+          "type": "string"
+        },
+        "description": "Telegram join target (URL, @handle, invite)."
+      },
+      "Group": {
+        "name": "group",
+        "in": "query",
+        "schema": {
+          "type": "string"
+        },
+        "description": "Telegram group alias parameter."
+      },
+      "Invite": {
+        "name": "invite",
+        "in": "query",
+        "schema": {
+          "type": "string"
+        },
+        "description": "Discord invite URL/code."
+      },
+      "Address": {
+        "name": "address",
+        "in": "query",
+        "schema": {
+          "type": "string"
+        },
+        "description": "Base profile address (0x...)."
+      },
+      "VoteType": {
+        "name": "voteType",
+        "in": "query",
+        "schema": {
+          "type": "string",
+          "enum": [
+            "skeleton_vote",
+            "moontok_vote",
+            "majortrending_vote",
+            "coingecko_vote",
+            "coinmarketcap_vote"
+          ]
+        },
+        "description": "Vote type for unified `/vote` endpoint."
+      },
+      "TypeAlias": {
+        "name": "type",
+        "in": "query",
+        "schema": {
+          "type": "string",
+          "enum": [
+            "skeleton_vote",
+            "moontok_vote",
+            "majortrending_vote",
+            "coingecko_vote",
+            "coinmarketcap_vote"
+          ]
+        },
+        "description": "Alias of `voteType` for unified `/vote`."
+      },
+      "Action": {
+        "name": "action",
+        "in": "query",
+        "schema": {
+          "type": "string",
+          "enum": [
+            "create",
+            "view",
+            "recover"
+          ]
+        },
+        "description": "Action selector for agent-to-human."
+      },
+      "Secret": {
+        "name": "secret",
+        "in": "query",
+        "schema": {
+          "type": "string"
+        },
+        "description": "Secret/view key for submission retrieval."
+      },
+      "Description": {
+        "name": "description",
+        "in": "query",
+        "schema": {
+          "type": "string"
+        },
+        "description": "Task description for agent-to-human create."
+      },
+      "Winners": {
+        "name": "winners",
+        "in": "query",
+        "schema": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 100
+        },
+        "description": "Number of winners."
+      },
+      "PerUser": {
+        "name": "perUser",
+        "in": "query",
+        "schema": {
+          "type": "number",
+          "minimum": 0.01
+        },
+        "description": "USDC reward per participant."
+      },
+      "Requirement": {
+        "name": "requirement",
+        "in": "query",
+        "schema": {
+          "type": "string",
+          "enum": [
+            "tweetScoutScore:0",
+            "tweetScoutScore:10",
+            "tweetScoutScore:25",
+            "xMetricScore:75",
+            "xMetricScore:250",
+            "seekerUser",
+            "xBlueVerified"
+          ]
+        },
+        "description": "Optional single requirement selector for `agenttohumanadvanced`. Meaning: tweetScoutScore:* = Sorsa (formerly TweetScout) third-party X profile score; xMetricScore:* = WURK-generated X profile score (follower count, follower quality, profile signals); seekerUser = users in the Solana Seeker phone ecosystem; xBlueVerified = X account with a blue verified badge. Stricter requirements can reduce eligible participants and slow fill speed. Policy: tweetScoutScore:0 => max winners 100 + min perUser 0.05; tweetScoutScore:10 => max 75 + min 0.075; tweetScoutScore:25 => max 50 + min 0.125; xMetricScore:75 => max 100 + min 0.0625; xMetricScore:250 => max 50 + min 0.125; xBlueVerified => max 50 + min 0.075; seekerUser => baseline only."
+      },
+      "WinnersPath": {
+        "name": "winners",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 250
+        },
+        "description": "Winner/slot count in path alias. Range is endpoint-specific (commonly 1..100 for agent-help, 5..250 for social jobs)."
+      },
+      "SecretPath": {
+        "name": "secret",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "string"
+        },
+        "description": "Secret/view key in path."
+      },
+      "LikesPath": {
+        "name": "likes",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "description": "Custom likes path value."
+      },
+      "RepostsPath": {
+        "name": "reposts",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "description": "Custom reposts path value."
+      },
+      "CommentsPath": {
+        "name": "comments",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "description": "Custom comments path value."
+      },
+      "BookmarksPath": {
+        "name": "bookmarks",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "description": "Custom bookmarks path value."
+      }
+    },
+    "schemas": {
+      "PaymentRequirement": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "scheme": {
+            "type": "string"
+          },
+          "network": {
+            "type": "string"
+          },
+          "maxAmountRequired": {
+            "type": "string"
+          },
+          "resource": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "mimeType": {
+            "type": "string"
+          },
+          "payTo": {
+            "type": "string"
+          },
+          "asset": {
+            "type": "string"
+          },
+          "maxTimeoutSeconds": {
+            "type": "integer"
+          },
+          "extra": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        }
+      },
+      "PaymentRequiredResponse": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": [
+          "x402Version",
+          "accepts",
+          "resource"
+        ],
+        "properties": {
+          "x402Version": {
+            "type": "integer",
+            "example": 2
+          },
+          "accepts": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "$ref": "#/components/schemas/PaymentRequirement"
+            }
+          },
+          "error": {
+            "type": "string"
+          },
+          "resource": {
+            "description": "Requested resource metadata echoed by payment middleware.",
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "object",
+                "additionalProperties": true
+              }
+            ]
+          },
+          "extensions": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        }
+      },
+      "PaidSuccessResponse": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "example": true
+          },
+          "paid": {
+            "type": "boolean",
+            "example": true
+          },
+          "alreadyConfirmed": {
+            "type": "boolean",
+            "example": false
+          },
+          "message": {
+            "type": "string"
+          },
+          "jobId": {
+            "type": "string"
+          },
+          "statusUrl": {
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      },
+      "ErrorResponse": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "message": {
+            "type": "string"
+          },
+          "error": {
+            "type": "string"
+          },
+          "errorCode": {
+            "type": "string",
+            "description": "Machine-readable application error code (when available)."
+          },
+          "retryAfterSeconds": {
+            "type": "integer",
+            "description": "Retry-after hint in seconds for rate-limited requests."
+          }
+        }
+      },
+      "AgentSupportSendInput": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "secret": {
+            "type": "string",
+            "description": "Optional when sent via query/header."
+          },
+          "message": {
+            "type": "string",
+            "maxLength": 2000
+          }
+        },
+        "required": [
+          "message"
+        ]
+      },
+      "AgentSupportSendSuccess": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "example": true
+          },
+          "message": {
+            "type": "string",
+            "example": "Thank you for your message. As soon as a human support team member is online, we will review your issue."
+          },
+          "messagesUrl": {
+            "type": "string",
+            "format": "uri"
+          }
+        },
+        "required": [
+          "ok",
+          "message",
+          "messagesUrl"
+        ]
+      },
+      "AgentSupportThreadMessage": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "role": {
+            "type": "string",
+            "enum": [
+              "agent",
+              "support"
+            ]
+          },
+          "message": {
+            "type": "string"
+          },
+          "jobId": {
+            "type": "string"
+          },
+          "customJobId": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "AgentSupportMessagesSuccess": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "example": true
+          },
+          "wallet": {
+            "type": "string"
+          },
+          "messages": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AgentSupportThreadMessage"
+            }
+          }
+        }
+      },
+      "AgentToHumanAdvancedChooseWinnersInput": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "secret": {
+            "type": "string",
+            "description": "Advanced job secret for creator-mode winner selection."
+          },
+          "submissionIds": {
+            "oneOf": [
+              {
+                "type": "array",
+                "minItems": 1,
+                "maxItems": 100,
+                "uniqueItems": true,
+                "items": {
+                  "type": "string"
+                }
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "description": "Winner submission ids as array or comma-separated string."
+          }
+        },
+        "required": [
+          "secret",
+          "submissionIds"
+        ]
+      },
+      "AgentToHumanAdvancedChooseWinnersSuccess": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "example": true
+          },
+          "jobId": {
+            "type": "string"
+          },
+          "customId": {
+            "type": "string"
+          },
+          "requested": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "updated": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "alreadyWinnerCountInRequest": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "winnersNow": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "winnerCap": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "remainingSlots": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "statusTransition": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "updatedSubmissionIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "ok",
+          "jobId",
+          "requested",
+          "updated",
+          "winnersNow",
+          "winnerCap",
+          "remainingSlots"
+        ]
+      }
+    },
+    "responses": {
+      "PaymentRequired": {
+        "description": "Payment required. Sign and retry with `PAYMENT-SIGNATURE` (public v2 flow).",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/PaymentRequiredResponse"
+            }
+          }
+        }
+      },
+      "PaidSuccess": {
+        "description": "Operation accepted/completed (after settlement on paid routes, or immediately for free variants).",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/PaidSuccessResponse"
+            }
+          }
+        }
+      },
+      "BadRequest": {
+        "description": "Invalid request input or malformed payment signature.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            }
+          }
+        }
+      },
+      "Unauthorized": {
+        "description": "Unauthorized secret context.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            }
+          }
+        }
+      },
+      "NotFound": {
+        "description": "Requested resource, job, or secret could not be found.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            }
+          }
+        }
+      },
+      "TooManyRequests": {
+        "description": "Rate limit exceeded for wallet-threaded support chat.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            }
+          }
+        }
+      },
+      "SupportSendSuccess": {
+        "description": "Support message accepted.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/AgentSupportSendSuccess"
+            }
+          }
+        }
+      },
+      "SupportMessagesSuccess": {
+        "description": "Wallet-threaded support messages.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/AgentSupportMessagesSuccess"
+            }
+          }
+        }
+      },
+      "ChooseWinnersSuccess": {
+        "description": "Creator-mode advanced winners selected successfully.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/AgentToHumanAdvancedChooseWinnersSuccess"
+            }
+          }
+        }
+      },
+      "Conflict": {
+        "description": "Conflict with current state (for example, duplicate/similar running job).",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            }
+          }
+        }
+      },
+      "ServerError": {
+        "description": "Unexpected server-side failure.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/providers/wurk/token-boosts/PAY.md
+++ b/providers/wurk/token-boosts/PAY.md
@@ -1,0 +1,28 @@
+---
+name: token-boosts
+title: "WURK Token Boosts"
+description: "Boost token visibility with x402-paid Solana endpoints for DexScreener rockets and community vote actions on CoinGecko, CoinMarketCap, Major, Moontok, and Skeleton."
+use_case: "Use for token launch support, DexScreener rocket campaigns, and paid community vote actions that increase visibility around crypto projects."
+category: finance
+service_url: https://wurkapi.fun
+openapi:
+ url: https://wurkapi.fun/openapi-x402-solana-token-boosts.json
+---
+
+WURK Token Boosts exposes x402 Solana USDC endpoints for token visibility and
+launch-support actions. The listing covers DexScreener rockets and vote routes
+for supported crypto discovery communities and token ranking surfaces.
+
+Paid routes follow the public x402 v2 flow: call the endpoint without
+`PAYMENT-SIGNATURE` to receive a 402 payment requirement, sign it with a Solana
+USDC-capable wallet, then retry the exact same URL with `PAYMENT-SIGNATURE`.
+
+## Spend-aware usage
+
+- Use `dex` or `dex-rocket` for DexScreener rocket campaigns when the user gives
+  a DexScreener target URL.
+- Use the specific vote endpoint when the vote surface is known. Use the unified
+  `vote` endpoint only when routing dynamically by `voteType`.
+- Start with the smallest useful `amount`, and ask before multi-surface launch
+  campaigns or repeated boost rounds.
+- Verify the target URL belongs to the requested platform before paying.

--- a/providers/wurk/token-boosts/PAY.md
+++ b/providers/wurk/token-boosts/PAY.md
@@ -6,7 +6,7 @@ use_case: "Use for token launch support, DexScreener rocket campaigns, and paid 
 category: finance
 service_url: https://wurkapi.fun
 openapi:
- url: https://wurkapi.fun/openapi-x402-solana-token-boosts.json
+ path: openapi.json
 ---
 
 WURK Token Boosts exposes x402 Solana USDC endpoints for token visibility and

--- a/providers/wurk/token-boosts/openapi.json
+++ b/providers/wurk/token-boosts/openapi.json
@@ -1,0 +1,1031 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "WURK x402 Solana Token Boost Endpoints",
+    "version": "1.1.0",
+    "description": "Category-specific x402 listing surface for WURK Solana token boost endpoints: DexScreener rockets and token/community vote actions. Public v2 flow uses `PAYMENT-SIGNATURE`."
+  },
+  "servers": [
+    {
+      "url": "https://wurkapi.fun"
+    }
+  ],
+  "tags": [
+    {
+      "name": "Dex"
+    },
+    {
+      "name": "Votes"
+    }
+  ],
+  "paths": {
+    "/solana/dex": {
+      "post": {
+        "operationId": "post_solana_dex",
+        "tags": [
+          "Dex"
+        ],
+        "summary": "Dex Rockets (POST)",
+        "description": "Public x402 endpoint: `/solana/dex`.\n\nFlow kind: **paid** endpoint.\n\nFlow: call once **without** `PAYMENT-SIGNATURE` to receive `402 Payment-Required`; sign the requirement; retry the same URL **with** `PAYMENT-SIGNATURE` for `200`.\n\nUse `PAYMENT-SIGNATURE` for public routes (`/solana/*`, `/base/*`). `X-PAYMENT` is legacy/test context.\n\nPricing hint: `{\"currency\":\"USDC\",\"perUnit\":0.025,\"unit\":\"rocket\"}`.\n\nDefaults: `{\"amount\":40}`.\n\nLimits: `{\"amountMin\":5,\"amountMax\":250}`.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PaymentSignature"
+          },
+          {
+            "$ref": "#/components/parameters/Url"
+          },
+          {
+            "$ref": "#/components/parameters/Amount"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/PaidSuccess"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      }
+    },
+    "/solana/vote": {
+      "post": {
+        "operationId": "post_solana_vote",
+        "tags": [
+          "Votes"
+        ],
+        "summary": "Unified Vote Endpoint (POST)",
+        "description": "Public x402 endpoint: `/solana/vote`.\n\nFlow kind: **paid** endpoint.\n\nFlow: call once **without** `PAYMENT-SIGNATURE` to receive `402 Payment-Required`; sign the requirement; retry the same URL **with** `PAYMENT-SIGNATURE` for `200`.\n\nUse `PAYMENT-SIGNATURE` for public routes (`/solana/*`, `/base/*`). `X-PAYMENT` is legacy/test context.\n\nPricing hint: `{\"currency\":\"USDC\",\"perUnit\":0.025,\"unit\":\"vote\"}`.\n\nDefaults: `{\"amount\":100,\"voteType\":\"skeleton_vote\"}`.\n\nLimits: `{\"amountMin\":5,\"amountMax\":250,\"voteTypeEnum\":[\"skeleton_vote\",\"moontok_vote\",\"majortrending_vote\",\"coingecko_vote\",\"coinmarketcap_vote\"]}`.\n\nSupported vote types: `skeleton_vote`, `moontok_vote`, `majortrending_vote`, `coingecko_vote`, `coinmarketcap_vote`.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PaymentSignature"
+          },
+          {
+            "$ref": "#/components/parameters/VoteType"
+          },
+          {
+            "$ref": "#/components/parameters/TypeAlias"
+          },
+          {
+            "$ref": "#/components/parameters/Url"
+          },
+          {
+            "$ref": "#/components/parameters/Amount"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/PaidSuccess"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      }
+    },
+    "/solana/skeletonvote": {
+      "post": {
+        "operationId": "post_solana_skeletonvote",
+        "tags": [
+          "Votes"
+        ],
+        "summary": "Skeleton Vote (POST)",
+        "description": "Public x402 endpoint: `/solana/skeletonvote`.\n\nFlow kind: **paid** endpoint.\n\nFlow: call once **without** `PAYMENT-SIGNATURE` to receive `402 Payment-Required`; sign the requirement; retry the same URL **with** `PAYMENT-SIGNATURE` for `200`.\n\nUse `PAYMENT-SIGNATURE` for public routes (`/solana/*`, `/base/*`). `X-PAYMENT` is legacy/test context.\n\nPricing hint: `{\"currency\":\"USDC\",\"perUnit\":0.025,\"unit\":\"vote\"}`.\n\nDefaults: `{\"amount\":100,\"voteType\":\"skeleton_vote\"}`.\n\nLimits: `{\"amountMin\":5,\"amountMax\":250,\"voteTypeEnum\":[\"skeleton_vote\",\"moontok_vote\",\"majortrending_vote\",\"coingecko_vote\",\"coinmarketcap_vote\"]}`.\n\nEquivalent voteType for unified `/vote`: `skeleton_vote`.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PaymentSignature"
+          },
+          {
+            "$ref": "#/components/parameters/Url"
+          },
+          {
+            "$ref": "#/components/parameters/Amount"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/PaidSuccess"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      }
+    },
+    "/solana/majorvote": {
+      "post": {
+        "operationId": "post_solana_majorvote",
+        "tags": [
+          "Votes"
+        ],
+        "summary": "Major Trending Vote (POST)",
+        "description": "Public x402 endpoint: `/solana/majorvote`.\n\nFlow kind: **paid** endpoint.\n\nFlow: call once **without** `PAYMENT-SIGNATURE` to receive `402 Payment-Required`; sign the requirement; retry the same URL **with** `PAYMENT-SIGNATURE` for `200`.\n\nUse `PAYMENT-SIGNATURE` for public routes (`/solana/*`, `/base/*`). `X-PAYMENT` is legacy/test context.\n\nPricing hint: `{\"currency\":\"USDC\",\"perUnit\":0.025,\"unit\":\"vote\"}`.\n\nDefaults: `{\"amount\":100,\"voteType\":\"skeleton_vote\"}`.\n\nLimits: `{\"amountMin\":5,\"amountMax\":250,\"voteTypeEnum\":[\"skeleton_vote\",\"moontok_vote\",\"majortrending_vote\",\"coingecko_vote\",\"coinmarketcap_vote\"]}`.\n\nEquivalent voteType for unified `/vote`: `majortrending_vote`.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PaymentSignature"
+          },
+          {
+            "$ref": "#/components/parameters/Url"
+          },
+          {
+            "$ref": "#/components/parameters/Amount"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/PaidSuccess"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      }
+    },
+    "/solana/cmcvote": {
+      "post": {
+        "operationId": "post_solana_cmcvote",
+        "tags": [
+          "Votes"
+        ],
+        "summary": "CoinMarketCap Vote (POST)",
+        "description": "Public x402 endpoint: `/solana/cmcvote`.\n\nFlow kind: **paid** endpoint.\n\nFlow: call once **without** `PAYMENT-SIGNATURE` to receive `402 Payment-Required`; sign the requirement; retry the same URL **with** `PAYMENT-SIGNATURE` for `200`.\n\nUse `PAYMENT-SIGNATURE` for public routes (`/solana/*`, `/base/*`). `X-PAYMENT` is legacy/test context.\n\nPricing hint: `{\"currency\":\"USDC\",\"perUnit\":0.025,\"unit\":\"vote\"}`.\n\nDefaults: `{\"amount\":100,\"voteType\":\"skeleton_vote\"}`.\n\nLimits: `{\"amountMin\":5,\"amountMax\":250,\"voteTypeEnum\":[\"skeleton_vote\",\"moontok_vote\",\"majortrending_vote\",\"coingecko_vote\",\"coinmarketcap_vote\"]}`.\n\nEquivalent voteType for unified `/vote`: `coinmarketcap_vote`.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PaymentSignature"
+          },
+          {
+            "$ref": "#/components/parameters/Url"
+          },
+          {
+            "$ref": "#/components/parameters/Amount"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/PaidSuccess"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      }
+    },
+    "/solana/cgvote": {
+      "post": {
+        "operationId": "post_solana_cgvote",
+        "tags": [
+          "Votes"
+        ],
+        "summary": "CoinGecko Vote (POST)",
+        "description": "Public x402 endpoint: `/solana/cgvote`.\n\nFlow kind: **paid** endpoint.\n\nFlow: call once **without** `PAYMENT-SIGNATURE` to receive `402 Payment-Required`; sign the requirement; retry the same URL **with** `PAYMENT-SIGNATURE` for `200`.\n\nUse `PAYMENT-SIGNATURE` for public routes (`/solana/*`, `/base/*`). `X-PAYMENT` is legacy/test context.\n\nPricing hint: `{\"currency\":\"USDC\",\"perUnit\":0.025,\"unit\":\"vote\"}`.\n\nDefaults: `{\"amount\":100,\"voteType\":\"skeleton_vote\"}`.\n\nLimits: `{\"amountMin\":5,\"amountMax\":250,\"voteTypeEnum\":[\"skeleton_vote\",\"moontok_vote\",\"majortrending_vote\",\"coingecko_vote\",\"coinmarketcap_vote\"]}`.\n\nEquivalent voteType for unified `/vote`: `coingecko_vote`.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PaymentSignature"
+          },
+          {
+            "$ref": "#/components/parameters/Url"
+          },
+          {
+            "$ref": "#/components/parameters/Amount"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/PaidSuccess"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      }
+    },
+    "/solana/moontokvote": {
+      "post": {
+        "operationId": "post_solana_moontokvote",
+        "tags": [
+          "Votes"
+        ],
+        "summary": "Moontok Vote (POST)",
+        "description": "Public x402 endpoint: `/solana/moontokvote`.\n\nFlow kind: **paid** endpoint.\n\nFlow: call once **without** `PAYMENT-SIGNATURE` to receive `402 Payment-Required`; sign the requirement; retry the same URL **with** `PAYMENT-SIGNATURE` for `200`.\n\nUse `PAYMENT-SIGNATURE` for public routes (`/solana/*`, `/base/*`). `X-PAYMENT` is legacy/test context.\n\nPricing hint: `{\"currency\":\"USDC\",\"perUnit\":0.025,\"unit\":\"vote\"}`.\n\nDefaults: `{\"amount\":100,\"voteType\":\"skeleton_vote\"}`.\n\nLimits: `{\"amountMin\":5,\"amountMax\":250,\"voteTypeEnum\":[\"skeleton_vote\",\"moontok_vote\",\"majortrending_vote\",\"coingecko_vote\",\"coinmarketcap_vote\"]}`.\n\nEquivalent voteType for unified `/vote`: `moontok_vote`.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PaymentSignature"
+          },
+          {
+            "$ref": "#/components/parameters/Url"
+          },
+          {
+            "$ref": "#/components/parameters/Amount"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/PaidSuccess"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "parameters": {
+      "PaymentSignature": {
+        "name": "PAYMENT-SIGNATURE",
+        "in": "header",
+        "required": false,
+        "description": "x402 v2 payment signature for public routes. Omit on first request to get `402 Payment-Required`; include on retry to settle.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "Url": {
+        "name": "url",
+        "in": "query",
+        "schema": {
+          "type": "string",
+          "format": "uri"
+        },
+        "description": "Target URL or profile URL."
+      },
+      "Amount": {
+        "name": "amount",
+        "in": "query",
+        "schema": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "description": "Requested amount/slots."
+      },
+      "Handle": {
+        "name": "handle",
+        "in": "query",
+        "schema": {
+          "type": "string"
+        },
+        "description": "Handle/username style target."
+      },
+      "Community": {
+        "name": "community",
+        "in": "query",
+        "schema": {
+          "type": "string"
+        },
+        "description": "X community URL or identifier."
+      },
+      "Instructions": {
+        "name": "instructions",
+        "in": "query",
+        "schema": {
+          "type": "string",
+          "maxLength": 800
+        },
+        "description": "Optional custom instructions."
+      },
+      "Size": {
+        "name": "size",
+        "in": "query",
+        "schema": {
+          "type": "string",
+          "enum": [
+            "small",
+            "medium",
+            "large"
+          ]
+        },
+        "description": "Raid preset size."
+      },
+      "Likes": {
+        "name": "likes",
+        "in": "query",
+        "schema": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "description": "Custom likes count."
+      },
+      "Reposts": {
+        "name": "reposts",
+        "in": "query",
+        "schema": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "description": "Custom reposts count."
+      },
+      "Comments": {
+        "name": "comments",
+        "in": "query",
+        "schema": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "description": "Custom comments count."
+      },
+      "Bookmarks": {
+        "name": "bookmarks",
+        "in": "query",
+        "schema": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "description": "Custom bookmarks count."
+      },
+      "Join": {
+        "name": "join",
+        "in": "query",
+        "schema": {
+          "type": "string"
+        },
+        "description": "Telegram join target (URL, @handle, invite)."
+      },
+      "Group": {
+        "name": "group",
+        "in": "query",
+        "schema": {
+          "type": "string"
+        },
+        "description": "Telegram group alias parameter."
+      },
+      "Invite": {
+        "name": "invite",
+        "in": "query",
+        "schema": {
+          "type": "string"
+        },
+        "description": "Discord invite URL/code."
+      },
+      "Address": {
+        "name": "address",
+        "in": "query",
+        "schema": {
+          "type": "string"
+        },
+        "description": "Base profile address (0x...)."
+      },
+      "VoteType": {
+        "name": "voteType",
+        "in": "query",
+        "schema": {
+          "type": "string",
+          "enum": [
+            "skeleton_vote",
+            "moontok_vote",
+            "majortrending_vote",
+            "coingecko_vote",
+            "coinmarketcap_vote"
+          ]
+        },
+        "description": "Vote type for unified `/vote` endpoint."
+      },
+      "TypeAlias": {
+        "name": "type",
+        "in": "query",
+        "schema": {
+          "type": "string",
+          "enum": [
+            "skeleton_vote",
+            "moontok_vote",
+            "majortrending_vote",
+            "coingecko_vote",
+            "coinmarketcap_vote"
+          ]
+        },
+        "description": "Alias of `voteType` for unified `/vote`."
+      },
+      "Action": {
+        "name": "action",
+        "in": "query",
+        "schema": {
+          "type": "string",
+          "enum": [
+            "create",
+            "view",
+            "recover"
+          ]
+        },
+        "description": "Action selector for agent-to-human."
+      },
+      "Secret": {
+        "name": "secret",
+        "in": "query",
+        "schema": {
+          "type": "string"
+        },
+        "description": "Secret/view key for submission retrieval."
+      },
+      "Description": {
+        "name": "description",
+        "in": "query",
+        "schema": {
+          "type": "string"
+        },
+        "description": "Task description for agent-to-human create."
+      },
+      "Winners": {
+        "name": "winners",
+        "in": "query",
+        "schema": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 100
+        },
+        "description": "Number of winners."
+      },
+      "PerUser": {
+        "name": "perUser",
+        "in": "query",
+        "schema": {
+          "type": "number",
+          "minimum": 0.01
+        },
+        "description": "USDC reward per participant."
+      },
+      "Requirement": {
+        "name": "requirement",
+        "in": "query",
+        "schema": {
+          "type": "string",
+          "enum": [
+            "tweetScoutScore:0",
+            "tweetScoutScore:10",
+            "tweetScoutScore:25",
+            "xMetricScore:75",
+            "xMetricScore:250",
+            "seekerUser",
+            "xBlueVerified"
+          ]
+        },
+        "description": "Optional single requirement selector for `agenttohumanadvanced`. Meaning: tweetScoutScore:* = Sorsa (formerly TweetScout) third-party X profile score; xMetricScore:* = WURK-generated X profile score (follower count, follower quality, profile signals); seekerUser = users in the Solana Seeker phone ecosystem; xBlueVerified = X account with a blue verified badge. Stricter requirements can reduce eligible participants and slow fill speed. Policy: tweetScoutScore:0 => max winners 100 + min perUser 0.05; tweetScoutScore:10 => max 75 + min 0.075; tweetScoutScore:25 => max 50 + min 0.125; xMetricScore:75 => max 100 + min 0.0625; xMetricScore:250 => max 50 + min 0.125; xBlueVerified => max 50 + min 0.075; seekerUser => baseline only."
+      },
+      "WinnersPath": {
+        "name": "winners",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 250
+        },
+        "description": "Winner/slot count in path alias. Range is endpoint-specific (commonly 1..100 for agent-help, 5..250 for social jobs)."
+      },
+      "SecretPath": {
+        "name": "secret",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "string"
+        },
+        "description": "Secret/view key in path."
+      },
+      "LikesPath": {
+        "name": "likes",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "description": "Custom likes path value."
+      },
+      "RepostsPath": {
+        "name": "reposts",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "description": "Custom reposts path value."
+      },
+      "CommentsPath": {
+        "name": "comments",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "description": "Custom comments path value."
+      },
+      "BookmarksPath": {
+        "name": "bookmarks",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "description": "Custom bookmarks path value."
+      }
+    },
+    "schemas": {
+      "PaymentRequirement": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "scheme": {
+            "type": "string"
+          },
+          "network": {
+            "type": "string"
+          },
+          "maxAmountRequired": {
+            "type": "string"
+          },
+          "resource": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "mimeType": {
+            "type": "string"
+          },
+          "payTo": {
+            "type": "string"
+          },
+          "asset": {
+            "type": "string"
+          },
+          "maxTimeoutSeconds": {
+            "type": "integer"
+          },
+          "extra": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        }
+      },
+      "PaymentRequiredResponse": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": [
+          "x402Version",
+          "accepts",
+          "resource"
+        ],
+        "properties": {
+          "x402Version": {
+            "type": "integer",
+            "example": 2
+          },
+          "accepts": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "$ref": "#/components/schemas/PaymentRequirement"
+            }
+          },
+          "error": {
+            "type": "string"
+          },
+          "resource": {
+            "description": "Requested resource metadata echoed by payment middleware.",
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "object",
+                "additionalProperties": true
+              }
+            ]
+          },
+          "extensions": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        }
+      },
+      "PaidSuccessResponse": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "example": true
+          },
+          "paid": {
+            "type": "boolean",
+            "example": true
+          },
+          "alreadyConfirmed": {
+            "type": "boolean",
+            "example": false
+          },
+          "message": {
+            "type": "string"
+          },
+          "jobId": {
+            "type": "string"
+          },
+          "statusUrl": {
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      },
+      "ErrorResponse": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "message": {
+            "type": "string"
+          },
+          "error": {
+            "type": "string"
+          },
+          "errorCode": {
+            "type": "string",
+            "description": "Machine-readable application error code (when available)."
+          },
+          "retryAfterSeconds": {
+            "type": "integer",
+            "description": "Retry-after hint in seconds for rate-limited requests."
+          }
+        }
+      },
+      "AgentSupportSendInput": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "secret": {
+            "type": "string",
+            "description": "Optional when sent via query/header."
+          },
+          "message": {
+            "type": "string",
+            "maxLength": 2000
+          }
+        },
+        "required": [
+          "message"
+        ]
+      },
+      "AgentSupportSendSuccess": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "example": true
+          },
+          "message": {
+            "type": "string",
+            "example": "Thank you for your message. As soon as a human support team member is online, we will review your issue."
+          },
+          "messagesUrl": {
+            "type": "string",
+            "format": "uri"
+          }
+        },
+        "required": [
+          "ok",
+          "message",
+          "messagesUrl"
+        ]
+      },
+      "AgentSupportThreadMessage": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "role": {
+            "type": "string",
+            "enum": [
+              "agent",
+              "support"
+            ]
+          },
+          "message": {
+            "type": "string"
+          },
+          "jobId": {
+            "type": "string"
+          },
+          "customJobId": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "AgentSupportMessagesSuccess": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "example": true
+          },
+          "wallet": {
+            "type": "string"
+          },
+          "messages": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AgentSupportThreadMessage"
+            }
+          }
+        }
+      },
+      "AgentToHumanAdvancedChooseWinnersInput": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "secret": {
+            "type": "string",
+            "description": "Advanced job secret for creator-mode winner selection."
+          },
+          "submissionIds": {
+            "oneOf": [
+              {
+                "type": "array",
+                "minItems": 1,
+                "maxItems": 100,
+                "uniqueItems": true,
+                "items": {
+                  "type": "string"
+                }
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "description": "Winner submission ids as array or comma-separated string."
+          }
+        },
+        "required": [
+          "secret",
+          "submissionIds"
+        ]
+      },
+      "AgentToHumanAdvancedChooseWinnersSuccess": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "example": true
+          },
+          "jobId": {
+            "type": "string"
+          },
+          "customId": {
+            "type": "string"
+          },
+          "requested": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "updated": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "alreadyWinnerCountInRequest": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "winnersNow": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "winnerCap": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "remainingSlots": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "statusTransition": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "updatedSubmissionIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "ok",
+          "jobId",
+          "requested",
+          "updated",
+          "winnersNow",
+          "winnerCap",
+          "remainingSlots"
+        ]
+      }
+    },
+    "responses": {
+      "PaymentRequired": {
+        "description": "Payment required. Sign and retry with `PAYMENT-SIGNATURE` (public v2 flow).",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/PaymentRequiredResponse"
+            }
+          }
+        }
+      },
+      "PaidSuccess": {
+        "description": "Operation accepted/completed (after settlement on paid routes, or immediately for free variants).",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/PaidSuccessResponse"
+            }
+          }
+        }
+      },
+      "BadRequest": {
+        "description": "Invalid request input or malformed payment signature.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            }
+          }
+        }
+      },
+      "Unauthorized": {
+        "description": "Unauthorized secret context.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            }
+          }
+        }
+      },
+      "NotFound": {
+        "description": "Requested resource, job, or secret could not be found.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            }
+          }
+        }
+      },
+      "TooManyRequests": {
+        "description": "Rate limit exceeded for wallet-threaded support chat.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            }
+          }
+        }
+      },
+      "SupportSendSuccess": {
+        "description": "Support message accepted.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/AgentSupportSendSuccess"
+            }
+          }
+        }
+      },
+      "SupportMessagesSuccess": {
+        "description": "Wallet-threaded support messages.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/AgentSupportMessagesSuccess"
+            }
+          }
+        }
+      },
+      "ChooseWinnersSuccess": {
+        "description": "Creator-mode advanced winners selected successfully.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/AgentToHumanAdvancedChooseWinnersSuccess"
+            }
+          }
+        }
+      },
+      "Conflict": {
+        "description": "Conflict with current state (for example, duplicate/similar running job).",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            }
+          }
+        }
+      },
+      "ServerError": {
+        "description": "Unexpected server-side failure.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add WURK Social Growth, Human Feedback, and Token Boosts provider listings.
- Point each listing at the live WURK Solana x402 OpenAPI surfaces.
- Include spend-aware usage notes for agent-driven paid calls.

## Test plan
- `npx @solana/pay catalog check providers/wurk/social-growth/PAY.md`
- `npx @solana/pay catalog check providers/wurk/human-feedback/PAY.md`
- `npx @solana/pay catalog check providers/wurk/token-boosts/PAY.md`


Made with [Cursor](https://cursor.com)