### PR TITLE
Add AgentLair — agent identity, trust scoring, and email

### DIFF
--- a/providers/agentlair/email/PAY.md
+++ b/providers/agentlair/email/PAY.md
@@ -11,18 +11,30 @@ openapi:
 
 Agent-native email. Claim addresses, send and receive email, with verifiable agent identity on each message.
 
-Each email address is claimed programmatically and cryptographically bound to the agent's identity (Agent Auth Token). Outbound emails carry verifiable sender metadata so recipients can confirm the message came from a specific agent identity.
+Each email address is claimed programmatically and cryptographically bound to the agent's identity. Outbound emails carry verifiable sender metadata so recipients can confirm the message came from a specific agent identity.
 
 ## Key endpoints
 
 - `POST /v1/email/claim` — claim a dedicated address for this agent (no human setup required)
-- `POST /v1/email/send` — send an email from a claimed address (0.01 USDC via x402 beyond free tier)
-- `GET /v1/email/inbox` — read inbound messages for a claimed address
-- `GET /v1/email/addresses` — list all claimed addresses for this agent
+- `POST /v1/email/send` — send an email from a claimed address
+- `GET /v1/email/inbox` — read inbound messages
+- `GET /v1/email/addresses` — list all addresses claimed by this agent
+
+## Calling order
+
+These endpoints are auth-gated, so a no-payment probe sees `401` before any payment challenge. The order for a paying agent is:
+
+1. **Get an API key.** Sign up at `https://agentlair.dev` and obtain a key (`al_live_...`). Pass it on every call as `Authorization: Bearer al_live_...`.
+2. **Claim an address.** `POST /v1/email/claim` returns the agent's permanent `@agentlair.dev` address. Free, one address per agent.
+3. **Send within the free tier.** First 10 sends/day (5/hour) per agent return `200`/`201` with no payment required.
+4. **x402 challenge above the free tier.** Once the limit is exhausted, `POST /v1/email/send` returns `402` with a v2 challenge: `0.01 USDC` on Base mainnet (`eip155:8453`), facilitator `ultravioletadao.xyz`.
+5. **Pay and retry.** Sign the EIP-3009 authorization, retry with `X-PAYMENT: <base64>`. The send goes through and the receipt is in `X-Payment-Response`.
+
+Inbox reads (`GET /v1/email/inbox`, `GET /v1/email/messages/{id}`) are auth-gated but free.
 
 ## Spend-aware usage
 
 - Claim one address per agent identity. Reuse it across tasks — do not claim new addresses for each workflow.
-- The free tier allows 10 sends per day and 5 per hour. x402 payments (0.01 USDC each) bypass rate limits when the agent needs to send more.
-- Read `GET /v1/email/inbox` with a limit parameter before fetching individual messages. Only fetch message bodies you need.
-- Send from claimed addresses only. Unclaimed addresses will be rejected.
+- Stay inside the free tier when possible. 10 sends/day covers most workflows; pay only for burst.
+- Read `GET /v1/email/inbox` with a `limit` parameter, then fetch only the message bodies you need.
+- Send from claimed addresses only. Unclaimed addresses are rejected before the paywall.

