### PR TITLE
Add PayAPI Market aggregator listing

### DIFF
--- a/aggregators/payapi-market.md
+++ b/aggregators/payapi-market.md
@@ -1,0 +1,9 @@
+---
+name: payapi-market
+title: "PayAPI Market"
+description: "An x402-powered marketplace for pay-per-request APIs on Base mainnet, covering UK property, vehicle, company, finance, weather, and HMO licensing data, with USDC settlement and MCP discovery."
+url: https://payapi.market
+contact: chet@payapi.market
+---
+
+PayAPI Market is a curated registry of x402-enabled APIs settling in USDC on Base mainnet. The platform focuses on UK domain-expert data — property, vehicle, company, finance, weather, and HMO licensing — and lets providers monetise endpoints via per-request micropayments without subscriptions or API keys. Each branded API is published on its own subdomain (e.g. `property.payapi.market`, `hmo.payapi.market`) and indexed for agent discovery via MCP and the CDP Bazaar.


### PR DESCRIPTION
Adds PayAPI Market to the aggregators list — an x402-powered marketplace for pay-per-request APIs on Base mainnet covering UK property, vehicle, company, finance, weather, and HMO licensing data.

PayAPI Market settles in USDC on Base via the x402 protocol (rather than Solana), and is included here under `aggregators/` rather than `providers/` as a peer registry of stablecoin-gated APIs that agents browsing pay.sh may find useful for x402/Base discovery.

- Site: https://payapi.market
- Contact: chet@payapi.market