### PR TITLE
feat: add payai/blockrun/inference and payai/xona/creative

### DIFF
--- a/providers/payai/blockrun/inference/PAY.md
+++ b/providers/payai/blockrun/inference/PAY.md
@@ -1,0 +1,27 @@
+---
+name: inference
+title: "BlockRun AI Gateway"
+description: "Pay-per-request AI gateway with chat and image models, plus market data (crypto, FX, stocks, commodities), web search, and X/Twitter analytics. Single endpoint, USDC settlement on Solana, no signup or API keys required."
+use_case: "Use for LLM inference, agent image generation, crypto/stock/FX/commodity price and history lookups, web search, and X/Twitter sentiment or follower analysis through one stablecoin-paid endpoint with no API keys."
+category: ai_ml
+service_url: https://sol.blockrun.ai
+openapi:
+  path: openapi.json
+---
+
+Agent-native stablecoin AI gateway routed through the [PayAI facilitator](https://facilitator.payai.network/). One HTTPS host exposes chat completions, image generation, web search, X/Twitter analytics, and multi-asset market data (crypto, FX, US stocks, commodities) — no signup, no API keys, no per-tenant credentials.
+
+## Payment
+
+- **x402** (default): An unauthenticated request to a paid route returns `402` with a base64 `Payment-Required` header carrying the x402 v2 challenge — Solana mainnet USDC, a per-call `amount`, and a real `payTo`. The agent signs the payment and replays the request with an `X-Payment` header.
+- Some routes (chat completions, image generation) validate the request body before issuing the challenge, so probe with a well-formed body to receive the `402`.
+
+This is a server-to-server API. CORS is not configured for browser clients, so browser-based agents should call through a backend proxy.
+
+## Spend-aware usage
+
+- Resolve identifiers once and reuse them. For X/Twitter analytics, call `/api/v1/x/users/info` to look up a `user_id`, then use that id for follower, tweet, and mention queries instead of re-resolving handles each call.
+- For "what's happening now" style requests, prefer a single `/api/v1/search` or `/api/v1/x/trending` call as agent context before invoking `/api/v1/chat/completions` — one cached search is cheaper than a retry loop that runs the model with no grounding.
+- Image generation is per-image. Pick one capable model (`/api/v1/images/generations`) with a concrete prompt rather than fanning out across providers; use `/api/v1/images/image2image` only when an input asset is already chosen.
+- Market data history endpoints accept date ranges. Ask for the smallest window that answers the task — daily granularity for trend questions, hourly only when intraday signal matters.
+- Batch crypto/FX/stock queries via the `*/list` endpoints when the agent needs many tickers at once, instead of N individual price calls.

--- a/providers/payai/blockrun/inference/PAY.md
+++ b/providers/payai/blockrun/inference/PAY.md
@@ -1,15 +1,22 @@
 ---
 name: inference
 title: "BlockRun AI Gateway"
-description: "Pay-per-request AI gateway with chat and image models, plus market data (crypto, FX, stocks, commodities), web search, and X/Twitter analytics. Single endpoint, USDC settlement on Solana, no signup or API keys required."
-use_case: "Use for LLM inference, agent image generation, crypto/stock/FX/commodity price and history lookups, web search, and X/Twitter sentiment or follower analysis through one stablecoin-paid endpoint with no API keys."
+description: "Pay-per-request gateway: LLM chat and image generation, web search, X/Twitter analytics, crypto/FX/stock/commodity and onchain market data, wallet intelligence, phone lookup/provisioning, and outbound voice calls. USDC on Solana, no API keys."
+use_case: "Use for LLM inference, image generation, web search, market and onchain data, wallet labels, X/Twitter analysis, phone-number lookup and provisioning, and placing outbound voice calls — all through one stablecoin-paid endpoint with no API keys."
 category: ai_ml
 service_url: https://sol.blockrun.ai
 openapi:
   path: openapi.json
 ---
 
-Agent-native stablecoin AI gateway routed through the [PayAI facilitator](https://facilitator.payai.network/). One HTTPS host exposes chat completions, image generation, web search, X/Twitter analytics, and multi-asset market data (crypto, FX, US stocks, commodities) — no signup, no API keys, no per-tenant credentials.
+Agent-native stablecoin gateway routed through the [PayAI facilitator](https://facilitator.payai.network/). One HTTPS host exposes 57 endpoints across several surfaces:
+
+- **AI** — chat completions (dynamic `$0.0001–$5.00` by token count) and image generation/editing (`$0.02–$0.08`).
+- **Web & social** — web search, X/Twitter search, trending, tweets, and user analytics (`$0.002–$0.20`).
+- **Market data** — crypto, FX, US stock, and commodity price/history (`$0.001`), plus a `surf` onchain-intelligence suite: exchange klines and funding, market rankings, fear/greed, ETF flows, gas, transactions, SQL-over-onchain, Polymarket markets, wallet detail and batch labels, and social mindshare (`$0.001–$0.02`).
+- **Comms** — phone lookup (`$0.01`) and fraud scoring (`$0.05`), phone-number provisioning (buy/renew `$5.00` per number), and outbound voice calls (`$0.54/call`).
+
+No signup, no API keys, no per-tenant credentials.
 
 ## Payment
 
@@ -20,7 +27,10 @@ This is a server-to-server API. CORS is not configured for browser clients, so b
 
 ## Spend-aware usage
 
+- Comms routes are the priciest by far: a phone number is `$5.00` to buy and `$5.00` to renew, and each `/api/v1/voice/call` is `$0.54`. Confirm the task genuinely needs telephony before provisioning, and reuse a purchased number across calls rather than buying one per task.
+- `/api/v1/chat/completions` is dynamically priced (`$0.0001–$5.00` by token count) — cap `max_tokens` to bound spend, and keep prompts tight.
 - Resolve identifiers once and reuse them. For X/Twitter analytics, call `/api/v1/x/users/info` to look up a `user_id`, then use that id for follower, tweet, and mention queries instead of re-resolving handles each call.
+- Onchain `surf` reads are cheap (`$0.001–$0.02`). Prefer a targeted `/api/v1/surf/wallet/detail` or `/api/v1/surf/wallet/labels/batch` over looping per-wallet, and use `/api/v1/surf/onchain/sql` for aggregate queries instead of many single reads.
 - For "what's happening now" style requests, prefer a single `/api/v1/search` or `/api/v1/x/trending` call as agent context before invoking `/api/v1/chat/completions` — one cached search is cheaper than a retry loop that runs the model with no grounding.
 - Image generation is per-image. Pick one capable model (`/api/v1/images/generations`) with a concrete prompt rather than fanning out across providers; use `/api/v1/images/image2image` only when an input asset is already chosen.
 - Market data history endpoints accept date ranges. Ask for the smallest window that answers the task — daily granularity for trend questions, hourly only when intraday signal matters.

--- a/providers/payai/blockrun/inference/openapi.json
+++ b/providers/payai/blockrun/inference/openapi.json
@@ -1,0 +1,2790 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "BlockRun AI Gateway",
+    "version": "1.0.0",
+    "description": "Agent-native stablecoin AI gateway. Pay-per-request with USDC on Solana. No accounts or API keys required.",
+    "x-logo": {
+      "url": "https://blockrun.ai/brand/logo-256.png",
+      "altText": "BlockRun"
+    },
+    "x-guidance": "Agent-native API gateway for AI inference + crypto/finance data, paid per-request with USDC on Solana via x402 — no accounts, no API keys. To call: GET an endpoint without a payment header → server returns 402 with x402 challenge → sign with your Solana wallet → POST/GET with X-Payment header → response (and on-chain settlement) returns. Free endpoints (Pyth crypto/fx/commodity feeds, voice call status polls) return 200 directly. Full per-endpoint pricing, error shapes, and rate-limit semantics: https://sol.blockrun.ai/llms.txt"
+  },
+  "servers": [
+    {
+      "url": "https://sol.blockrun.ai"
+    }
+  ],
+  "paths": {
+    "/api/v1/chat/completions": {
+      "post": {
+        "operationId": "chatCompletions",
+        "summary": "Chat Completions",
+        "description": "Access 40+ frontier LLMs with OpenAI-compatible API. Price depends on model and token usage.",
+        "security": [],
+        "x-payment-info": {
+          "price": {
+            "mode": "dynamic",
+            "currency": "USD",
+            "min": "0.0001",
+            "max": "5.00"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "model",
+                  "messages"
+                ],
+                "properties": {
+                  "model": {
+                    "type": "string",
+                    "description": "Model ID to use for completion",
+                    "enum": [
+                      "openai/gpt-5.5",
+                      "openai/gpt-5.4",
+                      "openai/gpt-5.4-pro",
+                      "openai/gpt-5.3",
+                      "openai/gpt-5.2",
+                      "openai/gpt-5.4-mini",
+                      "openai/gpt-5-mini",
+                      "openai/gpt-5.4-nano",
+                      "openai/gpt-5.2-pro",
+                      "openai/gpt-5.3-codex",
+                      "openai/o1",
+                      "openai/o1-mini",
+                      "openai/o3",
+                      "openai/o3-mini",
+                      "anthropic/claude-haiku-4.5",
+                      "anthropic/claude-sonnet-4.6",
+                      "anthropic/claude-opus-4.5",
+                      "anthropic/claude-opus-4.7",
+                      "google/gemini-3.1-pro",
+                      "google/gemini-3-pro-preview",
+                      "google/gemini-3-flash-preview",
+                      "google/gemini-2.5-pro",
+                      "google/gemini-2.5-flash",
+                      "google/gemini-3.1-flash-lite",
+                      "google/gemini-2.5-flash-lite",
+                      "deepseek/deepseek-v4-pro",
+                      "deepseek/deepseek-chat",
+                      "deepseek/deepseek-reasoner",
+                      "zai/glm-5.1",
+                      "zai/glm-5",
+                      "zai/glm-5-turbo",
+                      "moonshot/kimi-k2.6",
+                      "minimax/minimax-m2.7",
+                      "nvidia/deepseek-v4-flash",
+                      "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning",
+                      "nvidia/qwen3-coder-480b",
+                      "nvidia/llama-4-maverick",
+                      "nvidia/qwen3-next-80b-a3b-thinking",
+                      "nvidia/mistral-small-4-119b"
+                    ]
+                  },
+                  "messages": {
+                    "type": "array",
+                    "description": "Array of chat messages",
+                    "items": {
+                      "type": "object",
+                      "required": [
+                        "role",
+                        "content"
+                      ],
+                      "properties": {
+                        "role": {
+                          "type": "string",
+                          "enum": [
+                            "system",
+                            "user",
+                            "assistant"
+                          ]
+                        },
+                        "content": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  },
+                  "max_tokens": {
+                    "type": "integer",
+                    "description": "Maximum tokens to generate",
+                    "minimum": 1,
+                    "maximum": 128000
+                  },
+                  "temperature": {
+                    "type": "number",
+                    "description": "Sampling temperature (0-2)",
+                    "minimum": 0,
+                    "maximum": 2
+                  },
+                  "stream": {
+                    "type": "boolean",
+                    "description": "Enable streaming responses"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful completion"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        }
+      }
+    },
+    "/api/v1/search": {
+      "post": {
+        "operationId": "search",
+        "summary": "Grok Live Search",
+        "description": "Real-time X/Twitter and web search powered by xAI Grok with live data access.",
+        "security": [],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.01"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "query"
+                ],
+                "properties": {
+                  "query": {
+                    "type": "string",
+                    "description": "Search query",
+                    "minLength": 1,
+                    "maxLength": 1000
+                  },
+                  "sources": {
+                    "type": "array",
+                    "description": "Data sources to search",
+                    "items": {
+                      "type": "string",
+                      "enum": [
+                        "x",
+                        "web",
+                        "news"
+                      ]
+                    },
+                    "default": [
+                      "x",
+                      "web"
+                    ]
+                  },
+                  "max_results": {
+                    "type": "integer",
+                    "description": "Maximum number of results",
+                    "minimum": 1,
+                    "maximum": 50,
+                    "default": 10
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Search results"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        }
+      }
+    },
+    "/api/v1/images/generations": {
+      "post": {
+        "operationId": "imageGenerations",
+        "summary": "Image Generation",
+        "description": "Generate images with DALL-E 3, GPT Image 1/2, Gemini Nano Banana, Z.AI CogView-4, and xAI Grok Imagine.",
+        "security": [],
+        "x-payment-info": {
+          "price": {
+            "mode": "dynamic",
+            "currency": "USD",
+            "min": "0.02",
+            "max": "0.08"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "prompt"
+                ],
+                "properties": {
+                  "model": {
+                    "type": "string",
+                    "description": "Image model to use",
+                    "enum": [
+                      "openai/dall-e-3",
+                      "openai/gpt-image-1",
+                      "openai/gpt-image-2",
+                      "google/nano-banana",
+                      "google/nano-banana-pro",
+                      "zai/cogview-4",
+                      "xai/grok-imagine-image",
+                      "xai/grok-imagine-image-pro"
+                    ]
+                  },
+                  "prompt": {
+                    "type": "string",
+                    "description": "Text description of the image to generate",
+                    "minLength": 1,
+                    "maxLength": 4000
+                  },
+                  "size": {
+                    "type": "string",
+                    "description": "Image dimensions",
+                    "enum": [
+                      "1024x1024",
+                      "1024x1792",
+                      "1792x1024"
+                    ],
+                    "default": "1024x1024"
+                  },
+                  "n": {
+                    "type": "integer",
+                    "description": "Number of images to generate",
+                    "minimum": 1,
+                    "maximum": 4,
+                    "default": 1
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Generated images"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        }
+      }
+    },
+    "/api/v1/images/image2image": {
+      "post": {
+        "operationId": "imageEdit",
+        "summary": "Image Editing (Image-to-Image)",
+        "description": "Edit images with AI using text prompts. Supports inpainting with optional mask. Powered by OpenAI gpt-image-1 / gpt-image-2.",
+        "security": [],
+        "x-payment-info": {
+          "price": {
+            "mode": "dynamic",
+            "currency": "USD",
+            "min": "0.02",
+            "max": "0.08"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "prompt",
+                  "image"
+                ],
+                "properties": {
+                  "model": {
+                    "type": "string",
+                    "description": "Image model to use",
+                    "enum": [
+                      "openai/gpt-image-1",
+                      "openai/gpt-image-2"
+                    ],
+                    "default": "openai/gpt-image-2"
+                  },
+                  "prompt": {
+                    "type": "string",
+                    "description": "Text description of the desired edit"
+                  },
+                  "image": {
+                    "type": "string",
+                    "description": "Base64 data URI of the source image (data:image/...)"
+                  },
+                  "mask": {
+                    "type": "string",
+                    "description": "Base64 data URI of the mask image (optional, for inpainting)"
+                  },
+                  "size": {
+                    "type": "string",
+                    "enum": [
+                      "1024x1024",
+                      "1024x1536",
+                      "1536x1024"
+                    ],
+                    "default": "1024x1024"
+                  },
+                  "n": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 4,
+                    "default": 1
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Edited images"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        }
+      }
+    },
+    "/api/v1/x/users/lookup": {
+      "post": {
+        "operationId": "xUsersLookup",
+        "summary": "X/Twitter User Lookup",
+        "description": "Batch lookup Twitter/X user profiles — followers, bio, verification status, and more. Powered by AttentionVC.",
+        "security": [],
+        "x-payment-info": {
+          "price": {
+            "mode": "dynamic",
+            "currency": "USD",
+            "min": "0.02",
+            "max": "0.20"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ],
+          "partner": "AttentionVC"
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "usernames"
+                ],
+                "properties": {
+                  "usernames": {
+                    "oneOf": [
+                      {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "description": "Array of Twitter usernames"
+                      },
+                      {
+                        "type": "string",
+                        "description": "Comma-separated Twitter usernames"
+                      }
+                    ],
+                    "description": "Twitter usernames to look up (@ prefix auto-stripped, max 100)"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "User profiles"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        }
+      }
+    },
+    "/api/v1/x/users/followers": {
+      "post": {
+        "operationId": "xUsersFollowers",
+        "summary": "X/Twitter Follower List",
+        "description": "Fetch a Twitter/X user's follower list — ~200 followers per page with cursor-based pagination. Powered by AttentionVC.",
+        "security": [],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.05"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ],
+          "partner": "AttentionVC"
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "username"
+                ],
+                "properties": {
+                  "username": {
+                    "type": "string",
+                    "description": "Twitter username to fetch followers for (@ prefix auto-stripped)"
+                  },
+                  "cursor": {
+                    "type": "string",
+                    "description": "Pagination cursor from previous response (next_cursor field)"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Follower list"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        }
+      }
+    },
+    "/api/v1/x/users/followings": {
+      "post": {
+        "operationId": "xUsersFollowings",
+        "summary": "X/Twitter Following List",
+        "description": "Fetch the list of accounts a Twitter/X user follows — ~200 per page with cursor-based pagination. Powered by AttentionVC.",
+        "security": [],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.05"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ],
+          "partner": "AttentionVC"
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "username"
+                ],
+                "properties": {
+                  "username": {
+                    "type": "string",
+                    "description": "Twitter username to fetch following list for (@ prefix auto-stripped)"
+                  },
+                  "cursor": {
+                    "type": "string",
+                    "description": "Pagination cursor from previous response (next_cursor field)"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Following list"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        }
+      }
+    },
+    "/api/v1/x/users/info": {
+      "post": {
+        "operationId": "xUsersInfo",
+        "summary": "X/Twitter User Info",
+        "description": "Get detailed profile information for a single Twitter/X user. Powered by AttentionVC.",
+        "security": [],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.002"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ],
+          "partner": "AttentionVC"
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "username"
+                ],
+                "properties": {
+                  "username": {
+                    "type": "string",
+                    "description": "Twitter username (@ auto-stripped)"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "User profile"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        }
+      }
+    },
+    "/api/v1/x/users/tweets": {
+      "post": {
+        "operationId": "xUsersTweets",
+        "summary": "X/Twitter User Tweets",
+        "description": "Fetch a user's tweet timeline with pagination. Powered by AttentionVC.",
+        "security": [],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.032"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ],
+          "partner": "AttentionVC"
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "username": {
+                    "type": "string"
+                  },
+                  "userId": {
+                    "type": "string"
+                  },
+                  "cursor": {
+                    "type": "string"
+                  },
+                  "includeReplies": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "User tweets"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        }
+      }
+    },
+    "/api/v1/x/users/mentions": {
+      "post": {
+        "operationId": "xUsersMentions",
+        "summary": "X/Twitter User Mentions",
+        "description": "Fetch mentions/replies for a Twitter/X user with optional time filtering. Powered by AttentionVC.",
+        "security": [],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.032"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ],
+          "partner": "AttentionVC"
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "username"
+                ],
+                "properties": {
+                  "username": {
+                    "type": "string"
+                  },
+                  "sinceTime": {
+                    "type": "string"
+                  },
+                  "untilTime": {
+                    "type": "string"
+                  },
+                  "cursor": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "User mentions"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        }
+      }
+    },
+    "/api/v1/x/users/verified-followers": {
+      "post": {
+        "operationId": "xUsersVerifiedFollowers",
+        "summary": "X/Twitter Verified Followers",
+        "description": "Fetch verified followers for a Twitter/X user. Powered by AttentionVC.",
+        "security": [],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.048"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ],
+          "partner": "AttentionVC"
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "userId"
+                ],
+                "properties": {
+                  "userId": {
+                    "type": "string"
+                  },
+                  "cursor": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Verified followers"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        }
+      }
+    },
+    "/api/v1/x/tweets/lookup": {
+      "post": {
+        "operationId": "xTweetsLookup",
+        "summary": "X/Twitter Batch Tweet Lookup",
+        "description": "Look up multiple tweets by ID in a single request (max 200). Powered by AttentionVC.",
+        "security": [],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.16"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ],
+          "partner": "AttentionVC"
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "tweet_ids"
+                ],
+                "properties": {
+                  "tweet_ids": {
+                    "oneOf": [
+                      {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "description": "Tweet IDs (array or comma-separated, max 200)"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Tweet data"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        }
+      }
+    },
+    "/api/v1/x/tweets/replies": {
+      "post": {
+        "operationId": "xTweetReplies",
+        "summary": "X/Twitter Tweet Replies",
+        "description": "Fetch replies to a specific tweet with pagination. Powered by AttentionVC.",
+        "security": [],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.032"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ],
+          "partner": "AttentionVC"
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "tweetId"
+                ],
+                "properties": {
+                  "tweetId": {
+                    "type": "string"
+                  },
+                  "cursor": {
+                    "type": "string"
+                  },
+                  "queryType": {
+                    "type": "string",
+                    "enum": [
+                      "Latest",
+                      "Default"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Tweet replies"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        }
+      }
+    },
+    "/api/v1/x/tweets/thread": {
+      "post": {
+        "operationId": "xTweetThread",
+        "summary": "X/Twitter Tweet Thread",
+        "description": "Fetch a complete tweet thread/conversation. Powered by AttentionVC.",
+        "security": [],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.032"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ],
+          "partner": "AttentionVC"
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "tweetId"
+                ],
+                "properties": {
+                  "tweetId": {
+                    "type": "string"
+                  },
+                  "cursor": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Tweet thread"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        }
+      }
+    },
+    "/api/v1/x/search": {
+      "post": {
+        "operationId": "xSearch",
+        "summary": "X/Twitter Advanced Search",
+        "description": "Search tweets with query and pagination. Powered by AttentionVC.",
+        "security": [],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.032"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ],
+          "partner": "AttentionVC"
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "query"
+                ],
+                "properties": {
+                  "query": {
+                    "type": "string"
+                  },
+                  "queryType": {
+                    "type": "string",
+                    "enum": [
+                      "Latest",
+                      "Top",
+                      "Default"
+                    ]
+                  },
+                  "cursor": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Search results"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        }
+      }
+    },
+    "/api/v1/x/trending": {
+      "post": {
+        "operationId": "xTrending",
+        "summary": "X/Twitter Trending Topics",
+        "description": "Get current trending topics on Twitter/X. Powered by AttentionVC.",
+        "security": [],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.002"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ],
+          "partner": "AttentionVC"
+        },
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {},
+                "description": "No body required. Send {} or empty body."
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Trending topics"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        }
+      }
+    },
+    "/api/v1/x/articles/rising": {
+      "post": {
+        "operationId": "xArticlesRising",
+        "summary": "X/Twitter Rising Articles",
+        "description": "Get rising articles trending on Twitter/X. Powered by AttentionVC.",
+        "security": [],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.05"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ],
+          "partner": "AttentionVC"
+        },
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {},
+                "description": "No body required. Send {} or empty body."
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Rising articles"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        }
+      }
+    },
+    "/api/v1/crypto/list": {
+      "get": {
+        "operationId": "cryptoList",
+        "summary": "List Supported Crypto Pairs",
+        "description": "Enumerate crypto pairs available on the Pyth feed. Free discovery endpoint.",
+        "security": [],
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 100,
+              "maximum": 2000
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of supported crypto symbols"
+          }
+        }
+      }
+    },
+    "/api/v1/crypto/price/BTC-USD": {
+      "get": {
+        "operationId": "cryptoPrice",
+        "summary": "Crypto Realtime Price",
+        "description": "Realtime price for a crypto pair from Pyth. Free. Substitute the path tail with any valid symbol from /list (e.g. BTC-USD, ETH-USD, SOL-USD).",
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Latest price with confidence interval"
+          }
+        }
+      }
+    },
+    "/api/v1/crypto/history/BTC-USD": {
+      "get": {
+        "operationId": "cryptoHistory",
+        "summary": "Crypto OHLC History",
+        "description": "Historical OHLC bars for a crypto pair. TradingView resolution convention. Powered by Pyth Benchmarks. Free. Substitute the path tail with any valid symbol from /list.",
+        "security": [],
+        "parameters": [
+          {
+            "name": "resolution",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "1",
+                "5",
+                "15",
+                "60",
+                "240",
+                "D",
+                "W",
+                "M"
+              ],
+              "default": "D"
+            }
+          },
+          {
+            "name": "from",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "description": "Unix seconds"
+            }
+          },
+          {
+            "name": "to",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "description": "Unix seconds (defaults to now)"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Array of OHLC bars"
+          }
+        }
+      }
+    },
+    "/api/v1/fx/list": {
+      "get": {
+        "operationId": "fxList",
+        "summary": "List Supported FX Pairs",
+        "description": "Enumerate FX pairs available on the Pyth feed. Free.",
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "List of supported FX symbols"
+          }
+        }
+      }
+    },
+    "/api/v1/fx/price/EUR-USD": {
+      "get": {
+        "operationId": "fxPrice",
+        "summary": "FX Realtime Price",
+        "description": "Realtime FX rate from Pyth. Free. Substitute the path tail with any valid pair from /list (e.g. EUR-USD, GBP-USD, JPY-USD).",
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Latest FX rate"
+          }
+        }
+      }
+    },
+    "/api/v1/fx/history/EUR-USD": {
+      "get": {
+        "operationId": "fxHistory",
+        "summary": "FX OHLC History",
+        "description": "Historical OHLC bars for an FX pair. Free. Substitute the path tail with any valid pair from /list.",
+        "security": [],
+        "parameters": [
+          {
+            "name": "resolution",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "1",
+                "5",
+                "15",
+                "60",
+                "240",
+                "D",
+                "W",
+                "M"
+              ],
+              "default": "D"
+            }
+          },
+          {
+            "name": "from",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "to",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Array of OHLC bars"
+          }
+        }
+      }
+    },
+    "/api/v1/commodity/list": {
+      "get": {
+        "operationId": "commodityList",
+        "summary": "List Supported Commodities",
+        "description": "Enumerate commodities available on the Pyth feed. Free.",
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "List of supported commodity symbols"
+          }
+        }
+      }
+    },
+    "/api/v1/commodity/price/XAU-USD": {
+      "get": {
+        "operationId": "commodityPrice",
+        "summary": "Commodity Realtime Price",
+        "description": "Realtime commodity price from Pyth. Free. Substitute the path tail with any valid symbol from /list (e.g. XAU-USD gold, XAG-USD silver, XPT-USD platinum, WTI).",
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Latest commodity price"
+          }
+        }
+      }
+    },
+    "/api/v1/commodity/history/XAU-USD": {
+      "get": {
+        "operationId": "commodityHistory",
+        "summary": "Commodity OHLC History",
+        "description": "Historical OHLC bars for a commodity. Free. Substitute the path tail with any valid symbol from /list.",
+        "security": [],
+        "parameters": [
+          {
+            "name": "resolution",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "1",
+                "5",
+                "15",
+                "60",
+                "240",
+                "D",
+                "W",
+                "M"
+              ],
+              "default": "D"
+            }
+          },
+          {
+            "name": "from",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "to",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Array of OHLC bars"
+          }
+        }
+      }
+    },
+    "/api/v1/usstock/list": {
+      "get": {
+        "operationId": "usStockList",
+        "summary": "List US Stock Tickers",
+        "description": "Enumerate US equity tickers available on the Pyth feed. Free.",
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "List of supported US stock tickers"
+          }
+        }
+      }
+    },
+    "/api/v1/usstock/price/AAPL": {
+      "get": {
+        "operationId": "usStockPrice",
+        "summary": "US Stock Realtime Price",
+        "description": "Realtime US equity quote (NYSE, Nasdaq, AMEX). Pay per call in USDC on Solana. Powered by Pyth. Substitute the path tail with any valid ticker from /list (e.g. AAPL, TSLA, NVDA).",
+        "security": [],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "session",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "pre",
+                "post",
+                "on"
+              ],
+              "description": "Optional US market session"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Latest price"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        }
+      }
+    },
+    "/api/v1/usstock/history/AAPL": {
+      "get": {
+        "operationId": "usStockHistory",
+        "summary": "US Stock OHLC History",
+        "description": "Historical OHLC bars for a US equity. Pay per call in USDC on Solana. Substitute the path tail with any valid ticker from /list.",
+        "security": [],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "resolution",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "1",
+                "5",
+                "15",
+                "60",
+                "240",
+                "D",
+                "W",
+                "M"
+              ],
+              "default": "D"
+            }
+          },
+          {
+            "name": "from",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "to",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Array of OHLC bars"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        }
+      }
+    },
+    "/api/v1/stocks/us/list": {
+      "get": {
+        "operationId": "globalStockList",
+        "summary": "List Tickers in a Stock Market",
+        "description": "Enumerate tickers for a given market. Free. Substitute the `us` segment with any of: us, hk, jp, kr, gb, de, fr, nl, ie, lu, cn, ca.",
+        "security": [],
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 100,
+              "maximum": 2000
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of tickers"
+          }
+        }
+      }
+    },
+    "/api/v1/stocks/us/price/AAPL": {
+      "get": {
+        "operationId": "globalStockPrice",
+        "summary": "Global Stock Realtime Price",
+        "description": "Realtime equity quote across 12 markets. Pay per call in USDC on Solana. Powered by Pyth. Substitute the `us` segment with any of: us, hk, jp, kr, gb, de, fr, nl, ie, lu, cn, ca; substitute the path tail with any valid ticker from /list (e.g. /stocks/hk/price/0005-HK).",
+        "security": [],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "session",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "pre",
+                "post",
+                "on"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Latest price"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        }
+      }
+    },
+    "/api/v1/stocks/us/history/AAPL": {
+      "get": {
+        "operationId": "globalStockHistory",
+        "summary": "Global Stock OHLC History",
+        "description": "Historical OHLC bars for a global equity. Pay per call in USDC on Solana. Substitute the `us` segment and the ticker as needed.",
+        "security": [],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "resolution",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "1",
+                "5",
+                "15",
+                "60",
+                "240",
+                "D",
+                "W",
+                "M"
+              ],
+              "default": "D"
+            }
+          },
+          {
+            "name": "from",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "to",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Array of OHLC bars"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        }
+      }
+    },
+    "/api/v1/phone/lookup": {
+      "post": {
+        "operationId": "phoneLookup",
+        "summary": "Phone Carrier Lookup",
+        "description": "Look up carrier information and line type for a phone number (E.164). Powered by Twilio.",
+        "security": [],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.01"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ],
+          "partner": "Twilio"
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "phoneNumber"
+                ],
+                "properties": {
+                  "phoneNumber": {
+                    "type": "string",
+                    "description": "Phone number in E.164 format."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Carrier + line-type info"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        }
+      }
+    },
+    "/api/v1/phone/lookup/fraud": {
+      "post": {
+        "operationId": "phoneLookupFraud",
+        "summary": "Phone Fraud Signals Lookup",
+        "description": "Carrier info + SIM swap detection + call forwarding signals for a phone number. Powered by Twilio.",
+        "security": [],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.05"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ],
+          "partner": "Twilio"
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "phoneNumber"
+                ],
+                "properties": {
+                  "phoneNumber": {
+                    "type": "string",
+                    "description": "Phone number in E.164 format."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Carrier + fraud signals"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        }
+      }
+    },
+    "/api/v1/phone/numbers/buy": {
+      "post": {
+        "operationId": "phoneNumbersBuy",
+        "summary": "Provision a dedicated phone number (30 days)",
+        "description": "Buy a US or CA phone number bound to your wallet for 30 days. Number is auto-registered with Bland for outbound caller ID.",
+        "security": [],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "5.00"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ],
+          "partner": "Twilio"
+        },
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "country": {
+                    "type": "string",
+                    "description": "ISO country code: 'US' or 'CA'.",
+                    "default": "US"
+                  },
+                  "areaCode": {
+                    "type": "string",
+                    "description": "Preferred 3-digit area code."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Provisioned number"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        }
+      }
+    },
+    "/api/v1/phone/numbers/renew": {
+      "post": {
+        "operationId": "phoneNumbersRenew",
+        "summary": "Renew a provisioned phone number (+30 days)",
+        "description": "Extend the lease on a wallet-owned phone number by 30 days.",
+        "security": [],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "5.00"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ],
+          "partner": "Twilio"
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "phoneNumber"
+                ],
+                "properties": {
+                  "phoneNumber": {
+                    "type": "string",
+                    "description": "Your provisioned number in E.164 format."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Renewed expiry"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        }
+      }
+    },
+    "/api/v1/phone/numbers/list": {
+      "post": {
+        "operationId": "phoneNumbersList",
+        "summary": "List wallet's active phone numbers",
+        "description": "Return all active phone numbers provisioned to the caller wallet. Wallet identity is derived from the x402 payment header.",
+        "security": [],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ],
+          "partner": "Twilio"
+        },
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {},
+                "description": "No body required. Wallet is identified by the x402 payment header."
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Numbers list"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        }
+      }
+    },
+    "/api/v1/phone/numbers/release": {
+      "post": {
+        "operationId": "phoneNumbersRelease",
+        "summary": "Release a provisioned phone number",
+        "description": "Return a wallet-owned phone number to the Twilio pool. Free, but routed through x402 for wallet identity.",
+        "security": [],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ],
+          "partner": "Twilio"
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "phoneNumber"
+                ],
+                "properties": {
+                  "phoneNumber": {
+                    "type": "string",
+                    "description": "Your provisioned number in E.164 format."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Released"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        }
+      }
+    },
+    "/api/v1/voice/call": {
+      "post": {
+        "operationId": "voiceCall",
+        "summary": "AI Outbound Voice Call (Bland.ai)",
+        "description": "Initiate an AI-powered outbound phone call. The agent calls the recipient and conducts a conversation based on the 'task' instructions. Powered by Bland.ai.",
+        "security": [],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.54"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ],
+          "partner": "Bland.ai"
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "to",
+                  "task",
+                  "from"
+                ],
+                "properties": {
+                  "to": {
+                    "type": "string",
+                    "description": "Destination phone number (E.164)."
+                  },
+                  "task": {
+                    "type": "string",
+                    "description": "Natural language description of what the AI should do on the call (10–4000 chars)."
+                  },
+                  "from": {
+                    "type": "string",
+                    "description": "Caller-ID number — must be wallet-owned. Buy one at POST /api/v1/phone/numbers/buy ($5/30 days)."
+                  },
+                  "voice": {
+                    "type": "string",
+                    "description": "Voice preset or Bland.ai voice ID."
+                  },
+                  "max_duration": {
+                    "type": "integer",
+                    "description": "Max minutes (1–30, default 5)."
+                  },
+                  "language": {
+                    "type": "string",
+                    "description": "STT/TTS language (default en-US)."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Call queued"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        }
+      }
+    },
+    "/api/v1/voice/call/{callId}": {
+      "get": {
+        "operationId": "voiceCallStatus",
+        "summary": "Voice Call Status",
+        "description": "Poll for status, transcript, and recording URL for a previously-initiated voice call. Free.",
+        "security": [],
+        "parameters": [
+          {
+            "name": "callId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Call status"
+          }
+        }
+      }
+    },
+    "/api/v1/surf/exchange/price": {
+      "get": {
+        "operationId": "surfExchangePrice",
+        "summary": "Surf — CEX Ticker Price",
+        "description": "Live ticker price for a CEX trading pair (Binance, OKX, Bybit, Coinbase, …).",
+        "security": [],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ],
+          "partner": "Surf"
+        },
+        "parameters": [
+          {
+            "name": "exchange",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "binance | okx | bybit | coinbase | …"
+            }
+          },
+          {
+            "name": "symbol",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Trading pair, e.g. BTCUSDT"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Ticker price"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        }
+      }
+    },
+    "/api/v1/surf/exchange/klines": {
+      "get": {
+        "operationId": "surfExchangeKlines",
+        "summary": "Surf — CEX OHLCV Candlesticks",
+        "description": "OHLCV candlesticks for a CEX pair at any interval.",
+        "security": [],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.005"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ],
+          "partner": "Surf"
+        },
+        "parameters": [
+          {
+            "name": "exchange",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "symbol",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "interval",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "description": "1m | 5m | 15m | 1h | 4h | 1d"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "maximum": 1000
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Candles"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        }
+      }
+    },
+    "/api/v1/surf/exchange/funding-history": {
+      "get": {
+        "operationId": "surfExchangeFunding",
+        "summary": "Surf — Perp Funding Rate History",
+        "description": "Funding rate history for a perpetual contract.",
+        "security": [],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.005"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ],
+          "partner": "Surf"
+        },
+        "parameters": [
+          {
+            "name": "exchange",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "symbol",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Perp symbol, e.g. BTCUSDT"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "maximum": 500
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Funding history"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        }
+      }
+    },
+    "/api/v1/surf/market/price": {
+      "get": {
+        "operationId": "surfMarketPrice",
+        "summary": "Surf — Token Price History",
+        "description": "Token price history. Pass ?symbol=BTC.",
+        "security": [],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ],
+          "partner": "Surf"
+        },
+        "parameters": [
+          {
+            "name": "symbol",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Token symbol (BTC, ETH, SOL, …)"
+            }
+          },
+          {
+            "name": "from",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "description": "Unix seconds"
+            }
+          },
+          {
+            "name": "to",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "description": "Unix seconds"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Price history"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        }
+      }
+    },
+    "/api/v1/surf/market/ranking": {
+      "get": {
+        "operationId": "surfMarketRanking",
+        "summary": "Surf — Token Rankings",
+        "description": "Token rankings by market cap, volume, or change.",
+        "security": [],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ],
+          "partner": "Surf"
+        },
+        "parameters": [
+          {
+            "name": "by",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "description": "market_cap | volume | change_24h"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "maximum": 500
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Ranking list"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        }
+      }
+    },
+    "/api/v1/surf/market/fear-greed": {
+      "get": {
+        "operationId": "surfFearGreed",
+        "summary": "Surf — Fear & Greed Index History",
+        "description": "Daily Fear & Greed index history.",
+        "security": [],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ],
+          "partner": "Surf"
+        },
+        "parameters": [
+          {
+            "name": "from",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "description": "Unix seconds"
+            }
+          },
+          {
+            "name": "to",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "description": "Unix seconds"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Index history"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        }
+      }
+    },
+    "/api/v1/surf/market/etf": {
+      "get": {
+        "operationId": "surfMarketEtf",
+        "summary": "Surf — Spot ETF Flow History",
+        "description": "BTC/ETH spot ETF flow history (daily inflows / outflows).",
+        "security": [],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ],
+          "partner": "Surf"
+        },
+        "parameters": [
+          {
+            "name": "asset",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "description": "BTC | ETH"
+            }
+          },
+          {
+            "name": "from",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "description": "Unix seconds"
+            }
+          },
+          {
+            "name": "to",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "description": "Unix seconds"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ETF flows"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        }
+      }
+    },
+    "/api/v1/surf/market/onchain-indicator": {
+      "get": {
+        "operationId": "surfOnchainIndicator",
+        "summary": "Surf — On-Chain Indicator",
+        "description": "NUPL, SOPR, MVRV, Puell Multiple, NVT.",
+        "security": [],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.005"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ],
+          "partner": "Surf"
+        },
+        "parameters": [
+          {
+            "name": "indicator",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "nupl | sopr | mvrv | puell | nvt"
+            }
+          },
+          {
+            "name": "asset",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "description": "BTC | ETH"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Indicator"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        }
+      }
+    },
+    "/api/v1/surf/onchain/gas-price": {
+      "get": {
+        "operationId": "surfGasPrice",
+        "summary": "Surf — Current Gas Price",
+        "description": "Current gas price across supported chains.",
+        "security": [],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ],
+          "partner": "Surf"
+        },
+        "parameters": [
+          {
+            "name": "chain",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "description": "ethereum | polygon | arbitrum | optimism | base | bnb | …"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Gas snapshot"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        }
+      }
+    },
+    "/api/v1/surf/onchain/tx": {
+      "get": {
+        "operationId": "surfOnchainTx",
+        "summary": "Surf — Transaction Details by Hash",
+        "description": "Transaction details by hash.",
+        "security": [],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ],
+          "partner": "Surf"
+        },
+        "parameters": [
+          {
+            "name": "chain",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "hash",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Transaction hash (0x-prefixed for EVM)"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Tx detail"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        }
+      }
+    },
+    "/api/v1/surf/onchain/sql": {
+      "post": {
+        "operationId": "surfOnchainSql",
+        "summary": "Surf — Raw SQL on Blockchain Tables",
+        "description": "Raw SQL query against 80+ analyst-ready ClickHouse tables (DEX trades, transfers, lending, staking, bridges). Sub-second.",
+        "security": [],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.02"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ],
+          "partner": "Surf"
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "sql"
+                ],
+                "properties": {
+                  "sql": {
+                    "type": "string",
+                    "description": "ClickHouse SQL — see /api/v1/surf/onchain/schema for tables."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Query rows"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        }
+      }
+    },
+    "/api/v1/surf/wallet/detail": {
+      "get": {
+        "operationId": "surfWalletDetail",
+        "summary": "Surf — Aggregated Wallet Profile",
+        "description": "Cross-chain wallet profile + labels + balances.",
+        "security": [],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.005"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ],
+          "partner": "Surf"
+        },
+        "parameters": [
+          {
+            "name": "address",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Wallet address (EVM hex, Solana base58, …)"
+            }
+          },
+          {
+            "name": "chain",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "description": "Optional chain filter — defaults to all chains"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Wallet detail"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        }
+      }
+    },
+    "/api/v1/surf/wallet/labels/batch": {
+      "get": {
+        "operationId": "surfWalletLabelsBatch",
+        "summary": "Surf — Batch Wallet Labels",
+        "description": "Batch lookup wallet labels (CEX, Whale, Bridge, MEV, Bot, Fund) across 13 chains. 100M+ labeled addresses.",
+        "security": [],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.005"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ],
+          "partner": "Surf"
+        },
+        "parameters": [
+          {
+            "name": "addresses",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Comma-separated wallet addresses (max 100)"
+            }
+          },
+          {
+            "name": "chain",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Labels"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        }
+      }
+    },
+    "/api/v1/surf/social/mindshare": {
+      "get": {
+        "operationId": "surfSocialMindshare",
+        "summary": "Surf — Project Mindshare Time Series",
+        "description": "Project mindshare on Crypto Twitter over time.",
+        "security": [],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.005"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ],
+          "partner": "Surf"
+        },
+        "parameters": [
+          {
+            "name": "project",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Project ticker or name"
+            }
+          },
+          {
+            "name": "from",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "description": "Unix seconds"
+            }
+          },
+          {
+            "name": "to",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "description": "Unix seconds"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Mindshare series"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        }
+      }
+    },
+    "/api/v1/surf/news/feed": {
+      "get": {
+        "operationId": "surfNewsFeed",
+        "summary": "Surf — AI-Curated News Feed",
+        "description": "AI-curated crypto news feed aggregated from 30+ sources.",
+        "security": [],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ],
+          "partner": "Surf"
+        },
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "maximum": 200
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "description": "Pagination cursor from previous response"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "News feed"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        }
+      }
+    },
+    "/api/v1/surf/prediction-market/polymarket/markets": {
+      "get": {
+        "operationId": "surfPolymarketMarkets",
+        "summary": "Surf — Polymarket Markets",
+        "description": "Polymarket markets list. Cross-platform with /prediction-market/kalshi/* for arbitrage.",
+        "security": [],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ],
+          "partner": "Surf"
+        },
+        "parameters": [
+          {
+            "name": "category",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "description": "Optional category filter"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "maximum": 500
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Markets"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        }
+      }
+    },
+    "/api/v1/surf/search/wallet": {
+      "get": {
+        "operationId": "surfSearchWallet",
+        "summary": "Surf — Wallet Search",
+        "description": "Wallet search by address, ENS, or label (CEX, Whale, etc.).",
+        "security": [],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.005"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ],
+          "partner": "Surf"
+        },
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Search query: address prefix, ENS name, or label (CEX, Whale, …)"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "maximum": 100
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Wallet matches"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        }
+      }
+    }
+  }
+}

