### PR TITLE
Refresh GateCheck by LarryBuildsAI provider

### DIFF
--- a/providers/larrybuildsai/boundary-guard/PAY.md
+++ b/providers/larrybuildsai/boundary-guard/PAY.md
@@ -25,7 +25,7 @@ openapi:
 - **MCP tools:** `5`
 - **REST pricing:** `$0.05-$10.00/request`
 - **HTML page:** https://x402-resource-scanner.vercel.app/
-- **Markdown page:** https://x402-resource-scanner.vercel.app/llms.txt
+- **Agent docs:** https://x402-resource-scanner.vercel.app/llms.txt
 
 ## Service URLs
 
@@ -34,13 +34,13 @@ openapi:
 - **x402 manifest:** https://x402-resource-scanner.vercel.app/.well-known/x402
 - **MCP discovery:** https://x402-resource-scanner.vercel.app/.well-known/mcp.json
 - **MCP endpoint:** https://x402-resource-scanner.vercel.app/mcp
-- **Source:** https://github.com/LarryLemonBot/LarryBuildsAI/tree/main/tools/x402_resource_scanner
+- **Agent skill:** https://x402-resource-scanner.vercel.app/skill.md
 
 ## Why buyers use it
 
 Paid APIs fail in boring ways that still cost money: a listing is missing a price, an endpoint stops returning a parseable `402`, the network or asset metadata is wrong, or an agent cannot tell what was checked before it spent time on a paid workflow.
 
-Boundary Guard x402 gives sellers and agent builders a cheap preflight layer before the handoff breaks. It does not try to replace the payment flow. It checks the surfaces that help buyers trust the flow before they call it.
+Boundary Guard x402 gives sellers and agent builders a cheap preflight layer before the handoff breaks. It does not try to replace the payment flow or claim downstream settlement. It checks the public surfaces that help buyers trust the flow before they call it.
 
 Use it when you need to:
 

--- a/providers/larrybuildsai/boundary-guard/PAY.md
+++ b/providers/larrybuildsai/boundary-guard/PAY.md
@@ -1,8 +1,8 @@
 ---
 name: boundary-guard
-title: "Boundary Guard x402"
-description: "Revenue-safety checks for x402 sellers and agent builders: scan paid APIs before listing, probe unpaid 402 challenges, and attach receipts to risky agent actions."
-use_case: "Use before listing or routing to a paid x402 API, after deploys that may break payment metadata, or when an agent needs a receipt around a risky write, send, publish, or pay workflow."
+title: "GateCheck by LarryBuildsAI"
+description: "Paid preflight checks for x402 and MCP sellers: scan public metadata, probe unpaid 402 challenges, score agent-tool readiness, generate launch packs, and attach bounded receipts."
+use_case: "Use before listing or routing to a paid x402/MCP tool, after deploys that may break payment metadata, or when an agent needs a receipt around a risky write, send, publish, or pay workflow."
 category: devtools
 service_url: https://x402-resource-scanner.vercel.app
 version: "0.1.0"
@@ -10,9 +10,9 @@ openapi:
  path: openapi.json
 ---
 
-# Boundary Guard x402
+# GateCheck by LarryBuildsAI
 
-> Revenue-safety checks for x402 sellers and agent builders. Scan a paid API before listing it, probe the unpaid 402 challenge before buyers hit it, and attach receipts to agent actions that need a clean audit trail.
+> Paid preflight checks for x402 and MCP sellers. Scan public metadata before listing, probe the unpaid `402` challenge before buyers hit it, generate marketplace-safe launch artifacts, and attach receipts to agent actions that need a clean audit trail.
 
 ## Agent Summary
 
@@ -21,9 +21,9 @@ openapi:
 - **Operator:** `larrybuildsai`
 - **Origin:** `larrybuildsai`
 - **Version:** `0.1.0`
-- **REST endpoints:** `4`
-- **MCP tools:** `5`
-- **REST pricing:** `$0.05–$10.00/request`
+- **REST endpoints:** `5`
+- **MCP tools:** `6`
+- **REST pricing:** `$0.05-$49.00/request`
 - **HTML page:** https://x402-resource-scanner.vercel.app/
 - **Agent docs:** https://x402-resource-scanner.vercel.app/llms.txt
 
@@ -46,7 +46,7 @@ The live OpenAPI and discovery files are broader product surfaces. They also adv
 
 Paid APIs fail in boring ways that still cost money: a listing is missing a price, an endpoint stops returning a parseable `402`, the network or asset metadata is wrong, or an agent cannot tell what was checked before it spent time on a paid workflow.
 
-Boundary Guard x402 gives sellers and agent builders a cheap preflight layer before the handoff breaks. It does not try to replace the payment flow or claim downstream settlement. It checks the public surfaces that help buyers trust the flow before they call it.
+GateCheck by LarryBuildsAI gives sellers and agent builders a cheap preflight layer before the handoff breaks. It does not try to replace the payment flow or claim downstream settlement. It checks the public surfaces that help buyers trust the flow before they call it.
 
 Use it when you need to:
 
