### PR TITLE
feat(settle): add Settle Receipt-Pinned x402 Sandbox demo provider

### DIFF
--- a/providers/settle/demo/PAY.md
+++ b/providers/settle/demo/PAY.md
@@ -1,0 +1,82 @@
+---
+name: demo
+title: "Settle - Receipt-Pinned x402 Sandbox"
+description: "Solana devnet x402 sandbox with receipt-pinned spends. Three demo endpoints (arxiv abstract fetch, JA->EN translation, ELI12 summarization) exercise a full pay -> spend_via_pact -> on-chain receipt -> deliverable round-trip without touching mainnet funds."
+use_case: "Use for testing x402 client integrations on devnet, verifying credential envelopes, exercising spend_via_pact with a funded pact, debugging capability-hash mismatches, and confirming spend signatures and receipt hashes round-trip."
+category: devtools
+service_url: https://use-settle.vercel.app/api/x402/proxy
+openapi:
+  path: openapi.json
+---
+
+Settle is a Solana payment protocol that wraps x402 with a four-hash kernel
+commit (`receipt`, `reason`, `policy_snapshot`, `purpose`) and an on-chain
+`agent_card` + `pact` policy gate. This provider exposes three deliverable
+endpoints whose **payment flow is real** — every successful call submits a
+`spend_via_pact` instruction on Solana devnet that transfers USDC from the
+caller's pact vault to a registered merchant ATA, and the receipt is
+persisted with a verifiable hash chain.
+
+The deliverable JSON itself is canned (a stable arXiv abstract, a stable
+translation, a stable summary) so integrators can compare their client's
+behavior against a known-good fixture without paying for real arXiv,
+Translate, or LLM calls.
+
+## When to use
+
+- Building an x402 client (the `pay` CLI, a custom MCP server, an agent
+  runner) and you need a target that exercises every header
+  (`X-Settle-Sig`, `-Ts`, `-Nonce`, `-Capability-Hash`, `-Amount-Lamports`,
+  `-Pact-Pubkey`).
+- Verifying that your credential envelope round-trips correctly through
+  the dual-signature path (authority sig over the canonical envelope,
+  agent sig over canonical request bytes).
+- Confirming `spend_via_pact` lands on devnet with the expected merchant
+  pubkey, capability hash, and policy snapshot, and that the resulting
+  receipt is queryable.
+
+A reproducible end-to-end driver that creates a card, opens a pact, and
+calls one of these endpoints lives at
+[`apps/web/e2e/phantom-qa/test-roundtrip-proxy.mjs`](https://github.com/Pratiikpy/Settle/blob/main/apps/web/e2e/phantom-qa/test-roundtrip-proxy.mjs)
+in the Settle repo. Latest passing run on devnet:
+[`2R6euT6Hc8NgpdaWQX3CAY1pmTWURKv1vK2s8BTA6Lj8k86NZ5s1i96bAecSp4gkyK79E8yfiXD7WzFQXXEznNbj`](https://solscan.io/tx/2R6euT6Hc8NgpdaWQX3CAY1pmTWURKv1vK2s8BTA6Lj8k86NZ5s1i96bAecSp4gkyK79E8yfiXD7WzFQXXEznNbj?cluster=devnet).
+
+## Capability hashes
+
+The proxy verifies a BLAKE3 hash of the canonical capability spec on every
+request. The three demo capabilities are registered with `verified=true`
+in the public Settle capability registry at
+`https://use-settle.vercel.app/api/capabilities`:
+
+| Endpoint | Capability hash |
+|---|---|
+| `arxiv-fetch` | `c45734b2b7ccbde7914419c2589e7cedee90e9cd58d792b91b5bd8c8162f7e87` |
+| `translate` | `f86d8bb555733e6843b17a94346d71e8ca04d7378dcebff51851603e62530e08` |
+| `summarize` | `ab180f449d75d42c5974fc9023c9d388d320dd4a1907fd64eb705fb90ea1dfb3` |
+
+## Spend-aware usage
+
+- Don't loop. Each call costs $0.05 to $0.30 USDC (devnet) and lands a
+  real on-chain transaction. One per endpoint is enough for client
+  integration testing.
+- Pre-create the merchant USDC ATA before your first call; the proxy
+  returns Anchor error `3012` (`AccountNotInitialized`) otherwise. The
+  three merchant pubkeys are listed in `verified_merchants` and their
+  ATAs are pre-funded for the catalog-listed flow. Devnet USDC mint:
+  `4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU`.
+- Use a fresh `X-Settle-Nonce` per request. Nonces are rejected with
+  `409 nonce_replay` after first use; they live in the proxy's Upstash
+  layer with a 5-minute TTL.
+- Receipts are queryable at
+  `https://use-settle.vercel.app/api/verify/<receipt_hash>` and link out
+  to Solscan via the `spend_signature` field.
+- Keep `X-Settle-Purpose` short, plaintext, and honest — its BLAKE3 hash
+  is part of the kernel commit and the merchant can pin specific purposes
+  in policy.
+
+## Source
+
+The Settle protocol is open source at
+[github.com/Pratiikpy/Settle](https://github.com/Pratiikpy/Settle).
+The proxy implementation lives in
+[`apps/web/app/api/x402/proxy/[merchant]/route.ts`](https://github.com/Pratiikpy/Settle/blob/main/apps/web/app/api/x402/proxy/[merchant]/route.ts).

--- a/providers/settle/demo/PAY.md
+++ b/providers/settle/demo/PAY.md
@@ -4,10 +4,22 @@ title: "Settle - Receipt-Pinned x402 Sandbox"
 description: "Solana devnet x402 sandbox with receipt-pinned spends. Three demo endpoints (arxiv abstract fetch, JA->EN translation, ELI12 summarization) exercise a full pay -> spend_via_pact -> on-chain receipt -> deliverable round-trip without touching mainnet funds."
 use_case: "Use for testing x402 client integrations on devnet, verifying credential envelopes, exercising spend_via_pact with a funded pact, debugging capability-hash mismatches, and confirming spend signatures and receipt hashes round-trip."
 category: devtools
+network: solana-devnet
 service_url: https://use-settle.vercel.app/api/x402/proxy
 openapi:
   path: openapi.json
 ---
+
+> ## DEVNET SANDBOX — NOT MAINNET
+>
+> Every spend on this provider routes to **`solana-devnet`**. The USDC mint
+> is the devnet faucet token `4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU`,
+> not real mainnet USDC. Treat this provider as a **client-integration
+> testbed only** — no mainnet value is at stake on any successful call.
+>
+> If your agent runtime auto-discovers and pays providers from the catalog,
+> add `solana-devnet` to your allowed-networks list to opt in, or skip this
+> entry to filter out devnet sandboxes.
 
 Settle is a Solana payment protocol that wraps x402 with a four-hash kernel
 commit (`receipt`, `reason`, `policy_snapshot`, `purpose`) and an on-chain

--- a/providers/settle/demo/openapi.json
+++ b/providers/settle/demo/openapi.json
@@ -1,0 +1,171 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Settle Protocol — Receipt-Pinned x402 Demo",
+    "version": "0.1.0",
+    "description": "Three Solana devnet x402 demo endpoints whose payment flow lands a real spend_via_pact transaction on-chain. Deliverables are canned fixtures so integrators can compare client behavior against a stable target."
+  },
+  "servers": [
+    {
+      "url": "https://use-settle.vercel.app/api/x402/proxy",
+      "description": "Settle x402 proxy (devnet)"
+    }
+  ],
+  "paths": {
+    "/arxiv-fetch": {
+      "post": {
+        "operationId": "arxivFetch",
+        "summary": "Fetch a canned arXiv-style abstract.",
+        "description": "Demo endpoint priced at 0.10 USDC. Real on-chain spend_via_pact lands on Solana devnet; deliverable JSON is a stable fixture suitable for client integration tests.",
+        "x-pay-pricing": {
+          "dimensions": [
+            {
+              "direction": "usage",
+              "unit": "requests",
+              "scale": 1,
+              "tiers": [{ "price_usd": 0.10 }]
+            }
+          ]
+        },
+        "x-settle-capability-hash": "c45734b2b7ccbde7914419c2589e7cedee90e9cd58d792b91b5bd8c8162f7e87",
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "paper_id": { "type": "string", "example": "2305.12345" },
+                  "lang_hint": { "type": "string", "example": "ja" }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Canned arXiv abstract.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ProxyEnvelope" }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required. See X-402-* response headers."
+          }
+        }
+      }
+    },
+    "/translate": {
+      "post": {
+        "operationId": "translate",
+        "summary": "Return a canned JA->EN translation.",
+        "description": "Demo endpoint priced at 0.30 USDC. Real on-chain spend_via_pact lands on Solana devnet; deliverable JSON is a stable fixture.",
+        "x-pay-pricing": {
+          "dimensions": [
+            {
+              "direction": "usage",
+              "unit": "requests",
+              "scale": 1,
+              "tiers": [{ "price_usd": 0.30 }]
+            }
+          ]
+        },
+        "x-settle-capability-hash": "f86d8bb555733e6843b17a94346d71e8ca04d7378dcebff51851603e62530e08",
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "source": { "type": "string", "default": "ja" },
+                  "target": { "type": "string", "default": "en" }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Canned translation deliverable.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ProxyEnvelope" }
+              }
+            }
+          },
+          "402": { "description": "Payment required." }
+        }
+      }
+    },
+    "/summarize": {
+      "post": {
+        "operationId": "summarize",
+        "summary": "Return a canned ELI12-style summary.",
+        "description": "Demo endpoint priced at 0.05 USDC. Real on-chain spend_via_pact lands on Solana devnet; deliverable JSON is a stable fixture.",
+        "x-pay-pricing": {
+          "dimensions": [
+            {
+              "direction": "usage",
+              "unit": "requests",
+              "scale": 1,
+              "tiers": [{ "price_usd": 0.05 }]
+            }
+          ]
+        },
+        "x-settle-capability-hash": "ab180f449d75d42c5974fc9023c9d388d320dd4a1907fd64eb705fb90ea1dfb3",
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "audience": { "type": "string", "default": "eli12" }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Canned summary deliverable.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ProxyEnvelope" }
+              }
+            }
+          },
+          "402": { "description": "Payment required." }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ProxyEnvelope": {
+        "type": "object",
+        "properties": {
+          "ok": { "type": "boolean" },
+          "decision": { "type": "string", "enum": ["ALLOW"] },
+          "request_id": { "type": "string", "format": "uuid" },
+          "merchant": { "type": "string" },
+          "deliverable": { "type": "object" },
+          "spend_signature": {
+            "type": "string",
+            "description": "Solana transaction signature for the on-chain spend_via_pact ix."
+          },
+          "receipt_hash": {
+            "type": "string",
+            "description": "BLAKE3 hash of the canonical receipt; verify at /api/verify/<hash>."
+          },
+          "reason_hash": { "type": "string" },
+          "policy_snapshot_hash": { "type": "string" },
+          "purpose_hash": { "type": "string" }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds `providers/settle/demo/`, a Solana devnet x402 sandbox with three endpoints (arxiv-fetch, translate, summarize) priced 0.05 to 0.30 USDC. The deliverables are canned fixtures so client integrators have a stable target to compare against, but the payment flow is real: every successful call lands a `spend_via_pact` tx on devnet that moves USDC from the caller's pact vault to the merchant ATA, and the receipt persists with a verifiable BLAKE3 hash chain.

The proxy emits standard x402 challenge format (`x402Version` + `accepts`) so generic x402 clients work out of the box. Settle-native fields (`capability_hash`, `capability_spec`) ride alongside for callers that pin specific capabilities.

`pay catalog check providers/settle/demo/PAY.md --verbose`:
- PAY.md check successful (3 endpoints, 1 provider)
- Solana-compat 3/3 OK 402 x402 USDC

Last passing on-chain spend, 0.10 USDC delivered to the arxiv-fetch demo merchant: https://solscan.io/tx/2R6euT6Hc8NgpdaWQX3CAY1pmTWURKv1vK2s8BTA6Lj8k86NZ5s1i96bAecSp4gkyK79E8yfiXD7WzFQXXEznNbj?cluster=devnet

Reproducible end-to-end driver lives at `apps/web/e2e/phantom-qa/test-roundtrip-proxy.mjs` in the Settle repo: https://github.com/Pratiikpy/Settle. It creates a card, opens a pact, signs the credential envelope, and round-trips through the proxy in about 2.5 seconds.

Files:
- `providers/settle/demo/PAY.md`
- `providers/settle/demo/openapi.json` (OpenAPI 3.1 with `x-pay-pricing` and `x-settle-capability-hash` extensions)