--- a/providers/agentlair/email/PAY.md
+++ b/providers/agentlair/email/PAY.md
@@ -1,0 +1,28 @@
+---
+name: email
+title: "AgentLair Email"
+description: "Agent-native email with built-in identity. Claim dedicated email addresses for AI agents, send outbound email, and read inbound messages — all with verifiable sender identity and no manual account setup."
+use_case: "Use when an agent needs its own email address for outbound communication, receiving replies, or participating in email-based workflows. Unlike generic email APIs, each address is cryptographically bound to an agent identity."
+category: messaging
+service_url: https://agentlair.dev
+openapi:
+  url: https://agentlair.dev/api
+---
+
+Agent-native email. Claim addresses, send and receive email, with verifiable agent identity on each message.
+
+Each email address is claimed programmatically and cryptographically bound to the agent's identity (Agent Auth Token). Outbound emails carry verifiable sender metadata so recipients can confirm the message came from a specific agent identity.
+
+## Key endpoints
+
+- `POST /v1/email/claim` — claim a dedicated address for this agent (no human setup required)
+- `POST /v1/email/send` — send an email from a claimed address (0.01 USDC via x402 beyond free tier)
+- `GET /v1/email/inbox` — read inbound messages for a claimed address
+- `GET /v1/email/addresses` — list all claimed addresses for this agent
+
+## Spend-aware usage
+
+- Claim one address per agent identity. Reuse it across tasks — do not claim new addresses for each workflow.
+- The free tier allows 10 sends per day and 5 per hour. x402 payments (0.01 USDC each) bypass rate limits when the agent needs to send more.
+- Read `GET /v1/email/inbox` with a limit parameter before fetching individual messages. Only fetch message bodies you need.
+- Send from claimed addresses only. Unclaimed addresses will be rejected.

--- a/providers/agentlair/trust/PAY.md
+++ b/providers/agentlair/trust/PAY.md
@@ -1,7 +1,7 @@
 ---
 name: trust
 title: "AgentLair"
-description: "Agent identity and behavioral trust scoring. Query real-time trust scores for AI agents, verify agent tokens, and look up agent identities without an account or API key."
+description: "Agent identity and behavioral trust scoring. Query real-time trust scores for AI agents, verify agent tokens, and look up agent identities. Score and token introspection are free; name discovery is x402 pay-per-request."
 use_case: "Use when you need to verify the identity of an AI agent, check its behavioral reputation before granting access or permissions, introspect an Agent Auth Token (AAT) to validate claims, or discover registered agents by name."
 category: identity
 service_url: https://agentlair.dev
@@ -9,19 +9,26 @@ openapi:
   url: https://agentlair.dev/api
 ---
 
-Agent identity infrastructure. Trust scores, token verification, and agent discovery — all pay-per-request via x402 on Base.
+Agent identity infrastructure. Trust scores, token verification, and agent discovery.
 
 AgentLair provides the identity and trust layer for autonomous agents: each agent gets a verifiable identity (Agent Auth Token, EdDSA JWT), a behavioral track record, and a reputation score derived from observed behavior across interactions.
 
 ## Key endpoints
 
-- `GET /v1/trust/{agentId}` — real-time behavioral trust score (0–1000) for any registered agent
-- `POST /v1/tokens/introspect` — verify and decode an Agent Auth Token per RFC 7662
-- `GET /agents/{name}` — discover an agent by name, returns identity metadata
+- `GET /v1/trust/{agentId}` — real-time behavioral trust score (0–1000) for any registered agent. **Free public read.**
+- `POST /v1/tokens/introspect` — verify and decode an Agent Auth Token per RFC 7662. **Free public read.**
+- `GET /agents/{name}` (alias `GET /v1/agents/lookup?handle=…`) — discover an agent by name. **Paid: 0.005 USDC via x402 on Base mainnet (`eip155:8453`).**
+
+## Calling order
+
+A no-payment probe of the free endpoints returns the response directly (`200` for valid input, `400` for invalid format). Only `/agents/{name}` returns a `402` challenge:
+
+1. **Score and introspection are free.** Call `GET /v1/trust/{agentId}` and `POST /v1/tokens/introspect` without payment. `agentId` must be `acc_<alphanumeric>`; introspection follows RFC 7662 (returns `{"active": false}` for unknown tokens).
+2. **Name lookup is paid.** `GET /agents/{name}` returns `402` with an x402 v2 challenge: `0.005 USDC` on Base mainnet, facilitator `ultravioletadao.xyz`. Pay and retry with `X-PAYMENT: <base64>`.
 
 ## Spend-aware usage
 
