### PR TITLE
Add tensorfeed/ai-data

### DIFF
--- a/providers/tensorfeed/ai-data/PAY.md
+++ b/providers/tensorfeed/ai-data/PAY.md
@@ -1,0 +1,21 @@
+---
+name: ai-data
+title: "TensorFeed"
+description: "Live AI ecosystem intelligence for agents. Model pricing across 200+ models, service status across 30+ providers, news, benchmarks, funding, security data (CVE + CISA KEV + FIRST EPSS), and 36+ premium endpoints paid in USDC on Base."
+use_case: "Use when an agent needs to pick the right AI model for a task by cross-referencing live pricing, benchmarks, status, and recent news, or to triage CVE/KEV/EPSS data when running a security workflow. The endpoint to call on agent boot for a daily brief."
+category: data
+service_url: https://tensorfeed.ai
+openapi:
+  url: https://tensorfeed.ai/openapi.json
+---
+
+TensorFeed.ai is a real-time data and intelligence layer for AI agents. The free surface covers AI news from 15+ sources, live service status across the major LLM and cloud-AI providers, model pricing and benchmarks, agent traffic metrics, and a public CVE/KEV/IOC feed. The paid premium surface aggregates that data into agent-ready calls: routing recommendations, model comparisons, what-changed-since-last-run briefs, full historical time series, news search, story-level cross-source corroboration, and security fact cards that merge MITRE CVE, CISA KEV, FIRST.org EPSS, OSV.dev, and CISA Vulnrichment into one call.
+
+Settlement is USDC on Base mainnet via the canonical Coinbase x402 V2 wire format. Every paid response carries an Ed25519-signed Agent Fair-Trade Agreement (AFTA) receipt so an agent can prove what it paid for, what it received, and that the data was fresh at delivery time. Free trial of 100 calls per IP per day on most premium endpoints, no signup, no wallet required.
+
+## Spend-aware usage
+
+- Call `/api/premium/whats-new` on agent boot for a single-credit daily brief covering pricing changes, new and removed models, service incidents, and top news headlines from the last 1 to 7 days. Cheaper than calling four separate endpoints.
+- Use `/api/premium/routing` when picking a model for a task; one credit returns a top-N ranked recommendation by quality, availability, cost, and latency rather than fanning out across pricing, benchmark, and status endpoints.
+- For security agents, prefer `/api/premium/security/verified/{cve-id}` over five fan-out calls to MITRE, KEV, EPSS, OSV, and Vulnrichment. One credit returns the merged fact card with a `confirmed_by` array and a `corroboration_count` so you can audit which sources agreed.
+- The free trial covers prototyping. Once an agent is in production, buy credits once via `/api/payment/buy-credits` and use the bearer token for 50ms latency on every subsequent call. Credits do not expire.


### PR DESCRIPTION
## Summary

Adds **TensorFeed.ai** to the pay-skills registry. We provide a real-time AI ecosystem intelligence layer for AI agents: live model pricing across 200+ models, service status across 30+ providers, news from 15+ sources, benchmarks, funding, security data (MITRE CVE + CISA KEV + FIRST EPSS + OSV + Vulnrichment merged into a single fact card), and 36+ paid endpoints settling USDC on Base via the canonical Coinbase x402 V2 wire format.

**Service URL:** https://tensorfeed.ai
**OpenAPI:** https://tensorfeed.ai/openapi.json
**Manifest:** https://tensorfeed.ai/.well-known/x402.json

## What an agent typically calls

- \`GET /api/premium/whats-new\` — single-credit daily brief on agent boot (pricing changes, new/removed models, status incidents, top news, 1-7d window)
- \`GET /api/premium/routing\` — top-N model recommendation joining live pricing + benchmarks + status
- \`GET /api/premium/security/verified/{cve-id}\` — cross-database CVE fact card (MITRE + KEV + EPSS + OSV + Vulnrichment) in one call
- \`GET /api/premium/cost/projection\` — multi-model cost forecast for a workload

## Differentiators

- Ed25519-signed Agent Fair-Trade Agreement (AFTA) receipts on every paid response (verifiable at \`/api/receipt/verify\`)
- 100-call/day free trial per IP on most premium endpoints, no signup, no wallet
- Bearer-token credits flow OR per-call x402 V2, pick whichever fits the agent
- All upstream data sources permit commercial redistribution (attribution blocks on every response)
- Cataloged in Coinbase x402 Bazaar as of 2026-05-14

## Validation

\`\`\`
pay catalog check providers/tensorfeed/ai-data/PAY.md
  PAY.md check successful
  42 endpoints tested across 1 provider
\`\`\`

Schema check passes. Two notes on the probe results, for transparency:

1. Most paid endpoints probe as \`FREE\` because of our 100-call/day free trial layer (probe arrives with no auth, gets a 200 with trial data instead of a 402). This is intentional and similar to how \`x402.api.agentmail.to\` exposes \`\$0\`-priced operations in their OpenAPI.

2. \`/api/premium/whats-new\` probes as \`unknown_protocol\` because we emit the canonical Coinbase x402 V2 PaymentRequired headers (\`PAYMENT-REQUIRED\` + \`WWW-Authenticate: X402 requirements=\`) per the V2 HTTP transport spec at \`coinbase/x402/specs/transports-v2/http.md\`. We just shipped this to fix our CDP Bazaar cataloging earlier today (commit 25f2458 + d8b554a in our repo). If the probe needs to match a different protocol shape to register as paid, happy to add a sidecar response or adjust.

OpenAPI tags: 4 of our 36 paid endpoints are currently in the OpenAPI doc with \`x-payment-required\` + \`x-payment-info\` (routing, news/search, cost/projection, whats-new). The remaining 32 are documented at \`/.well-known/x402.json\` and \`/developers\` but not yet in the OpenAPI; followup work to mirror them in.

## Background

Coinbase x402 ecosystem page was sunsetted today (PR #2217 in coinbase/x402 closed with redirect to pay.sh + 3 other community directories). Happy to be early.

Built by Pizza Robot Studios LLC. Repo: https://github.com/RipperMercs/tensorfeed