@@ -98,6 +98,30 @@ Example body:
 }
 ```
 
+### Generate a Launch Pack
+
+`POST /v1/x402/launch-pack` — **$9/request**
+
+Generates marketplace-safe listing copy, buyer FAQ, launch checklist, approval packet, and claim boundaries for x402/MCP sellers from readiness evidence.
+
+Best for sellers who have a live paid endpoint or MCP tool and need buyer-facing copy plus a review checklist before submitting to pay.sh, xpay, CDP Bazaar, Glama, Agentic.Market, or another marketplace.
+
+Example body:
+
+```json
+{
+  "target": "https://seller.example",
+  "paid_path": "https://seller.example/v1/paid",
+  "method": "GET",
+  "expected_resources": 3,
+  "expected": {
+    "network": "base",
+    "asset": "USDC",
+    "priceUsd": "0.25"
+  }
+}
+```
+
 ### Create an Action Receipt
 
 `POST /v1/receipts/check` — **$0.05/request**
@@ -110,7 +134,7 @@ Send hashes, IDs, safe summaries, and policy labels. Do not send secrets, bearer
 
 ## MCP Tools
 
-Boundary Guard also exposes a Streamable HTTP MCP endpoint at `/mcp`.
+GateCheck also exposes a Streamable HTTP MCP endpoint at `/mcp`. Boundary Guard remains the legacy receipt layer and preserved registry slug.
 
 ### Boundary Guard Check
 
@@ -135,6 +159,12 @@ Probe a public x402 endpoint without payment, parse the 402 challenge, compare e
 Suggested xpay price: **$1.00/call** (quick) / **$5.00/call** (deep) / **$10.00/call** (report)
 
 Check whether an x402 or agent-facing tool is ready for agent routing, marketplace listing, and paid-path monitoring.
+
+### Generate x402 Launch Pack
+
+Suggested xpay price: **$9.00/call**
+
+Generate marketplace-safe listing copy, buyer FAQ, launch checklist, approval packet, and claim boundaries for x402/MCP sellers from readiness evidence.
 
 ### Generate Trust Receipt
 

--- a/providers/larrybuildsai/boundary-guard/PAY.md
+++ b/providers/larrybuildsai/boundary-guard/PAY.md
@@ -30,11 +30,17 @@ openapi:
 ## Service URLs
 
 - **Gateway:** https://x402-resource-scanner.vercel.app
-- **OpenAPI:** https://x402-resource-scanner.vercel.app/openapi.json
-- **x402 manifest:** https://x402-resource-scanner.vercel.app/.well-known/x402
-- **MCP discovery:** https://x402-resource-scanner.vercel.app/.well-known/mcp.json
-- **MCP endpoint:** https://x402-resource-scanner.vercel.app/mcp
-- **Agent skill:** https://x402-resource-scanner.vercel.app/skill.md
+- **Live OpenAPI:** https://x402-resource-scanner.vercel.app/openapi.json
+- **x402 Manifest:** https://x402-resource-scanner.vercel.app/.well-known/x402
+- **MCP Discovery:** https://x402-resource-scanner.vercel.app/.well-known/mcp.json
+- **MCP Endpoint:** https://x402-resource-scanner.vercel.app/mcp
+- **Agent Skill:** https://x402-resource-scanner.vercel.app/skill.md
+
+## Registry Scope
+
+This pay-skills listing uses the co-located `openapi.json` sidecar as the canonical registry surface. It intentionally focuses on paid buyer routes that the registry should inspect and route to.
+
+The live OpenAPI and discovery files are broader product surfaces. They also advertise documentation, discovery, MCP metadata, and additional product routes such as the launch-pack generator. That broader live discovery is intentional and should not be read as drift from this pay-skills sidecar.
 
 ## Why Buyers Use It
 
@@ -67,6 +73,8 @@ Best for sellers preparing a pay.sh, xpay, CDP Bazaar, Agentic.Market, or market
 Sends an unpaid request to a public paid endpoint and checks the conversion-critical part of the flow: does the endpoint return HTTP `402`, can the payment requirements be parsed, and do network, asset, and price match what the seller expected?
 
 This is a seller health check for the unpaid challenge. It does not sign a payment, spend buyer funds, or prove the paid action completed.
+
+The probe is intentionally limited to safe challenge reads by default. Use `target` or `url` in the JSON body, with `method` set to `GET`, `HEAD`, or `OPTIONS`. POST target probes are disabled by default and require a separately scoped opt-in; sellers should not expect POST paid-path probes from this listing.
 
 ### Check Agent-Tool Readiness
 

--- a/providers/larrybuildsai/boundary-guard/PAY.md
+++ b/providers/larrybuildsai/boundary-guard/PAY.md
@@ -2,19 +2,19 @@
 name: boundary-guard
 title: "Boundary Guard x402"
 description: "Revenue-safety checks for x402 sellers and agent builders: scan paid APIs before listing, probe unpaid 402 challenges, and attach receipts to risky agent actions."
-use_case: "Use before listing or routing to a paid x402 API, after deploys that may break payment metadata, or when an agent needs a receipt around a risky write/send/publish/pay workflow."
+use_case: "Use before listing or routing to a paid x402 API, after deploys that may break payment metadata, or when an agent needs a receipt around a risky write, send, publish, or pay workflow."
 category: devtools
 service_url: https://x402-resource-scanner.vercel.app
 version: "0.1.0"
 openapi:
-  path: openapi.json
+ path: openapi.json
 ---
 
 # Boundary Guard x402
 
 > Revenue-safety checks for x402 sellers and agent builders. Scan a paid API before listing it, probe the unpaid 402 challenge before buyers hit it, and attach receipts to agent actions that need a clean audit trail.
 
-## Agent summary
+## Agent Summary
 
 - **FQN:** `larrybuildsai/boundary-guard`
 - **Category:** `devtools`
@@ -23,7 +23,7 @@ openapi:
 - **Version:** `0.1.0`
 - **REST endpoints:** `4`
 - **MCP tools:** `5`
-- **REST pricing:** `$0.05-$10.00/request`
+- **REST pricing:** `$0.05–$10.00/request`
 - **HTML page:** https://x402-resource-scanner.vercel.app/
 - **Agent docs:** https://x402-resource-scanner.vercel.app/llms.txt
 
@@ -36,7 +36,7 @@ openapi:
 - **MCP endpoint:** https://x402-resource-scanner.vercel.app/mcp
 - **Agent skill:** https://x402-resource-scanner.vercel.app/skill.md
 
-## Why buyers use it
+## Why Buyers Use It
 
 Paid APIs fail in boring ways that still cost money: a listing is missing a price, an endpoint stops returning a parseable `402`, the network or asset metadata is wrong, or an agent cannot tell what was checked before it spent time on a paid workflow.
 
@@ -44,15 +44,15 @@ Boundary Guard x402 gives sellers and agent builders a cheap preflight layer bef
 
 Use it when you need to:
 
-- find listing gaps before submitting a paid API to a marketplace
-- catch broken `402` metadata before agents and buyers bounce
-- verify expected network, asset, and price metadata before launch
-- give support, ops, or buyers a receipt that shows what was checked
-- prove the boundary of a workflow without claiming more than the tool observed
+- Find listing gaps before submitting a paid API to a marketplace.
+- Catch broken `402` metadata before agents and buyers bounce.
+- Verify expected network, asset, and price metadata before launch.
+- Give support, ops, or buyers a receipt that shows what was checked.
+- Prove the boundary of a workflow without claiming more than the tool observed.
 
-## REST endpoints
+## REST Endpoints
 
-### Preflight a listing
+### Preflight a Listing
 
 `GET /v1/x402/scan?url={providerUrl}` — **$0.25/request**
 
@@ -60,7 +60,7 @@ Scans public x402 and OpenAPI metadata for a target service. Returns resource co
 
 Best for sellers preparing a pay.sh, xpay, CDP Bazaar, Agentic.Market, or marketplace submission. Run it before listing, after deploys, and before sending buyers to a paid endpoint.
 
-### Check the paid path before buyers do
+### Check the Paid Path Before Buyers Do
 
 `POST /v1/x402/health/probe` — **$0.50/request**
 
@@ -68,11 +68,11 @@ Sends an unpaid request to a public paid endpoint and checks the conversion-crit
 
 This is a seller health check for the unpaid challenge. It does not sign a payment, spend buyer funds, or prove the paid action completed.
 
-### Check agent-tool readiness
+### Check Agent-Tool Readiness
 
 `POST /v1/x402/agent-tools/readiness` — **$1 quick / $5 deep / $10 report**
 
-Checks whether an x402 or agent-facing paid tool is ready for marketplace listing, buyer routing, and paid-path monitoring. Quick checks metadata and listing surfaces, deep adds paid-path guidance when supplied, and report returns launch/report guidance.
+Checks whether an x402 or agent-facing paid tool is ready for marketplace listing, buyer routing, and paid-path monitoring. Quick checks metadata and listing surfaces, deep adds paid-path guidance when supplied, and report returns launch and report guidance.
 
 Best for sellers who want an agent-readable readiness score before submitting to pay.sh, xpay, CDP Bazaar, Agentic.Market, or another paid-tool marketplace.
 
@@ -90,7 +90,7 @@ Example body:
 }
 ```
 
-### Create an action receipt
+### Create an Action Receipt
 
 `POST /v1/receipts/check` — **$0.05/request**
 
@@ -100,51 +100,36 @@ Use it when an agent needs a compact record of what it was about to do, what pol
 
 Send hashes, IDs, safe summaries, and policy labels. Do not send secrets, bearer tokens, cookies, private keys, raw customer data, or payment signatures.
 
-## MCP tools
+## MCP Tools
 
 Boundary Guard also exposes a Streamable HTTP MCP endpoint at `/mcp`.
 
