### PR TITLE
Add Blocksize market data provider

### DIFF
--- a/providers/blocksize/market-data/PAY.md
+++ b/providers/blocksize/market-data/PAY.md
@@ -1,0 +1,27 @@
+---
+name: market-data
+title: "Blocksize Market Data"
+description: "Agent-native institutional crypto, FX, and metals market data with x402-paid per-call endpoints and free discovery."
+use_case: "Use when an AI agent needs live market prices, VWAP, bid/ask snapshots, FX, metals, or compact data for financial workflows without creating an API account."
+category: finance
+service_url: https://mcp.blocksize.info
+openapi:
+  path: openapi.json
+---
+
+Blocksize Market Data gives agents accountless access to live financial market
+data through free discovery endpoints and x402-paid HTTP calls.
+
+Use it for market-aware agent workflows that need crypto VWAP, crypto bid/ask,
+FX, metals, or small batches of structured financial data. Search the free
+instrument endpoints before paying for live data. Prefer a narrow lookup such as
+one VWAP pair, one bid/ask symbol, one FX pair, or one metals ticker before
+making batch calls.
+
+## Spend-aware usage
+
+- Search available instruments before making a paid market-data request.
+- Prefer one-symbol calls for exploratory tasks.
+- Use `/v1/batch` only when the user needs several prices in the same workflow.
+- Reuse returned symbols exactly instead of guessing unsupported pair formats.
+- Avoid polling unless the user has explicitly approved repeated paid calls.

--- a/providers/blocksize/market-data/PAY.md
+++ b/providers/blocksize/market-data/PAY.md
@@ -1,8 +1,8 @@
 ---
 name: market-data
 title: "Blocksize Market Data"
-description: "Agent-native institutional crypto, FX, and metals market data with x402-paid per-call endpoints and free discovery."
-use_case: "Use when an AI agent needs live market prices, VWAP, bid/ask snapshots, FX, metals, or compact data for financial workflows without creating an API account."
+description: "Agent-native institutional crypto, FX, and metals market data through listed x402-paid per-call routes."
+use_case: "Use when an AI agent needs live market prices, VWAP, bid/ask snapshots, FX, or metals from the listed paid sample routes without creating an API account."
 category: finance
 service_url: https://mcp.blocksize.info
 openapi:
@@ -10,18 +10,15 @@ openapi:
 ---
 
 Blocksize Market Data gives agents accountless access to live financial market
-data through free discovery endpoints and x402-paid HTTP calls.
+data through x402-paid HTTP calls.
 
 Use it for market-aware agent workflows that need crypto VWAP, crypto bid/ask,
-FX, metals, or small batches of structured financial data. Search the free
-instrument endpoints before paying for live data. Prefer a narrow lookup such as
-one VWAP pair, one bid/ask symbol, one FX pair, or one metals ticker before
-making batch calls.
+FX, or metals from the routes listed in the OpenAPI sidecar. Prefer a narrow
+lookup such as one VWAP pair, one bid/ask symbol, one FX pair, or one metals
+ticker.
 
 ## Spend-aware usage
 
-- Search available instruments before making a paid market-data request.
 - Prefer one-symbol calls for exploratory tasks.
-- Use `/v1/batch` only when the user needs several prices in the same workflow.
-- Reuse returned symbols exactly instead of guessing unsupported pair formats.
+- Use the listed route examples exactly as shown in the OpenAPI sidecar.
 - Avoid polling unless the user has explicitly approved repeated paid calls.

--- a/providers/blocksize/market-data/openapi.json
+++ b/providers/blocksize/market-data/openapi.json
@@ -1,0 +1,103 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Blocksize Market Data",
+    "version": "v1",
+    "description": "Filtered Pay.sh-facing OpenAPI spec for Blocksize x402-paid market data endpoints."
+  },
+  "servers": [
+    {
+      "url": "https://mcp.blocksize.info"
+    }
+  ],
+  "paths": {
+    "/v1/vwap/BTC-USD": {
+      "get": {
+        "summary": "Get crypto VWAP",
+        "description": "Return real-time crypto VWAP market data. Replace BTC-USD with another supported pair after using discovery.",
+        "operationId": "getCryptoVwap",
+        "responses": {
+          "200": {
+            "description": "Structured VWAP response."
+          },
+          "402": {
+            "description": "Payment Required."
+          }
+        },
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "dynamic",
+          "price": "$0.002-$0.004"
+        }
+      }
+    },
+    "/v1/bidask/BTC-USD": {
+      "get": {
+        "summary": "Get crypto bid/ask",
+        "description": "Return a real-time bid/ask snapshot. Replace BTC-USD with another supported symbol after using discovery.",
+        "operationId": "getCryptoBidAsk",
+        "responses": {
+          "200": {
+            "description": "Structured bid/ask response."
+          },
+          "402": {
+            "description": "Payment Required."
+          }
+        },
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "dynamic",
+          "price": "$0.002-$0.004"
+        }
+      }
+    },
+    "/v1/fx/EURUSD": {
+      "get": {
+        "summary": "Get FX rate",
+        "description": "Return real-time FX market data. Replace EURUSD with another supported FX pair after using discovery.",
+        "operationId": "getFxRate",
+        "responses": {
+          "200": {
+            "description": "Structured FX rate response."
+          },
+          "402": {
+            "description": "Payment Required."
+          }
+        },
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.005"
+        }
+      }
+    },
+    "/v1/metal/XAUUSD": {
+      "get": {
+        "summary": "Get metals price",
+        "description": "Return real-time metals market data. Replace XAUUSD with another supported metals ticker after using discovery.",
+        "operationId": "getMetalPrice",
+        "responses": {
+          "200": {
+            "description": "Structured metals price response."
+          },
+          "402": {
+            "description": "Payment Required."
+          }
+        },
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.005"
+        }
+      }
+    }
+  }
+}