--- a/providers/payai/xona/creative/PAY.md
+++ b/providers/payai/xona/creative/PAY.md
@@ -9,7 +9,7 @@ openapi:
   path: openapi.json
 ---
 
-Xona is the creative resource layer for the agent economy, routed through the [PayAI facilitator](https://facilitator.payai.network/). Pricing is per-call and declared in each operation's `x-payment-info` block (`$0.03–$0.15` for most image/audio routes, dynamic for high-end video). The 28 endpoints group into four surfaces:
+Xona is the creative resource layer for the agent economy, routed through the [PayAI facilitator](https://facilitator.payai.network/). Pricing is per-call, declared in each operation's `x-payment-info` block: image models `$0.03–$0.15` (one dynamic), video `$0.50–$0.80`, audio `$0.01–$1.50` (ElevenLabs music is the `$1.50` high end), social-AI `$0.05–$0.50`, and Solana token analytics `$0.001–$0.20`. The 28 endpoints group into four surfaces:
 
 - **Image generation** — `/image/flux-2-{flex,pro,max}`, `/image/nano-banana{,-2,-pro}`, `/image/gpt-image-2`, `/image/grok-imagine`, `/image-model/qwen-image`, `/image-model/seedream-4.5`, plus opinionated routes (`/image/creative-director`, `/image/designer`).
 - **Video generation** — `/video/seedance-generation`, `/video/short-generation` (dynamic pricing).
@@ -25,6 +25,7 @@ This is a server-to-server API. The 402 responses do not expose `Access-Control-
 
 ## Spend-aware usage
 
+- Mind the high-cost routes. `/audio/elevenlabs-music` is `$1.50`, `/video/seedance-generation` `$0.80`, `/video/short-generation` and `/ai/x-news` `$0.50` each — confirm the task needs them before calling. For quick voiceovers prefer `/audio/x-text-to-speech` (`$0.01`) over music generation.
 - Match the model to the brief. Use the cheapest image model that meets the prompt (`flux-2-flex` or a `nano-banana` variant for routine generations) and reserve `flux-2-max` or `creative-director` for higher-fidelity work.
 - For multi-image campaigns, generate a single key visual with the highest-quality model and use `image2image`-style variants from a cheaper model for follow-ups rather than re-paying for the premium model each time.
 - Cache token-analytics responses across a workflow. `/token/solana-market` and `/token/solana-discovery` change slowly enough that a single call usually answers a multi-step task — avoid re-querying every step.

--- a/providers/payai/xona/creative/PAY.md
+++ b/providers/payai/xona/creative/PAY.md
@@ -1,0 +1,32 @@
+---
+name: creative
+title: "Xona"
+description: "Pay-per-call creative AI for agents — image, video, music, speech, and transcription generation across Flux 2, Nano Banana, Seedream and other models, plus X/Twitter and Solana token analytics. USDC settlement on Solana via x402."
+use_case: "Use for agent image generation, video synthesis, music and speech generation, audio transcription, X/Twitter persona and news lookups, and Solana token discovery or pumpfun signal queries through one stablecoin-paid endpoint without API keys."
+category: media
+service_url: https://api.xona-agent.com
+openapi:
+  path: openapi.json
+---
+
+Xona is the creative resource layer for the agent economy, routed through the [PayAI facilitator](https://facilitator.payai.network/). Pricing is per-call and declared in each operation's `x-payment-info` block (`$0.03–$0.15` for most image/audio routes, dynamic for high-end video). The 28 endpoints group into four surfaces:
+
+- **Image generation** — `/image/flux-2-{flex,pro,max}`, `/image/nano-banana{,-2,-pro}`, `/image/gpt-image-2`, `/image/grok-imagine`, `/image-model/qwen-image`, `/image-model/seedream-4.5`, plus opinionated routes (`/image/creative-director`, `/image/designer`).
+- **Video generation** — `/video/seedance-generation`, `/video/short-generation` (dynamic pricing).
+- **Audio** — `/audio/elevenlabs-music` for music, `/audio/x-text-to-speech` for TTS, `/audio/speech-to-text` for transcription.
+- **Agent research** — `/ai/x-news` and `/ai/x-persona` for X/Twitter persona and news context; `/token/{news,signal,pumpfun-movers,pumpfun-trending,solana-discovery,solana-market,starter-kit}` for Solana token discovery and market data.
+
+## Payment
+
+- **x402** (default, this listing): A request to a paid route with no payment returns `402` carrying a structured x402 v2 challenge in both the body and a base64 `Payment-Required` header — Solana mainnet USDC, a per-call `amount`, and a real `payTo`. The agent signs and replays with an `X-Payment` header. These are the `openapi.json` routes (e.g. `/image/flux-2-max`).
+- **MPP**: Xona publishes a parallel MPP-paid surface at `/mpp/...` (e.g. `/mpp/image/flux-2-max`) returning an `application/problem+json` 402 with a `challengeId` for agents on the MPP wallet flow. Both protocols settle in Solana mainnet USDC.
+
+This is a server-to-server API. The 402 responses do not expose `Access-Control-Allow-Origin`, so browser-based agents should call through a backend proxy.
+
+## Spend-aware usage
+
+- Match the model to the brief. Use the cheapest image model that meets the prompt (`flux-2-flex` or a `nano-banana` variant for routine generations) and reserve `flux-2-max` or `creative-director` for higher-fidelity work.
+- For multi-image campaigns, generate a single key visual with the highest-quality model and use `image2image`-style variants from a cheaper model for follow-ups rather than re-paying for the premium model each time.
+- Cache token-analytics responses across a workflow. `/token/solana-market` and `/token/solana-discovery` change slowly enough that a single call usually answers a multi-step task — avoid re-querying every step.
+- Use `/token/starter-kit` once at the top of a Solana-research workflow rather than calling discovery + movers + trending sequentially.
+- For audio transcription, ask for the shortest meaningful segment; long-form `speech-to-text` is per-minute.

--- a/providers/payai/xona/creative/openapi.json
+++ b/providers/payai/xona/creative/openapi.json
@@ -1,0 +1,5214 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Xona Agent x402 API",
+    "version": "2.0.0",
+    "description": "Pay-per-call AI infrastructure for autonomous agents. Xona exposes image generation, video generation, music, text-to-speech, transcription, token analytics, and social AI endpoints — all gated by the x402 micro-payment protocol (USDC on Solana).\n\n## x402 Payment Flow\n\n1. **Probe** — Call any protected endpoint without the `payment-signature` header.\n2. **Challenge** — Receive `HTTP 402` with a `PAYMENT-REQUIRED` header (Base64-encoded requirements) and a JSON body describing the `accepts` array and `resource`.\n3. **Pay** — Submit an on-chain USDC transfer using an x402-compatible wallet or the `@x402/client` library. Obtain the `payment-signature` string.\n4. **Retry** — Re-send the original request with the `payment-signature: <sig>` header.\n5. **Success** — Receive `HTTP 200` with the result and an `X-PAYMENT-RESPONSE` header confirming settlement.",
+    "guidance": "payment-signature header carries the x402 payment credential. PAYMENT-REQUIRED response header carries the encoded x402 requirements JSON. X-PAYMENT-RESPONSE response header carries the encoded settlement confirmation."
+  },
+  "x-service-info": {
+    "categories": [
+      "ai",
+      "generation",
+      "research",
+      "blockchain"
+    ],
+    "protocol": "x402",
+    "docs": {
+      "homepage": "https://api.xona-agent.com",
+      "apiReference": "https://api.xona-agent.com/openapi.json",
+      "mppApiReference": "https://api.xona-agent.com/openapi-mpp.json"
+    }
+  },
+  "x-discovery": {
+    "ownershipProofs": [
+      "0x5af113143e64b76758d33a01e695fff3ef55028c1ce13da7bd47bff845c997213d0bfe5e1fd73d4aa6b1a6ee9050dd210f6bea8da7e56fbecbd863838cd350c11b"
+    ]
+  },
+  "servers": [
+    {
+      "url": "https://api.xona-agent.com",
+      "description": "Production server"
+    },
+    {
+      "url": "http://localhost:8000",
+      "description": "Development server"
+    }
+  ],
+  "tags": [
+    {
+      "name": "Image Generation",
+      "description": "x402 payment-gated AI image generation endpoints"
+    },
+    {
+      "name": "Image Models",
+      "description": "Direct image model endpoints (Dexter x402 middleware)"
+    },
+    {
+      "name": "Video",
+      "description": "x402 payment-gated AI video generation endpoints"
+    },
+    {
+      "name": "Audio",
+      "description": "Music generation, TTS, and transcription endpoints"
+    },
+    {
+      "name": "Token Tools",
+      "description": "Token analytics, signals, and branding kit endpoints"
+    },
+    {
+      "name": "AI Services",
+      "description": "AI-powered social intelligence endpoints"
+    },
+    {
+      "name": "Resources",
+      "description": "Public discovery endpoints listing available x402 resources"
+    }
+  ],
+  "paths": {
+    "/image/creative-director": {
+      "post": {
+        "tags": [
+          "Image Generation"
+        ],
+        "summary": "Research-enhanced creative prompt refinement",
+        "description": "Searches X (Twitter) and Google to research trends, then transforms your idea into an optimised image generation plan. Returns intent analysis, research snippets, and a refined generation direction.",
+        "operationId": "image_creative_director",
+        "x-payment-info": {
+          "protocol": "x402",
+          "pricingMode": "fixed",
+          "priceUsd": 0.03,
+          "network": "solana",
+          "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+        },
+        "parameters": [
+          {
+            "name": "payment-signature",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "x402 payment signature obtained after submitting an on-chain USDC payment. Omit on first call to receive the 402 payment challenge."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "idea": {
+                    "type": "string",
+                    "description": "User's prompt or idea for image generation"
+                  },
+                  "reference_images": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Existing image URLs to use as style references"
+                  }
+                },
+                "required": [
+                  "idea"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "X-PAYMENT-RESPONSE": {
+                "description": "Encoded x402 payment confirmation.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "intent": {
+                      "type": "object",
+                      "description": "Analysed user intent"
+                    },
+                    "research": {
+                      "type": "array",
+                      "items": {
+                        "type": "object"
+                      },
+                      "description": "Research results from X and Google"
+                    },
+                    "direction": {
+                      "type": "array",
+                      "items": {
+                        "type": "object"
+                      },
+                      "description": "Generation plan with refined prompt"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required — x402 challenge. Retry with payment-signature header.",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "Encoded x402 payment requirements (Base64 JSON).",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "x402Version": {
+                      "type": "integer",
+                      "example": 2
+                    },
+                    "accepts": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "scheme": {
+                            "type": "string",
+                            "example": "exact"
+                          },
+                          "network": {
+                            "type": "string",
+                            "example": "solana"
+                          },
+                          "amount": {
+                            "type": "string",
+                            "description": "Amount in atomic USDC units (6 decimals)",
+                            "example": "50000"
+                          },
+                          "payTo": {
+                            "type": "string",
+                            "description": "Receiving wallet address"
+                          },
+                          "asset": {
+                            "type": "string",
+                            "description": "USDC mint address",
+                            "example": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+                          },
+                          "maxTimeoutSeconds": {
+                            "type": "integer",
+                            "example": 1200
+                          }
+                        }
+                      }
+                    },
+                    "resource": {
+                      "type": "object",
+                      "properties": {
+                        "url": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "mimeType": {
+                          "type": "string",
+                          "example": "application/json"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/image/designer": {
+      "post": {
+        "tags": [
+          "Image Generation"
+        ],
+        "summary": "AI image generation with style blending",
+        "description": "Takes your prompt and style keywords, blends them intelligently, and generates a high-quality image. Supports up to 8 reference images.",
+        "operationId": "image_designer",
+        "x-payment-info": {
+          "protocol": "x402",
+          "pricingMode": "fixed",
+          "priceUsd": 0.06,
+          "network": "solana",
+          "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+        },
+        "parameters": [
+          {
+            "name": "payment-signature",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "x402 payment signature obtained after submitting an on-chain USDC payment. Omit on first call to receive the 402 payment challenge."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "prompt": {
+                    "type": "string",
+                    "description": "Detailed prompt description"
+                  },
+                  "style": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Style keywords to blend into the prompt"
+                  },
+                  "aspect_ratio": {
+                    "type": "string",
+                    "description": "Image aspect ratio (default: 1:1)"
+                  },
+                  "referenceImage": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Reference image URLs for style guidance"
+                  }
+                },
+                "required": [
+                  "prompt"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "X-PAYMENT-RESPONSE": {
+                "description": "Encoded x402 payment confirmation.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "image_url": {
+                      "type": "string",
+                      "description": "Generated image URL (CDN)"
+                    },
+                    "image_description": {
+                      "type": "string",
+                      "description": "Prompt used for generation"
+                    },
+                    "metadata": {
+                      "type": "object",
+                      "description": "Generation metadata (model, aspectRatio, cdn_key, etc.)"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required — x402 challenge. Retry with payment-signature header.",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "Encoded x402 payment requirements (Base64 JSON).",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "x402Version": {
+                      "type": "integer",
+                      "example": 2
+                    },
+                    "accepts": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "scheme": {
+                            "type": "string",
+                            "example": "exact"
+                          },
+                          "network": {
+                            "type": "string",
+                            "example": "solana"
+                          },
+                          "amount": {
+                            "type": "string",
+                            "description": "Amount in atomic USDC units (6 decimals)",
+                            "example": "50000"
+                          },
+                          "payTo": {
+                            "type": "string",
+                            "description": "Receiving wallet address"
+                          },
+                          "asset": {
+                            "type": "string",
+                            "description": "USDC mint address",
+                            "example": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+                          },
+                          "maxTimeoutSeconds": {
+                            "type": "integer",
+                            "example": 1200
+                          }
+                        }
+                      }
+                    },
+                    "resource": {
+                      "type": "object",
+                      "properties": {
+                        "url": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "mimeType": {
+                          "type": "string",
+                          "example": "application/json"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/image/nano-banana-pro": {
+      "post": {
+        "tags": [
+          "Image Generation"
+        ],
+        "summary": "Nano Banana Pro — high-quality image generation",
+        "description": "Generates a high-quality image from your prompt using the nano-banana-pro model. No style blending — pure prompt-to-image.",
+        "operationId": "image_nano_banana_pro",
+        "x-payment-info": {
+          "protocol": "x402",
+          "pricingMode": "fixed",
+          "priceUsd": 0.15,
+          "network": "solana",
+          "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+        },
+        "parameters": [
+          {
+            "name": "payment-signature",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "x402 payment signature obtained after submitting an on-chain USDC payment. Omit on first call to receive the 402 payment challenge."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "prompt": {
+                    "type": "string",
+                    "description": "Detailed prompt description for the image to generate"
+                  },
+                  "aspect_ratio": {
+                    "type": "string",
+                    "description": "Image aspect ratio (default: 1:1)"
+                  },
+                  "referenceImage": {
+                    "type": "array",
+                    "description": "Array of reference image URLs for style/composition guidance",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": [
+                  "prompt"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "X-PAYMENT-RESPONSE": {
+                "description": "Encoded x402 payment confirmation.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "image_url": {
+                      "type": "string",
+                      "description": "Generated image URL (CDN)"
+                    },
+                    "image_description": {
+                      "type": "string",
+                      "description": "Prompt used for generation"
+                    },
+                    "metadata": {
+                      "type": "object",
+                      "description": "Generation metadata (model, aspectRatio, cdn_key, etc.)"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required — x402 challenge. Retry with payment-signature header.",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "Encoded x402 payment requirements (Base64 JSON).",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "x402Version": {
+                      "type": "integer",
+                      "example": 2
+                    },
+                    "accepts": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "scheme": {
+                            "type": "string",
+                            "example": "exact"
+                          },
+                          "network": {
+                            "type": "string",
+                            "example": "solana"
+                          },
+                          "amount": {
+                            "type": "string",
+                            "description": "Amount in atomic USDC units (6 decimals)",
+                            "example": "50000"
+                          },
+                          "payTo": {
+                            "type": "string",
+                            "description": "Receiving wallet address"
+                          },
+                          "asset": {
+                            "type": "string",
+                            "description": "USDC mint address",
+                            "example": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+                          },
+                          "maxTimeoutSeconds": {
+                            "type": "integer",
+                            "example": 1200
+                          }
+                        }
+                      }
+                    },
+                    "resource": {
+                      "type": "object",
+                      "properties": {
+                        "url": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "mimeType": {
+                          "type": "string",
+                          "example": "application/json"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/image/nano-banana": {
+      "post": {
+        "tags": [
+          "Image Generation"
+        ],
+        "summary": "Nano Banana — fast image generation",
+        "description": "Generates a high-quality image from your prompt using the nano-banana model. Supports up to 8 reference images.",
+        "operationId": "image_nano_banana",
+        "x-payment-info": {
+          "protocol": "x402",
+          "pricingMode": "fixed",
+          "priceUsd": 0.05,
+          "network": "solana",
+          "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+        },
+        "parameters": [
+          {
+            "name": "payment-signature",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "x402 payment signature obtained after submitting an on-chain USDC payment. Omit on first call to receive the 402 payment challenge."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "prompt": {
+                    "type": "string",
+                    "description": "Detailed prompt description for the image to generate"
+                  },
+                  "aspect_ratio": {
+                    "type": "string",
+                    "description": "Image aspect ratio (default: 1:1)"
+                  },
+                  "referenceImage": {
+                    "type": "array",
+                    "description": "Array of reference image URLs for style/composition guidance",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": [
+                  "prompt"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "X-PAYMENT-RESPONSE": {
+                "description": "Encoded x402 payment confirmation.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "image_url": {
+                      "type": "string",
+                      "description": "Generated image URL (CDN)"
+                    },
+                    "image_description": {
+                      "type": "string",
+                      "description": "Prompt used for generation"
+                    },
+                    "metadata": {
+                      "type": "object",
+                      "description": "Generation metadata (model, aspectRatio, cdn_key, etc.)"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required — x402 challenge. Retry with payment-signature header.",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "Encoded x402 payment requirements (Base64 JSON).",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "x402Version": {
+                      "type": "integer",
+                      "example": 2
+                    },
+                    "accepts": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "scheme": {
+                            "type": "string",
+                            "example": "exact"
+                          },
+                          "network": {
+                            "type": "string",
+                            "example": "solana"
+                          },
+                          "amount": {
+                            "type": "string",
+                            "description": "Amount in atomic USDC units (6 decimals)",
+                            "example": "50000"
+                          },
+                          "payTo": {
+                            "type": "string",
+                            "description": "Receiving wallet address"
+                          },
+                          "asset": {
+                            "type": "string",
+                            "description": "USDC mint address",
+                            "example": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+                          },
+                          "maxTimeoutSeconds": {
+                            "type": "integer",
+                            "example": 1200
+                          }
+                        }
+                      }
+                    },
+                    "resource": {
+                      "type": "object",
+                      "properties": {
+                        "url": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "mimeType": {
+                          "type": "string",
+                          "example": "application/json"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/image/nano-banana-2": {
+      "post": {
+        "tags": [
+          "Image Generation"
+        ],
+        "summary": "Nano Banana 2 — resolution-based dynamic pricing",
+        "description": "Generates an image using the nano-banana-2 model with resolution-based pricing: 1k = $0.06, 2k = $0.10, 4k = $0.15.",
+        "operationId": "image_nano_banana_2",
+        "x-payment-info": {
+          "protocol": "x402",
+          "pricingMode": "dynamic",
+          "network": "solana"
+        },
+        "parameters": [
+          {
+            "name": "payment-signature",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "x402 payment signature obtained after submitting an on-chain USDC payment. Omit on first call to receive the 402 payment challenge."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "prompt": {
+                    "type": "string",
+                    "description": "Detailed prompt description"
+                  },
+                  "resolution": {
+                    "type": "string",
+                    "enum": [
+                      "1k",
+                      "2k",
+                      "4k"
+                    ],
+                    "description": "Output resolution. Determines price (1k=$0.06, 2k=$0.10, 4k=$0.15)",
+                    "default": "1k"
+                  },
+                  "aspect_ratio": {
+                    "type": "string",
+                    "description": "Image aspect ratio (default: 1:1)"
+                  },
+                  "referenceImage": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Reference image URLs"
+                  }
+                },
+                "required": [
+                  "prompt"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "X-PAYMENT-RESPONSE": {
+                "description": "Encoded x402 payment confirmation.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "image_url": {
+                      "type": "string",
+                      "description": "Generated image URL (CDN)"
+                    },
+                    "image_description": {
+                      "type": "string",
+                      "description": "Prompt used for generation"
+                    },
+                    "metadata": {
+                      "type": "object",
+                      "description": "Generation metadata (model, aspectRatio, cdn_key, etc.)"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required — x402 challenge. Retry with payment-signature header.",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "Encoded x402 payment requirements (Base64 JSON).",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "x402Version": {
+                      "type": "integer",
+                      "example": 2
+                    },
+                    "accepts": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "scheme": {
+                            "type": "string",
+                            "example": "exact"
+                          },
+                          "network": {
+                            "type": "string",
+                            "example": "solana"
+                          },
+                          "amount": {
+                            "type": "string",
+                            "description": "Amount in atomic USDC units (6 decimals)",
+                            "example": "50000"
+                          },
+                          "payTo": {
+                            "type": "string",
+                            "description": "Receiving wallet address"
+                          },
+                          "asset": {
+                            "type": "string",
+                            "description": "USDC mint address",
+                            "example": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+                          },
+                          "maxTimeoutSeconds": {
+                            "type": "integer",
+                            "example": 1200
+                          }
+                        }
+                      }
+                    },
+                    "resource": {
+                      "type": "object",
+                      "properties": {
+                        "url": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "mimeType": {
+                          "type": "string",
+                          "example": "application/json"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/image/grok-imagine": {
+      "post": {
+        "tags": [
+          "Image Generation"
+        ],
+        "summary": "Grok Imagine — xAI image generation",
+        "description": "Generates a high-quality image using xAI's Grok Imagine API. Supports a single reference image.",
+        "operationId": "image_grok_imagine",
+        "x-payment-info": {
+          "protocol": "x402",
+          "pricingMode": "fixed",
+          "priceUsd": 0.04,
+          "network": "solana",
+          "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+        },
+        "parameters": [
+          {
+            "name": "payment-signature",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "x402 payment signature obtained after submitting an on-chain USDC payment. Omit on first call to receive the 402 payment challenge."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "prompt": {
+                    "type": "string",
+                    "description": "Detailed prompt description"
+                  },
+                  "referenceImage": {
+                    "type": "string",
+                    "description": "Single reference image URL (Grok supports one image only)"
+                  }
+                },
+                "required": [
+                  "prompt"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "X-PAYMENT-RESPONSE": {
+                "description": "Encoded x402 payment confirmation.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "image_url": {
+                      "type": "string",
+                      "description": "Generated image URL (CDN)"
+                    },
+                    "image_description": {
+                      "type": "string",
+                      "description": "Prompt used for generation"
+                    },
+                    "metadata": {
+                      "type": "object",
+                      "description": "Generation metadata (model, aspectRatio, cdn_key, etc.)"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required — x402 challenge. Retry with payment-signature header.",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "Encoded x402 payment requirements (Base64 JSON).",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "x402Version": {
+                      "type": "integer",
+                      "example": 2
+                    },
+                    "accepts": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "scheme": {
+                            "type": "string",
+                            "example": "exact"
+                          },
+                          "network": {
+                            "type": "string",
+                            "example": "solana"
+                          },
+                          "amount": {
+                            "type": "string",
+                            "description": "Amount in atomic USDC units (6 decimals)",
+                            "example": "50000"
+                          },
+                          "payTo": {
+                            "type": "string",
+                            "description": "Receiving wallet address"
+                          },
+                          "asset": {
+                            "type": "string",
+                            "description": "USDC mint address",
+                            "example": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+                          },
+                          "maxTimeoutSeconds": {
+                            "type": "integer",
+                            "example": 1200
+                          }
+                        }
+                      }
+                    },
+                    "resource": {
+                      "type": "object",
+                      "properties": {
+                        "url": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "mimeType": {
+                          "type": "string",
+                          "example": "application/json"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/image/gpt-image-2": {
+      "post": {
+        "tags": [
+          "Image Generation"
+        ],
+        "summary": "GPT Image 2 — OpenAI photorealistic generation",
+        "description": "Generates a photorealistic image using GPT Image 2 (OpenAI via Replicate). Excellent text rendering and instruction following. Quality: medium. Aspect ratio: 1:1 only.",
+        "operationId": "image_gpt_image_2",
+        "x-payment-info": {
+          "protocol": "x402",
+          "pricingMode": "fixed",
+          "priceUsd": 0.12,
+          "network": "solana",
+          "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+        },
+        "parameters": [
+          {
+            "name": "payment-signature",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "x402 payment signature obtained after submitting an on-chain USDC payment. Omit on first call to receive the 402 payment challenge."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "prompt": {
+                    "type": "string",
+                    "description": "Detailed prompt describing the desired image"
+                  },
+                  "aspect_ratio": {
+                    "type": "string",
+                    "description": "Must be 1:1 (any other value is coerced)"
+                  },
+                  "referenceImage": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Optional reference image URLs (up to 16) for image-to-image editing"
+                  }
+                },
+                "required": [
+                  "prompt"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "X-PAYMENT-RESPONSE": {
+                "description": "Encoded x402 payment confirmation.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "image_url": {
+                      "type": "string",
+                      "description": "Generated image URL (CDN)"
+                    },
+                    "image_description": {
+                      "type": "string",
+                      "description": "Prompt used for generation"
+                    },
+                    "metadata": {
+                      "type": "object",
+                      "description": "Generation metadata (model, aspectRatio, cdn_key, etc.)"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required — x402 challenge. Retry with payment-signature header.",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "Encoded x402 payment requirements (Base64 JSON).",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "x402Version": {
+                      "type": "integer",
+                      "example": 2
+                    },
+                    "accepts": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "scheme": {
+                            "type": "string",
+                            "example": "exact"
+                          },
+                          "network": {
+                            "type": "string",
+                            "example": "solana"
+                          },
+                          "amount": {
+                            "type": "string",
+                            "description": "Amount in atomic USDC units (6 decimals)",
+                            "example": "50000"
+                          },
+                          "payTo": {
+                            "type": "string",
+                            "description": "Receiving wallet address"
+                          },
+                          "asset": {
+                            "type": "string",
+                            "description": "USDC mint address",
+                            "example": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+                          },
+                          "maxTimeoutSeconds": {
+                            "type": "integer",
+                            "example": 1200
+                          }
+                        }
+                      }
+                    },
+                    "resource": {
+                      "type": "object",
+                      "properties": {
+                        "url": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "mimeType": {
+                          "type": "string",
+                          "example": "application/json"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/image/flux-2-pro": {
+      "post": {
+        "tags": [
+          "Image Generation"
+        ],
+        "summary": "FLUX.2 Pro — high-quality image generation and editing",
+        "description": "High-quality image generation and editing with support for eight reference images, powered by Black Forest Labs FLUX.2 Pro.",
+        "operationId": "image_flux2_pro",
+        "x-payment-info": {
+          "protocol": "x402",
+          "pricingMode": "fixed",
+          "priceUsd": 0.05,
+          "network": "solana",
+          "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+        },
+        "parameters": [
+          {
+            "name": "payment-signature",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "x402 payment signature obtained after submitting an on-chain USDC payment. Omit on first call to receive the 402 payment challenge."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "prompt": {
+                    "type": "string",
+                    "description": "Detailed prompt description for the image"
+                  },
+                  "aspect_ratio": {
+                    "type": "string",
+                    "description": "Image aspect ratio (default: 1:1)"
+                  },
+                  "referenceImage": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Reference image URLs for style/composition guidance"
+                  }
+                },
+                "required": [
+                  "prompt"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "X-PAYMENT-RESPONSE": {
+                "description": "Encoded x402 payment confirmation.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "image_url": {
+                      "type": "string",
+                      "description": "Generated image URL (CDN)"
+                    },
+                    "image_description": {
+                      "type": "string",
+                      "description": "Prompt used for generation"
+                    },
+                    "metadata": {
+                      "type": "object",
+                      "description": "Generation metadata (model, aspectRatio, cdn_key, etc.)"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required — x402 challenge. Retry with payment-signature header.",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "Encoded x402 payment requirements (Base64 JSON).",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "x402Version": {
+                      "type": "integer",
+                      "example": 2
+                    },
+                    "accepts": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "scheme": {
+                            "type": "string",
+                            "example": "exact"
+                          },
+                          "network": {
+                            "type": "string",
+                            "example": "solana"
+                          },
+                          "amount": {
+                            "type": "string",
+                            "description": "Amount in atomic USDC units (6 decimals)",
+                            "example": "50000"
+                          },
+                          "payTo": {
+                            "type": "string",
+                            "description": "Receiving wallet address"
+                          },
+                          "asset": {
+                            "type": "string",
+                            "description": "USDC mint address",
+                            "example": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+                          },
+                          "maxTimeoutSeconds": {
+                            "type": "integer",
+                            "example": 1200
+                          }
+                        }
+                      }
+                    },
+                    "resource": {
+                      "type": "object",
+                      "properties": {
+                        "url": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "mimeType": {
+                          "type": "string",
+                          "example": "application/json"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/image/flux-2-max": {
+      "post": {
+        "tags": [
+          "Image Generation"
+        ],
+        "summary": "FLUX.2 Max — highest fidelity image model",
+        "description": "The highest fidelity image model from Black Forest Labs. Ideal for demanding generation tasks.",
+        "operationId": "image_flux2_max",
+        "x-payment-info": {
+          "protocol": "x402",
+          "pricingMode": "fixed",
+          "priceUsd": 0.08,
+          "network": "solana",
+          "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+        },
+        "parameters": [
+          {
+            "name": "payment-signature",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "x402 payment signature obtained after submitting an on-chain USDC payment. Omit on first call to receive the 402 payment challenge."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "prompt": {
+                    "type": "string",
+                    "description": "Detailed prompt description for the image"
+                  },
+                  "aspect_ratio": {
+                    "type": "string",
+                    "description": "Image aspect ratio (default: 1:1)"
+                  },
+                  "referenceImage": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Reference image URLs for style/composition guidance"
+                  }
+                },
+                "required": [
+                  "prompt"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "X-PAYMENT-RESPONSE": {
+                "description": "Encoded x402 payment confirmation.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "image_url": {
+                      "type": "string",
+                      "description": "Generated image URL (CDN)"
+                    },
+                    "image_description": {
+                      "type": "string",
+                      "description": "Prompt used for generation"
+                    },
+                    "metadata": {
+                      "type": "object",
+                      "description": "Generation metadata (model, aspectRatio, cdn_key, etc.)"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required — x402 challenge. Retry with payment-signature header.",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "Encoded x402 payment requirements (Base64 JSON).",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "x402Version": {
+                      "type": "integer",
+                      "example": 2
+                    },
+                    "accepts": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "scheme": {
+                            "type": "string",
+                            "example": "exact"
+                          },
+                          "network": {
+                            "type": "string",
+                            "example": "solana"
+                          },
+                          "amount": {
+                            "type": "string",
+                            "description": "Amount in atomic USDC units (6 decimals)",
+                            "example": "50000"
+                          },
+                          "payTo": {
+                            "type": "string",
+                            "description": "Receiving wallet address"
+                          },
+                          "asset": {
+                            "type": "string",
+                            "description": "USDC mint address",
+                            "example": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+                          },
+                          "maxTimeoutSeconds": {
+                            "type": "integer",
+                            "example": 1200
+                          }
+                        }
+                      }
+                    },
+                    "resource": {
+                      "type": "object",
+                      "properties": {
+                        "url": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "mimeType": {
+                          "type": "string",
+                          "example": "application/json"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/image/flux-2-flex": {
+      "post": {
+        "tags": [
+          "Image Generation"
+        ],
+        "summary": "FLUX.2 Flex — max-quality generation and editing",
+        "description": "Max-quality image generation and editing with support for ten reference images.",
+        "operationId": "image_flux2_flex",
+        "x-payment-info": {
+          "protocol": "x402",
+          "pricingMode": "fixed",
+          "priceUsd": 0.06,
+          "network": "solana",
+          "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+        },
+        "parameters": [
+          {
+            "name": "payment-signature",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "x402 payment signature obtained after submitting an on-chain USDC payment. Omit on first call to receive the 402 payment challenge."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "prompt": {
+                    "type": "string",
+                    "description": "Detailed prompt description for the image"
+                  },
+                  "aspect_ratio": {
+                    "type": "string",
+                    "description": "Image aspect ratio (default: 1:1)"
+                  },
+                  "referenceImage": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Reference image URLs for style/composition guidance"
+                  }
+                },
+                "required": [
+                  "prompt"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "X-PAYMENT-RESPONSE": {
+                "description": "Encoded x402 payment confirmation.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "image_url": {
+                      "type": "string",
+                      "description": "Generated image URL (CDN)"
+                    },
+                    "image_description": {
+                      "type": "string",
+                      "description": "Prompt used for generation"
+                    },
+                    "metadata": {
+                      "type": "object",
+                      "description": "Generation metadata (model, aspectRatio, cdn_key, etc.)"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required — x402 challenge. Retry with payment-signature header.",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "Encoded x402 payment requirements (Base64 JSON).",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "x402Version": {
+                      "type": "integer",
+                      "example": 2
+                    },
+                    "accepts": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "scheme": {
+                            "type": "string",
+                            "example": "exact"
+                          },
+                          "network": {
+                            "type": "string",
+                            "example": "solana"
+                          },
+                          "amount": {
+                            "type": "string",
+                            "description": "Amount in atomic USDC units (6 decimals)",
+                            "example": "50000"
+                          },
+                          "payTo": {
+                            "type": "string",
+                            "description": "Receiving wallet address"
+                          },
+                          "asset": {
+                            "type": "string",
+                            "description": "USDC mint address",
+                            "example": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+                          },
+                          "maxTimeoutSeconds": {
+                            "type": "integer",
+                            "example": 1200
+                          }
+                        }
+                      }
+                    },
+                    "resource": {
+                      "type": "object",
+                      "properties": {
+                        "url": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "mimeType": {
+                          "type": "string",
+                          "example": "application/json"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/image-model/qwen-image": {
+      "post": {
+        "tags": [
+          "Image Models"
+        ],
+        "summary": "Qwen Image — multimodal image generation",
+        "description": "Generates an image using the qwen/qwen-image multimodal model. Supports a single reference image for style/content guidance.",
+        "operationId": "image_model_qwen",
+        "x-payment-info": {
+          "protocol": "x402",
+          "pricingMode": "fixed",
+          "priceUsd": 0.05,
+          "network": "solana",
+          "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+        },
+        "parameters": [
+          {
+            "name": "payment-signature",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "x402 payment signature obtained after submitting an on-chain USDC payment. Omit on first call to receive the 402 payment challenge."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "prompt": {
+                    "type": "string",
+                    "description": "Detailed prompt description"
+                  },
+                  "aspect_ratio": {
+                    "type": "string",
+                    "description": "Image aspect ratio (default: 1:1)"
+                  },
+                  "referenceImage": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Reference image URLs (uses first image)"
+                  }
+                },
+                "required": [
+                  "prompt"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "X-PAYMENT-RESPONSE": {
+                "description": "Encoded x402 payment confirmation.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "image_url": {
+                      "type": "string",
+                      "description": "Generated image URL (CDN)"
+                    },
+                    "image_description": {
+                      "type": "string",
+                      "description": "Prompt used for generation"
+                    },
+                    "metadata": {
+                      "type": "object",
+                      "description": "Generation metadata (model, aspectRatio, cdn_key, etc.)"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required — x402 challenge. Retry with payment-signature header.",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "Encoded x402 payment requirements (Base64 JSON).",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "x402Version": {
+                      "type": "integer",
+                      "example": 2
+                    },
+                    "accepts": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "scheme": {
+                            "type": "string",
+                            "example": "exact"
+                          },
+                          "network": {
+                            "type": "string",
+                            "example": "solana"
+                          },
+                          "amount": {
+                            "type": "string",
+                            "description": "Amount in atomic USDC units (6 decimals)",
+                            "example": "50000"
+                          },
+                          "payTo": {
+                            "type": "string",
+                            "description": "Receiving wallet address"
+                          },
+                          "asset": {
+                            "type": "string",
+                            "description": "USDC mint address",
+                            "example": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+                          },
+                          "maxTimeoutSeconds": {
+                            "type": "integer",
+                            "example": 1200
+                          }
+                        }
+                      }
+                    },
+                    "resource": {
+                      "type": "object",
+                      "properties": {
+                        "url": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "mimeType": {
+                          "type": "string",
+                          "example": "application/json"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/image-model/seedream-4.5": {
+      "post": {
+        "tags": [
+          "Image Models"
+        ],
+        "summary": "Seedream-4.5 — ByteDance image generation",
+        "description": "Generates a high-quality image using the ByteDance Seedream-4.5 model. Supports up to 8 reference images.",
+        "operationId": "image_model_seedream45",
+        "x-payment-info": {
+          "protocol": "x402",
+          "pricingMode": "fixed",
+          "priceUsd": 0.08,
+          "network": "solana",
+          "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+        },
+        "parameters": [
+          {
+            "name": "payment-signature",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "x402 payment signature obtained after submitting an on-chain USDC payment. Omit on first call to receive the 402 payment challenge."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "prompt": {
+                    "type": "string",
+                    "description": "Detailed prompt description for the image to generate"
+                  },
+                  "aspect_ratio": {
+                    "type": "string",
+                    "description": "Image aspect ratio (default: 1:1)"
+                  },
+                  "referenceImage": {
+                    "type": "array",
+                    "description": "Array of reference image URLs for style/composition guidance",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": [
+                  "prompt"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "X-PAYMENT-RESPONSE": {
+                "description": "Encoded x402 payment confirmation.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "image_url": {
+                      "type": "string",
+                      "description": "Generated image URL (CDN)"
+                    },
+                    "image_description": {
+                      "type": "string",
+                      "description": "Prompt used for generation"
+                    },
+                    "metadata": {
+                      "type": "object",
+                      "description": "Generation metadata (model, aspectRatio, cdn_key, etc.)"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required — x402 challenge. Retry with payment-signature header.",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "Encoded x402 payment requirements (Base64 JSON).",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "x402Version": {
+                      "type": "integer",
+                      "example": 2
+                    },
+                    "accepts": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "scheme": {
+                            "type": "string",
+                            "example": "exact"
+                          },
+                          "network": {
+                            "type": "string",
+                            "example": "solana"
+                          },
+                          "amount": {
+                            "type": "string",
+                            "description": "Amount in atomic USDC units (6 decimals)",
+                            "example": "50000"
+                          },
+                          "payTo": {
+                            "type": "string",
+                            "description": "Receiving wallet address"
+                          },
+                          "asset": {
+                            "type": "string",
+                            "description": "USDC mint address",
+                            "example": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+                          },
+                          "maxTimeoutSeconds": {
+                            "type": "integer",
+                            "example": 1200
+                          }
+                        }
+                      }
+                    },
+                    "resource": {
+                      "type": "object",
+                      "properties": {
+                        "url": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "mimeType": {
+                          "type": "string",
+                          "example": "application/json"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/video/short-generation": {
+      "post": {
+        "tags": [
+          "Video"
+        ],
+        "summary": "Grok Video — 10-second AI video generation",
+        "description": "Generates a 10-second high-quality video using xAI's Grok Imagine Video API. Supports image-to-video via optional input image.",
+        "operationId": "video_short_generation",
+        "x-payment-info": {
+          "protocol": "x402",
+          "pricingMode": "fixed",
+          "priceUsd": 0.5,
+          "network": "solana",
+          "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+        },
+        "parameters": [
+          {
+            "name": "payment-signature",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "x402 payment signature obtained after submitting an on-chain USDC payment. Omit on first call to receive the 402 payment challenge."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "prompt": {
+                    "type": "string",
+                    "description": "Prompt for video generation"
+                  },
+                  "aspect_ratio": {
+                    "type": "string",
+                    "description": "Video aspect ratio (default: 16:9)"
+                  },
+                  "image_url": {
+                    "type": "string",
+                    "description": "Optional input image URL for image-to-video generation"
+                  }
+                },
+                "required": [
+                  "prompt"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "X-PAYMENT-RESPONSE": {
+                "description": "Encoded x402 payment confirmation.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "video_url": {
+                      "type": "string",
+                      "description": "Generated video URL (CDN)"
+                    },
+                    "duration": {
+                      "type": "number",
+                      "description": "Video duration in seconds (always 10)"
+                    },
+                    "model": {
+                      "type": "string",
+                      "description": "Model used for generation"
+                    },
+                    "metadata": {
+                      "type": "object",
+                      "description": "Generation metadata (request_id, aspect_ratio, etc.)"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required — x402 challenge. Retry with payment-signature header.",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "Encoded x402 payment requirements (Base64 JSON).",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "x402Version": {
+                      "type": "integer",
+                      "example": 2
+                    },
+                    "accepts": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "scheme": {
+                            "type": "string",
+                            "example": "exact"
+                          },
+                          "network": {
+                            "type": "string",
+                            "example": "solana"
+                          },
+                          "amount": {
+                            "type": "string",
+                            "description": "Amount in atomic USDC units (6 decimals)",
+                            "example": "50000"
+                          },
+                          "payTo": {
+                            "type": "string",
+                            "description": "Receiving wallet address"
+                          },
+                          "asset": {
+                            "type": "string",
+                            "description": "USDC mint address",
+                            "example": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+                          },
+                          "maxTimeoutSeconds": {
+                            "type": "integer",
+                            "example": 1200
+                          }
+                        }
+                      }
+                    },
+                    "resource": {
+                      "type": "object",
+                      "properties": {
+                        "url": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "mimeType": {
+                          "type": "string",
+                          "example": "application/json"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/video/seedance-generation": {
+      "post": {
+        "tags": [
+          "Video"
+        ],
+        "summary": "Seedance 2.0 — ByteDance video generation with audio",
+        "description": "Generates a video with audio using ByteDance Seedance 2.0 via Replicate. Defaults to 10-second 480p; supports up to 10s, up to 1080p.",
+        "operationId": "video_seedance_generation",
+        "x-payment-info": {
+          "protocol": "x402",
+          "pricingMode": "fixed",
+          "priceUsd": 0.8,
+          "network": "solana",
+          "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+        },
+        "parameters": [
+          {
+            "name": "payment-signature",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "x402 payment signature obtained after submitting an on-chain USDC payment. Omit on first call to receive the 402 payment challenge."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "prompt": {
+                    "type": "string",
+                    "description": "Prompt for video generation"
+                  },
+                  "aspect_ratio": {
+                    "type": "string",
+                    "description": "Video aspect ratio (default: 16:9)"
+                  },
+                  "duration": {
+                    "type": "number",
+                    "description": "Clip length in seconds (1–10, default: 10)"
+                  },
+                  "resolution": {
+                    "type": "string",
+                    "enum": [
+                      "480p",
+                      "720p",
+                      "1080p"
+                    ],
+                    "description": "Output resolution (default: 480p)"
+                  },
+                  "reference_images": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Optional reference image URLs"
+                  }
+                },
+                "required": [
+                  "prompt"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "X-PAYMENT-RESPONSE": {
+                "description": "Encoded x402 payment confirmation.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "video_url": {
+                      "type": "string",
+                      "description": "CDN URL of the generated video"
+                    },
+                    "thumbnail_url": {
+                      "type": "string",
+                      "description": "CDN URL of the first-frame thumbnail"
+                    },
+                    "duration": {
+                      "type": "number",
+                      "description": "Video duration in seconds"
+                    },
+                    "model": {
+                      "type": "string",
+                      "description": "Model used: bytedance/seedance-2.0"
+                    },
+                    "metadata": {
+                      "type": "object",
+                      "description": "Generation metadata"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required — x402 challenge. Retry with payment-signature header.",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "Encoded x402 payment requirements (Base64 JSON).",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "x402Version": {
+                      "type": "integer",
+                      "example": 2
+                    },
+                    "accepts": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "scheme": {
+                            "type": "string",
+                            "example": "exact"
+                          },
+                          "network": {
+                            "type": "string",
+                            "example": "solana"
+                          },
+                          "amount": {
+                            "type": "string",
+                            "description": "Amount in atomic USDC units (6 decimals)",
+                            "example": "50000"
+                          },
+                          "payTo": {
+                            "type": "string",
+                            "description": "Receiving wallet address"
+                          },
+                          "asset": {
+                            "type": "string",
+                            "description": "USDC mint address",
+                            "example": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+                          },
+                          "maxTimeoutSeconds": {
+                            "type": "integer",
+                            "example": 1200
+                          }
+                        }
+                      }
+                    },
+                    "resource": {
+                      "type": "object",
+                      "properties": {
+                        "url": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "mimeType": {
+                          "type": "string",
+                          "example": "application/json"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/audio/elevenlabs-music": {
+      "post": {
+        "tags": [
+          "Audio"
+        ],
+        "summary": "ElevenLabs Music — AI music generation",
+        "description": "Generates music from a text prompt using ElevenLabs Music (via Replicate). Dynamic pricing: $1 per 120 seconds, max 3 minutes. Base price covers 3 minutes.",
+        "operationId": "audio_elevenlabs_music",
+        "x-payment-info": {
+          "protocol": "x402",
+          "pricingMode": "fixed",
+          "priceUsd": 1.5,
+          "network": "solana",
+          "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+        },
+        "parameters": [
+          {
+            "name": "payment-signature",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "x402 payment signature obtained after submitting an on-chain USDC payment. Omit on first call to receive the 402 payment challenge."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "prompt": {
+                    "type": "string",
+                    "description": "Description of the music to generate"
+                  },
+                  "output_format": {
+                    "type": "string",
+                    "description": "Output format (e.g. mp3_standard)"
+                  },
+                  "music_length_ms": {
+                    "type": "number",
+                    "description": "Duration in milliseconds (1000–180000). Price = music_length_ms / 120000 USD."
+                  },
+                  "force_instrumental": {
+                    "type": "boolean",
+                    "description": "Force instrumental output (no vocals)"
+                  }
+                },
+                "required": [
+                  "prompt"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "X-PAYMENT-RESPONSE": {
+                "description": "Encoded x402 payment confirmation.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "music_url": {
+                      "type": "string",
+                      "description": "Generated audio URL (CDN)"
+                    },
+                    "duration_seconds": {
+                      "type": "number",
+                      "description": "Duration in seconds"
+                    },
+                    "metadata": {
+                      "type": "object",
+                      "description": "Generation metadata"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required — x402 challenge. Retry with payment-signature header.",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "Encoded x402 payment requirements (Base64 JSON).",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "x402Version": {
+                      "type": "integer",
+                      "example": 2
+                    },
+                    "accepts": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "scheme": {
+                            "type": "string",
+                            "example": "exact"
+                          },
+                          "network": {
+                            "type": "string",
+                            "example": "solana"
+                          },
+                          "amount": {
+                            "type": "string",
+                            "description": "Amount in atomic USDC units (6 decimals)",
+                            "example": "50000"
+                          },
+                          "payTo": {
+                            "type": "string",
+                            "description": "Receiving wallet address"
+                          },
+                          "asset": {
+                            "type": "string",
+                            "description": "USDC mint address",
+                            "example": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+                          },
+                          "maxTimeoutSeconds": {
+                            "type": "integer",
+                            "example": 1200
+                          }
+                        }
+                      }
+                    },
+                    "resource": {
+                      "type": "object",
+                      "properties": {
+                        "url": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "mimeType": {
+                          "type": "string",
+                          "example": "application/json"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/audio/x-text-to-speech": {
+      "post": {
+        "tags": [
+          "Audio"
+        ],
+        "summary": "xAI Text-to-Speech",
+        "description": "Converts text to speech (MP3) using the xAI TTS API. Choose from voices: Eve, Ara, Leo, Rex, or Sal.",
+        "operationId": "audio_x_tts",
+        "x-payment-info": {
+          "protocol": "x402",
+          "pricingMode": "fixed",
+          "priceUsd": 0.01,
+          "network": "solana",
+          "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+        },
+        "parameters": [
+          {
+            "name": "payment-signature",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "x402 payment signature obtained after submitting an on-chain USDC payment. Omit on first call to receive the 402 payment challenge."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "text": {
+                    "type": "string",
+                    "description": "Text to convert to speech"
+                  },
+                  "voice_id": {
+                    "type": "string",
+                    "enum": [
+                      "Eve",
+                      "Ara",
+                      "Leo",
+                      "Rex",
+                      "Sal"
+                    ],
+                    "description": "Voice to use (default: Eve)"
+                  },
+                  "output_format": {
+                    "type": "object",
+                    "description": "Optional output format: { codec, sample_rate, bit_rate }"
+                  }
+                },
+                "required": [
+                  "text"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "X-PAYMENT-RESPONSE": {
+                "description": "Encoded x402 payment confirmation.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "audio_url": {
+                      "type": "string",
+                      "description": "Generated audio URL (CDN)"
+                    },
+                    "duration_seconds": {
+                      "type": "number",
+                      "description": "Duration in seconds (optional)"
+                    },
+                    "metadata": {
+                      "type": "object",
+                      "description": "Generation metadata"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required — x402 challenge. Retry with payment-signature header.",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "Encoded x402 payment requirements (Base64 JSON).",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "x402Version": {
+                      "type": "integer",
+                      "example": 2
+                    },
+                    "accepts": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "scheme": {
+                            "type": "string",
+                            "example": "exact"
+                          },
+                          "network": {
+                            "type": "string",
+                            "example": "solana"
+                          },
+                          "amount": {
+                            "type": "string",
+                            "description": "Amount in atomic USDC units (6 decimals)",
+                            "example": "50000"
+                          },
+                          "payTo": {
+                            "type": "string",
+                            "description": "Receiving wallet address"
+                          },
+                          "asset": {
+                            "type": "string",
+                            "description": "USDC mint address",
+                            "example": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+                          },
+                          "maxTimeoutSeconds": {
+                            "type": "integer",
+                            "example": 1200
+                          }
+                        }
+                      }
+                    },
+                    "resource": {
+                      "type": "object",
+                      "properties": {
+                        "url": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "mimeType": {
+                          "type": "string",
+                          "example": "application/json"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/audio/speech-to-text": {
+      "post": {
+        "tags": [
+          "Audio"
+        ],
+        "summary": "Speech-to-Text — OpenAI GPT-4o Transcribe",
+        "description": "Transcribes audio from a URL using OpenAI GPT-4o Transcribe via Replicate.",
+        "operationId": "audio_stt",
+        "x-payment-info": {
+          "protocol": "x402",
+          "pricingMode": "fixed",
+          "priceUsd": 0.02,
+          "network": "solana",
+          "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+        },
+        "parameters": [
+          {
+            "name": "payment-signature",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "x402 payment signature obtained after submitting an on-chain USDC payment. Omit on first call to receive the 402 payment challenge."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "audio_file": {
+                    "type": "string",
+                    "description": "HTTPS URL of the audio file to transcribe (e.g. MP3)"
+                  },
+                  "language": {
+                    "type": "string",
+                    "description": "Language code (default: en)"
+                  }
+                },
+                "required": [
+                  "audio_file"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "X-PAYMENT-RESPONSE": {
+                "description": "Encoded x402 payment confirmation.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "text": {
+                      "type": "string",
+                      "description": "Transcribed text"
+                    },
+                    "metadata": {
+                      "type": "object",
+                      "description": "Model and language metadata"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required — x402 challenge. Retry with payment-signature header.",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "Encoded x402 payment requirements (Base64 JSON).",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "x402Version": {
+                      "type": "integer",
+                      "example": 2
+                    },
+                    "accepts": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "scheme": {
+                            "type": "string",
+                            "example": "exact"
+                          },
+                          "network": {
+                            "type": "string",
+                            "example": "solana"
+                          },
+                          "amount": {
+                            "type": "string",
+                            "description": "Amount in atomic USDC units (6 decimals)",
+                            "example": "50000"
+                          },
+                          "payTo": {
+                            "type": "string",
+                            "description": "Receiving wallet address"
+                          },
+                          "asset": {
+                            "type": "string",
+                            "description": "USDC mint address",
+                            "example": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+                          },
+                          "maxTimeoutSeconds": {
+                            "type": "integer",
+                            "example": 1200
+                          }
+                        }
+                      }
+                    },
+                    "resource": {
+                      "type": "object",
+                      "properties": {
+                        "url": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "mimeType": {
+                          "type": "string",
+                          "example": "application/json"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/token/pumpfun-trending": {
+      "get": {
+        "tags": [
+          "Token Tools"
+        ],
+        "summary": "PumpFun trending tokens with AI analysis",
+        "description": "Returns trending PumpFun tokens enriched with AI analysis: dominant meta summary, fresh launch suggestions, and per-token price change data with icon descriptions.",
+        "operationId": "token_pumpfun_trending",
+        "x-payment-info": {
+          "protocol": "x402",
+          "pricingMode": "fixed",
+          "priceUsd": 0.1,
+          "network": "solana",
+          "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+        },
+        "parameters": [
+          {
+            "name": "payment-signature",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "x402 payment signature obtained after submitting an on-chain USDC payment. Omit on first call to receive the 402 payment challenge."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "X-PAYMENT-RESPONSE": {
+                "description": "Encoded x402 payment confirmation.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "summary": {
+                      "type": "string",
+                      "description": "AI-generated summary of the dominant memecoin meta"
+                    },
+                    "suggestions": {
+                      "type": "array",
+                      "description": "Array of 3 fresh token ideas inspired by the current meta",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "idea": {
+                            "type": "string"
+                          },
+                          "reference_ca": {
+                            "type": "string"
+                          },
+                          "reason": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "trending_tokens": {
+                      "type": "array",
+                      "description": "List of trending tokens with price change data",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "icon": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "ticker": {
+                            "type": "string"
+                          },
+                          "mc": {
+                            "type": "string"
+                          },
+                          "ca": {
+                            "type": "string"
+                          },
+                          "5mpricechange": {
+                            "type": "number"
+                          },
+                          "1hpricechange": {
+                            "type": "number"
+                          },
+                          "6hpricechange": {
+                            "type": "number"
+                          },
+                          "24hpricechange": {
+                            "type": "number"
+                          },
+                          "icon_description": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "count": {
+                      "type": "number"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required — x402 challenge. Retry with payment-signature header.",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "Encoded x402 payment requirements (Base64 JSON).",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "x402Version": {
+                      "type": "integer",
+                      "example": 2
+                    },
+                    "accepts": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "scheme": {
+                            "type": "string",
+                            "example": "exact"
+                          },
+                          "network": {
+                            "type": "string",
+                            "example": "solana"
+                          },
+                          "amount": {
+                            "type": "string",
+                            "description": "Amount in atomic USDC units (6 decimals)",
+                            "example": "50000"
+                          },
+                          "payTo": {
+                            "type": "string",
+                            "description": "Receiving wallet address"
+                          },
+                          "asset": {
+                            "type": "string",
+                            "description": "USDC mint address",
+                            "example": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+                          },
+                          "maxTimeoutSeconds": {
+                            "type": "integer",
+                            "example": 1200
+                          }
+                        }
+                      }
+                    },
+                    "resource": {
+                      "type": "object",
+                      "properties": {
+                        "url": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "mimeType": {
+                          "type": "string",
+                          "example": "application/json"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/token/pumpfun-movers": {
+      "get": {
+        "tags": [
+          "Token Tools"
+        ],
+        "summary": "PumpFun top movers with AI analysis",
+        "description": "Returns PumpFun top-moving tokens enriched with AI analysis: meta summary, launch suggestions, and price change data.",
+        "operationId": "token_pumpfun_movers",
+        "x-payment-info": {
+          "protocol": "x402",
+          "pricingMode": "fixed",
+          "priceUsd": 0.1,
+          "network": "solana",
+          "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+        },
+        "parameters": [
+          {
+            "name": "payment-signature",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "x402 payment signature obtained after submitting an on-chain USDC payment. Omit on first call to receive the 402 payment challenge."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "X-PAYMENT-RESPONSE": {
+                "description": "Encoded x402 payment confirmation.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "summary": {
+                      "type": "string",
+                      "description": "AI-generated meta summary"
+                    },
+                    "suggestions": {
+                      "type": "array",
+                      "items": {
+                        "type": "object"
+                      },
+                      "description": "Fresh token ideas"
+                    },
+                    "trending_tokens": {
+                      "type": "array",
+                      "items": {
+                        "type": "object"
+                      },
+                      "description": "Top mover tokens with price data"
+                    },
+                    "count": {
+                      "type": "number"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required — x402 challenge. Retry with payment-signature header.",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "Encoded x402 payment requirements (Base64 JSON).",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "x402Version": {
+                      "type": "integer",
+                      "example": 2
+                    },
+                    "accepts": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "scheme": {
+                            "type": "string",
+                            "example": "exact"
+                          },
+                          "network": {
+                            "type": "string",
+                            "example": "solana"
+                          },
+                          "amount": {
+                            "type": "string",
+                            "description": "Amount in atomic USDC units (6 decimals)",
+                            "example": "50000"
+                          },
+                          "payTo": {
+                            "type": "string",
+                            "description": "Receiving wallet address"
+                          },
+                          "asset": {
+                            "type": "string",
+                            "description": "USDC mint address",
+                            "example": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+                          },
+                          "maxTimeoutSeconds": {
+                            "type": "integer",
+                            "example": 1200
+                          }
+                        }
+                      }
+                    },
+                    "resource": {
+                      "type": "object",
+                      "properties": {
+                        "url": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "mimeType": {
+                          "type": "string",
+                          "example": "application/json"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/token/signal": {
+      "post": {
+        "tags": [
+          "Token Tools"
+        ],
+        "summary": "AI-powered crypto sentiment signal",
+        "description": "Returns AI-powered market sentiment analysis for a crypto ticker: sentiment score (-1 to 1), price target, 3 key signals, risk level, and a one-line summary.",
+        "operationId": "token_signal",
+        "x-payment-info": {
+          "protocol": "x402",
+          "pricingMode": "fixed",
+          "priceUsd": 0.001,
+          "network": "solana",
+          "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+        },
+        "parameters": [
+          {
+            "name": "payment-signature",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "x402 payment signature obtained after submitting an on-chain USDC payment. Omit on first call to receive the 402 payment challenge."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "ticker": {
+                    "type": "string",
+                    "description": "Token ticker symbol (e.g. SOL, BTC, ETH)"
+                  }
+                },
+                "required": [
+                  "ticker"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "X-PAYMENT-RESPONSE": {
+                "description": "Encoded x402 payment confirmation.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "signal_id": {
+                          "type": "string"
+                        },
+                        "ticker": {
+                          "type": "string"
+                        },
+                        "asset_name": {
+                          "type": "string"
+                        },
+                        "current_price": {
+                          "type": "string",
+                          "description": "e.g. \"$145.23\""
+                        },
+                        "sentiment": {
+                          "type": "string",
+                          "enum": [
+                            "very_bullish",
+                            "bullish",
+                            "neutral",
+                            "bearish",
+                            "very_bearish"
+                          ]
+                        },
+                        "sentiment_score": {
+                          "type": "number",
+                          "description": "Float -1 (bearish) to 1 (bullish)"
+                        },
+                        "confidence": {
+                          "type": "number",
+                          "description": "Float 0–1"
+                        },
+                        "price_target": {
+                          "type": "object",
+                          "properties": {
+                            "7d_target": {
+                              "type": "string"
+                            },
+                            "direction": {
+                              "type": "string",
+                              "enum": [
+                                "up",
+                                "down",
+                                "sideways"
+                              ]
+                            },
+                            "change_pct": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "signals": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "description": "3 key market signals"
+                        },
+                        "risk_level": {
+                          "type": "string",
+                          "enum": [
+                            "low",
+                            "medium",
+                            "high"
+                          ]
+                        },
+                        "risk_flags": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "summary": {
+                          "type": "string"
+                        },
+                        "catalyst": {
+                          "type": "string"
+                        },
+                        "sources": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "generated_at": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "expires_at": {
+                          "type": "string",
+                          "format": "date-time"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required — x402 challenge. Retry with payment-signature header.",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "Encoded x402 payment requirements (Base64 JSON).",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "x402Version": {
+                      "type": "integer",
+                      "example": 2
+                    },
+                    "accepts": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "scheme": {
+                            "type": "string",
+                            "example": "exact"
+                          },
+                          "network": {
+                            "type": "string",
+                            "example": "solana"
+                          },
+                          "amount": {
+                            "type": "string",
+                            "description": "Amount in atomic USDC units (6 decimals)",
+                            "example": "50000"
+                          },
+                          "payTo": {
+                            "type": "string",
+                            "description": "Receiving wallet address"
+                          },
+                          "asset": {
+                            "type": "string",
+                            "description": "USDC mint address",
+                            "example": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+                          },
+                          "maxTimeoutSeconds": {
+                            "type": "integer",
+                            "example": 1200
+                          }
+                        }
+                      }
+                    },
+                    "resource": {
+                      "type": "object",
+                      "properties": {
+                        "url": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "mimeType": {
+                          "type": "string",
+                          "example": "application/json"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/token/news": {
+      "post": {
+        "tags": [
+          "Token Tools"
+        ],
+        "summary": "Token news — AI-generated news banner and tweet draft",
+        "description": "Looks up the token on Jupiter, fetches latest market news, and generates an AI news title, a tweet draft, and a banner image. Returns the CDN URL for the banner.",
+        "operationId": "token_news",
+        "x-payment-info": {
+          "protocol": "x402",
+          "pricingMode": "fixed",
+          "priceUsd": 0.1,
+          "network": "solana",
+          "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+        },
+        "parameters": [
+          {
+            "name": "payment-signature",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "x402 payment signature obtained after submitting an on-chain USDC payment. Omit on first call to receive the 402 payment challenge."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "token": {
+                    "type": "string",
+                    "description": "Token mint address, symbol, or name"
+                  }
+                },
+                "required": [
+                  "token"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "X-PAYMENT-RESPONSE": {
+                "description": "Encoded x402 payment confirmation.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "mint": {
+                      "type": "string",
+                      "description": "Token mint address from Jupiter"
+                    },
+                    "token": {
+                      "type": "string",
+                      "description": "Token name"
+                    },
+                    "ticker": {
+                      "type": "string",
+                      "description": "Token symbol"
+                    },
+                    "trending_news": {
+                      "type": "object",
+                      "properties": {
+                        "title": {
+                          "type": "string",
+                          "description": "AI-generated news title (max 4 words)"
+                        },
+                        "tweet_draft": {
+                          "type": "string"
+                        },
+                        "banner_url": {
+                          "type": "string",
+                          "description": "AI-generated news banner URL (CDN)"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required — x402 challenge. Retry with payment-signature header.",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "Encoded x402 payment requirements (Base64 JSON).",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "x402Version": {
+                      "type": "integer",
+                      "example": 2
+                    },
+                    "accepts": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "scheme": {
+                            "type": "string",
+                            "example": "exact"
+                          },
+                          "network": {
+                            "type": "string",
+                            "example": "solana"
+                          },
+                          "amount": {
+                            "type": "string",
+                            "description": "Amount in atomic USDC units (6 decimals)",
+                            "example": "50000"
+                          },
+                          "payTo": {
+                            "type": "string",
+                            "description": "Receiving wallet address"
+                          },
+                          "asset": {
+                            "type": "string",
+                            "description": "USDC mint address",
+                            "example": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+                          },
+                          "maxTimeoutSeconds": {
+                            "type": "integer",
+                            "example": 1200
+                          }
+                        }
+                      }
+                    },
+                    "resource": {
+                      "type": "object",
+                      "properties": {
+                        "url": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "mimeType": {
+                          "type": "string",
+                          "example": "application/json"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/token/starter-kit": {
+      "post": {
+        "tags": [
+          "Token Tools"
+        ],
+        "summary": "Token starter kit — logo + banner generation",
+        "description": "Generates a token logo and matching banner automatically from a prompt. Extracts token information (name, ticker, description), generates the logo, then creates a matching banner.",
+        "operationId": "token_starter_kit",
+        "x-payment-info": {
+          "protocol": "x402",
+          "pricingMode": "fixed",
+          "priceUsd": 0.2,
+          "network": "solana",
+          "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+        },
+        "parameters": [
+          {
+            "name": "payment-signature",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "x402 payment signature obtained after submitting an on-chain USDC payment. Omit on first call to receive the 402 payment challenge."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "prompt": {
+                    "type": "string",
+                    "description": "Description of the token (name, theme, vibe)"
+                  },
+                  "ca_reference": {
+                    "type": "string",
+                    "description": "Contract address of a reference token to extract logo from (optional)"
+                  }
+                },
+                "required": [
+                  "prompt"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "X-PAYMENT-RESPONSE": {
+                "description": "Encoded x402 payment confirmation.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "token_name": {
+                      "type": "string"
+                    },
+                    "token_ticker": {
+                      "type": "string"
+                    },
+                    "token_description": {
+                      "type": "string"
+                    },
+                    "logo_url": {
+                      "type": "string",
+                      "description": "CDN URL of the generated logo"
+                    },
+                    "banner_url": {
+                      "type": "string",
+                      "description": "CDN URL of the generated banner"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required — x402 challenge. Retry with payment-signature header.",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "Encoded x402 payment requirements (Base64 JSON).",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "x402Version": {
+                      "type": "integer",
+                      "example": 2
+                    },
+                    "accepts": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "scheme": {
+                            "type": "string",
+                            "example": "exact"
+                          },
+                          "network": {
+                            "type": "string",
+                            "example": "solana"
+                          },
+                          "amount": {
+                            "type": "string",
+                            "description": "Amount in atomic USDC units (6 decimals)",
+                            "example": "50000"
+                          },
+                          "payTo": {
+                            "type": "string",
+                            "description": "Receiving wallet address"
+                          },
+                          "asset": {
+                            "type": "string",
+                            "description": "USDC mint address",
+                            "example": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+                          },
+                          "maxTimeoutSeconds": {
+                            "type": "integer",
+                            "example": 1200
+                          }
+                        }
+                      }
+                    },
+                    "resource": {
+                      "type": "object",
+                      "properties": {
+                        "url": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "mimeType": {
+                          "type": "string",
+                          "example": "application/json"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/token/solana-discovery": {
+      "post": {
+        "tags": [
+          "Token Tools"
+        ],
+        "summary": "Solana token discovery — Onchain OS",
+        "description": "Multi-action Solana token discovery via Onchain OS. Actions: token_overview, token_risk, holder_analysis, candlesticks, whale_trades, cluster_check.",
+        "operationId": "token_solana_discovery",
+        "x-payment-info": {
+          "protocol": "x402",
+          "pricingMode": "fixed",
+          "priceUsd": 0.01,
+          "network": "solana",
+          "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+        },
+        "parameters": [
+          {
+            "name": "payment-signature",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "x402 payment signature obtained after submitting an on-chain USDC payment. Omit on first call to receive the 402 payment challenge."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "action": {
+                    "type": "string",
+                    "enum": [
+                      "token_overview",
+                      "token_risk",
+                      "holder_analysis",
+                      "candlesticks",
+                      "whale_trades",
+                      "cluster_check"
+                    ],
+                    "description": "Market data action to perform"
+                  },
+                  "tokenAddress": {
+                    "type": "string",
+                    "description": "Token contract address"
+                  },
+                  "tokenAddresses": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Array of token addresses (for token_overview)"
+                  },
+                  "bar": {
+                    "type": "string",
+                    "description": "Candlestick interval (default: 1H)"
+                  },
+                  "limit": {
+                    "type": "number",
+                    "description": "Number of results (default: 50)"
+                  }
+                },
+                "required": [
+                  "action"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "X-PAYMENT-RESPONSE": {
+                "description": "Encoded x402 payment confirmation.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "chain": {
+                      "type": "string"
+                    },
+                    "action": {
+                      "type": "string"
+                    },
+                    "data": {
+                      "type": "object",
+                      "description": "Market data response (shape depends on action)"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required — x402 challenge. Retry with payment-signature header.",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "Encoded x402 payment requirements (Base64 JSON).",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "x402Version": {
+                      "type": "integer",
+                      "example": 2
+                    },
+                    "accepts": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "scheme": {
+                            "type": "string",
+                            "example": "exact"
+                          },
+                          "network": {
+                            "type": "string",
+                            "example": "solana"
+                          },
+                          "amount": {
+                            "type": "string",
+                            "description": "Amount in atomic USDC units (6 decimals)",
+                            "example": "50000"
+                          },
+                          "payTo": {
+                            "type": "string",
+                            "description": "Receiving wallet address"
+                          },
+                          "asset": {
+                            "type": "string",
+                            "description": "USDC mint address",
+                            "example": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+                          },
+                          "maxTimeoutSeconds": {
+                            "type": "integer",
+                            "example": 1200
+                          }
+                        }
+                      }
+                    },
+                    "resource": {
+                      "type": "object",
+                      "properties": {
+                        "url": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "mimeType": {
+                          "type": "string",
+                          "example": "application/json"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/token/solana-market": {
+      "post": {
+        "tags": [
+          "Token Tools"
+        ],
+        "summary": "Solana token market data — Onchain OS",
+        "description": "Multi-action Solana token market data via Onchain OS. Returns price overview, risk analysis, candlestick charts, whale trades, and more.",
+        "operationId": "token_solana_market",
+        "x-payment-info": {
+          "protocol": "x402",
+          "pricingMode": "fixed",
+          "priceUsd": 0.01,
+          "network": "solana",
+          "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+        },
+        "parameters": [
+          {
+            "name": "payment-signature",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "x402 payment signature obtained after submitting an on-chain USDC payment. Omit on first call to receive the 402 payment challenge."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "action": {
+                    "type": "string",
+                    "enum": [
+                      "token_overview",
+                      "token_risk",
+                      "holder_analysis",
+                      "candlesticks",
+                      "whale_trades",
+                      "cluster_check"
+                    ],
+                    "description": "Market data action to perform"
+                  },
+                  "tokenAddress": {
+                    "type": "string",
+                    "description": "Token contract address"
+                  },
+                  "tokenAddresses": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Array of token addresses (for token_overview)"
+                  },
+                  "bar": {
+                    "type": "string",
+                    "description": "Candlestick interval (default: 1H)"
+                  },
+                  "limit": {
+                    "type": "number",
+                    "description": "Number of results (default: 50)"
+                  }
+                },
+                "required": [
+                  "action"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "X-PAYMENT-RESPONSE": {
+                "description": "Encoded x402 payment confirmation.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "chain": {
+                      "type": "string"
+                    },
+                    "action": {
+                      "type": "string"
+                    },
+                    "data": {
+                      "type": "object",
+                      "description": "Market data response (shape depends on action)"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required — x402 challenge. Retry with payment-signature header.",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "Encoded x402 payment requirements (Base64 JSON).",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "x402Version": {
+                      "type": "integer",
+                      "example": 2
+                    },
+                    "accepts": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "scheme": {
+                            "type": "string",
+                            "example": "exact"
+                          },
+                          "network": {
+                            "type": "string",
+                            "example": "solana"
+                          },
+                          "amount": {
+                            "type": "string",
+                            "description": "Amount in atomic USDC units (6 decimals)",
+                            "example": "50000"
+                          },
+                          "payTo": {
+                            "type": "string",
+                            "description": "Receiving wallet address"
+                          },
+                          "asset": {
+                            "type": "string",
+                            "description": "USDC mint address",
+                            "example": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+                          },
+                          "maxTimeoutSeconds": {
+                            "type": "integer",
+                            "example": 1200
+                          }
+                        }
+                      }
+                    },
+                    "resource": {
+                      "type": "object",
+                      "properties": {
+                        "url": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "mimeType": {
+                          "type": "string",
+                          "example": "application/json"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ai/x-persona": {
+      "post": {
+        "tags": [
+          "AI Services"
+        ],
+        "summary": "X (Twitter) persona extraction",
+        "description": "Analyses an X (Twitter) account — posts, profile, communication style — and produces a structured persona, style profile, content patterns, and avatar prompt.",
+        "operationId": "ai_x_persona",
+        "x-payment-info": {
+          "protocol": "x402",
+          "pricingMode": "fixed",
+          "priceUsd": 0.05,
+          "network": "solana",
+          "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+        },
+        "parameters": [
+          {
+            "name": "payment-signature",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "x402 payment signature obtained after submitting an on-chain USDC payment. Omit on first call to receive the 402 payment challenge."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "x_username": {
+                    "type": "string",
+                    "description": "X (Twitter) username (with or without @)"
+                  }
+                },
+                "required": [
+                  "x_username"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "X-PAYMENT-RESPONSE": {
+                "description": "Encoded x402 payment confirmation.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "persona": {
+                      "type": "object",
+                      "description": "Persona including summary, tone, core topics, and beliefs"
+                    },
+                    "style_profile": {
+                      "type": "object",
+                      "description": "Writing style and voice characteristics"
+                    },
+                    "content_patterns": {
+                      "type": "object",
+                      "description": "Content patterns and posting behaviour analysis"
+                    },
+                    "avatar": {
+                      "type": "object",
+                      "description": "Avatar information: image type, prompt, reference images"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required — x402 challenge. Retry with payment-signature header.",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "Encoded x402 payment requirements (Base64 JSON).",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "x402Version": {
+                      "type": "integer",
+                      "example": 2
+                    },
+                    "accepts": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "scheme": {
+                            "type": "string",
+                            "example": "exact"
+                          },
+                          "network": {
+                            "type": "string",
+                            "example": "solana"
+                          },
+                          "amount": {
+                            "type": "string",
+                            "description": "Amount in atomic USDC units (6 decimals)",
+                            "example": "50000"
+                          },
+                          "payTo": {
+                            "type": "string",
+                            "description": "Receiving wallet address"
+                          },
+                          "asset": {
+                            "type": "string",
+                            "description": "USDC mint address",
+                            "example": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+                          },
+                          "maxTimeoutSeconds": {
+                            "type": "integer",
+                            "example": 1200
+                          }
+                        }
+                      }
+                    },
+                    "resource": {
+                      "type": "object",
+                      "properties": {
+                        "url": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "mimeType": {
+                          "type": "string",
+                          "example": "application/json"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ai/x-news": {
+      "post": {
+        "tags": [
+          "AI Services"
+        ],
+        "summary": "X (Twitter) account latest news + tweet draft",
+        "description": "Extracts the latest activity from an X account, generates an AI news title, a tweet draft (optionally mimicking another account's style), and an AI-generated news banner.",
+        "operationId": "ai_x_news",
+        "x-payment-info": {
+          "protocol": "x402",
+          "pricingMode": "fixed",
+          "priceUsd": 0.5,
+          "network": "solana",
+          "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+        },
+        "parameters": [
+          {
+            "name": "payment-signature",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "x402 payment signature obtained after submitting an on-chain USDC payment. Omit on first call to receive the 402 payment challenge."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "x_username": {
+                    "type": "string",
+                    "description": "X username to extract news from (with or without @)"
+                  },
+                  "x_persona": {
+                    "type": "string",
+                    "description": "X username whose style to mimic for the tweet draft (optional)"
+                  }
+                },
+                "required": [
+                  "x_username"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "X-PAYMENT-RESPONSE": {
+                "description": "Encoded x402 payment confirmation.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "x_username": {
+                      "type": "string"
+                    },
+                    "trending_news": {
+                      "type": "object",
+                      "properties": {
+                        "title": {
+                          "type": "string"
+                        },
+                        "tweet_draft": {
+                          "type": "string"
+                        },
+                        "banner_url": {
+                          "type": "string",
+                          "description": "AI-generated news banner (CDN)"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required — x402 challenge. Retry with payment-signature header.",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "Encoded x402 payment requirements (Base64 JSON).",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "x402Version": {
+                      "type": "integer",
+                      "example": 2
+                    },
+                    "accepts": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "scheme": {
+                            "type": "string",
+                            "example": "exact"
+                          },
+                          "network": {
+                            "type": "string",
+                            "example": "solana"
+                          },
+                          "amount": {
+                            "type": "string",
+                            "description": "Amount in atomic USDC units (6 decimals)",
+                            "example": "50000"
+                          },
+                          "payTo": {
+                            "type": "string",
+                            "description": "Receiving wallet address"
+                          },
+                          "asset": {
+                            "type": "string",
+                            "description": "USDC mint address",
+                            "example": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+                          },
+                          "maxTimeoutSeconds": {
+                            "type": "integer",
+                            "example": 1200
+                          }
+                        }
+                      }
+                    },
+                    "resource": {
+                      "type": "object",
+                      "properties": {
+                        "url": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "mimeType": {
+                          "type": "string",
+                          "example": "application/json"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/x402-resources": {
+      "get": {
+        "tags": [
+          "Resources"
+        ],
+        "summary": "List all x402 resources",
+        "description": "Returns all available x402 resources with their slugs, prices, input/output schemas, and payment requirements. Public endpoint — no payment required.",
+        "operationId": "list_x402_resources",
+        "responses": {
+          "200": {
+            "description": "Array of x402 resources",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "slug": {
+                        "type": "string",
+                        "description": "Resource endpoint slug (e.g. image/nano-banana)"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "method": {
+                        "type": "string",
+                        "enum": [
+                          "GET",
+                          "POST"
+                        ]
+                      },
+                      "price": {
+                        "type": "number",
+                        "description": "Price in USD"
+                      },
+                      "network": {
+                        "type": "string"
+                      },
+                      "input_schema": {
+                        "type": "object"
+                      },
+                      "output_schema": {
+                        "type": "object"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/x402-resources/{slug}": {
+      "get": {
+        "tags": [
+          "Resources"
+        ],
+        "summary": "Get a specific x402 resource",
+        "description": "Returns detailed information for a single x402 resource identified by its slug.",
+        "operationId": "get_x402_resource",
+        "parameters": [
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Resource slug (e.g. image/nano-banana)"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "x402 resource details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "slug": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "method": {
+                      "type": "string"
+                    },
+                    "price": {
+                      "type": "number"
+                    },
+                    "network": {
+                      "type": "string"
+                    },
+                    "input_schema": {
+                      "type": "object"
+                    },
+                    "output_schema": {
+                      "type": "object"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Error": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "example": false
+          },
+          "error": {
+            "type": "string",
+            "description": "Error code or type"
+          },
+          "message": {
+            "type": "string",
+            "description": "Human-readable error message"
+          }
+        }
+      },
+      "X402PaymentRequired": {
+        "type": "object",
+        "description": "x402 payment required response body",
+        "properties": {
+          "x402Version": {
+            "type": "integer",
+            "example": 2
+          },
+          "accepts": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "scheme": {
+                  "type": "string",
+                  "example": "exact"
+                },
+                "network": {
+                  "type": "string",
+                  "example": "solana"
+                },
+                "amount": {
+                  "type": "string",
+                  "description": "Atomic USDC units (6 decimals)"
+                },
+                "payTo": {
+                  "type": "string",
+                  "description": "Receiving wallet address"
+                },
+                "asset": {
+                  "type": "string",
+                  "example": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+                },
+                "maxTimeoutSeconds": {
+                  "type": "integer"
+                }
+              }
+            }
+          },
+          "resource": {
+            "type": "object",
+            "properties": {
+              "url": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "mimeType": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds two PayAI-facilitated merchants under the proxied `payai/<merchant>/<name>` layout:

- **`payai/blockrun/inference`** (`ai_ml`) — BlockRun's stablecoin gateway, 57 endpoints: LLM chat completions and image generation, web search, X/Twitter analytics, crypto/FX/US-stock/commodity market data, an onchain "surf" intelligence suite (wallet detail/labels, market rankings, gas, transactions, SQL-over-onchain, Polymarket), phone lookup and number provisioning, and outbound voice calls. USDC settlement on Solana, no signup or API keys.
- **`payai/xona/creative`** (`media`) — Xona's creative AI surface (Flux 2, Nano Banana, Seedream and other image models), short and Seedance video, ElevenLabs music, TTS, transcription, plus X/Twitter and Solana token analytics. 28 endpoints, x402 USDC on Solana, with a parallel MPP-paid surface at `/mpp/*` settling in the same asset.

Both route through the [PayAI facilitator](https://facilitator.payai.network/) and use the proxied three-level layout, matching the `solana-foundation/google/*` and `merit-systems/stable*` patterns already in the registry.

OpenAPI specs are committed as co-located, prettyprinted `openapi.json` sidecars (`openapi.path`) rather than live URL refs, so the listings stay stable if a provider's spec endpoint changes. Each PAY.md documents per-surface pricing, its x402 (and Xona's MPP) payment flow, and its server-to-server / CORS posture (following the pattern landed in #42).

Rebased on current `main` (includes #42).

> **Note:** Nansen was originally in this PR but has been removed — it now lives at `nansen-ai/nansen-api` via #42.

## Validation

`pay catalog check` against the diff vs current `main`, mirroring PR CI:

```
$ npx @solana/pay catalog check . --changed-from upstream/main
│ Changed providers check successful
│ 85 endpoints tested across 2 providers
│ 52/52 gates compatible with Solana
```

## Links

- PayAI facilitator bazaar: https://facilitator.payai.network/discovery/resources
- BlockRun: https://blockrun.ai · OpenAPI: https://sol.blockrun.ai/openapi.json
- Xona: https://xona-agent.com · OpenAPI (x402): https://api.xona-agent.com/openapi-x402.json · OpenAPI (MPP): https://api.xona-agent.com/openapi-mpp.json