-- Call `GET /v1/trust/{agentId}` when you need a fresh score. Cache the result for the same agent within a session — behavioral scores change slowly.
+- Call `GET /v1/trust/{agentId}` directly when you need a fresh score — no payment required. Cache the result for the same agent within a session; behavioral scores change slowly.
 - Use `POST /v1/tokens/introspect` to verify untrusted agent tokens before granting elevated access. One call per token is enough; introspection results are stable for the token lifetime.
-- Prefer `GET /agents/{name}` for human-readable lookups; use `GET /v1/trust/{agentId}` with the returned `agent_id` for follow-up score queries.
+- For human-readable lookups, `GET /agents/{name}` returns the `acc_…` id and metadata for a paid call; then use `GET /v1/trust/{agentId}` (free) for the score. Cache the name→id mapping to avoid repeated lookups.
 - A score above 700 generally indicates an established agent with consistent behavior. Treat scores below 300 as untrusted.

--- a/providers/agentlair/trust/PAY.md
+++ b/providers/agentlair/trust/PAY.md
@@ -1,0 +1,27 @@
+---
+name: trust
+title: "AgentLair"
+description: "Agent identity and behavioral trust scoring. Query real-time trust scores for AI agents, verify agent tokens, and look up agent identities without an account or API key."
+use_case: "Use when you need to verify the identity of an AI agent, check its behavioral reputation before granting access or permissions, introspect an Agent Auth Token (AAT) to validate claims, or discover registered agents by name."
+category: identity
+service_url: https://agentlair.dev
+openapi:
+  url: https://agentlair.dev/api
+---
+
+Agent identity infrastructure. Trust scores, token verification, and agent discovery — all pay-per-request via x402 on Base.
+
+AgentLair provides the identity and trust layer for autonomous agents: each agent gets a verifiable identity (Agent Auth Token, EdDSA JWT), a behavioral track record, and a reputation score derived from observed behavior across interactions.
+
+## Key endpoints
+
+- `GET /v1/trust/{agentId}` — real-time behavioral trust score (0–1000) for any registered agent
+- `POST /v1/tokens/introspect` — verify and decode an Agent Auth Token per RFC 7662
+- `GET /agents/{name}` — discover an agent by name, returns identity metadata
+
+## Spend-aware usage
+
+- Call `GET /v1/trust/{agentId}` when you need a fresh score. Cache the result for the same agent within a session — behavioral scores change slowly.
+- Use `POST /v1/tokens/introspect` to verify untrusted agent tokens before granting elevated access. One call per token is enough; introspection results are stable for the token lifetime.
+- Prefer `GET /agents/{name}` for human-readable lookups; use `GET /v1/trust/{agentId}` with the returned `agent_id` for follow-up score queries.
+- A score above 700 generally indicates an established agent with consistent behavior. Treat scores below 300 as untrusted.


### PR DESCRIPTION
## What is AgentLair?

AgentLair is an identity infrastructure layer for AI agents: verifiable identities (Agent Auth Tokens, EdDSA JWTs), behavioral trust scores, and agent-native email addresses — all pay-per-request via x402 v2 on Base mainnet.

Live at https://agentlair.dev · OpenAPI: https://agentlair.dev/api

## Services added

### `providers/agentlair/trust` (category: identity)
- `GET /v1/trust/{agentId}` — behavioral trust score (0–1000) per agent
- `POST /v1/tokens/introspect` — verify Agent Auth Tokens per RFC 7662
- `GET /agents/{name}` — discover agents by name

### `providers/agentlair/email` (category: messaging)
- `POST /v1/email/claim` — claim a dedicated address for this agent
- `POST /v1/email/send` — send email (0.01 USDC via x402 beyond free tier)
- `GET /v1/email/inbox` — read inbound messages

## x402 integration

- **Spec:** x402-specification-v2
- **Network:** Base mainnet (eip155:8453)
- **Asset:** USDC (`0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`)
- **Facilitator:** ultravioletadao.xyz