-Tools:
+### Boundary Guard Check
 
-- `boundary_guard_check` — suggested xpay price `$0.03/call`
-- `scan_x402_resource` — suggested xpay price `$0.10/call`
-- `probe_x402_paid_path` — suggested xpay price `$0.50/call`
-- `check_agent_tool_readiness` — suggested x402 price `$1-$10/call`, depending on tier
-- `generate_trust_receipt` — suggested xpay price `$0.05/call`
+Suggested xpay price: **$0.03/call**
 
-Use the MCP endpoint when an agent needs these checks inside a tool workflow instead of a direct REST call.
+Create a Boundary Guard pre-action checkpoint receipt for an agent request, policy decision, and result summary.
 
-## Buyer jobs
+### Scan x402 Resource
 
-### Seller launch check
+Suggested xpay price: **$0.10/call**
 
-Before announcing a paid API, scan the service and probe the paid path. The goal is simple: buyers should see a clean listing, a parseable `402`, and payment metadata that matches what you meant to charge.
+Read-only scan of public x402 and OpenAPI metadata, with optional comparison to a marketplace listing for staleness.
 
-### Ongoing uptime check
+### Probe x402 Paid Path
 
-After deploys, run the health probe against paid endpoints. A normal uptime monitor can say the URL is alive while the x402 challenge is broken. Boundary Guard checks the part that matters for paid conversion.
+Suggested xpay price: **$0.50/call**
 
-### Agent trust checkpoint
+Probe a public x402 endpoint without payment, parse the 402 challenge, compare expected network, asset, and price, and return a deterministic health receipt.
 
-Before an agent writes, sends, publishes, or calls another paid tool, attach a receipt. The receipt gives the operator a clean record without pretending it proves downstream work that Boundary Guard did not see.
+### Check Agent Tool Readiness
 
-## Spend-aware usage
+Suggested xpay price: **$1.00/call** (quick) / **$5.00/call** (deep) / **$10.00/call** (report)
 
-- Run one scan before marketplace submission, then re-run only after deploys, pricing changes, manifest changes, or listing edits.
-- Use the health probe for targeted endpoint checks, not broad crawling or polling loops.
-- Cache receipts by workflow/action ID when the underlying evidence has not changed.
-- Prefer hashes, IDs, and short summaries over raw payloads in receipt requests.
+Check whether an x402 or agent-facing tool is ready for agent routing, marketplace listing, and paid-path monitoring.
 
-## Safety notes
+### Generate Trust Receipt
 
-- Direct REST endpoints advertise Solana mainnet USDC and Base USDC x402 accepts.
-- Unpaid protected calls return HTTP `402` with payment metadata.
-- Health Probe v1 only checks unpaid challenge shape and advertised payment requirements.
-- Health probes reject localhost, private, internal, credentialed, redirecting, and DNS-to-non-global targets.
-- Health probes allow only unpaid `GET`, `HEAD`, and `OPTIONS` target methods.
-- Receipts prove what Boundary Guard received, hashed, and returned. They do not prove downstream real-world execution.
-- Privacy-safe analytics avoid raw request bodies, secrets, full URLs, auth headers, payment signatures, cookies, private keys, full IPs, and full user agents.
+Suggested xpay price: **$0.05/call**
 
-## Claim boundary
-
-Boundary Guard x402 is a verification layer, not an escrow service and not a payment executor. It helps sellers avoid broken paid-path launches, helps agent builders add evidence to risky workflows, and helps marketplaces see whether a provider is ready to be routed to buyers.
+Generate a deterministic trust receipt from arbitrary request, policy, result, and payment evidence.

