### PR TITLE
Add DeepSearch Korean Stock Intelligence

### DIFF
--- a/providers/deepsearch/korean-stock-intelligence/PAY.md
+++ b/providers/deepsearch/korean-stock-intelligence/PAY.md
@@ -1,0 +1,53 @@
+---
+name: korean-stock-intelligence
+title: "DeepSearch Korean Stock Intelligence"
+description: "Real-time Korean stock market intelligence via x402. Returns company fundamentals (market cap, PER, PBR, ROE, revenue, operating profit), news-driven issue analysis with sentiment scoring, and investment risk assessment from regulatory filings. Covers all KRX-listed companies."
+use_case: "Use for Korean stock research, investment due diligence, portfolio monitoring, and financial Q&A. Call get_company_pack for valuation and financials, get_issue_pack to understand current news sentiment, and get_risk_pack before recommending or analyzing a Korean stock."
+category: finance
+service_url: https://x402.deepsearch.com
+openapi:
+  path: openapi.json
+---
+
+Real-time Korean stock market intelligence for AI agents. Pay-per-query via USDC on Base Mainnet.
+
+Covers all KRX-listed companies. Ticker format: 6-digit code (e.g. 005930 for Samsung Electronics).
+
+## Endpoints
+
+### GET /v1/context/company/{ticker} — $0.05 USDC
+Company fundamentals snapshot:
+- Market cap, stock price, 52-week range
+- PER, PBR, ROE, EPS, dividend yield
+- Revenue, operating profit, net income, debt ratio
+- Sector, industry, company summary
+
+### GET /v1/context/issue/{ticker} — $0.10 USDC
+News-driven issue intelligence (last 30 days):
+- Ranked issues with headline and summary
+- Sentiment: positive / negative / neutral
+- Relevance score (0–1) and publication date
+
+### GET /v1/context/risk/{ticker} — $0.15 USDC
+Investment risk assessment (last 60 days):
+- Overall risk level: high / medium / low
+- Risk items by category: financial, legal, operational, market, ESG
+- Mitigating factors
+
+## Common tickers
+
+| Ticker | Company |
+|--------|---------|
+| 005930 | Samsung Electronics |
+| 000660 | SK Hynix |
+| 035420 | NAVER |
+| 005380 | Hyundai Motor |
+| 051910 | LG Chem |
+| 035720 | Kakao |
+
+## Spend-aware usage
+
+- Call `company` first for any financial overview question — it's the cheapest ($0.05) and covers most valuation queries.
+- Call `issue` when the user asks "what's happening with X" or wants current news context. Do not call it just for historical background.
+- Call `risk` only when the user explicitly asks about risks, red flags, or downside scenarios — or before making an investment recommendation.
+- Do not call all three endpoints unless all three types of data are needed for the task.

