### PR TITLE
Add Crypto ETF Sentinel — US spot crypto ETF regulatory intelligence (dual-chain)

### DIFF
--- a/providers/cryptoetfsentinel/regulatory-intel/PAY.md
+++ b/providers/cryptoetfsentinel/regulatory-intel/PAY.md
@@ -1,0 +1,23 @@
+---
+name: regulatory-intel
+title: "Crypto ETF Sentinel"
+description: "Regulatory data oracle for US spot crypto ETFs. Real-time SEC EDGAR filings, issuer pipeline classification (registration_filed / under_review / launch_imminent / trading), comment letters, XBRL financials, POS AM profiles, and predictive launch signals."
+use_case: "Use for crypto ETF approval research, regulatory pipeline monitoring, issuer comment-letter tracking, fee-war analysis, AUM growth charts, predictive launch signals, and POS AM in-kind / AP / redemption-structure data not surfaced by retail trackers."
+category: finance
+service_url: https://api.cryptoetfsentinel.com
+version: v1
+openapi:
+  path: openapi.json
+---
+
+Curated regulatory data oracle for the US spot crypto ETF universe — 105 active issuers across 34 cryptocurrencies, ~3,150 indexed filings, ~19,800 XBRL facts. Every paid endpoint accepts USDC via x402 on Base mainnet (`eip155:8453`) or Solana mainnet (`solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp`); both `accepts[]` entries are returned in every 402 challenge.
+
+The catalogue covers the full pipeline lifecycle: registration filings (S-1 / S-1A), SEC review activity (UPLOAD / CORRESP comment letters), launch certifications (EFFECT, 8-A12B, CERT), and post-launch financials (XBRL leaderboards, AUM growth, fee war tracker).
+
+## Spend-aware usage
+
+- Start with `/v1/agent/snapshot` ($0.05) for a one-call regulatory pipeline overview — issuers under review, recent filings, fee leaderboard, AUM totals.
+- Use `/v1/agent/issuers` ($1.00) for the full curated catalogue when you need every active issuer (~105 entries). Cache the result — the issuer list changes slowly.
+- For per-issuer drilldowns, pair the catalogue with cheap per-CIK routes: `/v1/profiles/issuer?cik=...` ($0.03), `/v1/xbrl/issuer?cik=...` ($0.05), `/v1/issuers/comment-letters?cik=...` ($0.05).
+- Predictive signals (`/v1/pipeline/risk-scores`, `outcome-signals`, `launch-monitor`, `velocity`, `cohort-state`) are $0.50 each — the most expensive routes, each replaces ~hours of manual pipeline reading. Pick the one matching your task; don't fetch all five.
+- Free tier (no key, no payment) exists at `/v1/issuers` (top-10 by AUM only), `/v1/filings` (24-hour delay), and `/v1/stats` — use these for exploration before paying.