--- a/providers/larrybuildsai/boundary-guard/PAY.md
+++ b/providers/larrybuildsai/boundary-guard/PAY.md
@@ -1,0 +1,150 @@
+---
+name: boundary-guard
+title: "Boundary Guard x402"
+description: "Revenue-safety checks for x402 sellers and agent builders: scan paid APIs before listing, probe unpaid 402 challenges, and attach receipts to risky agent actions."
+use_case: "Use before listing or routing to a paid x402 API, after deploys that may break payment metadata, or when an agent needs a receipt around a risky write/send/publish/pay workflow."
+category: devtools
+service_url: https://x402-resource-scanner.vercel.app
+version: "0.1.0"
+openapi:
+  path: openapi.json
+---
+
+# Boundary Guard x402
+
+> Revenue-safety checks for x402 sellers and agent builders. Scan a paid API before listing it, probe the unpaid 402 challenge before buyers hit it, and attach receipts to agent actions that need a clean audit trail.
+
+## Agent summary
+
+- **FQN:** `larrybuildsai/boundary-guard`
+- **Category:** `devtools`
+- **Operator:** `larrybuildsai`
+- **Origin:** `larrybuildsai`
+- **Version:** `0.1.0`
+- **REST endpoints:** `4`
+- **MCP tools:** `5`
+- **REST pricing:** `$0.05-$10.00/request`
+- **HTML page:** https://x402-resource-scanner.vercel.app/
+- **Markdown page:** https://x402-resource-scanner.vercel.app/llms.txt
+
+## Service URLs
+
+- **Gateway:** https://x402-resource-scanner.vercel.app
+- **OpenAPI:** https://x402-resource-scanner.vercel.app/openapi.json
+- **x402 manifest:** https://x402-resource-scanner.vercel.app/.well-known/x402
+- **MCP discovery:** https://x402-resource-scanner.vercel.app/.well-known/mcp.json
+- **MCP endpoint:** https://x402-resource-scanner.vercel.app/mcp
+- **Source:** https://github.com/LarryLemonBot/LarryBuildsAI/tree/main/tools/x402_resource_scanner
+
+## Why buyers use it
+
+Paid APIs fail in boring ways that still cost money: a listing is missing a price, an endpoint stops returning a parseable `402`, the network or asset metadata is wrong, or an agent cannot tell what was checked before it spent time on a paid workflow.
+
+Boundary Guard x402 gives sellers and agent builders a cheap preflight layer before the handoff breaks. It does not try to replace the payment flow. It checks the surfaces that help buyers trust the flow before they call it.
+
+Use it when you need to:
+
+- find listing gaps before submitting a paid API to a marketplace
+- catch broken `402` metadata before agents and buyers bounce
+- verify expected network, asset, and price metadata before launch
+- give support, ops, or buyers a receipt that shows what was checked
+- prove the boundary of a workflow without claiming more than the tool observed
+
+## REST endpoints
+
+### Preflight a listing
+
+`GET /v1/x402/scan?url={providerUrl}` — **$0.25/request**
+
+Scans public x402 and OpenAPI metadata for a target service. Returns resource counts, price surfaces, listing gaps, issue flags, a readiness score, and next steps.
+
+Best for sellers preparing a pay.sh, xpay, CDP Bazaar, Agentic.Market, or marketplace submission. Run it before listing, after deploys, and before sending buyers to a paid endpoint.
+
+### Check the paid path before buyers do
+
+`POST /v1/x402/health/probe` — **$0.50/request**
+
+Sends an unpaid request to a public paid endpoint and checks the conversion-critical part of the flow: does the endpoint return HTTP `402`, can the payment requirements be parsed, and do network, asset, and price match what the seller expected?
+
+This is a seller health check for the unpaid challenge. It does not sign a payment, spend buyer funds, or prove the paid action completed.
+
+### Check agent-tool readiness
+
+`POST /v1/x402/agent-tools/readiness` — **$1 quick / $5 deep / $10 report**
+
+Checks whether an x402 or agent-facing paid tool is ready for marketplace listing, buyer routing, and paid-path monitoring. Quick checks metadata and listing surfaces, deep adds paid-path guidance when supplied, and report returns launch/report guidance.
+
+Best for sellers who want an agent-readable readiness score before submitting to pay.sh, xpay, CDP Bazaar, Agentic.Market, or another paid-tool marketplace.
+
+Example body:
+
+```json
+{
+  "target": "https://seller.example/v1/paid",
+  "method": "GET",
+  "expected": {
+    "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+    "asset": "USDC",
+    "priceUsd": "0.25"
+  }
+}
+```
+
+### Create an action receipt
+
+`POST /v1/receipts/check` — **$0.05/request**
+
+Creates a deterministic receipt from submitted request metadata, policy outcome, result summary, optional payment metadata, and next-step guidance.
+
+Use it when an agent needs a compact record of what it was about to do, what policy said, what happened, and what remains unproven.
+
+Send hashes, IDs, safe summaries, and policy labels. Do not send secrets, bearer tokens, cookies, private keys, raw customer data, or payment signatures.
+
+## MCP tools
+
+Boundary Guard also exposes a Streamable HTTP MCP endpoint at `/mcp`.
+
+Tools:
+
+- `boundary_guard_check` — suggested xpay price `$0.03/call`
+- `scan_x402_resource` — suggested xpay price `$0.10/call`
+- `probe_x402_paid_path` — suggested xpay price `$0.50/call`
+- `check_agent_tool_readiness` — suggested x402 price `$1-$10/call`, depending on tier
+- `generate_trust_receipt` — suggested xpay price `$0.05/call`
+
+Use the MCP endpoint when an agent needs these checks inside a tool workflow instead of a direct REST call.
+
+## Buyer jobs
+
+### Seller launch check
+
+Before announcing a paid API, scan the service and probe the paid path. The goal is simple: buyers should see a clean listing, a parseable `402`, and payment metadata that matches what you meant to charge.
+
+### Ongoing uptime check
+
+After deploys, run the health probe against paid endpoints. A normal uptime monitor can say the URL is alive while the x402 challenge is broken. Boundary Guard checks the part that matters for paid conversion.
+
+### Agent trust checkpoint
+
+Before an agent writes, sends, publishes, or calls another paid tool, attach a receipt. The receipt gives the operator a clean record without pretending it proves downstream work that Boundary Guard did not see.
+
+## Spend-aware usage
+
+- Run one scan before marketplace submission, then re-run only after deploys, pricing changes, manifest changes, or listing edits.
+- Use the health probe for targeted endpoint checks, not broad crawling or polling loops.
+- Cache receipts by workflow/action ID when the underlying evidence has not changed.
+- Prefer hashes, IDs, and short summaries over raw payloads in receipt requests.
+
+## Safety notes
+
+- Direct REST endpoints advertise Solana mainnet USDC and Base USDC x402 accepts.
+- Unpaid protected calls return HTTP `402` with payment metadata.
+- Health Probe v1 only checks unpaid challenge shape and advertised payment requirements.
+- Health probes reject localhost, private, internal, credentialed, redirecting, and DNS-to-non-global targets.
+- Health probes allow only unpaid `GET`, `HEAD`, and `OPTIONS` target methods.
+- Receipts prove what Boundary Guard received, hashed, and returned. They do not prove downstream real-world execution.
+- Privacy-safe analytics avoid raw request bodies, secrets, full URLs, auth headers, payment signatures, cookies, private keys, full IPs, and full user agents.
+
+## Claim boundary
+
+Boundary Guard x402 is a verification layer, not an escrow service and not a payment executor. It helps sellers avoid broken paid-path launches, helps agent builders add evidence to risky workflows, and helps marketplaces see whether a provider is ready to be routed to buyers.