--- a/providers/blocksize/market-data/openapi.json
+++ b/providers/blocksize/market-data/openapi.json
@@ -13,7 +13,7 @@
   "paths": {
     "/v1/vwap/BTC-USD": {
       "get": {
-        "summary": "Get crypto VWAP",
+        "summary": "Fetch crypto VWAP market data",
         "description": "Return real-time crypto VWAP market data. Replace BTC-USD with another supported pair after using discovery.",
         "operationId": "getCryptoVwap",
         "responses": {
@@ -35,7 +35,7 @@
     },
     "/v1/bidask/BTC-USD": {
       "get": {
-        "summary": "Get crypto bid/ask",
+        "summary": "Fetch crypto bid-ask snapshot",
         "description": "Return a real-time bid/ask snapshot. Replace BTC-USD with another supported symbol after using discovery.",
         "operationId": "getCryptoBidAsk",
         "responses": {
@@ -57,7 +57,7 @@
     },
     "/v1/fx/EURUSD": {
       "get": {
-        "summary": "Get FX rate",
+        "summary": "Fetch FX exchange rate data",
         "description": "Return real-time FX market data. Replace EURUSD with another supported FX pair after using discovery.",
         "operationId": "getFxRate",
         "responses": {
@@ -79,7 +79,7 @@
     },
     "/v1/metal/XAUUSD": {
       "get": {
-        "summary": "Get metals price",
+        "summary": "Fetch precious metals price data",
         "description": "Return real-time metals market data. Replace XAUUSD with another supported metals ticker after using discovery.",
         "operationId": "getMetalPrice",
         "responses": {

--- a/providers/blocksize/market-data/openapi.json
+++ b/providers/blocksize/market-data/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Blocksize Market Data",
     "version": "v1",
-    "description": "Filtered Pay.sh-facing OpenAPI spec for Blocksize x402-paid market data endpoints."
+    "description": "Filtered Pay.sh-facing OpenAPI spec for sampled Blocksize x402-paid market data endpoints."
   },
   "servers": [
     {
@@ -14,7 +14,7 @@
     "/v1/vwap/BTC-USD": {
       "get": {
         "summary": "Fetch crypto VWAP market data",
-        "description": "Return real-time crypto VWAP market data. Replace BTC-USD with another supported pair after using discovery.",
+        "description": "Return real-time crypto VWAP market data for the listed BTC-USD sample route.",
         "operationId": "getCryptoVwap",
         "responses": {
           "200": {
@@ -36,7 +36,7 @@
     "/v1/bidask/BTC-USD": {
       "get": {
         "summary": "Fetch crypto bid-ask snapshot",
-        "description": "Return a real-time bid/ask snapshot. Replace BTC-USD with another supported symbol after using discovery.",
+        "description": "Return a real-time crypto bid-ask snapshot for the listed BTC-USD sample route.",
         "operationId": "getCryptoBidAsk",
         "responses": {
           "200": {
@@ -58,7 +58,7 @@
     "/v1/fx/EURUSD": {
       "get": {
         "summary": "Fetch FX exchange rate data",
-        "description": "Return real-time FX market data. Replace EURUSD with another supported FX pair after using discovery.",
+        "description": "Return real-time FX market data for the listed EURUSD sample route.",
         "operationId": "getFxRate",
         "responses": {
           "200": {
@@ -80,7 +80,7 @@
     "/v1/metal/XAUUSD": {
       "get": {
         "summary": "Fetch precious metals price data",
-        "description": "Return real-time metals market data. Replace XAUUSD with another supported metals ticker after using discovery.",
+        "description": "Return real-time precious metals market data for the listed XAUUSD sample route.",
         "operationId": "getMetalPrice",
         "responses": {
           "200": {


### PR DESCRIPTION
## Summary

Adds Blocksize Market Data as a Pay.sh provider under `providers/blocksize/market-data`.

The listing exposes a filtered Pay.sh-facing OpenAPI sidecar for x402-paid market data endpoints covering crypto VWAP, crypto bid/ask, FX, and metals. The PAY.md copy is spend-aware: it directs agents to use discovery first, prefer single-symbol paid calls, batch only when useful, and avoid polling unless explicitly approved.

## Validation

- `pay catalog check providers/blocksize/market-data/PAY.md --no-probe`
- `pay catalog check providers/blocksize/market-data/PAY.md -v --probe-timeout 20`

Live probe result: 4/4 endpoints returned Solana-compatible x402 USDC payment gates.