--- a/providers/deepsearch/korean-stock-intelligence/openapi.json
+++ b/providers/deepsearch/korean-stock-intelligence/openapi.json
@@ -1,0 +1,191 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "DeepSearch Korean Stock Intelligence API",
+    "version": "1.0.0",
+    "description": "Real-time Korean stock market intelligence via x402 micropayments. Pay-per-query with USDC on Base Mainnet.",
+    "x-agentcash-auth": {
+      "mode": "paid"
+    }
+  },
+  "servers": [
+    { "url": "https://x402.deepsearch.com" }
+  ],
+  "paths": {
+    "/v1/context/company/{ticker}": {
+      "get": {
+        "summary": "Company fundamentals pack",
+        "description": "Real-time company fundamentals: market cap, PER, PBR, ROE, revenue, operating profit, net income, debt ratio, and latest stock price. Use for valuation and financial overview.",
+        "parameters": [
+          {
+            "name": "ticker",
+            "in": "path",
+            "required": true,
+            "description": "6-digit KRX ticker code. e.g. 005930 (Samsung Electronics), 000660 (SK Hynix)",
+            "schema": { "type": "string", "example": "005930" }
+          },
+          {
+            "name": "exchange",
+            "in": "query",
+            "required": false,
+            "description": "Exchange code. Default: KRX",
+            "schema": { "type": "string", "default": "KRX" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Company fundamentals data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ticker": { "type": "string" },
+                    "companyName": { "type": "string" },
+                    "marketCap": { "type": "string" },
+                    "keyFinancials": {
+                      "type": "object",
+                      "properties": {
+                        "revenue": { "type": "string" },
+                        "operatingProfit": { "type": "string" },
+                        "per": { "type": "number" },
+                        "pbr": { "type": "number" },
+                        "roe": { "type": "string" }
+                      }
+                    },
+                    "recentStock": {
+                      "type": "object",
+                      "properties": {
+                        "latestClose": { "type": "number" },
+                        "changePercent": { "type": "number" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "402": { "description": "Payment Required — $0.05 USDC on Base Mainnet (eip155:8453)" }
+        },
+        "x-x402": {
+          "price": "$0.05",
+          "network": "eip155:8453",
+          "asset": "USDC"
+        }
+      }
+    },
+    "/v1/context/issue/{ticker}": {
+      "get": {
+        "summary": "News-driven issue intelligence pack",
+        "description": "Top news-driven issues from last 30 days with sentiment (positive/negative/neutral), relevance score, and publication date. Use to understand what is happening with a company right now.",
+        "parameters": [
+          {
+            "name": "ticker",
+            "in": "path",
+            "required": true,
+            "description": "6-digit KRX ticker code",
+            "schema": { "type": "string", "example": "005930" }
+          },
+          {
+            "name": "exchange",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "string", "default": "KRX" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Issue intelligence data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ticker": { "type": "string" },
+                    "issues": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "title": { "type": "string" },
+                          "sentiment": { "type": "string", "enum": ["positive", "negative", "neutral"] },
+                          "relevance": { "type": "string", "enum": ["high", "medium", "low"] },
+                          "summary": { "type": "string" },
+                          "publishedAt": { "type": "string" }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "402": { "description": "Payment Required — $0.10 USDC on Base Mainnet (eip155:8453)" }
+        },
+        "x-x402": {
+          "price": "$0.10",
+          "network": "eip155:8453",
+          "asset": "USDC"
+        }
+      }
+    },
+    "/v1/context/risk/{ticker}": {
+      "get": {
+        "summary": "Investment risk assessment pack",
+        "description": "Investment risk assessment from 60 days of news and regulatory filings. Returns overall risk level (high/medium/low), categorized risk items, and mitigating factors. Use before making or recommending an investment decision.",
+        "parameters": [
+          {
+            "name": "ticker",
+            "in": "path",
+            "required": true,
+            "description": "6-digit KRX ticker code",
+            "schema": { "type": "string", "example": "005930" }
+          },
+          {
+            "name": "exchange",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "string", "default": "KRX" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Risk assessment data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ticker": { "type": "string" },
+                    "overallRiskLevel": { "type": "string", "enum": ["high", "medium", "low"] },
+                    "risks": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "category": { "type": "string" },
+                          "severity": { "type": "string" },
+                          "description": { "type": "string" }
+                        }
+                      }
+                    },
+                    "mitigatingFactors": {
+                      "type": "array",
+                      "items": { "type": "string" }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "402": { "description": "Payment Required — $0.15 USDC on Base Mainnet (eip155:8453)" }
+        },
+        "x-x402": {
+          "price": "$0.15",
+          "network": "eip155:8453",
+          "asset": "USDC"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## New provider: DeepSearch Korean Stock Intelligence

Real-time Korean stock market intelligence via x402 micropayments on Base Mainnet.

**Endpoints:**
- `GET /v1/context/company/{ticker}` — $0.05 USDC — Company fundamentals (market cap, PER, PBR, ROE)
- `GET /v1/context/issue/{ticker}` — $0.10 USDC — News-driven issue analysis with sentiment
- `GET /v1/context/risk/{ticker}` — $0.15 USDC — Investment risk assessment

**Coverage:** All KRX-listed companies (KOSPI + KOSDAQ)

**Service URL:** https://x402.deepsearch.com