--- a/providers/larrybuildsai/boundary-guard/openapi.json
+++ b/providers/larrybuildsai/boundary-guard/openapi.json
@@ -1,9 +1,9 @@
 {
   "openapi": "3.1.0",
   "info": {
-    "title": "Boundary Guard x402",
+    "title": "GateCheck by LarryBuildsAI",
     "version": "0.1.0",
-    "description": "Canonical pay-skills sidecar for Boundary Guard x402 paid buyer routes. The live service OpenAPI may expose broader documentation, discovery, MCP metadata, and launch-pack product routes; this sidecar intentionally keeps the registry surface focused on paid listing, health-probe, readiness, and receipt endpoints."
+    "description": "Canonical pay-skills sidecar for GateCheck by LarryBuildsAI paid buyer routes. The live service also exposes documentation, discovery, MCP metadata, product-card, and revenue surfaces; this sidecar focuses on paid x402 scan, health-probe, readiness, launch-pack, and receipt endpoints."
   },
   "servers": [
     {
@@ -11,280 +11,669 @@
     }
   ],
   "paths": {
-    "/v1/x402/scan?url=https%3A%2F%2Fx402-resource-scanner.vercel.app": {
+    "/v1/x402/scan": {
       "get": {
-        "summary": "Scan x402 resource readiness",
-        "description": "Scan public x402 and OpenAPI metadata for resource counts, price surfaces, listing gaps, readiness issues, and next steps.",
+        "description": "Checks public /.well-known/x402 and /openapi.json metadata, price surfaces, and optional marketplace listing staleness. Private/internal targets are rejected by default.",
         "operationId": "scanX402Resource",
         "parameters": [
           {
+            "in": "query",
             "name": "url",
-            "in": "query",
             "required": true,
-            "description": "Public service URL to scan.",
             "schema": {
-              "type": "string",
               "format": "uri",
-              "example": "https://x402-resource-scanner.vercel.app"
-            },
-            "example": "https://x402-resource-scanner.vercel.app"
-          },
-          {
-            "name": "marketplace_url",
-            "in": "query",
-            "required": false,
-            "description": "Optional marketplace listing URL to compare against the live provider metadata.",
-            "schema": {
-              "type": "string",
-              "format": "uri"
+              "type": "string"
             }
           },
           {
-            "name": "expected_resources",
             "in": "query",
+            "name": "marketplace_url",
             "required": false,
-            "description": "Optional expected resource count for readiness checks.",
             "schema": {
-              "type": "integer",
-              "minimum": 0
+              "format": "uri",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "expected_resources",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
             }
           }
         ],
         "responses": {
           "200": {
-            "description": "Readiness scan result."
+            "description": "Normalized scan report with score, issues, next steps, and payment summary"
+          },
+          "400": {
+            "description": "Invalid request, malformed target URL, or private/internal target refused"
           },
           "402": {
-            "description": "x402 payment required."
+            "description": "x402 payment required"
           }
+        },
+        "summary": "Scan x402 metadata surfaces for a target URL",
+        "tags": [
+          "x402"
+        ],
+        "x-x402-price": {
+          "amount": "0.25",
+          "asset": "USDC"
         }
       }
     },
     "/v1/x402/health/probe": {
       "post": {
-        "summary": "Probe x402 paid-path health",
-        "description": "Probe a public paid endpoint without payment, parse its 402 challenge, compare expected payment metadata, and return a health receipt. This listing is limited to safe unpaid challenge reads by default: use target or url in the JSON body with method GET, HEAD, or OPTIONS. POST target probes are disabled unless separately opted in.",
-        "operationId": "probeX402PaidPath",
+        "description": "Sends a conservative unpaid public request, parses PAYMENT-REQUIRED/accepts metadata, compares expected network/asset/price, and returns a deterministic health receipt. v1 does not sign payments or spend funds.",
+        "operationId": "probeX402PaidPathHealth",
         "requestBody": {
-          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/HealthProbeRequest"
-              },
-              "examples": {
-                "selfScan": {
-                  "value": {
-                    "target": "https://x402-resource-scanner.vercel.app/v1/x402/scan?url=https%3A%2F%2Fx402-resource-scanner.vercel.app",
-                    "method": "GET",
-                    "expected": {
-                      "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
-                      "asset": "USDC",
-                      "priceUsd": "0.25"
-                    }
+                "additionalProperties": false,
+                "properties": {
+                  "expected": {
+                    "additionalProperties": true,
+                    "properties": {
+                      "asset": {
+                        "type": "string"
+                      },
+                      "network": {
+                        "type": "string"
+                      },
+                      "priceUsd": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "method": {
+                    "default": "GET",
+                    "enum": [
+                      "GET",
+                      "HEAD",
+                      "OPTIONS"
+                    ],
+                    "type": "string"
+                  },
+                  "mode": {
+                    "default": "unpaid_402",
+                    "enum": [
+                      "unpaid_402",
+                      "metadata_only"
+                    ],
+                    "type": "string"
+                  },
+                  "target": {
+                    "format": "uri",
+                    "type": "string"
                   }
-                }
+                },
+                "required": [
+                  "target"
+                ],
+                "type": "object"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {
-            "description": "Paid-path health result."
+            "description": "Paid-path health report with receipt and payment summary"
+          },
+          "400": {
+            "description": "Invalid request, malformed target URL, private/internal target, or unsafe method"
           },
           "402": {
-            "description": "x402 payment required."
+            "description": "x402 payment required"
           }
+        },
+        "summary": "Probe an x402 paid endpoint's unpaid 402 health",
+        "tags": [
+          "x402"
+        ],
+        "x-x402-price": {
+          "amount": "0.50",
+          "asset": "USDC"
         }
       }
     },
     "/v1/x402/agent-tools/readiness": {
       "post": {
-        "summary": "Check x402 agent-tool readiness",
-        "description": "Check whether an x402 or agent-facing paid tool is ready for marketplace listing, buyer routing, and paid-path monitoring. Quick tier checks metadata; deep adds paid-path guidance when supplied; report returns launch/report guidance.",
+        "description": "Composes the existing public x402 resource scan with agent discovery checks (/llms.txt, /agents.txt, /.well-known/mcp.json, /mcp) and an optional unpaid paid-path health probe. Quick tier checks metadata and discovery; deep adds paid-path health when supplied; report adds a Markdown handoff report. No payment signatures are generated and no funds are spent by this checker.",
         "operationId": "checkAgentToolReadiness",
         "requestBody": {
-          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/ReadinessRequest"
-              },
-              "examples": {
-                "quickSelf": {
-                  "value": {
-                    "target": "https://x402-resource-scanner.vercel.app",
-                    "tier": "quick",
-                    "expected_resources": 4
+                "additionalProperties": false,
+                "properties": {
+                  "expected": {
+                    "additionalProperties": true,
+                    "type": "object"
+                  },
+                  "expected_resources": {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "marketplace_url": {
+                    "format": "uri",
+                    "type": "string"
+                  },
+                  "method": {
+                    "default": "GET",
+                    "enum": [
+                      "GET",
+                      "HEAD",
+                      "OPTIONS"
+                    ],
+                    "type": "string"
+                  },
+                  "paid_path": {
+                    "format": "uri",
+                    "type": "string"
+                  },
+                  "target": {
+                    "format": "uri",
+                    "type": "string"
+                  },
+                  "tier": {
+                    "default": "quick",
+                    "enum": [
+                      "quick",
+                      "deep",
+                      "report"
+                    ],
+                    "type": "string"
                   }
-                }
+                },
+                "required": [
+                  "target"
+                ],
+                "type": "object"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {
-            "description": "Agent-tool readiness report."
+            "description": "Agent tool readiness report with score, checks, issues, fixes, and payment summary"
           },
           "400": {
-            "description": "Invalid request or unsafe target."
+            "description": "Invalid request, malformed URL, credentialed URL, private/internal target, or unsafe method"
           },
           "402": {
-            "description": "x402 payment required."
+            "description": "x402 payment required"
+          }
+        },
+        "summary": "Check agent-tool readiness for x402 listing and buyer routing",
+        "tags": [
+          "x402"
+        ],
+        "x-bazaar": {
+          "bodyType": "json",
+          "category": "Agent Verification & Security",
+          "description": "LarryBuildsAI readiness checks for x402 and MCP paid-tool launches: public metadata, unpaid 402 probes, agent-discovery checks, launch-pack guidance, and claim boundaries before marketplace listing.",
+          "discoverable": true,
+          "docsUrl": "https://x402-resource-scanner.vercel.app/llms.txt",
+          "homepageUrl": "https://x402-resource-scanner.vercel.app",
+          "inputExample": {
+            "target": "https://x402-resource-scanner.vercel.app",
+            "tier": "quick"
+          },
+          "inputSchema": {
+            "additionalProperties": false,
+            "properties": {
+              "expected": {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              "expected_resources": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "marketplace_url": {
+                "format": "uri",
+                "type": "string"
+              },
+              "method": {
+                "default": "GET",
+                "enum": [
+                  "GET",
+                  "HEAD",
+                  "OPTIONS"
+                ],
+                "type": "string"
+              },
+              "paid_path": {
+                "format": "uri",
+                "type": "string"
+              },
+              "target": {
+                "description": "Public x402/API/MCP service URL to inspect.",
+                "format": "uri",
+                "type": "string"
+              },
+              "tier": {
+                "default": "quick",
+                "enum": [
+                  "quick",
+                  "deep",
+                  "report"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "target"
+            ],
+            "type": "object"
+          },
+          "mcpUrl": "https://x402-resource-scanner.vercel.app/mcp",
+          "method": "POST",
+          "name": "GateCheck Readiness by LarryBuildsAI",
+          "openapiUrl": "https://x402-resource-scanner.vercel.app/openapi.json",
+          "outputExample": {
+            "claimBoundaries": [
+              "Observed public metadata only; no security certification or marketplace endorsement is implied."
+            ],
+            "issues": [],
+            "ready": true,
+            "recommendedFixes": [],
+            "score": 96
+          },
+          "outputSchema": {
+            "properties": {
+              "checks": {
+                "type": "object"
+              },
+              "claimBoundaries": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "issues": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "ready": {
+                "type": "boolean"
+              },
+              "recommendedFixes": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "score": {
+                "maximum": 100,
+                "minimum": 0,
+                "type": "integer"
+              },
+              "x402Payment": {
+                "type": "object"
+              }
+            },
+            "type": "object"
+          },
+          "provider": "LarryBuildsAI",
+          "providerName": "LarryBuildsAI",
+          "providerUrl": "https://x402-resource-scanner.vercel.app",
+          "service": {
+            "aliases": [
+              "Agent Tool Readiness Checker by LarryBuildsAI",
+              "x402 Resource Scanner",
+              "x402 Launch Pack Generator"
+            ],
+            "category": "Agent Verification & Security",
+            "discoverable": true,
+            "docsUrl": "https://x402-resource-scanner.vercel.app/llms.txt",
+            "homepageUrl": "https://x402-resource-scanner.vercel.app",
+            "id": "x402-resource-scanner",
+            "legacyName": "Boundary Guard x402",
+            "mcpUrl": "https://x402-resource-scanner.vercel.app/mcp",
+            "name": "GateCheck by LarryBuildsAI",
+            "openapiUrl": "https://x402-resource-scanner.vercel.app/openapi.json",
+            "provider": "LarryBuildsAI",
+            "providerName": "LarryBuildsAI",
+            "providerUrl": "https://x402-resource-scanner.vercel.app",
+            "x402WellKnownUrl": "https://x402-resource-scanner.vercel.app/.well-known/x402"
+          },
+          "tags": [
+            "x402",
+            "MCP",
+            "agent-tools",
+            "paid-api",
+            "seller-readiness",
+            "marketplace-readiness",
+            "launch-pack"
+          ],
+          "x402WellKnownUrl": "https://x402-resource-scanner.vercel.app/.well-known/x402"
+        },
+        "x-x402-price": {
+          "amount": "1.00",
+          "asset": "USDC"
+        },
+        "x-x402-pricing-tiers": {
+          "deep": {
+            "amount": "5.00",
+            "asset": "USDC"
+          },
+          "quick": {
+            "amount": "1.00",
+            "asset": "USDC"
+          },
+          "report": {
+            "amount": "10.00",
+            "asset": "USDC"
+          }
+        }
+      }
+    },
+    "/v1/x402/launch-pack": {
+      "post": {
+        "description": "Generates listing copy, buyer FAQ, launch checklist, distribution approval notes, and claim boundaries from readiness evidence. Does not post, submit, contact prospects, sign payments, or spend funds.",
+        "operationId": "generateX402LaunchPack",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "audience": {
+                    "type": "string"
+                  },
+                  "desired_marketplaces": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "expected": {
+                    "additionalProperties": true,
+                    "type": "object"
+                  },
+                  "expected_resources": {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "marketplace_url": {
+                    "format": "uri",
+                    "type": "string"
+                  },
+                  "method": {
+                    "default": "GET",
+                    "enum": [
+                      "GET",
+                      "HEAD",
+                      "OPTIONS"
+                    ],
+                    "type": "string"
+                  },
+                  "paid_path": {
+                    "format": "uri",
+                    "type": "string"
+                  },
+                  "primary_use_case": {
+                    "type": "string"
+                  },
+                  "product_name": {
+                    "type": "string"
+                  },
+                  "target": {
+                    "format": "uri",
+                    "type": "string"
+                  },
+                  "tier": {
+                    "default": "single",
+                    "enum": [
+                      "single",
+                      "service",
+                      "premium"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "target"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "x402 launch pack with listing copy, FAQ, checklist, approval packet, report, and payment summary"
+          },
+          "400": {
+            "description": "Invalid request, malformed URL, credentialed URL, private/internal target, or unsafe method"
+          },
+          "402": {
+            "description": "x402 payment required"
+          }
+        },
+        "summary": "Generate marketplace-safe x402 launch artifacts",
+        "tags": [
+          "x402"
+        ],
+        "x-bazaar": {
+          "bodyType": "json",
+          "category": "Agent Verification & Security",
+          "description": "Generates marketplace-safe x402 launch artifacts from readiness evidence: listing copy, buyer FAQ, checklist, approval packet, and claim boundaries.",
+          "discoverable": true,
+          "docsUrl": "https://x402-resource-scanner.vercel.app/llms.txt",
+          "homepageUrl": "https://x402-resource-scanner.vercel.app",
+          "inputExample": {
+            "target": "https://x402-resource-scanner.vercel.app",
+            "tier": "single"
+          },
+          "inputSchema": {
+            "additionalProperties": false,
+            "properties": {
+              "audience": {
+                "type": "string"
+              },
+              "desired_marketplaces": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "expected": {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              "expected_resources": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "marketplace_url": {
+                "format": "uri",
+                "type": "string"
+              },
+              "method": {
+                "default": "GET",
+                "enum": [
+                  "GET",
+                  "HEAD",
+                  "OPTIONS"
+                ],
+                "type": "string"
+              },
+              "paid_path": {
+                "format": "uri",
+                "type": "string"
+              },
+              "primary_use_case": {
+                "type": "string"
+              },
+              "product_name": {
+                "type": "string"
+              },
+              "target": {
+                "description": "Public x402/API/MCP service URL to package for launch.",
+                "format": "uri",
+                "type": "string"
+              },
+              "tier": {
+                "default": "single",
+                "enum": [
+                  "single",
+                  "service",
+                  "premium"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "target"
+            ],
+            "type": "object"
+          },
+          "mcpUrl": "https://x402-resource-scanner.vercel.app/mcp",
+          "method": "POST",
+          "name": "x402 Launch Pack Generator",
+          "openapiUrl": "https://x402-resource-scanner.vercel.app/openapi.json",
+          "outputExample": {
+            "approvalPacket": {
+              "status": "draft"
+            },
+            "buyerFaq": [],
+            "claimBoundaries": [
+              "Generated pack does not post, submit listings, spend funds, or imply official endorsement."
+            ],
+            "launchChecklist": [],
+            "listingCopy": {
+              "oneLiner": "GateCheck by LarryBuildsAI: x402 readiness and launch-pack artifacts for paid API/MCP builders."
+            }
+          },
+          "outputSchema": {
+            "properties": {
+              "approvalPacket": {
+                "type": "object"
+              },
+              "buyerFaq": {
+                "type": "array"
+              },
+              "claimBoundaries": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "launchChecklist": {
+                "type": "array"
+              },
+              "listingCopy": {
+                "type": "object"
+              },
+              "x402Payment": {
+                "type": "object"
+              }
+            },
+            "type": "object"
+          },
+          "provider": "LarryBuildsAI",
+          "providerName": "LarryBuildsAI",
+          "providerUrl": "https://x402-resource-scanner.vercel.app",
+          "service": {
+            "aliases": [
+              "Agent Tool Readiness Checker by LarryBuildsAI",
+              "x402 Resource Scanner",
+              "x402 Launch Pack Generator"
+            ],
+            "category": "Agent Verification & Security",
+            "discoverable": true,
+            "docsUrl": "https://x402-resource-scanner.vercel.app/llms.txt",
+            "homepageUrl": "https://x402-resource-scanner.vercel.app",
+            "id": "x402-resource-scanner",
+            "legacyName": "Boundary Guard x402",
+            "mcpUrl": "https://x402-resource-scanner.vercel.app/mcp",
+            "name": "GateCheck by LarryBuildsAI",
+            "openapiUrl": "https://x402-resource-scanner.vercel.app/openapi.json",
+            "provider": "LarryBuildsAI",
+            "providerName": "LarryBuildsAI",
+            "providerUrl": "https://x402-resource-scanner.vercel.app",
+            "x402WellKnownUrl": "https://x402-resource-scanner.vercel.app/.well-known/x402"
+          },
+          "tags": [
+            "x402",
+            "MCP",
+            "agent-tools",
+            "paid-api",
+            "seller-readiness",
+            "marketplace-readiness",
+            "launch-pack"
+          ],
+          "x402WellKnownUrl": "https://x402-resource-scanner.vercel.app/.well-known/x402"
+        },
+        "x-x402-price": {
+          "amount": "9.00",
+          "asset": "USDC"
+        },
+        "x-x402-pricing-tiers": {
+          "premium": {
+            "amount": "49.00",
+            "asset": "USDC"
+          },
+          "service": {
+            "amount": "29.00",
+            "asset": "USDC"
+          },
+          "single": {
+            "amount": "9.00",
+            "asset": "USDC"
           }
         }
       }
     },
     "/v1/receipts/check": {
       "post": {
-        "summary": "Create Boundary Guard receipt",
-        "description": "Create a deterministic receipt from request metadata, policy outcome, result summary, payment evidence, and claim boundaries.",
         "operationId": "createBoundaryGuardReceipt",
         "requestBody": {
-          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/ReceiptRequest"
-              },
-              "examples": {
-                "basic": {
-                  "value": {
-                    "request": {
-                      "action": "x402_launch_check",
-                      "target": "https://seller.example/v1/paid"
-                    },
-                    "policy": {
-                      "decision": "allow_after_payment_metadata_check"
-                    },
-                    "result": {
-                      "status": "checked",
-                      "summary": "Unpaid 402 challenge was parseable."
-                    }
-                  }
-                }
+                "type": "object"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {
-            "description": "Receipt response."
+            "description": "Receipt evidence document"
+          },
+          "400": {
+            "description": "Invalid request"
           },
           "402": {
-            "description": "x402 payment required."
+            "description": "x402 payment required"
           }
-        }
-      }
-    }
-  },
-  "components": {
-    "schemas": {
-      "HealthProbeRequest": {
-        "type": "object",
-        "required": [
-          "target"
+        },
+        "summary": "Create a Boundary Guard-style receipt for request/policy/result evidence",
+        "tags": [
+          "x402"
         ],
-        "properties": {
-          "target": {
-            "type": "string",
-            "format": "uri",
-            "description": "Public paid endpoint to probe. The live service also accepts url as an alias."
-          },
-          "method": {
-            "type": "string",
-            "enum": [
-              "GET",
-              "HEAD",
-              "OPTIONS"
-            ],
-            "default": "GET"
-          },
-          "expected": {
-            "type": "object",
-            "properties": {
-              "network": {
-                "type": "string"
-              },
-              "asset": {
-                "type": "string"
-              },
-              "priceUsd": {
-                "type": "string"
-              }
-            }
-          }
-        }
-      },
-      "ReceiptRequest": {
-        "type": "object",
-        "required": [
-          "request"
-        ],
-        "properties": {
-          "request": {
-            "type": "object"
-          },
-          "policy": {
-            "type": "object"
-          },
-          "result": {
-            "type": "object"
-          },
-          "payment": {
-            "type": "object"
-          }
-        }
-      },
-      "ReadinessRequest": {
-        "type": "object",
-        "required": [
-          "target"
-        ],
-        "properties": {
-          "target": {
-            "type": "string",
-            "format": "uri"
-          },
-          "tier": {
-            "type": "string",
-            "enum": [
-              "quick",
-              "deep",
-              "report"
-            ],
-            "default": "quick"
-          },
-          "marketplace_url": {
-            "type": "string",
-            "format": "uri"
-          },
-          "expected_resources": {
-            "type": "integer",
-            "minimum": 0
-          },
-          "paid_path": {
-            "type": "string",
-            "format": "uri"
-          },
-          "method": {
-            "type": "string",
-            "enum": [
-              "GET",
-              "HEAD",
-              "OPTIONS"
-            ],
-            "default": "GET"
-          },
-          "expected": {
-            "type": "object"
-          }
+        "x-x402-price": {
+          "amount": "0.05",
+          "asset": "USDC"
         }
       }
     }
   },
   "externalDocs": {
-    "description": "Live public docs and agent-readable discovery for Boundary Guard x402",
+    "description": "Live public docs, discovery, and agent-readable product surfaces for GateCheck by LarryBuildsAI",
     "url": "https://x402-resource-scanner.vercel.app/llms.txt"
   }
 }

--- a/providers/larrybuildsai/boundary-guard/openapi.json
+++ b/providers/larrybuildsai/boundary-guard/openapi.json
@@ -281,5 +281,9 @@
         }
       }
     }
+  },
+  "externalDocs": {
+    "description": "Live public docs and agent-readable discovery for Boundary Guard x402",
+    "url": "https://x402-resource-scanner.vercel.app/llms.txt"
   }
 }

--- a/providers/larrybuildsai/boundary-guard/openapi.json
+++ b/providers/larrybuildsai/boundary-guard/openapi.json
@@ -1,0 +1,285 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Boundary Guard x402",
+    "version": "0.1.0",
+    "description": "Revenue-safety checks for x402 sellers and agent builders: scan paid APIs before listing, probe unpaid 402 challenges, and attach receipts to risky agent actions."
+  },
+  "servers": [
+    {
+      "url": "https://x402-resource-scanner.vercel.app"
+    }
+  ],
+  "paths": {
+    "/v1/x402/scan?url=https%3A%2F%2Fx402-resource-scanner.vercel.app": {
+      "get": {
+        "summary": "Scan x402 resource readiness",
+        "description": "Scan public x402 and OpenAPI metadata for resource counts, price surfaces, listing gaps, readiness issues, and next steps.",
+        "operationId": "scanX402Resource",
+        "parameters": [
+          {
+            "name": "url",
+            "in": "query",
+            "required": true,
+            "description": "Public service URL to scan.",
+            "schema": {
+              "type": "string",
+              "format": "uri",
+              "example": "https://x402-resource-scanner.vercel.app"
+            },
+            "example": "https://x402-resource-scanner.vercel.app"
+          },
+          {
+            "name": "marketplace_url",
+            "in": "query",
+            "required": false,
+            "description": "Optional marketplace listing URL to compare against the live provider metadata.",
+            "schema": {
+              "type": "string",
+              "format": "uri"
+            }
+          },
+          {
+            "name": "expected_resources",
+            "in": "query",
+            "required": false,
+            "description": "Optional expected resource count for readiness checks.",
+            "schema": {
+              "type": "integer",
+              "minimum": 0
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Readiness scan result."
+          },
+          "402": {
+            "description": "x402 payment required."
+          }
+        }
+      }
+    },
+    "/v1/x402/health/probe": {
+      "post": {
+        "summary": "Probe x402 paid-path health",
+        "description": "Probe a public paid endpoint without payment, parse its 402 challenge, compare expected payment metadata, and return a health receipt.",
+        "operationId": "probeX402PaidPath",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HealthProbeRequest"
+              },
+              "examples": {
+                "selfScan": {
+                  "value": {
+                    "target": "https://x402-resource-scanner.vercel.app/v1/x402/scan?url=https%3A%2F%2Fx402-resource-scanner.vercel.app",
+                    "method": "GET",
+                    "expected": {
+                      "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                      "asset": "USDC",
+                      "priceUsd": "0.25"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Paid-path health result."
+          },
+          "402": {
+            "description": "x402 payment required."
+          }
+        }
+      }
+    },
+    "/v1/x402/agent-tools/readiness": {
+      "post": {
+        "summary": "Check x402 agent-tool readiness",
+        "description": "Check whether an x402 or agent-facing paid tool is ready for marketplace listing, buyer routing, and paid-path monitoring. Quick tier checks metadata; deep adds paid-path guidance when supplied; report returns launch/report guidance.",
+        "operationId": "checkAgentToolReadiness",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReadinessRequest"
+              },
+              "examples": {
+                "quickSelf": {
+                  "value": {
+                    "target": "https://x402-resource-scanner.vercel.app",
+                    "tier": "quick",
+                    "expected_resources": 4
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Agent-tool readiness report."
+          },
+          "400": {
+            "description": "Invalid request or unsafe target."
+          },
+          "402": {
+            "description": "x402 payment required."
+          }
+        }
+      }
+    },
+    "/v1/receipts/check": {
+      "post": {
+        "summary": "Create Boundary Guard receipt",
+        "description": "Create a deterministic receipt from request metadata, policy outcome, result summary, payment evidence, and claim boundaries.",
+        "operationId": "createBoundaryGuardReceipt",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReceiptRequest"
+              },
+              "examples": {
+                "basic": {
+                  "value": {
+                    "request": {
+                      "action": "x402_launch_check",
+                      "target": "https://seller.example/v1/paid"
+                    },
+                    "policy": {
+                      "decision": "allow_after_payment_metadata_check"
+                    },
+                    "result": {
+                      "status": "checked",
+                      "summary": "Unpaid 402 challenge was parseable."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Receipt response."
+          },
+          "402": {
+            "description": "x402 payment required."
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "HealthProbeRequest": {
+        "type": "object",
+        "required": [
+          "target"
+        ],
+        "properties": {
+          "target": {
+            "type": "string",
+            "format": "uri"
+          },
+          "method": {
+            "type": "string",
+            "enum": [
+              "GET",
+              "HEAD",
+              "OPTIONS"
+            ],
+            "default": "GET"
+          },
+          "expected": {
+            "type": "object",
+            "properties": {
+              "network": {
+                "type": "string"
+              },
+              "asset": {
+                "type": "string"
+              },
+              "priceUsd": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "ReceiptRequest": {
+        "type": "object",
+        "required": [
+          "request"
+        ],
+        "properties": {
+          "request": {
+            "type": "object"
+          },
+          "policy": {
+            "type": "object"
+          },
+          "result": {
+            "type": "object"
+          },
+          "payment": {
+            "type": "object"
+          }
+        }
+      },
+      "ReadinessRequest": {
+        "type": "object",
+        "required": [
+          "target"
+        ],
+        "properties": {
+          "target": {
+            "type": "string",
+            "format": "uri"
+          },
+          "tier": {
+            "type": "string",
+            "enum": [
+              "quick",
+              "deep",
+              "report"
+            ],
+            "default": "quick"
+          },
+          "marketplace_url": {
+            "type": "string",
+            "format": "uri"
+          },
+          "expected_resources": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "paid_path": {
+            "type": "string",
+            "format": "uri"
+          },
+          "method": {
+            "type": "string",
+            "enum": [
+              "GET",
+              "HEAD",
+              "OPTIONS"
+            ],
+            "default": "GET"
+          },
+          "expected": {
+            "type": "object"
+          }
+        }
+      }
+    }
+  }
+}

--- a/providers/larrybuildsai/boundary-guard/openapi.json
+++ b/providers/larrybuildsai/boundary-guard/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Boundary Guard x402",
     "version": "0.1.0",
-    "description": "Revenue-safety checks for x402 sellers and agent builders: scan paid APIs before listing, probe unpaid 402 challenges, and attach receipts to risky agent actions."
+    "description": "Canonical pay-skills sidecar for Boundary Guard x402 paid buyer routes. The live service OpenAPI may expose broader documentation, discovery, MCP metadata, and launch-pack product routes; this sidecar intentionally keeps the registry surface focused on paid listing, health-probe, readiness, and receipt endpoints."
   },
   "servers": [
     {
@@ -63,7 +63,7 @@
     "/v1/x402/health/probe": {
       "post": {
         "summary": "Probe x402 paid-path health",
-        "description": "Probe a public paid endpoint without payment, parse its 402 challenge, compare expected payment metadata, and return a health receipt.",
+        "description": "Probe a public paid endpoint without payment, parse its 402 challenge, compare expected payment metadata, and return a health receipt. This listing is limited to safe unpaid challenge reads by default: use target or url in the JSON body with method GET, HEAD, or OPTIONS. POST target probes are disabled unless separately opted in.",
         "operationId": "probeX402PaidPath",
         "requestBody": {
           "required": true,
@@ -188,7 +188,8 @@
         "properties": {
           "target": {
             "type": "string",
-            "format": "uri"
+            "format": "uri",
+            "description": "Public paid endpoint to probe. The live service also accepts url as an alias."
           },
           "method": {
             "type": "string",


### PR DESCRIPTION
## Summary

Refreshes `larrybuildsai/boundary-guard` as the GateCheck by LarryBuildsAI pay-skills provider listing.

GateCheck is a paid preflight layer for x402 sellers, MCP publishers, and tool marketplaces. It checks public listing/readiness metadata, verifies unpaid `402` payment challenge shape, scores agent-tool launch readiness, generates launch-pack artifacts, and creates bounded receipts.

The provider slug remains `larrybuildsai/boundary-guard` to preserve existing registry and xpay references. Buyer-facing title/copy is GateCheck by LarryBuildsAI.

## Public surfaces

- Service: https://x402-resource-scanner.vercel.app
- OpenAPI: https://x402-resource-scanner.vercel.app/openapi.json
- x402 manifest: https://x402-resource-scanner.vercel.app/.well-known/x402
- MCP discovery: https://x402-resource-scanner.vercel.app/.well-known/mcp.json
- Glama metadata: https://x402-resource-scanner.vercel.app/.well-known/glama.json
- Product card: https://x402-resource-scanner.vercel.app/product-card.md
- Agent docs: https://x402-resource-scanner.vercel.app/llms.txt
- Agent skill: https://x402-resource-scanner.vercel.app/skill.md

## Changed files

- `providers/larrybuildsai/boundary-guard/PAY.md`
- `providers/larrybuildsai/boundary-guard/openapi.json`

The sidecar OpenAPI focuses on paid buyer routes: scan, health probe, readiness, launch pack, and receipt.

## Validation

```text
npx -y @solana/pay catalog check providers/larrybuildsai/boundary-guard/PAY.md -v

Solana-compat verdict
PASS providers/larrybuildsai/boundary-guard (4/4)
  OK POST v1/receipts/check paid via x402 (ok)
  OK POST v1/x402/agent-tools/readiness paid via x402 (ok)
  OK POST v1/x402/health/probe paid via x402 (ok)
  OK POST v1/x402/launch-pack paid via x402 (ok)
  ?  GET v1/x402/scan server rejected empty/dummy body before paywall (unprobeable_needs_body)
PAY.md check successful
5 endpoints tested across 1 provider
4/4 gates compatible with Solana
```

## Safety / claim boundary

- Health probes are unpaid checks of `402` challenge shape and advertised payment requirements; they do not sign payments or prove downstream settlement.
- Health probes reject localhost/private/internal/credentialed/redirecting targets and DNS-to-non-global targets.
- Launch packs generate copy and review artifacts only; they do not post, submit, contact prospects, sign payments, or spend funds.
- Receipt endpoints store hashes, IDs, and safe summaries only; no secrets, auth headers, raw payer data, payment signatures, cookies, private keys, or customer data are required.
