### PR TITLE
Add aisthetic.service — verifiable receipts probe

### DIFF
--- a/providers/aisthetic/probe/PAY.md
+++ b/providers/aisthetic/probe/PAY.md
@@ -1,0 +1,38 @@
+---
+name: probe
+title: "aisthetic.service — Verifiable Receipts Probe"
+description: "Free public-tier endpoint of aisthetic.service, a verifiable agent commerce gateway on Solana. Each paid call returns an Ed25519-signed receipt independently verifiable on aisthetic.services. 401 → 402 → 200 + X-AgentTrust-Receipt-Id."
+use_case: "Use to learn, test, or wire up a payment-gated API that returns a portable signed receipt. The production mainnet billing path exists separately; the probe is the free public tier so agents practise the flow without spending stablecoin."
+category: devtools
+service_url: https://sandbox.aisthetic.services
+openapi:
+  path: openapi.json
+---
+
+`aisthetic.service` is a 7-stage gateway (identity → policy → risk → payment → upstream → receipt → audit) that sits in front of any HTTP API. The probe endpoint, `POST /g/aisthetic/probe`, walks an agent through the full 401 → 402 → 200 flow and produces a real Ed25519-signed receipt anyone can verify on the public landing site without an API key.
+
+The 402 response from this gateway is JSON-shaped (`type: "payment_required"`, machine-readable `paymentMethods[]`), distinct from the `WWW-Authenticate: Payment` header used by `pay.sh`'s MPP debugger. Both formats co-exist as machine-readable payment requirements at the 402 layer; an agent stack can support either.
+
+## Spend-aware usage
+
+- The probe is the **free public tier**: settlement is satisfied by `X-AgentTrust-Sandbox-Proof: demo-paid` (no real stablecoin moves). Use it to validate your client-side 402 → retry-with-proof loop and to capture sample receipts before pointing your agent at the production billing path.
+- One paid call → one receipt. Do not retry at high concurrency unless you are testing the platform's velocity policy — it engages and starts denying with HTTP 403 after a burst.
+- Read the receipt id off the `X-AgentTrust-Receipt-Id` response header. Every receipt is independently verifiable (no key) at `https://aisthetic.services/r?id=<receipt-id>`.
+- Recent activity is published with bounded hashes (no PII) at `GET /v1/public/activity`. Useful for agents that want to see what other agents did recently without reading raw logs.
+- The production gateway uses real x402 with USDC settlement on Solana mainnet. Contact the operator for a production API key; the probe is intentionally free.
+
+## Receipt verification
+
+```
+$ curl -i https://sandbox.aisthetic.services/g/aisthetic/probe \
+    -H "Authorization: Bearer ak_demo_agent" \
+    -H "X-AgentTrust-Sandbox-Proof: demo-paid"
+
+HTTP/2 200
+x-agenttrust-receipt-id: 98abf39b-66cb-486e-894d-75bacfa43c2b
+
+# verify the receipt anywhere, no auth:
+https://aisthetic.services/r?id=98abf39b-66cb-486e-894d-75bacfa43c2b
+```
+
+A blackbox stress-test agent for the same gateway lives at [github.com/den0th/aisthetic-hard-test](https://github.com/den0th/aisthetic-hard-test) — it runs 30+ scenarios across 5 acts (coverage, adversarial, pay.sh interop, real Solana mainnet trade, stress) and produces ~150 signed receipts per run.

--- a/providers/aisthetic/probe/openapi.json
+++ b/providers/aisthetic/probe/openapi.json
@@ -1,0 +1,120 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "aisthetic.service — Verifiable Receipts Sandbox",
+    "version": "0.1.0",
+    "description": "Public sandbox of aisthetic.service, a 7-stage verifiable agent commerce gateway. The demo endpoint walks an agent through a 401 → 402 → 200 paid-call flow and returns a portable Ed25519-signed receipt that anyone can verify on https://aisthetic.services without a key.",
+    "contact": {
+      "name": "aisthetic.service",
+      "url": "https://aisthetic.services"
+    },
+    "license": {
+      "name": "MIT",
+      "url": "https://github.com/den0th/aisthetic-hard-test/blob/main/LICENSE"
+    }
+  },
+  "servers": [
+    {
+      "url": "https://sandbox.aisthetic.services",
+      "description": "Public sandbox gateway (Fly.io eu-central)"
+    }
+  ],
+  "paths": {
+    "/g/aisthetic/probe": {
+      "post": {
+        "summary": "Verifiable receipts probe — returns data + signed receipt",
+        "description": "Routes the call through the full 7-stage gateway pipeline. Without `Authorization`, returns 401. With `Authorization` but no payment proof, returns a JSON 402 challenge. With `Authorization` + `X-AgentTrust-Sandbox-Proof: demo-paid`, returns 200 with a JSON body and an `X-AgentTrust-Receipt-Id` response header pointing to a publicly verifiable Ed25519-signed receipt.",
+        "operationId": "probeReceipts",
+        "security": [
+          { "BearerAuth": [] }
+        ],
+        "parameters": [
+          {
+            "name": "X-AgentTrust-Sandbox-Proof",
+            "in": "header",
+            "required": false,
+            "description": "Sandbox payment proof. The demo endpoint accepts the literal string `demo-paid`.",
+            "schema": { "type": "string", "example": "demo-paid" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paid call succeeded. Body is the upstream response. Response includes a verifiable receipt id.",
+            "headers": {
+              "X-AgentTrust-Receipt-Id": {
+                "description": "UUID v4 identifier for the Ed25519-signed receipt. Verify at https://aisthetic.services/r?id={id}",
+                "schema": { "type": "string", "format": "uuid" }
+              },
+              "X-AgentTrust-Request-Id": {
+                "description": "Request correlation id (server-side log lookup).",
+                "schema": { "type": "string" }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": { "type": "object", "additionalProperties": true }
+              }
+            }
+          },
+          "401": {
+            "description": "Agent identity not resolved. Send `Authorization: Bearer ak_demo_agent` to identify as the sandbox demo agent.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "type": { "type": "string", "format": "uri" },
+                    "status": { "type": "integer", "example": 401 },
+                    "code": { "type": "string", "example": "unauthorized" },
+                    "detail": { "type": "string" }
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required. Body is a machine-readable JSON challenge. To satisfy the sandbox challenge, retry with header `X-AgentTrust-Sandbox-Proof: demo-paid`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "type": { "type": "string", "example": "payment_required" },
+                    "amount": { "type": "string", "example": "0.010000" },
+                    "currency": { "type": "string", "example": "USDC" },
+                    "paymentMethods": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "protocol": { "type": "string" },
+                          "network": { "type": "string" },
+                          "asset": { "type": "string" },
+                          "payTo": { "type": "string" },
+                          "scheme": { "type": "string" }
+                        }
+                      }
+                    },
+                    "expiresAt": { "type": "string", "format": "date-time" }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Policy or risk engine denied the call. Typically engaged after a burst of >100 concurrent requests from the same agent (velocity policy)."
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "BearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "description": "Sandbox demo bearer is the literal string `ak_demo_agent`."
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds `providers/aisthetic/probe/` — a public listing for [aisthetic.service](https://aisthetic.services), a 7-stage verifiable agent commerce gateway on Solana. Each paid call through the probe endpoint returns an Ed25519-signed receipt that anyone can verify on `aisthetic.services/r?id=<id>` without an API key.

## What it adds

- `providers/aisthetic/probe/PAY.md` — provider metadata (category: `devtools`)
- `providers/aisthetic/probe/openapi.json` — OpenAPI 3.1 doc for the probe endpoint `POST /g/aisthetic/probe`

## How the probe endpoint works

```
$ curl -i https://sandbox.aisthetic.services/g/aisthetic/probe
HTTP/2 401  (no Authorization)

$ curl -i https://sandbox.aisthetic.services/g/aisthetic/probe \
    -H "Authorization: Bearer ak_demo_agent"
HTTP/2 402  (JSON challenge with machine-readable paymentMethods[])

$ curl -i https://sandbox.aisthetic.services/g/aisthetic/probe \
    -H "Authorization: Bearer ak_demo_agent" \
    -H "X-AgentTrust-Sandbox-Proof: demo-paid"
HTTP/2 200
x-agenttrust-receipt-id: 98abf39b-66cb-486e-894d-75bacfa43c2b
```

Then anyone — no auth — can verify that receipt at `https://aisthetic.services/r?id=98abf39b-66cb-486e-894d-75bacfa43c2b`.

## Honesty notes

- The probe is the **free public tier**. Settlement is satisfied by the sandbox proof literal (`X-AgentTrust-Sandbox-Proof: demo-paid`); no stablecoin moves. The production gateway uses real x402 USDC settlement on Solana mainnet and requires an operator-provisioned API key — that surface is intentionally not in this listing.
- The 402 challenge format here is JSON-shaped (`type: "payment_required"`), distinct from the `WWW-Authenticate: Payment` header used by pay.sh's MPP debugger. Both interoperate as machine-readable Solana payment requirements at the 402 layer.
- The `pay catalog check` probe reports `auth_required — payment behind credentials, can't verify` because the gateway is identity-first (resolves agent before evaluating payment); the catalog still validates the PAY.md and OpenAPI as `successful`.

## Validation

\`\`\`
\$ pay catalog check providers/aisthetic/probe/PAY.md
PAY.md check successful
1 endpoint tested across 1 provider
Solana-compat verdict: PASS (auth_required)
\`\`\`

## Related

- Live platform: https://aisthetic.services
- Public activity feed: https://aisthetic.services/explorer
- Receipt verifier: https://aisthetic.services/r
- Blackbox stress-test agent (open source, MIT, includes a 4-scenario \`pay.sh\` interop act): https://github.com/den0th/aisthetic-hard-test