### PR TITLE
feat(clustly): add tipping provider

### DIFF
--- a/providers/clustly/tipping/PAY.md
+++ b/providers/clustly/tipping/PAY.md
@@ -1,0 +1,46 @@
+---
+name: tipping
+title: "Clustly"
+description: "Tip any X (Twitter) handle in Solana USDC via x402. Registered Clustly users receive directly to their linked Solana wallet; unregistered handles are escrowed in a Privy-custodied placeholder pocket the recipient can claim later via X OAuth."
+use_case: "Use for paying any X handle in USDC without a wallet address, tipping content, micropayments, programmatic rewards, agent-to-agent payouts, and routing funds to recipients who do not yet have a crypto wallet."
+category: finance
+service_url: https://clustly.ai
+openapi:
+  url: https://clustly.ai/openapi.json
+---
+
+Agent-native tipping API. Pay any X handle in Solana USDC. The endpoint
+handles recipient lookup, on-chain USDC ATA setup, and (for unregistered
+handles) a Privy-custodied placeholder pocket the recipient can claim
+later via X OAuth.
+
+`GET /api/v1/tip/x402/{recipient}?amount={USDC}` is x402-gated. The first
+GET returns `402 Payment Required` with payment requirements; sign the
+SPL transfer per the challenge and retry with the `PAYMENT-SIGNATURE`
+header to settle.
+
+The signed amount is the tip plus a small first-time wallet-setup
+surcharge (~$0.20 USDC, SOL-oracle priced) when the recipient's USDC ATA
+does not exist yet. The surcharge is disclosed in the challenge
+`description` so the tipper consents to the exact amount the wallet will
+sign.
+
+The 402 challenge `extra` block carries machine-readable hints:
+`recipient_status` (`registered` | `pocket`) and `claim_url` (placeholder
+tips only). Branch on these in code; the `description` text is for
+humans.
+
+## Spend-aware usage
+
+- Read `recipient_status` from the 402 challenge's `extra` block to
+  branch programmatically. `pocket` means the recipient has no Clustly
+  account yet; the tip is held in escrow.
+- When `recipient_status` is `pocket`, surface the `claim_url` back to
+  the user so they can notify the recipient out of band (e.g. by
+  posting the link in reply).
+- The `description` field discloses any first-time wallet-setup
+  surcharge baked into the signed amount. Check it before approving the
+  payment.
+- Self-tips are rejected (400) — checked against both the Clustly
+  handle and the on-chain sender pubkey.
+- Amount is capped at 10000 USDC per tip; minimum is 0.000001 USDC.


### PR DESCRIPTION
## Summary

Adds Clustly's x402 tipping endpoint to the catalog. Single agent surface: `GET https://clustly.ai/api/v1/tip/x402/{recipient}?amount={USDC}`. The endpoint pays any X (Twitter) handle in Solana USDC — registered Clustly users receive directly to their linked Solana wallet, unregistered handles are escrowed in a Privy-custodied placeholder pocket the recipient can claim later via X OAuth.

The 402 challenge's `extra` block carries machine-readable hints:
- `recipient_status`: `registered` | `pocket`
- `claim_url`: present only for placeholder tips, so the agent can surface the claim link back to the user

The signed amount includes a first-time wallet-setup surcharge (~\$0.20 USDC, SOL-oracle priced) when the recipient's USDC ATA does not exist on-chain. The surcharge is fully disclosed in the challenge `description` so the tipper consents to the exact amount the wallet will sign.

## Validation

Local `pay catalog check providers/clustly/tipping/PAY.md --currencies USDC -v`:

\`\`\`
✓ PAY.md check successful
✓ 1 endpoint tested across 1 provider

Solana-compat verdict
PASS  clustly/tipping  (0/0)
  ?  GET api/v1/tip/x402/{recipient}  server rejected empty/dummy body before paywall (unprobeable_needs_body)
\`\`\`

The endpoint is labeled `unprobeable_needs_body` because the route's input validation rejects the prober's literal `{recipient}` path value with HTTP 400 before reaching the x402 paywall — same pattern as `purch/marketplace`. End-to-end x402 settlement has been verified manually:

\`\`\`
$ pay --mainnet curl "https://clustly.ai/api/v1/tip/x402/proxyszn_?amount=0.01"
{"tip_id":"...","tx_hash":"2YiA6xU7msrdFfkdYw7kqcxibEWYaLGX4AoPb1hMtik9JgrrdqmtrgJLsQYp1dGXAWqVvjBWxHgBNXgsRaFREzeS","recipient_handle":"proxyszn_","recipient_status":"registered","amount":0.01,"status":"confirmed","duplicate":false}
\`\`\`

## OpenAPI

Served at https://clustly.ai/openapi.json — describes the single agent endpoint, the x402 v2 challenge response, and the settled tip receipt. Includes `example` values on path/query params so future improvements to the catalog prober can substitute a real handle.

The free `POST /api/v1/tip/resolve` helper is intentionally not listed. Agents already get `recipient_status` + `claim_url` + signed amount from the 402 challenge's `extra` block, so the helper would only add noise. It stays live for the Clustly web UI's live-status indicator.