### PR TITLE
Add crypterian/score — cross-chain agent-wallet credit bureau

### DIFF
--- a/providers/crypterian/score/PAY.md
+++ b/providers/crypterian/score/PAY.md
@@ -1,0 +1,45 @@
+---
+name: score
+title: "Crypterian — agent-wallet credit score"
+description: "Credit bureau for autonomous agents. Pay $0.001 USDC to query a calibrated 0-100 reliability score, tier (S/A/B/C/D/unranked), confidence, txn_count, and last_seen for any on-chain agent wallet — Base ERC-4337 smart accounts and Solana agent-controlled wallets."
+use_case: "Use for filtering inbound agent traffic by demonstrated reliability, screening counterparty wallets before paid x402 calls, scoring smart accounts before high-value automation, and triaging fraud or low-quality agents on Base and Solana. Returns tier='unranked' honestly when observed activity is insufficient — never fabricated."
+category: data
+service_url: https://crypterian.io
+openapi:
+  url: https://crypterian.io/openapi.json
+---
+
+Crypterian is a cross-chain credit bureau for autonomous agents. It indexes
+on-chain agent-wallet activity continuously (Base ERC-4337 UserOperationEvents
+every 5 min, Solana receiver-watching via Helius hourly) and exposes a single
+paid endpoint that returns a calibrated reliability score.
+
+The scoring formula is deliberately simple and publicly committed: success
+rate, recency, transaction volume, and paymaster quality, with a 45-day
+exponential decay for inactivity. Wallets with fewer than 100 observed
+events return `tier: "unranked"` regardless of score — Crypterian does not
+fabricate signal where evidence is thin.
+
+Payment is x402 USDC at $0.001 per call. The 402 response advertises both
+Base Sepolia and Solana devnet payment options today (mainnet payTos move
+in once EIN clears). Buyers pay with whichever chain they hold USDC on;
+the score returned is independent of the payment chain — wallet format
+auto-detects which chain the queried address lives on.
+
+## Spend-aware usage
+
+- **Cache results within a session.** Scores update at most hourly per
+  wallet. If you've queried `0xabc…` recently in the same task, reuse the
+  cached value instead of re-paying.
+- **Skip the call when `txn_count < 100`.** Crypterian returns
+  `tier: "unranked"` for low-volume wallets and the score has limited
+  decisional value at that confidence. Use it as a filter input only when
+  the wallet's reliability matters more than a few cents per check.
+- **Batch by wallet, not by route.** The endpoint takes one wallet per
+  request — there is no bulk variant. For sweeps over many wallets, prefer
+  pre-filtering candidates on `txn_count` proxies (your own usage logs)
+  before paying for the full score.
+- **Treat `score: null` as "unobserved", not "bad".** A null score means
+  Crypterian has never indexed activity for that wallet; it is silent, not
+  negative. Decide whether you weight unknown-wallet traffic conservatively
+  on the consumer side.


### PR DESCRIPTION
## Summary

- New `providers/crypterian/score/PAY.md` for **Crypterian** — an x402-paywalled credit bureau for autonomous agents.
- OpenAPI 3.1 spec at `https://crypterian.io/openapi.json`.
- Single endpoint `GET /score/{wallet}` — \$0.001 USDC per call.
- Cross-chain: accepts payment on Base Sepolia (\`eip155:84532\`) **or** Solana devnet (\`solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1\`). Wallet format auto-detects which chain to look up the score on (Base \`0x…\` vs Solana base58).
- Category: \`data\`. Use case: filtering agent traffic, screening counterparty wallets, fraud triage on Base + Solana.

## What it does

Indexes on-chain activity for ERC-4337 smart accounts on Base (every 5 min via EntryPoint v0.6 + v0.7 logs) and agent-controlled wallets on Solana (hourly receiver-watching via Helius Enhanced). Computes a calibrated 0-100 reliability score per the formula in [docs](https://crypterian.io/methodology) — success rate, recency, txn volume, paymaster quality, 45-day exp decay.

Wallets with <100 observed events return \`tier: "unranked"\` regardless of score — the project's stance is "don't fabricate signal without evidence."

## Validation

- [x] \`category\` is one of the 18 allowed values (\`data\`)
- [x] \`use_case\` ≥ 32 chars, starts with "Use for"
- [x] \`description\` within 64-255 chars, says *what* the service does
- [x] \`service_url\` is production HTTPS
- [x] OpenAPI doc reachable at the declared URL
- [x] Live x402 endpoint returns 402 with correct \`accepts[]\` shape (both chains)

## Test plan

- [ ] \`pay catalog check providers/crypterian/score/PAY.md\` runs clean (will run locally before merge)
- [ ] Endpoint reachable: \`curl -I https://crypterian.io/score/0xabcdef1234567890abcdef1234567890abcdef12\` returns 402
- [ ] Payment-Required header decodes to valid x402 v2 payload with Base + Solana \`accepts\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)