--- a/providers/cryptoetfsentinel/regulatory-intel/PAY.md
+++ b/providers/cryptoetfsentinel/regulatory-intel/PAY.md
@@ -21,4 +21,13 @@ The catalogue covers the full pipeline lifecycle: registration filings (S-1 / S-
 - Use `/v1/agent/issuers` ($1.00) for the full curated catalogue when you need every active issuer (~105 entries). Cache the result — the issuer list changes slowly.
 - For per-issuer drilldowns, pair the catalogue with cheap per-CIK routes: `/v1/profiles/issuer?cik=...` ($0.03), `/v1/xbrl/issuer?cik=...` ($0.05), `/v1/issuers/comment-letters?cik=...` ($0.05).
 - Predictive signals (`/v1/pipeline/risk-scores`, `outcome-signals`, `launch-monitor`, `velocity`, `cohort-state`) are $0.50 each — each replaces ~hours of manual pipeline reading. Pick the one matching your task; don't fetch all five.
-- Free tier (no key, no payment) exists at `/v1/issuers` (top-10 by AUM only), `/v1/filings` (24-hour delay), and `/v1/stats` — use these for exploration before paying.
+
+## Free routes (no key, no payment)
+
+Use these for exploration before paying. They return `200` directly (no x402 challenge); a malformed parameter returns `422` for input validation, not `402`.
+
+- `GET /v1/filings` — paginated filings list (24-hour delay vs paid `/v1/agent/filings/recent`).
+- `GET /v1/filings/search` — full-text search across the same delayed corpus.
+- `GET /v1/filings/{accession}` — single filing by SEC accession number (24-hour delay).
+- `GET /v1/issuers` — top-10 issuers by AUM only. Paid `/v1/agent/issuers` ($1.00) returns the full ~105-issuer catalogue.
+- `GET /v1/stats`, `GET /v1/currencies`, `GET /v1/form-types` — metadata endpoints.

--- a/providers/cryptoetfsentinel/regulatory-intel/PAY.md
+++ b/providers/cryptoetfsentinel/regulatory-intel/PAY.md
@@ -20,5 +20,5 @@ The catalogue covers the full pipeline lifecycle: registration filings (S-1 / S-
 - Use `/v1/agent/filings/recent` ($0.20) for the real-time delay-free filings feed when you need to poll for newly filed forms; the free `/v1/filings` mirror lags by 24 hours.
 - Use `/v1/agent/issuers` ($1.00) for the full curated catalogue when you need every active issuer (~105 entries). Cache the result — the issuer list changes slowly.
 - For per-issuer drilldowns, pair the catalogue with cheap per-CIK routes: `/v1/profiles/issuer?cik=...` ($0.03), `/v1/xbrl/issuer?cik=...` ($0.05), `/v1/issuers/comment-letters?cik=...` ($0.05).
-- Predictive signals (`/v1/pipeline/risk-scores`, `outcome-signals`, `launch-monitor`, `velocity`, `cohort-state`) are $0.50 each — the most expensive routes, each replaces ~hours of manual pipeline reading. Pick the one matching your task; don't fetch all five.
+- Predictive signals (`/v1/pipeline/risk-scores`, `outcome-signals`, `launch-monitor`, `velocity`, `cohort-state`) are $0.50 each — each replaces ~hours of manual pipeline reading. Pick the one matching your task; don't fetch all five.
 - Free tier (no key, no payment) exists at `/v1/issuers` (top-10 by AUM only), `/v1/filings` (24-hour delay), and `/v1/stats` — use these for exploration before paying.

--- a/providers/cryptoetfsentinel/regulatory-intel/PAY.md
+++ b/providers/cryptoetfsentinel/regulatory-intel/PAY.md
@@ -17,6 +17,7 @@ The catalogue covers the full pipeline lifecycle: registration filings (S-1 / S-
 ## Spend-aware usage
 
 - Start with `/v1/agent/snapshot` ($0.05) for a one-call regulatory pipeline overview — issuers under review, recent filings, fee leaderboard, AUM totals.
+- Use `/v1/agent/filings/recent` ($0.20) for the real-time delay-free filings feed when you need to poll for newly filed forms; the free `/v1/filings` mirror lags by 24 hours.
 - Use `/v1/agent/issuers` ($1.00) for the full curated catalogue when you need every active issuer (~105 entries). Cache the result — the issuer list changes slowly.
 - For per-issuer drilldowns, pair the catalogue with cheap per-CIK routes: `/v1/profiles/issuer?cik=...` ($0.03), `/v1/xbrl/issuer?cik=...` ($0.05), `/v1/issuers/comment-letters?cik=...` ($0.05).
 - Predictive signals (`/v1/pipeline/risk-scores`, `outcome-signals`, `launch-monitor`, `velocity`, `cohort-state`) are $0.50 each — the most expensive routes, each replaces ~hours of manual pipeline reading. Pick the one matching your task; don't fetch all five.

--- a/providers/cryptoetfsentinel/regulatory-intel/openapi.json
+++ b/providers/cryptoetfsentinel/regulatory-intel/openapi.json
@@ -1,0 +1,5625 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Crypto ETF Sentinel",
+    "description": "Regulatory data oracle for US spot crypto ETFs. Real-time SEC EDGAR filings, issuer pipeline classification, comment-letter tracking, XBRL financials, POS AM in-kind/AP-roster profiles, and predictive launch signals. All paid endpoints settle on Base USDC via x402.",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/v1/issuers/comment-letters": {
+      "get": {
+        "summary": "Issuer comment letters",
+        "description": "Returns the Regulatory Review Profile and individual comment letter history for an issuer. Only returns crypto-relevant letters (noise filtered). ``UPLOAD`` = SEC\u2192issuer comment letter. ``CORRESP`` = issuer\u2192SEC response.",
+        "operationId": "get_issuer_comment_letters_v1_issuers_comment_letters_get",
+        "parameters": [
+          {
+            "name": "cik",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^[0-9]{1,10}$",
+              "description": "Zero-padded SEC CIK (e.g. ``0001980994``).",
+              "examples": [
+                "0001980994"
+              ],
+              "title": "Cik"
+            },
+            "description": "Zero-padded SEC CIK (e.g. ``0001980994``)."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse_IssuerCommentLettersOut_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required. Pay $0.05 USDC via x402 on Base mainnet (eip155:8453) or Solana mainnet (solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp) to access this resource."
+          }
+        },
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.05"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        }
+      }
+    },
+    "/v1/xbrl/leaderboard": {
+      "get": {
+        "tags": [
+          "XBRL"
+        ],
+        "summary": "XBRL leaderboard",
+        "description": "Ranks crypto ETFs by a financial metric (default: AUM). Uses the latest period data for each issuer. Only XBRL-eligible issuers (dedicated ETFs, not umbrella trusts) are included.",
+        "operationId": "get_leaderboard_v1_xbrl_leaderboard_get",
+        "parameters": [
+          {
+            "name": "concept",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "XBRL concept to rank by (must be a TIER1 concept)",
+              "default": "InvestmentOwnedAtFairValue",
+              "title": "Concept"
+            },
+            "description": "XBRL concept to rank by (must be a TIER1 concept)"
+          },
+          {
+            "name": "unit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Unit filter (auto-resolved from concept if omitted)",
+              "title": "Unit"
+            },
+            "description": "Unit filter (auto-resolved from concept if omitted)"
+          },
+          {
+            "name": "taxonomy",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Taxonomy filter (auto-resolved from concept if omitted)",
+              "title": "Taxonomy"
+            },
+            "description": "Taxonomy filter (auto-resolved from concept if omitted)"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 50,
+              "minimum": 1,
+              "description": "Max results (1-50)",
+              "default": 20,
+              "title": "Limit"
+            },
+            "description": "Max results (1-50)"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse_list_LeaderboardEntryOut__"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required. Pay $0.10 USDC via x402 on Base mainnet (eip155:8453) or Solana mainnet (solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp) to access this resource."
+          }
+        },
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.10"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        }
+      }
+    },
+    "/v1/xbrl/issuer": {
+      "get": {
+        "tags": [
+          "XBRL"
+        ],
+        "summary": "XBRL financial snapshot",
+        "description": "Returns a financial snapshot for a single issuer \u2014 latest AUM, NAV per share, shares outstanding, expense ratio, sponsor fees, and total return. Accepts bare CIK (``1588489``) or zero-padded (``0001588489``).",
+        "operationId": "get_xbrl_issuer_v1_xbrl_issuer_get",
+        "parameters": [
+          {
+            "name": "cik",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^[0-9]{1,10}$",
+              "description": "Zero-padded SEC CIK (e.g. ``0001980994``).",
+              "examples": [
+                "0001980994"
+              ],
+              "title": "Cik"
+            },
+            "description": "Zero-padded SEC CIK (e.g. ``0001980994``)."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse_XBRLSnapshotOut_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required. Pay $0.05 USDC via x402 on Base mainnet (eip155:8453) or Solana mainnet (solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp) to access this resource."
+          }
+        },
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.05"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        }
+      }
+    },
+    "/v1/xbrl/series": {
+      "get": {
+        "tags": [
+          "XBRL"
+        ],
+        "summary": "XBRL time series",
+        "description": "Returns historical time series for one XBRL concept for a specific issuer. Ideal for charting AUM growth, NAV trends, or expense ratio changes over time. Ordered by period end date ascending.",
+        "operationId": "get_xbrl_series_v1_xbrl_series_get",
+        "parameters": [
+          {
+            "name": "cik",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^[0-9]{1,10}$",
+              "description": "Zero-padded SEC CIK (e.g. ``0001980994``).",
+              "examples": [
+                "0001980994"
+              ],
+              "title": "Cik"
+            },
+            "description": "Zero-padded SEC CIK (e.g. ``0001980994``)."
+          },
+          {
+            "name": "concept",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "XBRL concept (must be a TIER1 concept)",
+              "default": "InvestmentOwnedAtFairValue",
+              "title": "Concept"
+            },
+            "description": "XBRL concept (must be a TIER1 concept)"
+          },
+          {
+            "name": "unit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Unit filter (auto-resolved from concept if omitted)",
+              "title": "Unit"
+            },
+            "description": "Unit filter (auto-resolved from concept if omitted)"
+          },
+          {
+            "name": "taxonomy",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Taxonomy filter (auto-resolved from concept if omitted)",
+              "title": "Taxonomy"
+            },
+            "description": "Taxonomy filter (auto-resolved from concept if omitted)"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse_list_TimeSeriesPointOut__"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required. Pay $0.10 USDC via x402 on Base mainnet (eip155:8453) or Solana mainnet (solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp) to access this resource."
+          }
+        },
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.10"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        }
+      }
+    },
+    "/v1/xbrl/aum-growth": {
+      "get": {
+        "tags": [
+          "XBRL"
+        ],
+        "summary": "Aggregate AUM growth",
+        "description": "Returns quarterly aggregate AUM across all crypto ETFs, broken down by cryptocurrency category (Bitcoin, Ethereum, Other). Data is bucketed into standard quarters from SEC XBRL filings.",
+        "operationId": "get_aum_growth_v1_xbrl_aum_growth_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse_list_AUMGrowthPointOut__"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required. Pay $0.10 USDC via x402 on Base mainnet (eip155:8453) or Solana mainnet (solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp) to access this resource."
+          }
+        },
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.10"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        }
+      }
+    },
+    "/v1/xbrl/fee-war": {
+      "get": {
+        "tags": [
+          "XBRL"
+        ],
+        "summary": "Fee war comparison",
+        "description": "Returns current expense ratio for each crypto ETF issuer, sorted cheapest first. Uses a multi-concept priority fallback to maximise coverage. Optionally filter by cryptocurrency.",
+        "operationId": "get_fee_war_v1_xbrl_fee_war_get",
+        "parameters": [
+          {
+            "name": "crypto",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by cryptocurrency (bitcoin, ethereum, solana, etc.)",
+              "title": "Crypto"
+            },
+            "description": "Filter by cryptocurrency (bitcoin, ethereum, solana, etc.)"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse_list_FeeWarIssuerOut__"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required. Pay $0.10 USDC via x402 on Base mainnet (eip155:8453) or Solana mainnet (solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp) to access this resource."
+          }
+        },
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.10"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        }
+      }
+    },
+    "/v1/xbrl/fee-war/history": {
+      "get": {
+        "tags": [
+          "XBRL"
+        ],
+        "summary": "Fee war history",
+        "description": "Returns quarterly fee history for all crypto ETF issuers. Each quarter contains a list of issuers with their expense ratio. Useful for charting the fee war progression over time.",
+        "operationId": "get_fee_war_history_endpoint_v1_xbrl_fee_war_history_get",
+        "parameters": [
+          {
+            "name": "crypto",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by cryptocurrency (bitcoin, ethereum, solana, etc.)",
+              "title": "Crypto"
+            },
+            "description": "Filter by cryptocurrency (bitcoin, ethereum, solana, etc.)"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse_list_FeeWarHistoryPointOut__"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required. Pay $0.10 USDC via x402 on Base mainnet (eip155:8453) or Solana mainnet (solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp) to access this resource."
+          }
+        },
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.10"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        }
+      }
+    },
+    "/v1/events": {
+      "get": {
+        "summary": "Activity feed",
+        "description": "Chronological feed of notable SEC filings and comment letters, merged and sorted by date. Each event includes a human-readable description. Returns the most recent events first. Requires Developer tier.",
+        "operationId": "list_events_v1_events_get",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 50,
+              "minimum": 1,
+              "description": "Maximum events to return (1-50)",
+              "default": 15,
+              "title": "Limit"
+            },
+            "description": "Maximum events to return (1-50)"
+          },
+          {
+            "name": "days",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 180,
+              "minimum": 1,
+              "description": "Recency window in days. Events older than this are excluded (1-180, default 60).",
+              "default": 60,
+              "title": "Days"
+            },
+            "description": "Recency window in days. Events older than this are excluded (1-180, default 60)."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse_list_EventOut__"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required. Pay $0.10 USDC via x402 on Base mainnet (eip155:8453) or Solana mainnet (solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp) to access this resource."
+          }
+        },
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.10"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        }
+      }
+    },
+    "/v1/pipeline/stalled": {
+      "get": {
+        "summary": "Stalled issuers",
+        "description": "Returns issuers in ``under_review`` stage where the SEC has been silent for 148+ days (P75-calibrated threshold).  Sorted by days since last letter descending.",
+        "operationId": "stalled_issuers_v1_pipeline_stalled_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse_list_StalledIssuerOut__"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required. Pay $0.10 USDC via x402 on Base mainnet (eip155:8453) or Solana mainnet (solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp) to access this resource."
+          }
+        },
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.10"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        }
+      }
+    },
+    "/v1/pipeline/risk-scores": {
+      "get": {
+        "summary": "Under-review risk scores",
+        "description": "Risk assessment for all under_review issuers.  Compares each issuer's time-in-review against historical approved durations.  Sorted by risk level (high first).",
+        "operationId": "risk_scores_v1_pipeline_risk_scores_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse_list_RiskScoreOut__"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required. Pay $0.50 USDC via x402 on Base mainnet (eip155:8453) or Solana mainnet (solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp) to access this resource."
+          }
+        },
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.50"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        }
+      }
+    },
+    "/v1/pipeline/launch-monitor": {
+      "get": {
+        "summary": "Launch timing monitor",
+        "description": "Launch countdown for ``launch_imminent`` issuers.  Compares each issuer's wait time since 8-A12B filing against the historical 8-A12B \u2192 CERT/EFFECT distribution.  Sorted by days waiting descending.\n\n**``meta.historical_baseline``** is populated on every call, even when the current cohort is empty \u2014 the historical wait distribution (p50/p75/p90/max + sample size) is the anchor value of this endpoint.",
+        "operationId": "launch_monitor_v1_pipeline_launch_monitor_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse_list_LaunchTimingOut__"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required. Pay $0.50 USDC via x402 on Base mainnet (eip155:8453) or Solana mainnet (solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp) to access this resource."
+          }
+        },
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.50"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        }
+      }
+    },
+    "/v1/pipeline/outcome-signals": {
+      "get": {
+        "summary": "Outcome predictions",
+        "description": "Compares each under_review issuer's filing pattern against approved and withdrawn baselines.  Returns a 0-100 score indicating approval likelihood.",
+        "operationId": "outcome_signals_v1_pipeline_outcome_signals_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse_list_OutcomeSignalOut__"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required. Pay $0.50 USDC via x402 on Base mainnet (eip155:8453) or Solana mainnet (solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp) to access this resource."
+          }
+        },
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.50"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        }
+      }
+    },
+    "/v1/pipeline/velocity": {
+      "get": {
+        "summary": "Filing velocity",
+        "description": "Pipeline issuers with the most action filing activity in the last 6 weeks.  Excludes trading-stage issuers.  Sorted by filing count descending.",
+        "operationId": "filing_velocity_v1_pipeline_velocity_get",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 6,
+              "title": "Limit"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse_list_VelocityOut__"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required. Pay $0.50 USDC via x402 on Base mainnet (eip155:8453) or Solana mainnet (solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp) to access this resource."
+          }
+        },
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.50"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        }
+      }
+    },
+    "/v1/pipeline/deltas": {
+      "get": {
+        "summary": "Dashboard deltas",
+        "description": "Week-over-week delta indicators comparing today's pipeline snapshot against a previous snapshot.\n\n**Returns 404** when no historical snapshot exists for the requested ``days_back`` (first week of operation or an agent downtime gap). x402 callers are NOT charged for 4xx responses, so a missing baseline costs nothing.",
+        "operationId": "pipeline_deltas_v1_pipeline_deltas_get",
+        "parameters": [
+          {
+            "name": "days_back",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 90,
+              "minimum": 1,
+              "default": 7,
+              "title": "Days Back"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse_DeltaOut_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required. Pay $0.10 USDC via x402 on Base mainnet (eip155:8453) or Solana mainnet (solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp) to access this resource."
+          }
+        },
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.10"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        }
+      }
+    },
+    "/v1/pipeline/cohort-state": {
+      "get": {
+        "summary": "Per-cohort regulatory wave state",
+        "description": "**Pre-computed regulatory wave state per crypto.** Answers questions like *'is asset X in an active SEC approval cycle right now?'* and *'how far through the wave is it?'* without making the consumer compute it from raw issuer data.\n\n**Agent use cases:**\n- **Trading agents**: regulatory-tailwind signal \u2014 issuers in an active wave have measurably higher near-term approval odds than those outside one.\n- **Research agents**: temporal anchoring \u2014 when did the wave start, who led it, who's still pending.\n- **Aggregator agents**: skip the cohort-graphing compute; ingest structured wave state directly.\n\n**Returns:** ``{crypto: CohortStateOut}`` map. Each state includes ``in_wave`` (bool), ``first_anchor_date`` (when the wave started), ``first_anchor_ticker`` (which issuer led), and counts of approved vs pending cohort members.\n\n**Methodology:** wave clock anchors on the earliest EFFECT or CERT filing per cohort (not 8-A12B, which can hang up to ~50 days before approval per the BAVA case). The wave window is fixed at 50 days from the anchor; subsequent approvals within that window are graduates of the same wave, not new anchors.",
+        "operationId": "cohort_state_v1_pipeline_cohort_state_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse_dict_str__CohortStateOut__"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required. Pay $0.50 USDC via x402 on Base mainnet (eip155:8453) or Solana mainnet (solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp) to access this resource."
+          }
+        },
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.50"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        }
+      }
+    },
+    "/v1/profiles/latest": {
+      "get": {
+        "summary": "Latest ETF profiles",
+        "description": "Returns the most recent operational profile for each trading issuer. Extracted from POS AM (Post-Effective Amendment) filings. Includes custodian, sponsor fee, reference rate, basket size, AP counts, and in-kind eligibility.",
+        "operationId": "latest_profiles_v1_profiles_latest_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse_list_ETFProfileOut__"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required. Pay $0.50 USDC via x402 on Base mainnet (eip155:8453) or Solana mainnet (solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp) to access this resource."
+          }
+        },
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.50"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        }
+      }
+    },
+    "/v1/profiles/issuer": {
+      "get": {
+        "summary": "Current ETF profile",
+        "description": "Returns the current operational profile for a single issuer.",
+        "operationId": "issuer_latest_profile_v1_profiles_issuer_get",
+        "parameters": [
+          {
+            "name": "cik",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^[0-9]{1,10}$",
+              "description": "Zero-padded SEC CIK (e.g. ``0001980994``).",
+              "examples": [
+                "0001980994"
+              ],
+              "title": "Cik"
+            },
+            "description": "Zero-padded SEC CIK (e.g. ``0001980994``)."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse_Union_ETFProfileOut__NoneType__"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required. Pay $0.03 USDC via x402 on Base mainnet (eip155:8453) or Solana mainnet (solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp) to access this resource."
+          }
+        },
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.03"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        }
+      }
+    },
+    "/v1/profiles/history": {
+      "get": {
+        "summary": "Profile evolution timeline",
+        "description": "Returns chronological operational profile changes for an issuer. Each entry shows what changed vs the prior POS AM filing (deltas).",
+        "operationId": "profile_history_v1_profiles_history_get",
+        "parameters": [
+          {
+            "name": "cik",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^[0-9]{1,10}$",
+              "description": "Zero-padded SEC CIK (e.g. ``0001980994``).",
+              "examples": [
+                "0001980994"
+              ],
+              "title": "Cik"
+            },
+            "description": "Zero-padded SEC CIK (e.g. ``0001980994``)."
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 50,
+              "minimum": 1,
+              "default": 20,
+              "title": "Limit"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse_list_ProfileHistoryEntryOut__"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required. Pay $0.05 USDC via x402 on Base mainnet (eip155:8453) or Solana mainnet (solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp) to access this resource."
+          }
+        },
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.05"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        }
+      }
+    },
+    "/v1/profiles/comparison": {
+      "get": {
+        "summary": "Trading ETF comparison",
+        "description": "Side-by-side comparison of all trading crypto ETFs. Merges operational profile data (custodian, fees, APs) with XBRL financial data (AUM, NAV, expense ratio). Issuers without profile data appear with null profile fields.",
+        "operationId": "comparison_v1_profiles_comparison_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse_list_ETFComparisonOut__"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required. Pay $0.03 USDC via x402 on Base mainnet (eip155:8453) or Solana mainnet (solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp) to access this resource."
+          }
+        },
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.03"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        }
+      }
+    },
+    "/v1/agent/issuers": {
+      "get": {
+        "tags": [
+          "Agent Directory"
+        ],
+        "summary": "Curated issuer catalogue (paid)",
+        "description": "Full curated catalogue of every active US spot crypto ETF issuer with regulatory stage classification. Bazaar-discoverable directory feed at $1.00 \u2014 agents can drill into per-issuer data via the ``?cik=`` query-param routes.",
+        "operationId": "list_issuers_v1_agent_issuers_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse_list_IssuerOut__"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required. Pay $1.00 USDC via x402 on Base mainnet (eip155:8453) or Solana mainnet (solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp) to access this resource."
+          }
+        },
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "1.00"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        }
+      }
+    },
+    "/v1/agent/filings/recent": {
+      "get": {
+        "tags": [
+          "Agent Directory"
+        ],
+        "summary": "Recent filings feed (paid, no delay)",
+        "description": "Recent SEC filings for US spot crypto ETFs \u2014 no data delay, no daily cap (vs. free ``/v1/filings`` which is delayed 24 hours). Default ``limit=50`` newest-first. Optional ``currency``, ``filing_type``, ``date_after`` filters. Use for continuous polling at predictable per-call cost.",
+        "operationId": "recent_filings_v1_agent_filings_recent_get",
+        "parameters": [
+          {
+            "name": "currency",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "maxLength": 100
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by cryptocurrency (e.g. ``bitcoin``).",
+              "title": "Currency"
+            },
+            "description": "Filter by cryptocurrency (e.g. ``bitcoin``)."
+          },
+          {
+            "name": "filing_type",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "maxLength": 50
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by SEC form type (e.g. ``S-1``, ``CERT``).",
+              "title": "Filing Type"
+            },
+            "description": "Filter by SEC form type (e.g. ``S-1``, ``CERT``)."
+          },
+          {
+            "name": "date_after",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "maxLength": 25
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Earliest publication date (ISO-8601, e.g. ``2026-05-01``).",
+              "title": "Date After"
+            },
+            "description": "Earliest publication date (ISO-8601, e.g. ``2026-05-01``)."
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 100,
+              "minimum": 1,
+              "description": "Results (1-100).",
+              "default": 50,
+              "title": "Limit"
+            },
+            "description": "Results (1-100)."
+          },
+          {
+            "name": "order_by",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "enum": [
+                "published_desc",
+                "published_asc"
+              ],
+              "type": "string",
+              "description": "Sort order.",
+              "default": "published_desc",
+              "title": "Order By"
+            },
+            "description": "Sort order."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse_list_FilingOut__"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required. Pay $0.20 USDC via x402 on Base mainnet (eip155:8453) or Solana mainnet (solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp) to access this resource."
+          }
+        },
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.20"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        }
+      }
+    },
+    "/v1/agent/snapshot": {
+      "get": {
+        "tags": [
+          "Agent Directory"
+        ],
+        "summary": "Pipeline snapshot (paid)",
+        "description": "Single-call pipeline snapshot \u2014 DB totals, filings broken down by crypto + form type, and regulatory stage counts (trading / launch_imminent / under_review / etc.). Includes ``as_of`` ISO timestamp so agents can stale-check.",
+        "operationId": "snapshot_v1_agent_snapshot_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse_SnapshotOut_"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required. Pay $0.05 USDC via x402 on Base mainnet (eip155:8453) or Solana mainnet (solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp) to access this resource."
+          }
+        },
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.05"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "AUMBreakdownOut": {
+        "properties": {
+          "bitcoin": {
+            "type": "number",
+            "title": "Bitcoin",
+            "default": 0
+          },
+          "ethereum": {
+            "type": "number",
+            "title": "Ethereum",
+            "default": 0
+          },
+          "solana": {
+            "type": "number",
+            "title": "Solana",
+            "default": 0
+          },
+          "multi": {
+            "type": "number",
+            "title": "Multi",
+            "default": 0
+          },
+          "other": {
+            "type": "number",
+            "title": "Other",
+            "default": 0
+          }
+        },
+        "type": "object",
+        "title": "AUMBreakdownOut",
+        "description": "AUM breakdown by cryptocurrency category.\n\nAttributes:\n    bitcoin: Total AUM for Bitcoin ETFs (USD).\n    ethereum: Total AUM for Ethereum ETFs (USD).\n    other: Total AUM for all other crypto ETFs (USD)."
+      },
+      "AUMGrowthPointOut": {
+        "properties": {
+          "quarter": {
+            "type": "string",
+            "title": "Quarter"
+          },
+          "period_end": {
+            "type": "string",
+            "title": "Period End"
+          },
+          "total_aum": {
+            "type": "number",
+            "title": "Total Aum"
+          },
+          "issuer_count": {
+            "type": "integer",
+            "title": "Issuer Count"
+          },
+          "breakdown": {
+            "$ref": "#/components/schemas/AUMBreakdownOut"
+          }
+        },
+        "type": "object",
+        "required": [
+          "quarter",
+          "period_end",
+          "total_aum",
+          "issuer_count",
+          "breakdown"
+        ],
+        "title": "AUMGrowthPointOut",
+        "description": "A single quarterly data point for aggregate AUM growth.\n\nAttributes:\n    quarter: Quarter label (e.g. ``2024-Q3``).\n    period_end: Representative period end date (``YYYY-MM-DD``).\n    total_aum: Total AUM across all crypto ETFs (USD).\n    issuer_count: Number of distinct issuers reporting in this quarter.\n    breakdown: AUM split by cryptocurrency category."
+      },
+      "AggregateEntryOut": {
+        "properties": {
+          "value": {
+            "type": "string",
+            "title": "Value"
+          },
+          "count": {
+            "type": "integer",
+            "title": "Count"
+          }
+        },
+        "type": "object",
+        "required": [
+          "value",
+          "count"
+        ],
+        "title": "AggregateEntryOut",
+        "description": "Single row in an aggregate query result."
+      },
+      "ApiResponse_DeltaOut_": {
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/DeltaOut"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/Meta"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "ApiResponse[DeltaOut]"
+      },
+      "ApiResponse_FilingDetailOut_": {
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/FilingDetailOut"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/Meta"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "ApiResponse[FilingDetailOut]"
+      },
+      "ApiResponse_IssuerCommentLettersOut_": {
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/IssuerCommentLettersOut"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/Meta"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "ApiResponse[IssuerCommentLettersOut]"
+      },
+      "ApiResponse_ParsedIntentOut_": {
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/ParsedIntentOut"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/Meta"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "ApiResponse[ParsedIntentOut]"
+      },
+      "ApiResponse_SearchOut_": {
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/SearchOut"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/Meta"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "ApiResponse[SearchOut]"
+      },
+      "ApiResponse_SnapshotOut_": {
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/SnapshotOut"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/Meta"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "ApiResponse[SnapshotOut]"
+      },
+      "ApiResponse_StatsOut_": {
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/StatsOut"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/Meta"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "ApiResponse[StatsOut]"
+      },
+      "ApiResponse_Union_ETFProfileOut__NoneType__": {
+        "properties": {
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ETFProfileOut"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "meta": {
+            "$ref": "#/components/schemas/Meta"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "ApiResponse[Union[ETFProfileOut, NoneType]]"
+      },
+      "ApiResponse_Union_IssuerDetailOut__IssuerGatedOut__": {
+        "properties": {
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/IssuerDetailOut"
+              },
+              {
+                "$ref": "#/components/schemas/IssuerGatedOut"
+              }
+            ],
+            "title": "Data"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/Meta"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "ApiResponse[Union[IssuerDetailOut, IssuerGatedOut]]"
+      },
+      "ApiResponse_XBRLSnapshotOut_": {
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/XBRLSnapshotOut"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/Meta"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "ApiResponse[XBRLSnapshotOut]"
+      },
+      "ApiResponse_dict_str__CohortStateOut__": {
+        "properties": {
+          "data": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/CohortStateOut"
+            },
+            "type": "object",
+            "title": "Data"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/Meta"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "ApiResponse[dict[str, CohortStateOut]]"
+      },
+      "ApiResponse_list_AUMGrowthPointOut__": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/AUMGrowthPointOut"
+            },
+            "type": "array",
+            "title": "Data"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/Meta"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "ApiResponse[list[AUMGrowthPointOut]]"
+      },
+      "ApiResponse_list_AggregateEntryOut__": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/AggregateEntryOut"
+            },
+            "type": "array",
+            "title": "Data"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/Meta"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "ApiResponse[list[AggregateEntryOut]]"
+      },
+      "ApiResponse_list_ETFComparisonOut__": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/ETFComparisonOut"
+            },
+            "type": "array",
+            "title": "Data"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/Meta"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "ApiResponse[list[ETFComparisonOut]]"
+      },
+      "ApiResponse_list_ETFProfileOut__": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/ETFProfileOut"
+            },
+            "type": "array",
+            "title": "Data"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/Meta"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "ApiResponse[list[ETFProfileOut]]"
+      },
+      "ApiResponse_list_EventOut__": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/EventOut"
+            },
+            "type": "array",
+            "title": "Data"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/Meta"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "ApiResponse[list[EventOut]]"
+      },
+      "ApiResponse_list_FeeWarHistoryPointOut__": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/FeeWarHistoryPointOut"
+            },
+            "type": "array",
+            "title": "Data"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/Meta"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "ApiResponse[list[FeeWarHistoryPointOut]]"
+      },
+      "ApiResponse_list_FeeWarIssuerOut__": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/FeeWarIssuerOut"
+            },
+            "type": "array",
+            "title": "Data"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/Meta"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "ApiResponse[list[FeeWarIssuerOut]]"
+      },
+      "ApiResponse_list_FilingOut__": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/FilingOut"
+            },
+            "type": "array",
+            "title": "Data"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/Meta"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "ApiResponse[list[FilingOut]]"
+      },
+      "ApiResponse_list_IssuerOut__": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/IssuerOut"
+            },
+            "type": "array",
+            "title": "Data"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/Meta"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "ApiResponse[list[IssuerOut]]"
+      },
+      "ApiResponse_list_LaunchTimingOut__": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/LaunchTimingOut"
+            },
+            "type": "array",
+            "title": "Data"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/Meta"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "ApiResponse[list[LaunchTimingOut]]"
+      },
+      "ApiResponse_list_LeaderboardEntryOut__": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/LeaderboardEntryOut"
+            },
+            "type": "array",
+            "title": "Data"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/Meta"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "ApiResponse[list[LeaderboardEntryOut]]"
+      },
+      "ApiResponse_list_OutcomeSignalOut__": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/OutcomeSignalOut"
+            },
+            "type": "array",
+            "title": "Data"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/Meta"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "ApiResponse[list[OutcomeSignalOut]]"
+      },
+      "ApiResponse_list_ProfileHistoryEntryOut__": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/ProfileHistoryEntryOut"
+            },
+            "type": "array",
+            "title": "Data"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/Meta"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "ApiResponse[list[ProfileHistoryEntryOut]]"
+      },
+      "ApiResponse_list_RiskScoreOut__": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/RiskScoreOut"
+            },
+            "type": "array",
+            "title": "Data"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/Meta"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "ApiResponse[list[RiskScoreOut]]"
+      },
+      "ApiResponse_list_StalledIssuerOut__": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/StalledIssuerOut"
+            },
+            "type": "array",
+            "title": "Data"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/Meta"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "ApiResponse[list[StalledIssuerOut]]"
+      },
+      "ApiResponse_list_TimeSeriesPointOut__": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/TimeSeriesPointOut"
+            },
+            "type": "array",
+            "title": "Data"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/Meta"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "ApiResponse[list[TimeSeriesPointOut]]"
+      },
+      "ApiResponse_list_VelocityOut__": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/VelocityOut"
+            },
+            "type": "array",
+            "title": "Data"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/Meta"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "ApiResponse[list[VelocityOut]]"
+      },
+      "ApiResponse_list_dict_str__Any___": {
+        "properties": {
+          "data": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "type": "array",
+            "title": "Data"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/Meta"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "ApiResponse[list[dict[str, Any]]]"
+      },
+      "CohortStateOut": {
+        "properties": {
+          "state": {
+            "type": "string",
+            "enum": [
+              "holding_pool",
+              "in_wave",
+              "cohort_cleared"
+            ],
+            "title": "State"
+          },
+          "wave_anchor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Wave Anchor"
+          },
+          "wave_end": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Wave End"
+          },
+          "latest_approval_date": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Latest Approval Date"
+          },
+          "latest_8a12b": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Latest 8A12B"
+          },
+          "launch_imminent_ciks": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Launch Imminent Ciks"
+          },
+          "current_wave_graduate_ciks": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Current Wave Graduate Ciks"
+          }
+        },
+        "type": "object",
+        "required": [
+          "state"
+        ],
+        "title": "CohortStateOut",
+        "description": "Per-cohort wave state.\n\nCohorts (one per crypto category) sit in one of three states:\n\n* ``holding_pool`` \u2014 no active wave. Cohort is waiting for an EFFECT\n  or CERT to start the next wave. Issuers with a pending 8-A12B sit\n  at the front of the queue (``latest_8a12b`` populated).\n* ``in_wave`` \u2014 within 50 days of ``wave_anchor``. Pending issuers\n  with stage ``under_review`` or ``launch_imminent`` are wave riders;\n  approved-within-window issuers are graduates.\n* ``cohort_cleared`` \u2014 every cohort member has been approved; no\n  pending issuers remain. Hidden from the wave page (cleared funds\n  live in ``/fund-monitor``).\n\nThe wave window is FIXED \u2014 once ``wave_anchor`` is set, ``wave_end``\nis locked at ``wave_anchor + 50d``. Subsequent EFFECT/CERTs within\nthe window become graduates of THIS wave; they don't extend it. A\nnew wave starts only when an EFFECT/CERT lands more than 50 days\nafter the previous approval.\n\nAttributes:\n    state: Current cohort state.\n    wave_anchor: ISO date the current wave started (the EFFECT/CERT\n        that opened it). ``null`` when ``state == \"holding_pool\"``.\n    wave_end: ISO date the current wave closes (``wave_anchor + 50d``).\n        ``null`` when ``state == \"holding_pool\"``.\n    latest_approval_date: ISO date of the latest EFFECT/CERT in the\n        cohort, regardless of which wave it belongs to. Used by the\n        frontend to determine whether a recently-registered issuer\n        has \"sat through\" any cohort wave (which would clear their\n        ``New`` badge).\n    latest_8a12b: ISO date of the most recent 8-A12B from a CIK that\n        has not yet been approved (no EFFECT/CERT). Indicates that\n        the cohort has at least one issuer in launch-imminent state,\n        sitting at the front of the pre-wave queue. ``null`` when no\n        such pending 8-A12B exists.\n    launch_imminent_ciks: CIKs of issuers in ``launch_imminent``\n        stage (8-A12B filed, no CERT/EFFECT yet). These are the\n        trigger-issuers that put the cohort in pre-wave urgency.\n        Empty when no such pending issuer exists. Surfaced so the\n        frontend wave-pin can render the actual triggering issuer\n        alongside the ``latest_8a12b`` date.\n    current_wave_graduate_ciks: CIKs whose first EFFECT/CERT date\n        falls within the current wave window. Empty when no wave is\n        active."
+      },
+      "CommentLetterOut": {
+        "properties": {
+          "accession": {
+            "type": "string",
+            "title": "Accession"
+          },
+          "cik": {
+            "type": "string",
+            "title": "Cik"
+          },
+          "form_type": {
+            "type": "string",
+            "title": "Form Type"
+          },
+          "filing_date": {
+            "type": "string",
+            "title": "Filing Date"
+          },
+          "file_number": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "File Number"
+          },
+          "company": {
+            "type": "string",
+            "title": "Company"
+          },
+          "crypto_relevant": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Crypto Relevant"
+          }
+        },
+        "type": "object",
+        "required": [
+          "accession",
+          "cik",
+          "form_type",
+          "filing_date",
+          "company"
+        ],
+        "title": "CommentLetterOut",
+        "description": "A single SEC comment letter filing (UPLOAD or CORRESP).\n\nform_type values:\n    UPLOAD: SEC\u2192issuer comment letter.\n    CORRESP: Issuer\u2192SEC response."
+      },
+      "ConversionJourneyOut": {
+        "properties": {
+          "cik": {
+            "type": "string",
+            "title": "Cik"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "crypto": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Crypto"
+          },
+          "conversion_phase": {
+            "type": "string",
+            "title": "Conversion Phase"
+          },
+          "milestones": {
+            "items": {
+              "$ref": "#/components/schemas/ConversionMilestoneOut"
+            },
+            "type": "array",
+            "title": "Milestones"
+          },
+          "days_in_current_phase": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Days In Current Phase"
+          },
+          "d_to_10_12g_days": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "D To 10 12G Days"
+          },
+          "d_to_registration_days": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "D To Registration Days"
+          },
+          "ten_12g_to_registration_days": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ten 12G To Registration Days"
+          },
+          "registration_to_cert_days": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Registration To Cert Days"
+          },
+          "total_journey_days": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Total Journey Days"
+          }
+        },
+        "type": "object",
+        "required": [
+          "cik",
+          "name",
+          "conversion_phase"
+        ],
+        "title": "ConversionJourneyOut",
+        "description": "Trust-to-ETF conversion timeline.\n\nTracks the multi-stage conversion path for crypto trust entities:\nForm D \u2192 10-12G \u2192 S-1/S-3 \u2192 CERT \u2192 Trading.\n\nAttributes:\n    conversion_phase: Current phase \u2014 one of: ``pre_filing``,\n        ``private_offering``, ``reporting_entity``, ``registration_filed``,\n        ``under_review``, ``approved``, ``trading``.\n    milestones: Ordered list of achieved milestones with dates and links.\n    days_in_current_phase: Days since the most recent milestone.\n    d_to_10_12g_days: Gap between Form D and 10-12G filing.\n    d_to_registration_days: Gap between Form D and S-1/S-3 registration.\n    ten_12g_to_registration_days: Gap between 10-12G and S-1/S-3 filing.\n    registration_to_cert_days: Gap between registration and CERT/approval.\n    total_journey_days: Total days from earliest to latest milestone."
+      },
+      "ConversionMilestoneOut": {
+        "properties": {
+          "form_type": {
+            "type": "string",
+            "title": "Form Type"
+          },
+          "filed_date": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Filed Date"
+          },
+          "link": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Link"
+          }
+        },
+        "type": "object",
+        "required": [
+          "form_type"
+        ],
+        "title": "ConversionMilestoneOut",
+        "description": "A single milestone in the trust-to-ETF conversion path.\n\nAttributes:\n    form_type: SEC form type (``D``, ``10-12G``, ``S-1``, ``S-3``, ``CERT``).\n    filed_date: Date the milestone filing was published (``YYYY-MM-DD``).\n    link: EDGAR filing URL."
+      },
+      "DeltaOut": {
+        "properties": {
+          "filings_7d_delta": {
+            "type": "integer",
+            "title": "Filings 7D Delta"
+          },
+          "pipeline_active_delta": {
+            "type": "integer",
+            "title": "Pipeline Active Delta"
+          },
+          "under_review_delta": {
+            "type": "integer",
+            "title": "Under Review Delta"
+          },
+          "now_trading_delta": {
+            "type": "integer",
+            "title": "Now Trading Delta"
+          },
+          "likely_delta": {
+            "type": "integer",
+            "title": "Likely Delta"
+          },
+          "unclear_delta": {
+            "type": "integer",
+            "title": "Unclear Delta"
+          },
+          "at_risk_delta": {
+            "type": "integer",
+            "title": "At Risk Delta"
+          },
+          "stage_deltas": {
+            "additionalProperties": {
+              "type": "integer"
+            },
+            "type": "object",
+            "title": "Stage Deltas"
+          },
+          "comparison_date": {
+            "type": "string",
+            "title": "Comparison Date"
+          }
+        },
+        "type": "object",
+        "required": [
+          "filings_7d_delta",
+          "pipeline_active_delta",
+          "under_review_delta",
+          "now_trading_delta",
+          "likely_delta",
+          "unclear_delta",
+          "at_risk_delta",
+          "comparison_date"
+        ],
+        "title": "DeltaOut",
+        "description": "Week-over-week dashboard delta indicators.\n\nCompares today's pipeline snapshot against a previous snapshot\n(default 7 days ago) to surface aggregate changes."
+      },
+      "ETFComparisonOut": {
+        "properties": {
+          "cik": {
+            "type": "string",
+            "title": "Cik"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "ticker": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ticker"
+          },
+          "crypto": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Crypto"
+          },
+          "exchange": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Exchange"
+          },
+          "custodian": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Custodian"
+          },
+          "sponsor_fee": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sponsor Fee"
+          },
+          "reference_rate": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reference Rate"
+          },
+          "basket_size": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Basket Size"
+          },
+          "inkind_eligible": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Inkind Eligible"
+          },
+          "ap_count_cash": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ap Count Cash"
+          },
+          "ap_count_inkind": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ap Count Inkind"
+          },
+          "profile_date": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Profile Date"
+          },
+          "fee_waiver_expiry": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fee Waiver Expiry"
+          },
+          "aum": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Aum"
+          },
+          "nav_per_share": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Nav Per Share"
+          },
+          "expense_ratio": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expense Ratio"
+          },
+          "shares_outstanding": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Shares Outstanding"
+          },
+          "market_price": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Market Price"
+          },
+          "market_volume": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Market Volume"
+          },
+          "market_cap": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Market Cap"
+          },
+          "market_date": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Market Date"
+          },
+          "market_source": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Market Source"
+          },
+          "premium_discount_pct": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Premium Discount Pct"
+          },
+          "xbrl_period_end": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Xbrl Period End"
+          },
+          "return_1d": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Return 1D"
+          },
+          "return_1w": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Return 1W"
+          },
+          "return_1m": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Return 1M"
+          },
+          "return_ytd": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Return Ytd"
+          },
+          "tracking_error_xbrl_pct": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tracking Error Xbrl Pct"
+          },
+          "tracking_error_xbrl_period": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tracking Error Xbrl Period"
+          },
+          "fund_return_pct": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fund Return Pct"
+          },
+          "crypto_return_pct": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Crypto Return Pct"
+          },
+          "tracking_error_live_pct": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tracking Error Live Pct"
+          },
+          "effective_fee_rate": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Effective Fee Rate"
+          },
+          "implied_nav": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Implied Nav"
+          },
+          "live_premium_discount_pct": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Live Premium Discount Pct"
+          },
+          "crypto_per_share": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Crypto Per Share"
+          },
+          "holdings_crypto_units": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Holdings Crypto Units"
+          },
+          "holdings_source": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Holdings Source"
+          },
+          "holdings_as_of": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Holdings As Of"
+          },
+          "spot_price_usd": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Spot Price Usd"
+          }
+        },
+        "type": "object",
+        "required": [
+          "cik",
+          "name"
+        ],
+        "title": "ETFComparisonOut",
+        "description": "Side-by-side comparison row merging profile + XBRL data per issuer."
+      },
+      "ETFProfileOut": {
+        "properties": {
+          "cik": {
+            "type": "string",
+            "title": "Cik"
+          },
+          "filing_date": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Filing Date"
+          },
+          "custodian": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Custodian"
+          },
+          "sponsor_fee": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sponsor Fee"
+          },
+          "fee_waiver_expiry": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fee Waiver Expiry"
+          },
+          "reference_rate": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reference Rate"
+          },
+          "basket_size": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Basket Size"
+          },
+          "inkind_eligible": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Inkind Eligible"
+          },
+          "ap_count_cash": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ap Count Cash"
+          },
+          "ap_count_inkind": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ap Count Inkind"
+          },
+          "fee_delta": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fee Delta"
+          },
+          "custodian_changed": {
+            "type": "boolean",
+            "title": "Custodian Changed",
+            "default": false
+          },
+          "ap_count_cash_delta": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ap Count Cash Delta"
+          }
+        },
+        "type": "object",
+        "required": [
+          "cik"
+        ],
+        "title": "ETFProfileOut",
+        "description": "Operational profile extracted from a POS AM filing.\n\nAP roster names are withheld (terminal-only). Counts and deltas\nare exposed for API consumers."
+      },
+      "EducationOut": {
+        "properties": {
+          "topic": {
+            "type": "string",
+            "title": "Topic"
+          },
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "explanation": {
+            "type": "string",
+            "title": "Explanation"
+          },
+          "investor_impact": {
+            "type": "string",
+            "title": "Investor Impact"
+          },
+          "related_topics": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Related Topics"
+          }
+        },
+        "type": "object",
+        "required": [
+          "topic",
+          "title",
+          "explanation",
+          "investor_impact"
+        ],
+        "title": "EducationOut",
+        "description": "Education content for an explain-intent query."
+      },
+      "EventOut": {
+        "properties": {
+          "event_type": {
+            "type": "string",
+            "title": "Event Type"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description"
+          },
+          "timestamp": {
+            "type": "string",
+            "title": "Timestamp"
+          },
+          "company": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Company"
+          },
+          "cik": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cik"
+          },
+          "crypto": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Crypto"
+          },
+          "filing_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Filing Type"
+          },
+          "link": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Link"
+          },
+          "accession": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Accession"
+          },
+          "primary_doc": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Primary Doc"
+          },
+          "ticker": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ticker"
+          },
+          "exchange": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Exchange"
+          },
+          "symbol": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Symbol"
+          }
+        },
+        "type": "object",
+        "required": [
+          "event_type",
+          "description",
+          "timestamp"
+        ],
+        "title": "EventOut",
+        "description": "A single activity feed event.\n\nMerges notable filings and comment letters into a unified chronological\nfeed with human-readable descriptions.\n\nAttributes:\n    event_type: ``filing`` for SEC filings, ``comment_letter`` for\n        UPLOAD/CORRESP comment letters.\n    description: Plain-English sentence describing the event.\n    timestamp: ISO date (``YYYY-MM-DD``) from ``published`` or ``filing_date``.\n    company: Company name from the filing or comment letter.\n    cik: Zero-padded 10-digit SEC CIK (for linking to issuer detail).\n    crypto: Primary cryptocurrency (e.g. ``bitcoin``), or ``null``.\n    filing_type: SEC form type (``S-1``, ``EFFECT``, ``UPLOAD``, etc.).\n    link: EDGAR filing URL (for click-through).\n    accession: Accession number (for comment letters).\n    ticker: Primary exchange ticker (e.g. ``IBIT``), or ``null`` for\n        issuers that haven't disclosed/registered one yet.\n    exchange: Primary listing exchange (e.g. ``NASDAQ``, ``NYSEArca``,\n        ``Cboe BZX``), or ``null``.\n    symbol: Convenience composite of ``TICKER:EXCHANGE`` when both\n        are known (e.g. ``IBIT:NASDAQ``). Useful for piping the feed\n        into brokerage APIs that require full symbology."
+      },
+      "FeeWarHistoryIssuerOut": {
+        "properties": {
+          "cik": {
+            "type": "string",
+            "title": "Cik"
+          },
+          "company": {
+            "type": "string",
+            "title": "Company"
+          },
+          "ticker": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ticker"
+          },
+          "expense_ratio": {
+            "type": "number",
+            "title": "Expense Ratio"
+          },
+          "expense_ratio_bps": {
+            "type": "number",
+            "title": "Expense Ratio Bps"
+          }
+        },
+        "type": "object",
+        "required": [
+          "cik",
+          "company",
+          "expense_ratio",
+          "expense_ratio_bps"
+        ],
+        "title": "FeeWarHistoryIssuerOut",
+        "description": "One issuer's fee at a specific quarter.\n\nAttributes:\n    cik: Issuer CIK.\n    company: Company name.\n    ticker: ETF ticker symbol.\n    expense_ratio: Expense ratio as decimal.\n    expense_ratio_bps: Expense ratio in basis points."
+      },
+      "FeeWarHistoryPointOut": {
+        "properties": {
+          "quarter": {
+            "type": "string",
+            "title": "Quarter"
+          },
+          "period_end": {
+            "type": "string",
+            "title": "Period End"
+          },
+          "issuers": {
+            "items": {
+              "$ref": "#/components/schemas/FeeWarHistoryIssuerOut"
+            },
+            "type": "array",
+            "title": "Issuers"
+          }
+        },
+        "type": "object",
+        "required": [
+          "quarter",
+          "period_end",
+          "issuers"
+        ],
+        "title": "FeeWarHistoryPointOut",
+        "description": "One quarter's fee data for all issuers.\n\nAttributes:\n    quarter: Quarter label (e.g. ``2024-Q3``).\n    period_end: Representative period end date.\n    issuers: Fee data for each issuer in this quarter."
+      },
+      "FeeWarIssuerOut": {
+        "properties": {
+          "cik": {
+            "type": "string",
+            "title": "Cik"
+          },
+          "company": {
+            "type": "string",
+            "title": "Company"
+          },
+          "crypto": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Crypto"
+          },
+          "ticker": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ticker"
+          },
+          "expense_ratio": {
+            "type": "number",
+            "title": "Expense Ratio"
+          },
+          "expense_ratio_bps": {
+            "type": "number",
+            "title": "Expense Ratio Bps"
+          },
+          "concept_source": {
+            "type": "string",
+            "title": "Concept Source"
+          },
+          "period_end": {
+            "type": "string",
+            "title": "Period End"
+          },
+          "effective_rate": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Effective Rate"
+          },
+          "effective_rate_bps": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Effective Rate Bps"
+          },
+          "sponsor_fees": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sponsor Fees"
+          },
+          "aum": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Aum"
+          },
+          "fee_waiver_expiry": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fee Waiver Expiry"
+          }
+        },
+        "type": "object",
+        "required": [
+          "cik",
+          "company",
+          "expense_ratio",
+          "expense_ratio_bps",
+          "concept_source",
+          "period_end"
+        ],
+        "title": "FeeWarIssuerOut",
+        "description": "Current fee snapshot for one issuer.\n\nAttributes:\n    cik: Issuer CIK.\n    company: Company name.\n    crypto: Cryptocurrency tracked (e.g. ``bitcoin``).\n    ticker: ETF ticker symbol (e.g. ``IBIT``).\n    expense_ratio: Stated expense ratio as decimal (0.0025 = 0.25%).\n    expense_ratio_bps: Expense ratio in basis points (25.0).\n    concept_source: XBRL concept that provided the value.\n    period_end: Period end date for this value.\n    effective_rate: Computed SponsorFees / AUM, if available.\n    effective_rate_bps: Effective rate in basis points.\n    sponsor_fees: Raw sponsor fees in USD.\n    aum: Assets under management in USD."
+      },
+      "FilingDetailOut": {
+        "properties": {
+          "link": {
+            "type": "string",
+            "title": "Link"
+          },
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "company": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Company"
+          },
+          "cik": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cik"
+          },
+          "filing_type": {
+            "type": "string",
+            "title": "Filing Type"
+          },
+          "changes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Changes"
+          },
+          "published": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Published"
+          },
+          "keywords": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Keywords"
+          },
+          "source": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source"
+          },
+          "currency": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Currency"
+          },
+          "currencies": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Currencies"
+          },
+          "primary_doc": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Primary Doc"
+          },
+          "accession": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Accession"
+          },
+          "sec_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sec Url"
+          },
+          "full_text": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Full Text"
+          },
+          "data_delayed": {
+            "type": "boolean",
+            "title": "Data Delayed",
+            "default": false
+          }
+        },
+        "type": "object",
+        "required": [
+          "link",
+          "title",
+          "filing_type"
+        ],
+        "title": "FilingDetailOut",
+        "description": "Single filing detail view \u2014 includes full_text (Developer tier required)."
+      },
+      "FilingOut": {
+        "properties": {
+          "link": {
+            "type": "string",
+            "title": "Link"
+          },
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "company": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Company"
+          },
+          "cik": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cik"
+          },
+          "filing_type": {
+            "type": "string",
+            "title": "Filing Type"
+          },
+          "changes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Changes"
+          },
+          "published": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Published"
+          },
+          "keywords": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Keywords"
+          },
+          "source": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source"
+          },
+          "currency": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Currency"
+          },
+          "currencies": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Currencies"
+          },
+          "primary_doc": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Primary Doc"
+          },
+          "accession": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Accession"
+          },
+          "sec_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sec Url"
+          }
+        },
+        "type": "object",
+        "required": [
+          "link",
+          "title",
+          "filing_type"
+        ],
+        "title": "FilingOut",
+        "description": "A single SEC filing (list view \u2014 full_text excluded).\n\nAttributes:\n    link: Primary key \u2014 canonical EDGAR filing URL.\n    accession: Derived dashed accession number (e.g. ``0001193125-26-061537``).\n    sec_url: EDGAR viewer URL derived from link.\n    currencies: Constituent currencies for multi-crypto filings.\n        Empty list for single-crypto filings."
+      },
+      "GatedField": {
+        "properties": {
+          "gated": {
+            "type": "boolean",
+            "title": "Gated",
+            "default": true
+          },
+          "required_tier": {
+            "type": "string",
+            "title": "Required Tier",
+            "default": "developer"
+          }
+        },
+        "type": "object",
+        "title": "GatedField",
+        "description": "Sentinel returned in place of a gated field.\n\nAllows API consumers to distinguish three states:\n\n* ``null`` \u2014 the issuer genuinely has no data for this field.\n* ``GatedField`` \u2014 the field exists but requires a higher tier to access.\n* actual data \u2014 the caller has sufficient access.\n\nExample response for a free-tier caller::\n\n    {\"review_intensity\": {\"gated\": true, \"required_tier\": \"developer\"}}"
+      },
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "type": "array",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "title": "HTTPValidationError"
+      },
+      "IssuerCommentLettersOut": {
+        "properties": {
+          "review_profile": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ReviewProfileOut"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "letters": {
+            "items": {
+              "$ref": "#/components/schemas/CommentLetterOut"
+            },
+            "type": "array",
+            "title": "Letters"
+          }
+        },
+        "type": "object",
+        "title": "IssuerCommentLettersOut",
+        "description": "Comment letter history for a single issuer."
+      },
+      "IssuerDetailOut": {
+        "properties": {
+          "cik": {
+            "type": "string",
+            "title": "Cik"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "crypto": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Crypto"
+          },
+          "currencies": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Currencies"
+          },
+          "ticker": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ticker"
+          },
+          "exchange": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Exchange"
+          },
+          "owner_org": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Owner Org"
+          },
+          "sic": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sic"
+          },
+          "entity_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Entity Type"
+          },
+          "issuer_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Issuer Type"
+          },
+          "stage": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Stage"
+          },
+          "first_registration_date": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "First Registration Date"
+          },
+          "review_profile": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ReviewProfileOut"
+              },
+              {
+                "$ref": "#/components/schemas/GatedField"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Review Profile"
+          },
+          "filing_count": {
+            "type": "integer",
+            "title": "Filing Count",
+            "default": 0
+          },
+          "filing_type_counts": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "type": "array",
+            "title": "Filing Type Counts"
+          },
+          "series": {
+            "items": {
+              "$ref": "#/components/schemas/SeriesOut"
+            },
+            "type": "array",
+            "title": "Series"
+          },
+          "conversion_journey": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ConversionJourneyOut"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "etf_profile": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ETFProfileOut"
+              },
+              {
+                "$ref": "#/components/schemas/GatedField"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Etf Profile"
+          },
+          "shelf_status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Shelf Status"
+          }
+        },
+        "type": "object",
+        "required": [
+          "cik",
+          "name"
+        ],
+        "title": "IssuerDetailOut",
+        "description": "Issuer detail view \u2014 includes review profile and filing count.\n\n``review_profile`` has three distinct states:\n\n* ``null`` \u2014 issuer has no review data (no comment letters or EFFECT filing).\n* ``GatedField`` \u2014 field exists but caller needs a higher tier (free).\n* ``ReviewProfileOut`` \u2014 full data for professional callers.\n\n``conversion_journey`` is populated only for trust-path entities with\nForm D or 10-12G evidence. ``null`` for all other issuers."
+      },
+      "IssuerGatedOut": {
+        "properties": {
+          "cik": {
+            "type": "string",
+            "title": "Cik"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "gated": {
+            "type": "boolean",
+            "title": "Gated",
+            "default": true
+          },
+          "required_tier": {
+            "type": "string",
+            "title": "Required Tier",
+            "default": "developer"
+          },
+          "upgrade_url": {
+            "type": "string",
+            "title": "Upgrade Url",
+            "default": "https://cryptoetfsentinel.com/pricing"
+          }
+        },
+        "type": "object",
+        "required": [
+          "cik",
+          "name"
+        ],
+        "title": "IssuerGatedOut",
+        "description": "Minimal issuer response for free-tier callers requesting a CIK\noutside the top-10-by-AUM allowlist.\n\nSurfaces the bare facts that are public from SEC EDGAR anyway (CIK +\nname) plus an upgrade signal so the caller knows the curation\nmetadata is gated, not absent."
+      },
+      "IssuerOut": {
+        "properties": {
+          "cik": {
+            "type": "string",
+            "title": "Cik"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "crypto": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Crypto"
+          },
+          "currencies": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Currencies"
+          },
+          "ticker": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ticker"
+          },
+          "exchange": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Exchange"
+          },
+          "owner_org": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Owner Org"
+          },
+          "sic": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sic"
+          },
+          "entity_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Entity Type"
+          },
+          "issuer_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Issuer Type"
+          },
+          "stage": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Stage"
+          },
+          "first_registration_date": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "First Registration Date"
+          }
+        },
+        "type": "object",
+        "required": [
+          "cik",
+          "name"
+        ],
+        "title": "IssuerOut",
+        "description": "Known crypto ETF issuer (list view).\n\nAttributes:\n    cik: Zero-padded 10-digit SEC CIK.\n    crypto: Primary cryptocurrency (e.g. ``bitcoin``), ``multi`` for index\n        funds, or ``null`` for umbrella trusts.\n    currencies: Constituent currencies for multi-crypto issuers.\n        Empty list for single-crypto issuers.\n    first_registration_date: Earliest S-1/S-3/N-1A/N-2 filing date for\n        this CIK (``YYYY-MM-DD``). ``null`` if no registration filing\n        exists in the DB \u2014 caller should fall back to cohort-level state\n        rather than assuming the issuer is brand new."
+      },
+      "LaunchTimingOut": {
+        "properties": {
+          "cik": {
+            "type": "string",
+            "title": "Cik"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "ticker": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ticker"
+          },
+          "crypto": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Crypto"
+          },
+          "days_waiting": {
+            "type": "integer",
+            "title": "Days Waiting"
+          },
+          "filing_date_8a12b": {
+            "type": "string",
+            "title": "Filing Date 8A12B"
+          },
+          "percentile": {
+            "type": "number",
+            "title": "Percentile"
+          }
+        },
+        "type": "object",
+        "required": [
+          "cik",
+          "name",
+          "days_waiting",
+          "filing_date_8a12b",
+          "percentile"
+        ],
+        "title": "LaunchTimingOut",
+        "description": "Launch timing for a launch_imminent issuer.\n\nPercentile position indicates how this issuer's wait compares to\nthe historical distribution of 8-A12B \u2192 CERT/EFFECT gaps."
+      },
+      "LeaderboardEntryOut": {
+        "properties": {
+          "cik": {
+            "type": "string",
+            "title": "Cik"
+          },
+          "company": {
+            "type": "string",
+            "title": "Company"
+          },
+          "value": {
+            "type": "number",
+            "title": "Value"
+          },
+          "period_end": {
+            "type": "string",
+            "title": "Period End"
+          },
+          "fiscal_year": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fiscal Year"
+          },
+          "fiscal_period": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fiscal Period"
+          }
+        },
+        "type": "object",
+        "required": [
+          "cik",
+          "company",
+          "value",
+          "period_end"
+        ],
+        "title": "LeaderboardEntryOut",
+        "description": "A single entry in the XBRL leaderboard (e.g. AUM ranking).\n\nAttributes:\n    cik: Zero-padded 10-digit SEC CIK.\n    company: Issuer name (enriched from known_issuers.json).\n    value: Latest value for the requested concept.\n    period_end: Date of the value (``YYYY-MM-DD``).\n    fiscal_year: Fiscal year (e.g. 2025).\n    fiscal_period: Fiscal period (``Q1``, ``Q2``, ``Q3``, ``FY``)."
+      },
+      "Meta": {
+        "properties": {
+          "total": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Total"
+          },
+          "limit": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Limit"
+          },
+          "offset": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Offset"
+          },
+          "page": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Page"
+          },
+          "full_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Full Count"
+          },
+          "note": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Note"
+          }
+        },
+        "type": "object",
+        "title": "Meta",
+        "description": "Pagination and result-set metadata attached to every response."
+      },
+      "OutcomeSignalOut": {
+        "properties": {
+          "cik": {
+            "type": "string",
+            "title": "Cik"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "ticker": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ticker"
+          },
+          "crypto": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Crypto"
+          },
+          "score": {
+            "type": "integer",
+            "title": "Score"
+          },
+          "pattern_match": {
+            "type": "string",
+            "title": "Pattern Match"
+          },
+          "factors": {
+            "items": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "type": "array",
+            "title": "Factors"
+          },
+          "signals": {
+            "additionalProperties": {
+              "anyOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "type": "object",
+            "title": "Signals"
+          }
+        },
+        "type": "object",
+        "required": [
+          "cik",
+          "name",
+          "score",
+          "pattern_match"
+        ],
+        "title": "OutcomeSignalOut",
+        "description": "Outcome prediction for an under-review issuer.\n\nScore represents approval likelihood on a 1-99 scale, stage-weighted\n(the displayed score reflects stage-aware adjustments to the underlying\nreadiness signals, not the raw signal-extraction values)."
+      },
+      "ParsedIntentOut": {
+        "properties": {
+          "intent": {
+            "type": "string",
+            "title": "Intent"
+          },
+          "confidence": {
+            "type": "number",
+            "title": "Confidence"
+          },
+          "filters": {
+            "$ref": "#/components/schemas/QueryFiltersOut"
+          },
+          "group_by": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Group By"
+          },
+          "limit": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Limit"
+          },
+          "topic": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Topic"
+          },
+          "education": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/EducationOut"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "type": "object",
+        "required": [
+          "intent",
+          "confidence",
+          "filters"
+        ],
+        "title": "ParsedIntentOut",
+        "description": "Result of natural-language query parsing."
+      },
+      "ProfileHistoryEntryOut": {
+        "properties": {
+          "cik": {
+            "type": "string",
+            "title": "Cik"
+          },
+          "filing_date": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Filing Date"
+          },
+          "custodian": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Custodian"
+          },
+          "sponsor_fee": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sponsor Fee"
+          },
+          "fee_waiver_expiry": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fee Waiver Expiry"
+          },
+          "reference_rate": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reference Rate"
+          },
+          "basket_size": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Basket Size"
+          },
+          "inkind_eligible": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Inkind Eligible"
+          },
+          "ap_count_cash": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ap Count Cash"
+          },
+          "ap_count_inkind": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ap Count Inkind"
+          },
+          "fee_delta": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fee Delta"
+          },
+          "custodian_changed": {
+            "type": "boolean",
+            "title": "Custodian Changed",
+            "default": false
+          },
+          "ap_count_cash_delta": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ap Count Cash Delta"
+          },
+          "accession": {
+            "type": "string",
+            "title": "Accession"
+          },
+          "inkind_changed": {
+            "type": "boolean",
+            "title": "Inkind Changed",
+            "default": false
+          },
+          "basket_size_delta": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Basket Size Delta"
+          },
+          "ap_count_inkind_delta": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ap Count Inkind Delta"
+          }
+        },
+        "type": "object",
+        "required": [
+          "cik",
+          "accession"
+        ],
+        "title": "ProfileHistoryEntryOut",
+        "description": "A single entry in an issuer's profile evolution timeline."
+      },
+      "QueryFiltersOut": {
+        "properties": {
+          "currency": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Currency"
+          },
+          "filing_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Filing Type"
+          },
+          "company": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Company"
+          },
+          "date_after": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Date After"
+          },
+          "date_before": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Date Before"
+          }
+        },
+        "type": "object",
+        "title": "QueryFiltersOut",
+        "description": "Extracted filter criteria from a natural-language query."
+      },
+      "ReviewProfileOut": {
+        "properties": {
+          "review_status": {
+            "type": "string",
+            "title": "Review Status"
+          },
+          "review_rounds": {
+            "type": "integer",
+            "title": "Review Rounds"
+          },
+          "first_letter": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "First Letter"
+          },
+          "last_letter": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Letter"
+          },
+          "review_duration_days": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Review Duration Days"
+          },
+          "days_since_last_letter": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Days Since Last Letter"
+          },
+          "approval_date": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Approval Date"
+          },
+          "withdrawal_date": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Withdrawal Date"
+          },
+          "registration_date": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Registration Date"
+          },
+          "uploads": {
+            "type": "integer",
+            "title": "Uploads"
+          },
+          "correspondences": {
+            "type": "integer",
+            "title": "Correspondences"
+          }
+        },
+        "type": "object",
+        "required": [
+          "review_status",
+          "review_rounds",
+          "uploads",
+          "correspondences"
+        ],
+        "title": "ReviewProfileOut",
+        "description": "Multi-dimensional Regulatory Review Profile for an issuer.\n\nProvides a richer view than the legacy intensity score:\n\n* ``review_status``: ``\"approved\"`` (EFFECT filing found),\n  ``\"active\"`` (recent correspondence), or ``\"stalled\"``\n  (no activity for 180+ days and no approval).\n* ``review_rounds``: UPLOAD count = SEC\u2192issuer comment rounds.\n* ``first_letter`` / ``last_letter``: Date range of review.\n* ``approval_date``: Date of EFFECT filing, if any."
+      },
+      "RiskScoreOut": {
+        "properties": {
+          "cik": {
+            "type": "string",
+            "title": "Cik"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "ticker": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ticker"
+          },
+          "crypto": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Crypto"
+          },
+          "risk_level": {
+            "type": "string",
+            "title": "Risk Level"
+          },
+          "days_in_review": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Days In Review"
+          },
+          "amendment_count": {
+            "type": "integer",
+            "title": "Amendment Count",
+            "default": 0
+          },
+          "upload_count": {
+            "type": "integer",
+            "title": "Upload Count",
+            "default": 0
+          },
+          "corresp_count": {
+            "type": "integer",
+            "title": "Corresp Count",
+            "default": 0
+          },
+          "registration_date": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Registration Date"
+          },
+          "last_letter": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Letter"
+          },
+          "days_since_last_letter": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Days Since Last Letter"
+          },
+          "review_rounds": {
+            "type": "integer",
+            "title": "Review Rounds",
+            "default": 0
+          },
+          "activity_status": {
+            "type": "string",
+            "title": "Activity Status",
+            "default": "active"
+          },
+          "last_activity_date": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Activity Date"
+          },
+          "avg_response_days": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Avg Response Days"
+          },
+          "response_speed": {
+            "type": "string",
+            "title": "Response Speed",
+            "default": "unknown"
+          }
+        },
+        "type": "object",
+        "required": [
+          "cik",
+          "name",
+          "risk_level"
+        ],
+        "title": "RiskScoreOut",
+        "description": "Risk assessment for an under-review issuer.\n\nRisk levels based on percentile position vs historical approved\nissuers' review durations:\n- normal: <50th percentile\n- moderate: 50th\u201370th percentile\n- elevated: 70th\u201390th percentile\n- high: >90th percentile\n- unknown: insufficient data to compute"
+      },
+      "SearchOut": {
+        "properties": {
+          "query": {
+            "type": "string",
+            "title": "Query"
+          },
+          "results": {
+            "items": {
+              "$ref": "#/components/schemas/SearchResult"
+            },
+            "type": "array",
+            "title": "Results"
+          },
+          "method": {
+            "type": "string",
+            "title": "Method",
+            "description": "Retrieval strategy used for this query. ``faiss`` = vector/semantic search against the FAISS index (typical case). ``keyword`` = text fallback when FAISS returned zero results above the similarity threshold. Exposed so clients can adjust trust/ranking accordingly.",
+            "examples": [
+              "faiss",
+              "keyword"
+            ]
+          }
+        },
+        "type": "object",
+        "required": [
+          "query",
+          "method"
+        ],
+        "title": "SearchOut",
+        "description": "Semantic search response.\n\nAttributes:\n    method: ``faiss`` when FAISS index available, ``keyword`` for text fallback."
+      },
+      "SearchResult": {
+        "properties": {
+          "filing": {
+            "$ref": "#/components/schemas/FilingOut"
+          },
+          "score": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Score"
+          }
+        },
+        "type": "object",
+        "required": [
+          "filing"
+        ],
+        "title": "SearchResult",
+        "description": "A single semantic search result."
+      },
+      "SeriesOut": {
+        "properties": {
+          "series_id": {
+            "type": "string",
+            "title": "Series Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "tickers": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Tickers"
+          },
+          "crypto": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Crypto"
+          },
+          "product_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Product Type"
+          }
+        },
+        "type": "object",
+        "required": [
+          "series_id",
+          "name"
+        ],
+        "title": "SeriesOut",
+        "description": "A single crypto ETF/ETP series registered with the SEC.\n\nFrom the SEC series registry \u2014 each umbrella trust may have multiple\nseries, each with its own set of tickers and crypto classification."
+      },
+      "SnapshotOut": {
+        "properties": {
+          "total_filings": {
+            "type": "integer",
+            "title": "Total Filings"
+          },
+          "earliest_filing": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Earliest Filing"
+          },
+          "latest_filing": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Latest Filing"
+          },
+          "filings_by_currency": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "type": "array",
+            "title": "Filings By Currency"
+          },
+          "filings_by_type": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "type": "array",
+            "title": "Filings By Type"
+          },
+          "known_issuers": {
+            "type": "integer",
+            "title": "Known Issuers"
+          },
+          "stage_counts": {
+            "additionalProperties": {
+              "type": "integer"
+            },
+            "type": "object",
+            "title": "Stage Counts"
+          },
+          "as_of": {
+            "type": "string",
+            "title": "As Of"
+          }
+        },
+        "type": "object",
+        "required": [
+          "total_filings",
+          "known_issuers",
+          "as_of"
+        ],
+        "title": "SnapshotOut",
+        "description": "Agent-facing pipeline snapshot \u2014 StatsOut plus regulatory stage counts\nand an ``as_of`` timestamp so agents can stale-check.\n\nThe stage_counts breakdown turns the snapshot into an actionable view of\nthe regulatory pipeline rather than just DB stats."
+      },
+      "StalledIssuerOut": {
+        "properties": {
+          "cik": {
+            "type": "string",
+            "title": "Cik"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "ticker": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ticker"
+          },
+          "crypto": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Crypto"
+          },
+          "days_since_last_letter": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Days Since Last Letter"
+          },
+          "last_letter": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Letter"
+          },
+          "review_rounds": {
+            "type": "integer",
+            "title": "Review Rounds"
+          },
+          "registration_date": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Registration Date"
+          }
+        },
+        "type": "object",
+        "required": [
+          "cik",
+          "name",
+          "review_rounds"
+        ],
+        "title": "StalledIssuerOut",
+        "description": "An issuer with a stalled SEC review (180+ days of silence).\n\nPurpose-built for the dashboard Stalled Review Detector widget."
+      },
+      "StatsOut": {
+        "properties": {
+          "total_filings": {
+            "type": "integer",
+            "title": "Total Filings"
+          },
+          "earliest_filing": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Earliest Filing"
+          },
+          "latest_filing": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Latest Filing"
+          },
+          "filings_by_currency": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "type": "array",
+            "title": "Filings By Currency"
+          },
+          "filings_by_type": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "type": "array",
+            "title": "Filings By Type"
+          },
+          "known_issuers": {
+            "type": "integer",
+            "title": "Known Issuers"
+          }
+        },
+        "type": "object",
+        "required": [
+          "total_filings",
+          "known_issuers"
+        ],
+        "title": "StatsOut",
+        "description": "Aggregate database statistics."
+      },
+      "TimeSeriesPointOut": {
+        "properties": {
+          "period_end": {
+            "type": "string",
+            "title": "Period End"
+          },
+          "value": {
+            "type": "number",
+            "title": "Value"
+          },
+          "filed_date": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Filed Date"
+          },
+          "form_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Form Type"
+          },
+          "fiscal_year": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fiscal Year"
+          },
+          "fiscal_period": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fiscal Period"
+          }
+        },
+        "type": "object",
+        "required": [
+          "period_end",
+          "value"
+        ],
+        "title": "TimeSeriesPointOut",
+        "description": "A single data point in an XBRL time series.\n\nAttributes:\n    period_end: Period end date (``YYYY-MM-DD``).\n    value: Numeric value for the concept.\n    filed_date: Filing submission date.\n    form_type: SEC form type (``10-K``, ``10-Q``).\n    fiscal_year: Fiscal year.\n    fiscal_period: Fiscal period (``Q1``, ``Q2``, ``Q3``, ``FY``)."
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "type": "array",
+            "title": "Location"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Message"
+          },
+          "type": {
+            "type": "string",
+            "title": "Error Type"
+          },
+          "input": {
+            "title": "Input"
+          },
+          "ctx": {
+            "type": "object",
+            "title": "Context"
+          }
+        },
+        "type": "object",
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError"
+      },
+      "VelocityOut": {
+        "properties": {
+          "cik": {
+            "type": "string",
+            "title": "Cik"
+          },
+          "company": {
+            "type": "string",
+            "title": "Company"
+          },
+          "crypto": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Crypto"
+          },
+          "ticker": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ticker"
+          },
+          "filings": {
+            "type": "integer",
+            "title": "Filings"
+          },
+          "types": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Types"
+          },
+          "signal": {
+            "type": "string",
+            "title": "Signal"
+          },
+          "label": {
+            "type": "string",
+            "title": "Label"
+          },
+          "density_days": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Density Days"
+          }
+        },
+        "type": "object",
+        "required": [
+          "cik",
+          "company",
+          "filings",
+          "signal",
+          "label"
+        ],
+        "title": "VelocityOut",
+        "description": "Filing velocity alert for a pipeline issuer.\n\nTracks action filing counts over the current vs previous 30-day window\nto surface issuers ramping up SEC activity.\n\nSignal levels:\n    - ramping_up: 3+ filings in current window AND more than previous.\n    - new_activity: 1+ filings in current window, zero in previous.\n    - active: 1+ filings in current window (baseline activity)."
+      },
+      "XBRLSnapshotOut": {
+        "properties": {
+          "cik": {
+            "type": "string",
+            "title": "Cik"
+          },
+          "company": {
+            "type": "string",
+            "title": "Company"
+          },
+          "period_end": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Period End"
+          },
+          "aum": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Aum"
+          },
+          "nav_per_share": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Nav Per Share"
+          },
+          "shares_outstanding": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Shares Outstanding"
+          },
+          "expense_ratio": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expense Ratio"
+          },
+          "sponsor_fees": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sponsor Fees"
+          },
+          "total_return": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Total Return"
+          },
+          "fact_count": {
+            "type": "integer",
+            "title": "Fact Count",
+            "default": 0
+          }
+        },
+        "type": "object",
+        "required": [
+          "cik",
+          "company"
+        ],
+        "title": "XBRLSnapshotOut",
+        "description": "Financial snapshot for an issuer \u2014 latest AUM, NAV, expense ratio, etc.\n\nAll metric fields are optional because not every issuer reports every\nconcept (e.g. newer ETFs may not yet have a full annual period).\n\nAttributes:\n    cik: Issuer CIK (zero-padded).\n    company: Company name.\n    period_end: Latest period end date across all concepts.\n    aum: Assets under management (USD).\n    nav_per_share: Net asset value per share (USD).\n    shares_outstanding: Total shares outstanding.\n    expense_ratio: Expense ratio (decimal, e.g. 0.0025).\n    sponsor_fees: Sponsor fees earned (USD, period).\n    total_return: Total return (decimal, period).\n    fact_count: Total XBRL facts stored for this issuer."
+      },
+      "_QueryParseRequest": {
+        "properties": {
+          "q": {
+            "type": "string",
+            "title": "Q"
+          }
+        },
+        "type": "object",
+        "required": [
+          "q"
+        ],
+        "title": "_QueryParseRequest"
+      }
+    }
+  },
+  "servers": [
+    {
+      "url": "https://api.cryptoetfsentinel.com"
+    }
+  ]
+}

--- a/providers/cryptoetfsentinel/regulatory-intel/openapi.json
+++ b/providers/cryptoetfsentinel/regulatory-intel/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Crypto ETF Sentinel",
-    "description": "Regulatory data oracle for US spot crypto ETFs. Real-time SEC EDGAR filings, issuer pipeline classification, comment-letter tracking, XBRL financials, POS AM in-kind/AP-roster profiles, and predictive launch signals. All paid endpoints settle on Base USDC via x402.",
+    "description": "Regulatory data oracle for US spot crypto ETFs. Real-time SEC EDGAR filings, issuer pipeline classification, comment-letter tracking, XBRL financials, POS AM in-kind/AP-roster profiles, and predictive launch signals. All paid endpoints accept USDC via x402 on Base mainnet (eip155:8453) or Solana mainnet (solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp); both accepts[] entries are returned in every 402 challenge.",
     "version": "1.0.0"
   },
   "paths": {


### PR DESCRIPTION
## Summary

Re-submission of #76 with the Solana acceptance now live. Crypto ETF Sentinel is a regulatory data oracle for the US spot crypto ETF universe — 22 paid endpoints covering the full SEC filing pipeline.

- **Service URL**: https://api.cryptoetfsentinel.com
- **Networks**: Base mainnet (`eip155:8453`) AND Solana mainnet (`solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp`) — both `accepts[]` entries returned in every 402 challenge, USDC settlement, CDP facilitator
- **Coverage**: 105 active issuers, 34 cryptocurrencies, ~3,150 indexed filings, ~19,800 XBRL facts

## What's distinctive

Existing crypto providers in the registry focus on **market data** (prices, TVL, DEX pools). This is **regulatory data** — SEC EDGAR filings, comment letters, XBRL financials, POS AM in-kind / AP-roster structures — surfaced through a curated pipeline-classification layer. Vertical to crypto ETFs, not a general SEC wrapper.

## Changes since #76

1. **Solana payment requirement** (blocker resolved): every paid route now returns a dual-chain `accepts[]` array (Base + Solana, in that order). Verified on-chain — first Solana settlement [`5Zp6UqCz5...`](https://solscan.io/tx/5Zp6UqCz5YNSZW3GcfkwdAVW4sLK1qAouCmiyCZXziZ5tt2yyXcCVtyGPzoVJeQuwZeG3dHUPeuHhNqTG1onivh6). Bazaar discovery already reflects dual-chain on all 22 routes.
2. **`/v1/agent/issuers` price contradiction**: cleaned up in production.
3. **PAY.md "24-hour" vs openapi "7-day" inconsistency**: fixed (free-tier delay is 24 hours).

## Spend-aware pricing

- `/v1/agent/snapshot` — \$0.05 (one-call pipeline overview)
- per-CIK drilldowns — \$0.03 to \$0.05
- predictive signals (risk-scores, launch-monitor, velocity, cohort-state) — \$0.50 each
- full issuer catalogue (`/v1/agent/issuers`) — \$1.00

## Validation

- All 22 paths carry `x-payment-info` with fixed USD pricing
- 22 paid + 0 free operations in the snapshot
- Frontmatter under length limits (per CONTRIBUTING.md)
- OpenAPI committed as sidecar (not remote URL)