### PR TITLE
Add Verifik KYC/KYB provider (paysponge)

### DIFF
--- a/providers/paysponge/verifik/PAY.md
+++ b/providers/paysponge/verifik/PAY.md
@@ -1,0 +1,42 @@
+---
+name: verifik
+title: "Verifik — x402 KYC, KYB & Identity Verification"
+description: "x402-native KYC, KYB, and public-record APIs with strong Latin American coverage. Verify identities, businesses, vehicles, sanctions lists, and government records across 15+ countries."
+use_case: "Use for identity verification, background checks, sanctions screening (OFAC, FBI, DEA, Interpol, UN), business registry lookups, vehicle verification, and driver license checks — especially in Latin America."
+category: identity
+service_url: https://verifik.x402.paysponge.com
+openapi:
+  path: openapi.json
+---
+
+Verifik identity and compliance data exposed through x402 payments via paysponge.
+
+122 endpoints covering KYC, KYB, vehicle lookups, sanctions checks, and government
+records — with particularly deep coverage across Latin America (Colombia, Mexico,
+Argentina, Brazil, Chile, Peru, Ecuador, and more) plus global sanctions databases.
+
+All endpoints are paid `GET` (or `POST` for OCR) routes accepting x402 USDC on
+Base, Avalanche, Polygon, and Solana mainnet.
+
+## Pricing
+
+Most endpoints are **$0.30** per call. Exceptions include:
+
+- **$0.01** — Email verification, WhatsApp check
+- **$0.07** — OCR Document Scan (GPT)
+- **$0.10** — OCR Document Scan Studio, SMS verification
+- **$0.15** — OCR Document Scan Pro
+- **$0.20** — IP geolocation, police records (basic), autodata selection
+- **$0.40** — Extended ID lookups, complete vehicle reports, SIMIT fines
+- **$0.50** — Peru national ID, US passport entries
+- **$0.60** — Peru vehicle SOAT, extended Peru ID
+- **$1.00** — Panama ID/company, credit intents
+
+## Spend-aware usage
+
+- **Sanctions screening** — Use `/v2/ofac`, `/v2/onu`, `/v2/dea`, `/v2/fbi`, `/v2/interpol`, `/v2/europol` for global watchlist and criminal database checks ($0.30 each). Batch separate checks per database as needed.
+- **LATAM national ID** — Use `/v2/{country}/cedula` for most countries (AR, BO, BR, CL, CO, CR, DO, EC, ES, GT, HN, MX, PA, VE) at $0.30. Use `/v3/pe/cedula` for Peru ($0.50).
+- **Business registry** — Use `/v2/{country}/company` for company lookups across AR, BO, BR, CA, CL, CR, EC, ES, MX, PA, PY, USA ($0.30). Use `/v3/co/rues` or `/v3/co/rues-complete` for Colombia.
+- **Vehicle verification** — Use `/v2/{country}/vehicle` for basic plate lookups. Use `/v2/co/runt/vehicle-by-plate` or `/v2/co/runt/vehicle-by-vin` for full Colombian vehicle reports ($0.40).
+- **OCR** — Use `/v2/ocr/scan-gpt` ($0.07) for lightweight document extraction, `/v2/ocr/scan-studio` ($0.10) for studio-grade, or `/v2/ocr/scan-pro` ($0.15) for maximum accuracy.
+- **Colombia deep coverage** — Verifik has the broadest Colombia dataset: driver licenses (RUNT), police records (SIMIT, Procuraduría), legal cases (Rama Judicial), health records, military records, electoral certificates, and transit fines (Bogotá, Medellín).

--- a/providers/paysponge/verifik/openapi.json
+++ b/providers/paysponge/verifik/openapi.json
@@ -35,7 +35,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "Global - DEA Background Check",
+        "summary": "Run DEA background check",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -245,7 +245,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "Global - FBI Background Check",
+        "summary": "Run FBI background check",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -455,7 +455,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "Global - UN Sanctions Check",
+        "summary": "Check UN sanctions list",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -665,7 +665,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "Global - OFAC Sanctions Check",
+        "summary": "Check OFAC sanctions list",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -875,7 +875,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "Paraguay - National ID Verification",
+        "summary": "Verify Paraguay national ID",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -984,7 +984,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "El Salvador - National ID Verification",
+        "summary": "Verify El Salvador national ID",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -1106,7 +1106,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "Global - Europol Background Check",
+        "summary": "Run Europol background check",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -1316,7 +1316,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "Mexico - National ID Verification",
+        "summary": "Verify Mexico national ID",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -1444,7 +1444,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "USA - SSN Verification",
+        "summary": "Verify USA SSN",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -1553,7 +1553,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "Global - Interpol Background Check",
+        "summary": "Run Interpol background check",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -1763,7 +1763,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "Argentina - National ID Verification",
+        "summary": "Verify Argentina national ID",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -1891,7 +1891,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "Bolivia - National ID Verification",
+        "summary": "Verify Bolivia national ID",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -2032,7 +2032,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "Brazil - National ID Verification",
+        "summary": "Verify Brazil national ID",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -2173,7 +2173,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "Chile - National ID Verification",
+        "summary": "Verify Chile national ID",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -2301,7 +2301,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "Colombia - National ID Verification",
+        "summary": "Verify Colombia national ID",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -2433,7 +2433,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "Colombia - SISBEN Score Verification",
+        "summary": "Fetch Colombia SISBEN social score",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -2569,7 +2569,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "Costa Rica - National ID Verification",
+        "summary": "Verify Costa Rica national ID",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -2697,7 +2697,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "Dominican Republic - National ID Verification",
+        "summary": "Verify Dominican Republic national ID",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -2825,7 +2825,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "Ecuador - National ID Verification",
+        "summary": "Verify Ecuador national ID",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -2934,7 +2934,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "Spain - National ID Verification",
+        "summary": "Verify Spain national ID",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -3077,7 +3077,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "Guatemala - National ID Verification",
+        "summary": "Verify Guatemala national ID",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -3205,7 +3205,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "Honduras - National ID Verification",
+        "summary": "Verify Honduras national ID",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -3333,7 +3333,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "IP Geolocation Lookup",
+        "summary": "Look up IP geolocation",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -3442,7 +3442,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "Panama - National ID Verification",
+        "summary": "Verify Panama national ID",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -3583,7 +3583,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "Venezuela - National ID Verification",
+        "summary": "Verify Venezuela national ID",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -3711,7 +3711,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "Argentina - Company Lookup",
+        "summary": "Look up Argentina company",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -3839,7 +3839,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "Argentina - Vehicle Verification",
+        "summary": "Verify Argentina vehicle",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -3948,7 +3948,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "Bolivia - Company Lookup",
+        "summary": "Look up Bolivia company",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -4076,7 +4076,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "Bolivia - Vehicle Verification",
+        "summary": "Verify Bolivia vehicle",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -4185,7 +4185,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "Brazil - Company Lookup",
+        "summary": "Look up Brazil company",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -4313,7 +4313,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "Brazil - Vehicle Verification",
+        "summary": "Verify Brazil vehicle",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -4422,7 +4422,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "Canada - Company Lookup",
+        "summary": "Look up Canada company",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -4562,7 +4562,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "Chile - Company Lookup",
+        "summary": "Look up Chile company",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -4690,7 +4690,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "Chile - Vehicle Verification",
+        "summary": "Verify Chile vehicle",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -4799,7 +4799,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": " - Company Lookup",
+        "summary": "Look up company",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -4927,7 +4927,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": " - Vehicle Verification",
+        "summary": "Verify vehicle",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -5036,7 +5036,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "Ecuador - Company Lookup",
+        "summary": "Look up Ecuador company",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -5164,7 +5164,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "Spain - Company Lookup",
+        "summary": "Look up Spain company",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -5292,7 +5292,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "Spain - Vehicle Verification",
+        "summary": "Verify Spain vehicle",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -5401,7 +5401,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "Mexico - Company Lookup",
+        "summary": "Look up Mexico company",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -5529,7 +5529,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "Panama - Company Lookup",
+        "summary": "Look up Panama company",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -5670,7 +5670,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "Paraguay - Company Lookup",
+        "summary": "Look up Paraguay company",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -5798,7 +5798,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "Paraguay - Vehicle Verification",
+        "summary": "Verify Paraguay vehicle",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -5907,7 +5907,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "chile api taxpayer lookup",
+        "summary": "Look up Chile taxpayer record",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -6035,7 +6035,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "USA - Company Lookup",
+        "summary": "Look up USA company",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -6144,7 +6144,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "USA - Vehicle Verification",
+        "summary": "Verify USA vehicle",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -6370,7 +6370,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "Colombia - Government Contracts Verification",
+        "summary": "Check Colombia government contracts",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -6518,7 +6518,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "OCR Document Scan GPT",
+        "summary": "Scan document with OCR (GPT)",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -6651,7 +6651,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "Colombia - National ID Verification",
+        "summary": "Verify Colombia national ID",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -6792,7 +6792,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "Colombia - Tax Information Verification",
+        "summary": "Verify Colombia DIAN tax information",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -6920,7 +6920,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "Colombia - Police Records Check",
+        "summary": "Check Colombia police records",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -7067,7 +7067,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "OCR Document Scan Studio",
+        "summary": "Scan document with OCR (Studio)",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -7200,7 +7200,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "Venezuela - Immigration Status Verification",
+        "summary": "Verify Venezuela immigration status",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -7309,7 +7309,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "Colombia - Health Records Verification",
+        "summary": "Verify Colombia health records",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -7437,7 +7437,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "Colombia - Lawyers Verification",
+        "summary": "Verify Colombia lawyer status",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -7569,7 +7569,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "Colombia - Basic Vehicle Information",
+        "summary": "Fetch Colombia basic vehicle information",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -7718,7 +7718,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "Peru - Vehicle Verification",
+        "summary": "Verify Peru vehicle",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -7827,7 +7827,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "Colombia - Driver License Verification (RUNT)",
+        "summary": "Verify Colombia driver license via RUNT",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -7963,7 +7963,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "Ecuador - Vehicle Verification",
+        "summary": "Verify Ecuador vehicle",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -8072,7 +8072,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "Mexico - Vehicle Verification",
+        "summary": "Verify Mexico vehicle",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -8181,7 +8181,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "Peru - Vehicle Verification",
+        "summary": "Verify Peru vehicle",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -8290,7 +8290,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "Colombia - Immigration Status Verification",
+        "summary": "Verify Colombia immigration status",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -8412,7 +8412,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "Colombia - SIMIT Complete Transit History",
+        "summary": "Fetch Colombia SIMIT complete transit history",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -8550,7 +8550,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "Peru - Immigration Status Verification",
+        "summary": "Verify Peru immigration status",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -8672,7 +8672,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "USA - Vehicle Lookup by VIN",
+        "summary": "Look up USA vehicle by VIN",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -8781,7 +8781,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "Colombia - Immigration Status Verification",
+        "summary": "Verify Colombia immigration status",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -8903,7 +8903,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "Colombia - Immigration Status Verification",
+        "summary": "Verify Colombia immigration status",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -9025,7 +9025,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "United States - Identity Verification",
+        "summary": "Verify United States identity (passport)",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -9186,7 +9186,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "Colombia - Police Records Check",
+        "summary": "Check Colombia police records",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -9316,7 +9316,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "Colombia - Data Verification Service",
+        "summary": "Verify Colombia vehicle ownership data",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -9425,7 +9425,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "Colombia - Military Service Records",
+        "summary": "Fetch Colombia military service records",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -9558,7 +9558,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "Colombia - Vehicle Tax Status",
+        "summary": "Fetch Colombia vehicle tax status",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -9701,7 +9701,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "Colombia - SISCONMP Transport Verification",
+        "summary": "Check Colombia SISCONMP transport certification",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -9831,7 +9831,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "Colombia - Complete Vehicle Report (By VIN)",
+        "summary": "Fetch Colombia complete vehicle report (by VIN)",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -9940,7 +9940,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "Colombia - Bogota Transit Fines",
+        "summary": "Fetch Colombia Bogota transit fines",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -10049,7 +10049,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "Colombia - DIAN Electronic Invoicer Status",
+        "summary": "Fetch Colombia DIAN electronic invoicer status",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -10177,7 +10177,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "Colombia - Complete Vehicle Report (By Plate)",
+        "summary": "Fetch Colombia complete vehicle report (by plate)",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -10324,7 +10324,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "Colombia - SIMIT Fines by Plate",
+        "summary": "Fetch Colombia SIMIT fines by plate",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -10433,7 +10433,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "Colombia - Pico y Placa Restrictions",
+        "summary": "Fetch Colombia Pico y Placa restrictions",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -10542,7 +10542,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "Ecuador - Vehicle Fines",
+        "summary": "Fetch Ecuador vehicle fines",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -10651,7 +10651,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "Colombia - Medellin Transit Fines",
+        "summary": "Fetch Colombia Medellin transit fines",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -10760,7 +10760,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "Colombia - Electoral Records Verification",
+        "summary": "Verify Colombia electoral records",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -10869,7 +10869,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "USA - Driver License Verification",
+        "summary": "Verify USA driver license",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -10978,7 +10978,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "Colombia - Legal Background Check",
+        "summary": "Run Colombia legal background check",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -11110,7 +11110,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "Colombia - Lawyers Verification",
+        "summary": "Verify Colombia lawyer status",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -11265,7 +11265,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "Colombia - Electoral Records Verification",
+        "summary": "Verify Colombia electoral records",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -11406,7 +11406,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "Colombia - Politically Exposed Persons (PEP) Lookup",
+        "summary": "Look up Colombia politically exposed persons (PEP)",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -11534,7 +11534,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "Colombia - Bogota Vehicle Accidents",
+        "summary": "Fetch Colombia Bogota vehicle accidents",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -11643,7 +11643,7 @@
           "Data",
           "LATAM"
         ],
-        "summary": "Colombia - Simplified Vehicle Report",
+        "summary": "Fetch Colombia simplified vehicle report",
         "responses": {
           "200": {
             "description": "Success \u2014 proxied Verifik response"
@@ -11786,7 +11786,7 @@
     },
     "/v2/communication/whatsapp": {
       "get": {
-        "summary": "GET /v2/communication/whatsapp",
+        "summary": "Check WhatsApp number",
         "responses": {
           "200": {
             "description": "Success"
@@ -11869,7 +11869,7 @@
     },
     "/v2/co/simit/acuerdos": {
       "get": {
-        "summary": "GET /v2/co/simit/acuerdos",
+        "summary": "Fetch Colombia SIMIT payment agreements",
         "responses": {
           "200": {
             "description": "Success"
@@ -11952,7 +11952,7 @@
     },
     "/v3/pe/company": {
       "get": {
-        "summary": "GET /v3/pe/company",
+        "summary": "Look up Peru company",
         "responses": {
           "200": {
             "description": "Success"
@@ -12035,7 +12035,7 @@
     },
     "/v3/pe/cedula": {
       "get": {
-        "summary": "GET /v3/pe/cedula",
+        "summary": "Verify Peru national ID",
         "responses": {
           "200": {
             "description": "Success"
@@ -12118,7 +12118,7 @@
     },
     "/v3/co/rues": {
       "get": {
-        "summary": "GET /v3/co/rues",
+        "summary": "Fetch Colombia RUES business registry",
         "responses": {
           "200": {
             "description": "Success"
@@ -12201,7 +12201,7 @@
     },
     "/v2/appointments": {
       "get": {
-        "summary": "GET /v2/appointments",
+        "summary": "Fetch appointments",
         "responses": {
           "200": {
             "description": "Success"
@@ -12284,7 +12284,7 @@
     },
     "/v2/ca/quebec/driver-license": {
       "get": {
-        "summary": "GET /v2/ca/quebec/driver-license",
+        "summary": "Verify Canada Quebec driver license",
         "responses": {
           "200": {
             "description": "Success"
@@ -12367,7 +12367,7 @@
     },
     "/v2/br/background-check": {
       "get": {
-        "summary": "GET /v2/br/background-check",
+        "summary": "Run Brazil background check",
         "responses": {
           "200": {
             "description": "Success"
@@ -12450,7 +12450,7 @@
     },
     "/v2/co/deudoresmorosos": {
       "get": {
-        "summary": "GET /v2/co/deudoresmorosos",
+        "summary": "Check Colombia delinquent debtors",
         "responses": {
           "200": {
             "description": "Success"
@@ -12533,7 +12533,7 @@
     },
     "/v3/pe/cedula/extra": {
       "get": {
-        "summary": "GET /v3/pe/cedula/extra",
+        "summary": "Verify Peru national ID (extended)",
         "responses": {
           "200": {
             "description": "Success"
@@ -12616,7 +12616,7 @@
     },
     "/v2/co/rama/proceso": {
       "get": {
-        "summary": "GET /v2/co/rama/proceso",
+        "summary": "Fetch Colombia judicial process",
         "responses": {
           "200": {
             "description": "Success"
@@ -12699,7 +12699,7 @@
     },
     "/v2/cl/driver-license": {
       "get": {
-        "summary": "GET /v2/cl/driver-license",
+        "summary": "Verify Chile driver license",
         "responses": {
           "200": {
             "description": "Success"
@@ -12782,7 +12782,7 @@
     },
     "/v2/co/sena/certificados": {
       "get": {
-        "summary": "GET /v2/co/sena/certificados",
+        "summary": "Fetch Colombia SENA training certificates",
         "responses": {
           "200": {
             "description": "Success"
@@ -12865,7 +12865,7 @@
     },
     "/v2/credit-intents": {
       "get": {
-        "summary": "GET /v2/credit-intents",
+        "summary": "Fetch credit intents",
         "responses": {
           "200": {
             "description": "Success"
@@ -12948,7 +12948,7 @@
     },
     "/v2/ca/ontario/driver-license": {
       "get": {
-        "summary": "GET /v2/ca/ontario/driver-license",
+        "summary": "Verify Canada Ontario driver license",
         "responses": {
           "200": {
             "description": "Success"
@@ -13031,7 +13031,7 @@
     },
     "/v2/co/rama/procesos": {
       "get": {
-        "summary": "GET /v2/co/rama/procesos",
+        "summary": "Fetch Colombia judicial processes",
         "responses": {
           "200": {
             "description": "Success"
@@ -13114,7 +13114,7 @@
     },
     "/v2/communication/email": {
       "get": {
-        "summary": "GET /v2/communication/email",
+        "summary": "Verify email address",
         "responses": {
           "200": {
             "description": "Success"
@@ -13197,7 +13197,7 @@
     },
     "/v2/communication/sms": {
       "get": {
-        "summary": "GET /v2/communication/sms",
+        "summary": "Send SMS verification",
         "responses": {
           "200": {
             "description": "Success"
@@ -13280,7 +13280,7 @@
     },
     "/v2/ocr/scan-pro": {
       "post": {
-        "summary": "POST /v2/ocr/scan-pro",
+        "summary": "Scan document with OCR (Pro)",
         "responses": {
           "200": {
             "description": "Success"
@@ -13363,7 +13363,7 @@
     },
     "/v2/co/fasecolda/values-by-plate": {
       "get": {
-        "summary": "GET /v2/co/fasecolda/values-by-plate",
+        "summary": "Fetch Colombia FASECOLDA vehicle values by plate",
         "responses": {
           "200": {
             "description": "Success"
@@ -13446,7 +13446,7 @@
     },
     "/v2/co/rama/juzgado/expedientes": {
       "get": {
-        "summary": "GET /v2/co/rama/juzgado/expedientes",
+        "summary": "Fetch Colombia court case files",
         "responses": {
           "200": {
             "description": "Success"
@@ -13529,7 +13529,7 @@
     },
     "/v2/co/afiliaciones": {
       "get": {
-        "summary": "GET /v2/co/afiliaciones",
+        "summary": "Fetch Colombia social security affiliations",
         "responses": {
           "200": {
             "description": "Success"
@@ -13612,7 +13612,7 @@
     },
     "/v2/ca/british-columbia/driver-license": {
       "get": {
-        "summary": "GET /v2/ca/british-columbia/driver-license",
+        "summary": "Verify Canada British Columbia driver license",
         "responses": {
           "200": {
             "description": "Success"
@@ -13695,7 +13695,7 @@
     },
     "/v2/co/contraloria/certificado": {
       "get": {
-        "summary": "GET /v2/co/contraloria/certificado",
+        "summary": "Fetch Colombia Contralor\u00eda certificate",
         "responses": {
           "200": {
             "description": "Success"
@@ -13778,7 +13778,7 @@
     },
     "/v3/co/rues-complete": {
       "get": {
-        "summary": "GET /v3/co/rues-complete",
+        "summary": "Fetch Colombia RUES complete business registry",
         "responses": {
           "200": {
             "description": "Success"
@@ -13861,7 +13861,7 @@
     },
     "/v2/co/fasecolda/values-by-code": {
       "get": {
-        "summary": "GET /v2/co/fasecolda/values-by-code",
+        "summary": "Fetch Colombia FASECOLDA vehicle values by code",
         "responses": {
           "200": {
             "description": "Success"
@@ -13944,7 +13944,7 @@
     },
     "/v2/co/fasecolda/sinister": {
       "get": {
-        "summary": "GET /v2/co/fasecolda/sinister",
+        "summary": "Fetch Colombia FASECOLDA vehicle sinister history",
         "responses": {
           "200": {
             "description": "Success"
@@ -14027,7 +14027,7 @@
     },
     "/v2/cl/validate/documents": {
       "get": {
-        "summary": "GET /v2/cl/validate/documents",
+        "summary": "Validate Chile documents",
         "responses": {
           "200": {
             "description": "Success"
@@ -14110,7 +14110,7 @@
     },
     "/v2/co/simit/suspensiones": {
       "get": {
-        "summary": "GET /v2/co/simit/suspensiones",
+        "summary": "Fetch Colombia SIMIT license suspensions",
         "responses": {
           "200": {
             "description": "Success"
@@ -14193,7 +14193,7 @@
     },
     "/v3/co/ministerio-de-trabajo/certificados": {
       "get": {
-        "summary": "GET /v3/co/ministerio-de-trabajo/certificados",
+        "summary": "Fetch Colombia Ministry of Labor certificates",
         "responses": {
           "200": {
             "description": "Success"
@@ -14276,7 +14276,7 @@
     },
     "/v2/autodata/selection": {
       "get": {
-        "summary": "GET /v2/autodata/selection",
+        "summary": "Fetch autodata vehicle selection",
         "responses": {
           "200": {
             "description": "Success"
@@ -14359,7 +14359,7 @@
     },
     "/v2/co/simit/resoluciones": {
       "get": {
-        "summary": "GET /v2/co/simit/resoluciones",
+        "summary": "Fetch Colombia SIMIT resolutions",
         "responses": {
           "200": {
             "description": "Success"
@@ -14442,7 +14442,7 @@
     },
     "/v2/co/simit/comparendo": {
       "get": {
-        "summary": "GET /v2/co/simit/comparendo",
+        "summary": "Fetch Colombia SIMIT traffic ticket",
         "responses": {
           "200": {
             "description": "Success"

--- a/providers/paysponge/verifik/openapi.json
+++ b/providers/paysponge/verifik/openapi.json
@@ -1,0 +1,14607 @@
+{
+  "info": {
+    "title": "Verifik AI \u2014 x402 KYC & Verifik proxy",
+    "version": "1.0.0",
+    "x-guidance": "Verifik Smart Agent proxy API \u2014 base URL: https://ai.verifik.co\n\nPAYMENT (x402): Most clients call concrete paths under /v2 or /v3. Without a valid Verifik **user** Bearer JWT, the API responds **402 Payment Required** until you pay.\n- Submit on-chain payment, then retry with header **x-payment-tx** set to the transaction hash (or **Authorization: L402 <txHash>**).\n- Optional **x-payment-chain-id** (decimal or 0x hex) selects the settlement chain; default is Avalanche C-Chain. Assets: native gas token, USDC, or VKA where configured \u2014 see runtime 402 JSON for chain-specific fields.\n\nCREDITS BYPASS: **Authorization: Bearer <user JWT>** (a normal Verifik client token, not the server service token) skips on-chain payment for the same routes.\n\nALTERNATE ENTRY: **GET/POST /api/proxy** with required header **x-target-url** pointing at the same /v2 or /v3 path (absolute or relative). Price is resolved from that target path. Prefer documented /v2 and /v3 operations when possible.\n\nOpenAPI is canonical for listing; **/.well-known/x402** lists payable resource strings (METHOD + path).",
+    "description": "x402-native KYC, KYB, and public-record APIs with strong Latin American coverage. Paid proxy to Verifik; pricing matches tools-manifest.json and runtime x402 middleware.",
+    "x-agentcash-auth": {
+      "mode": "paid"
+    }
+  },
+  "tags": [
+    {
+      "name": "KYC",
+      "description": "Identity verification, sanctions, and watchlists"
+    },
+    {
+      "name": "KYB",
+      "description": "Business, registry, and company lookups"
+    },
+    {
+      "name": "Data",
+      "description": "Government and proprietary datasets via API"
+    },
+    {
+      "name": "LATAM",
+      "description": "Strong coverage in Latin America and regional registries"
+    }
+  ],
+  "paths": {
+    "/v2/dea": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "Global - DEA Background Check",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "fullName",
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "description": "Full name for search (alternative to document search)"
+          },
+          {
+            "in": "query",
+            "name": "documentType",
+            "schema": {
+              "enum": [
+                "CC",
+                "CE",
+                "PEP",
+                "PPT",
+                "NIT",
+                "CCVE",
+                "CCEC",
+                "DNI",
+                "DNIAR",
+                "DNIHN",
+                "CIC",
+                "CIE",
+                "RUN",
+                "CURP",
+                "CUI",
+                "CCPA",
+                "CI",
+                "CPF",
+                "DUI",
+                "CCUY",
+                "CUIT",
+                "RUCEC",
+                "FME",
+                "RUC",
+                "RUT",
+                "CNPJ"
+              ],
+              "type": "string"
+            },
+            "required": false,
+            "description": "Document type (required if not using fullName)"
+          },
+          {
+            "in": "query",
+            "name": "documentNumber",
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "description": "Document number (required if not using fullName)"
+          },
+          {
+            "in": "query",
+            "name": "dateOfBirth",
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "description": "Date of birth (required for certain document types: CCPA, CI, CPF, DUI, CCUY)"
+          },
+          {
+            "in": "query",
+            "name": "expirationDate",
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "description": "Document expiration date (required for document types CE, PPT, and PEP; dd/mm/yyyy)"
+          }
+        ],
+        "description": "Comprehensive background check service using DEA (Drug Enforcement Administration) databases. Search by full name OR document number with document type. Verify individuals against international drug enforcement records.",
+        "operationId": "world_api_dea",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "fullName": {
+                    "type": "string"
+                  },
+                  "documentType": {
+                    "enum": [
+                      "CC",
+                      "CE",
+                      "PEP",
+                      "PPT",
+                      "NIT",
+                      "CCVE",
+                      "CCEC",
+                      "DNI",
+                      "DNIAR",
+                      "DNIHN",
+                      "CIC",
+                      "CIE",
+                      "RUN",
+                      "CURP",
+                      "CUI",
+                      "CCPA",
+                      "CI",
+                      "CPF",
+                      "DUI",
+                      "CCUY",
+                      "CUIT",
+                      "RUCEC",
+                      "FME",
+                      "RUC",
+                      "RUT",
+                      "CNPJ"
+                    ],
+                    "type": "string"
+                  },
+                  "documentNumber": {
+                    "type": "string"
+                  },
+                  "dateOfBirth": {
+                    "type": "string"
+                  },
+                  "expirationDate": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/dea",
+          "description": "Global - DEA Background Check",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/fbi": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "Global - FBI Background Check",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "fullName",
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "description": "Full name for search (alternative to document search)"
+          },
+          {
+            "in": "query",
+            "name": "documentType",
+            "schema": {
+              "enum": [
+                "CC",
+                "CE",
+                "PEP",
+                "PPT",
+                "NIT",
+                "CCVE",
+                "CCEC",
+                "DNI",
+                "DNIAR",
+                "DNIHN",
+                "CIC",
+                "CIE",
+                "RUN",
+                "CURP",
+                "CUI",
+                "CCPA",
+                "CI",
+                "CPF",
+                "DUI",
+                "CCUY",
+                "CUIT",
+                "RUCEC",
+                "FME",
+                "RUC",
+                "RUT",
+                "CNPJ"
+              ],
+              "type": "string"
+            },
+            "required": false,
+            "description": "Document type (required if not using fullName)"
+          },
+          {
+            "in": "query",
+            "name": "documentNumber",
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "description": "Document number (required if not using fullName)"
+          },
+          {
+            "in": "query",
+            "name": "dateOfBirth",
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "description": "Date of birth (required for certain document types: CCPA, CI, CPF, DUI, CCUY)"
+          },
+          {
+            "in": "query",
+            "name": "expirationDate",
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "description": "Document expiration date (required for document types CE, PPT, and PEP; dd/mm/yyyy)"
+          }
+        ],
+        "description": "Comprehensive background check using FBI (Federal Bureau of Investigation) databases. Search by full name OR document number with document type. Verify individuals against federal criminal records.",
+        "operationId": "world_api_fbi",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "fullName": {
+                    "type": "string"
+                  },
+                  "documentType": {
+                    "enum": [
+                      "CC",
+                      "CE",
+                      "PEP",
+                      "PPT",
+                      "NIT",
+                      "CCVE",
+                      "CCEC",
+                      "DNI",
+                      "DNIAR",
+                      "DNIHN",
+                      "CIC",
+                      "CIE",
+                      "RUN",
+                      "CURP",
+                      "CUI",
+                      "CCPA",
+                      "CI",
+                      "CPF",
+                      "DUI",
+                      "CCUY",
+                      "CUIT",
+                      "RUCEC",
+                      "FME",
+                      "RUC",
+                      "RUT",
+                      "CNPJ"
+                    ],
+                    "type": "string"
+                  },
+                  "documentNumber": {
+                    "type": "string"
+                  },
+                  "dateOfBirth": {
+                    "type": "string"
+                  },
+                  "expirationDate": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/fbi",
+          "description": "Global - FBI Background Check",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/onu": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "Global - UN Sanctions Check",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "fullName",
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "description": "Full name for search (alternative to document search)"
+          },
+          {
+            "in": "query",
+            "name": "documentType",
+            "schema": {
+              "enum": [
+                "CC",
+                "CE",
+                "PEP",
+                "PPT",
+                "NIT",
+                "CCVE",
+                "CCEC",
+                "DNI",
+                "DNIAR",
+                "DNIHN",
+                "CIC",
+                "CIE",
+                "RUN",
+                "CURP",
+                "CUI",
+                "CCPA",
+                "CI",
+                "CPF",
+                "DUI",
+                "CCUY",
+                "CUIT",
+                "RUCEC",
+                "FME",
+                "RUC",
+                "RUT",
+                "CNPJ"
+              ],
+              "type": "string"
+            },
+            "required": false,
+            "description": "Document type (required if not using fullName)"
+          },
+          {
+            "in": "query",
+            "name": "documentNumber",
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "description": "Document number (required if not using fullName)"
+          },
+          {
+            "in": "query",
+            "name": "dateOfBirth",
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "description": "Date of birth (required for certain document types: CCPA, CI, CPF, DUI, CCUY)"
+          },
+          {
+            "in": "query",
+            "name": "expirationDate",
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "description": "Document expiration date (required for document types CE, PPT, and PEP; dd/mm/yyyy)"
+          }
+        ],
+        "description": "Check individuals and entities against United Nations sanctions lists. Search by full name OR document number with document type. Verify compliance with international sanctions regimes.",
+        "operationId": "world_api_onu",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "fullName": {
+                    "type": "string"
+                  },
+                  "documentType": {
+                    "enum": [
+                      "CC",
+                      "CE",
+                      "PEP",
+                      "PPT",
+                      "NIT",
+                      "CCVE",
+                      "CCEC",
+                      "DNI",
+                      "DNIAR",
+                      "DNIHN",
+                      "CIC",
+                      "CIE",
+                      "RUN",
+                      "CURP",
+                      "CUI",
+                      "CCPA",
+                      "CI",
+                      "CPF",
+                      "DUI",
+                      "CCUY",
+                      "CUIT",
+                      "RUCEC",
+                      "FME",
+                      "RUC",
+                      "RUT",
+                      "CNPJ"
+                    ],
+                    "type": "string"
+                  },
+                  "documentNumber": {
+                    "type": "string"
+                  },
+                  "dateOfBirth": {
+                    "type": "string"
+                  },
+                  "expirationDate": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/onu",
+          "description": "Global - UN Sanctions Check",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/ofac": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "Global - OFAC Sanctions Check",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "fullName",
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "description": "Full name for search (alternative to document search)"
+          },
+          {
+            "in": "query",
+            "name": "documentType",
+            "schema": {
+              "enum": [
+                "CC",
+                "CE",
+                "PEP",
+                "PPT",
+                "NIT",
+                "CCVE",
+                "CCEC",
+                "DNI",
+                "DNIAR",
+                "DNIHN",
+                "CIC",
+                "CIE",
+                "RUN",
+                "CURP",
+                "CUI",
+                "CCPA",
+                "CI",
+                "CPF",
+                "DUI",
+                "CCUY",
+                "CUIT",
+                "RUCEC",
+                "FME",
+                "RUC",
+                "RUT",
+                "CNPJ"
+              ],
+              "type": "string"
+            },
+            "required": false,
+            "description": "Document type (required if not using fullName)"
+          },
+          {
+            "in": "query",
+            "name": "documentNumber",
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "description": "Document number (required if not using fullName)"
+          },
+          {
+            "in": "query",
+            "name": "dateOfBirth",
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "description": "Date of birth (required for certain document types: CCPA, CI, CPF, DUI, CCUY)"
+          },
+          {
+            "in": "query",
+            "name": "expirationDate",
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "description": "Document expiration date (required for document types CE, PPT, and PEP; dd/mm/yyyy)"
+          }
+        ],
+        "description": "Check individuals and entities against OFAC (Office of Foreign Assets Control) sanctions lists. Search by full name OR document number with document type. Verify compliance with US economic sanctions.",
+        "operationId": "world_api_ofac",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "fullName": {
+                    "type": "string"
+                  },
+                  "documentType": {
+                    "enum": [
+                      "CC",
+                      "CE",
+                      "PEP",
+                      "PPT",
+                      "NIT",
+                      "CCVE",
+                      "CCEC",
+                      "DNI",
+                      "DNIAR",
+                      "DNIHN",
+                      "CIC",
+                      "CIE",
+                      "RUN",
+                      "CURP",
+                      "CUI",
+                      "CCPA",
+                      "CI",
+                      "CPF",
+                      "DUI",
+                      "CCUY",
+                      "CUIT",
+                      "RUCEC",
+                      "FME",
+                      "RUC",
+                      "RUT",
+                      "CNPJ"
+                    ],
+                    "type": "string"
+                  },
+                  "documentNumber": {
+                    "type": "string"
+                  },
+                  "dateOfBirth": {
+                    "type": "string"
+                  },
+                  "expirationDate": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/ofac",
+          "description": "Global - OFAC Sanctions Check",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/py/cic": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "Paraguay - National ID Verification",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "documentNumber",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentNumber"
+          }
+        ],
+        "description": "Verify a Paraguayan citizen using documentNumber (CIC). Returns identity fields to support KYC and compliance.",
+        "operationId": "paraguay_api_identity_lookup",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "documentNumber": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "documentNumber"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/py/cic",
+          "description": "Paraguay - National ID Verification",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/sv/dui": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "El Salvador - National ID Verification",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "documentNumber",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentNumber"
+          },
+          {
+            "in": "query",
+            "name": "dateOfBirth",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: dateOfBirth"
+          }
+        ],
+        "description": "Verifik's Identity Verification API helps you authenticate Salvadoran citizens using official government data. It's designed to streamline your KYC (Know Your Customer) processes, prevent fraud, and ensure you meet all regulatory requirements effortlessly.",
+        "operationId": "el_salvador_api_identity_lookup",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "documentNumber": {
+                    "type": "string"
+                  },
+                  "dateOfBirth": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "documentNumber",
+                  "dateOfBirth"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/sv/dui",
+          "description": "El Salvador - National ID Verification",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/europol": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "Global - Europol Background Check",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "fullName",
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "description": "Full name for search (alternative to document search)"
+          },
+          {
+            "in": "query",
+            "name": "documentType",
+            "schema": {
+              "enum": [
+                "CC",
+                "CE",
+                "PEP",
+                "PPT",
+                "NIT",
+                "CCVE",
+                "CCEC",
+                "DNI",
+                "DNIAR",
+                "DNIHN",
+                "CIC",
+                "CIE",
+                "RUN",
+                "CURP",
+                "CUI",
+                "CCPA",
+                "CI",
+                "CPF",
+                "DUI",
+                "CCUY",
+                "CUIT",
+                "RUCEC",
+                "FME",
+                "RUC",
+                "RUT",
+                "CNPJ"
+              ],
+              "type": "string"
+            },
+            "required": false,
+            "description": "Document type (required if not using fullName)"
+          },
+          {
+            "in": "query",
+            "name": "documentNumber",
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "description": "Document number (required if not using fullName)"
+          },
+          {
+            "in": "query",
+            "name": "dateOfBirth",
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "description": "Date of birth (required for certain document types: CCPA, CI, CPF, DUI, CCUY)"
+          },
+          {
+            "in": "query",
+            "name": "expirationDate",
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "description": "Document expiration date (required for document types CE, PPT, and PEP; dd/mm/yyyy)"
+          }
+        ],
+        "description": "European background check using Europol databases. Search by full name OR document number with document type. Verify individuals against European criminal records and intelligence databases.",
+        "operationId": "world_api_europol",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "fullName": {
+                    "type": "string"
+                  },
+                  "documentType": {
+                    "enum": [
+                      "CC",
+                      "CE",
+                      "PEP",
+                      "PPT",
+                      "NIT",
+                      "CCVE",
+                      "CCEC",
+                      "DNI",
+                      "DNIAR",
+                      "DNIHN",
+                      "CIC",
+                      "CIE",
+                      "RUN",
+                      "CURP",
+                      "CUI",
+                      "CCPA",
+                      "CI",
+                      "CPF",
+                      "DUI",
+                      "CCUY",
+                      "CUIT",
+                      "RUCEC",
+                      "FME",
+                      "RUC",
+                      "RUT",
+                      "CNPJ"
+                    ],
+                    "type": "string"
+                  },
+                  "documentNumber": {
+                    "type": "string"
+                  },
+                  "dateOfBirth": {
+                    "type": "string"
+                  },
+                  "expirationDate": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/europol",
+          "description": "Global - Europol Background Check",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/mx/curp": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "Mexico - National ID Verification",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "documentType",
+            "schema": {
+              "enum": [
+                "CURP"
+              ],
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentType"
+          },
+          {
+            "in": "query",
+            "name": "documentNumber",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentNumber"
+          }
+        ],
+        "description": "This endpoint verifies a Mexican national\u2019s CURP (Clave \u00danica de Registro de Poblaci\u00f3n) against official records. Send documentType and documentNumber on a GET request; a successful response confirms the identity record and returns validated name and biographical fields when the CURP is recognized.",
+        "operationId": "mexico_identity_lookup",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "documentType": {
+                    "enum": [
+                      "CURP"
+                    ],
+                    "type": "string"
+                  },
+                  "documentNumber": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "documentType",
+                  "documentNumber"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/mx/curp",
+          "description": "Mexico - National ID Verification",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/usa/ssn": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "USA - SSN Verification",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "documentNumber",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentNumber"
+          }
+        ],
+        "description": "Validate a U.S. Social Security Number (SSN). Pass the SSN as the documentNumber query parameter (formatted as on the document).",
+        "operationId": "usa_api_ssn",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "documentNumber": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "documentNumber"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/usa/ssn",
+          "description": "USA - SSN Verification",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/interpol": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "Global - Interpol Background Check",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "fullName",
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "description": "Full name for search (alternative to document search)"
+          },
+          {
+            "in": "query",
+            "name": "documentType",
+            "schema": {
+              "enum": [
+                "CC",
+                "CE",
+                "PEP",
+                "PPT",
+                "NIT",
+                "CCVE",
+                "CCEC",
+                "DNI",
+                "DNIAR",
+                "DNIHN",
+                "CIC",
+                "CIE",
+                "RUN",
+                "CURP",
+                "CUI",
+                "CCPA",
+                "CI",
+                "CPF",
+                "DUI",
+                "CCUY",
+                "CUIT",
+                "RUCEC",
+                "FME",
+                "RUC",
+                "RUT",
+                "CNPJ"
+              ],
+              "type": "string"
+            },
+            "required": false,
+            "description": "Document type (required if not using fullName)"
+          },
+          {
+            "in": "query",
+            "name": "documentNumber",
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "description": "Document number (required if not using fullName)"
+          },
+          {
+            "in": "query",
+            "name": "dateOfBirth",
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "description": "Date of birth (required for certain document types: CCPA, CI, CPF, DUI, CCUY)"
+          },
+          {
+            "in": "query",
+            "name": "expirationDate",
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "description": "Document expiration date (required for document types CE, PPT, and PEP; dd/mm/yyyy)"
+          }
+        ],
+        "description": "International background check using Interpol databases. Search by full name OR document number with document type. Verify individuals against international criminal records and wanted lists.",
+        "operationId": "world_api_interpol",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "fullName": {
+                    "type": "string"
+                  },
+                  "documentType": {
+                    "enum": [
+                      "CC",
+                      "CE",
+                      "PEP",
+                      "PPT",
+                      "NIT",
+                      "CCVE",
+                      "CCEC",
+                      "DNI",
+                      "DNIAR",
+                      "DNIHN",
+                      "CIC",
+                      "CIE",
+                      "RUN",
+                      "CURP",
+                      "CUI",
+                      "CCPA",
+                      "CI",
+                      "CPF",
+                      "DUI",
+                      "CCUY",
+                      "CUIT",
+                      "RUCEC",
+                      "FME",
+                      "RUC",
+                      "RUT",
+                      "CNPJ"
+                    ],
+                    "type": "string"
+                  },
+                  "documentNumber": {
+                    "type": "string"
+                  },
+                  "dateOfBirth": {
+                    "type": "string"
+                  },
+                  "expirationDate": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/interpol",
+          "description": "Global - Interpol Background Check",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/ar/cedula": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "Argentina - National ID Verification",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "documentType",
+            "schema": {
+              "enum": [
+                "DNIAR"
+              ],
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentType"
+          },
+          {
+            "in": "query",
+            "name": "documentNumber",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentNumber"
+          }
+        ],
+        "description": "Verify an Argentine identity using documentType DNIAR and documentNumber. Returns identity fields to support KYC and compliance.",
+        "operationId": "argentina_api_identity_lookup",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "documentType": {
+                    "enum": [
+                      "DNIAR"
+                    ],
+                    "type": "string"
+                  },
+                  "documentNumber": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "documentType",
+                  "documentNumber"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/ar/cedula",
+          "description": "Argentina - National ID Verification",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/bo/cedula": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "Bolivia - National ID Verification",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "documentType",
+            "schema": {
+              "enum": [
+                "CI"
+              ],
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentType"
+          },
+          {
+            "in": "query",
+            "name": "documentNumber",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentNumber"
+          },
+          {
+            "in": "query",
+            "name": "dateOfBirth",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: dateOfBirth"
+          }
+        ],
+        "description": "Verify a Bolivian citizen using documentType CI, documentNumber, and dateOfBirth (DD/MM/YYYY). Returns identity fields to support KYC and compliance.",
+        "operationId": "bolivia_api_identity_lookup",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "documentType": {
+                    "enum": [
+                      "CI"
+                    ],
+                    "type": "string"
+                  },
+                  "documentNumber": {
+                    "type": "string"
+                  },
+                  "dateOfBirth": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "documentType",
+                  "documentNumber",
+                  "dateOfBirth"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/bo/cedula",
+          "description": "Bolivia - National ID Verification",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/br/cedula": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "Brazil - National ID Verification",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "documentType",
+            "schema": {
+              "enum": [
+                "CPF"
+              ],
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentType"
+          },
+          {
+            "in": "query",
+            "name": "documentNumber",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentNumber"
+          },
+          {
+            "in": "query",
+            "name": "dateOfBirth",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: dateOfBirth"
+          }
+        ],
+        "description": "Confirms a Brazilian natural person\u2019s CPF against official sources. Provide CPF, date of birth in DD/MM/YYYY, and the document number with or without separators; when the data matches, the response returns normalized name parts and identifiers. Built for KYC, fraud prevention, and regulated onboarding.",
+        "operationId": "brasil_api_identity_lookup",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "documentType": {
+                    "enum": [
+                      "CPF"
+                    ],
+                    "type": "string"
+                  },
+                  "documentNumber": {
+                    "type": "string"
+                  },
+                  "dateOfBirth": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "documentType",
+                  "documentNumber",
+                  "dateOfBirth"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/br/cedula",
+          "description": "Brazil - National ID Verification",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/cl/cedula": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "Chile - National ID Verification",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "documentType",
+            "schema": {
+              "enum": [
+                "RUN"
+              ],
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentType"
+          },
+          {
+            "in": "query",
+            "name": "documentNumber",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentNumber"
+          }
+        ],
+        "description": "Verify Chilean national ID (RUN/RUT): confirm name and identity fields against official civil-registry sources for KYC, onboarding, and fraud prevention.",
+        "operationId": "chile_api_identity_lookup",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "documentType": {
+                    "enum": [
+                      "RUN"
+                    ],
+                    "type": "string"
+                  },
+                  "documentNumber": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "documentType",
+                  "documentNumber"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/cl/cedula",
+          "description": "Chile - National ID Verification",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/co/cedula": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "Colombia - National ID Verification",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "documentType",
+            "schema": {
+              "enum": [
+                "CC",
+                "CE",
+                "PEP"
+              ],
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentType"
+          },
+          {
+            "in": "query",
+            "name": "documentNumber",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentNumber"
+          }
+        ],
+        "description": "Verify Colombian national ID (c\u00e9dula) information. Get full name, document status, and basic citizen verification data.",
+        "operationId": "colombia_api_identity_lookup",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "documentType": {
+                    "enum": [
+                      "CC",
+                      "CE",
+                      "PEP"
+                    ],
+                    "type": "string"
+                  },
+                  "documentNumber": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "documentType",
+                  "documentNumber"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/co/cedula",
+          "description": "Colombia - National ID Verification",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/co/sisben": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "Colombia - SISBEN Score Verification",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "documentType",
+            "schema": {
+              "enum": [
+                "CC",
+                "CE",
+                "PEP",
+                "PPT",
+                "PA"
+              ],
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentType"
+          },
+          {
+            "in": "query",
+            "name": "documentNumber",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentNumber"
+          }
+        ],
+        "description": "Verify SISBEN (Sistema de Identificaci\u00f3n de Potenciales Beneficiarios) score and classification.",
+        "operationId": "colombia_sisben_api_lookup",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "documentType": {
+                    "enum": [
+                      "CC",
+                      "CE",
+                      "PEP",
+                      "PPT",
+                      "PA"
+                    ],
+                    "type": "string"
+                  },
+                  "documentNumber": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "documentType",
+                  "documentNumber"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/co/sisben",
+          "description": "Colombia - SISBEN Score Verification",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/cr/cedula": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "Costa Rica - National ID Verification",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "documentType",
+            "schema": {
+              "enum": [
+                "CCCR"
+              ],
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentType"
+          },
+          {
+            "in": "query",
+            "name": "documentNumber",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentNumber"
+          }
+        ],
+        "description": "This endpoint verifies the CCCR (C\u00e9dula de Identidad Costarricense) against official sources. Send documentType as CCCR and the documentNumber (c\u00e9dula number without spaces) on a GET request; the response includes structured name fields for KYC, onboarding, and fraud checks.",
+        "operationId": "costarica_api_identity_lookup",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "documentType": {
+                    "enum": [
+                      "CCCR"
+                    ],
+                    "type": "string"
+                  },
+                  "documentNumber": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "documentType",
+                  "documentNumber"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/cr/cedula",
+          "description": "Costa Rica - National ID Verification",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/do/cedula": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "Dominican Republic - National ID Verification",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "documentType",
+            "schema": {
+              "enum": [
+                "CIE"
+              ],
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentType"
+          },
+          {
+            "in": "query",
+            "name": "documentNumber",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentNumber"
+          }
+        ],
+        "description": "Verifik's Identity Verification API helps you authenticate Dominican citizens using official government data. It's designed to streamline your KYC (Know Your Customer) processes, prevent fraud, and ensure you meet all regulatory requirements effortlessly.",
+        "operationId": "republica_dominicana_api_citizen_lookup",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "documentType": {
+                    "enum": [
+                      "CIE"
+                    ],
+                    "type": "string"
+                  },
+                  "documentNumber": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "documentType",
+                  "documentNumber"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/do/cedula",
+          "description": "Dominican Republic - National ID Verification",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/ec/cedula": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "Ecuador - National ID Verification",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "documentNumber",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentNumber"
+          }
+        ],
+        "description": "Verify an Ecuadorian citizen using documentType CCEC and documentNumber. Returns identity fields from official records to support KYC and compliance.",
+        "operationId": "ecuador_api_identity_lookup",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "documentNumber": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "documentNumber"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/ec/cedula",
+          "description": "Ecuador - National ID Verification",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/es/cedula": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "Spain - National ID Verification",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "documentType",
+            "schema": {
+              "enum": [
+                "NIE",
+                "DNIES"
+              ],
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentType"
+          },
+          {
+            "in": "query",
+            "name": "expirationDate",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: expirationDate"
+          },
+          {
+            "in": "query",
+            "name": "documentNumber",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentNumber"
+          }
+        ],
+        "description": "Verifies a Spanish natural person\u2019s identity against official sources using documentType (DNIES or NIE), documentNumber (no spaces), and date (expiry in DD/MM/YYYY). Use for KYC, fraud prevention, and regulated onboarding.",
+        "operationId": "spain_api_identity_lookup",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "documentType": {
+                    "enum": [
+                      "NIE",
+                      "DNIES"
+                    ],
+                    "type": "string"
+                  },
+                  "expirationDate": {
+                    "type": "string"
+                  },
+                  "documentNumber": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "documentType",
+                  "expirationDate",
+                  "documentNumber"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/es/cedula",
+          "description": "Spain - National ID Verification",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/gt/cedula": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "Guatemala - National ID Verification",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "documentType",
+            "schema": {
+              "enum": [
+                "CUI"
+              ],
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentType"
+          },
+          {
+            "in": "query",
+            "name": "documentNumber",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentNumber"
+          }
+        ],
+        "description": "Verifik's Identity Verification API helps you authenticate Guatemalan citizens using official government data. It's designed to streamline your KYC (Know Your Customer) processes, prevent fraud, and ensure you meet all regulatory requirements effortlessly.",
+        "operationId": "guatemala_api_identity_lookup",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "documentType": {
+                    "enum": [
+                      "CUI"
+                    ],
+                    "type": "string"
+                  },
+                  "documentNumber": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "documentType",
+                  "documentNumber"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/gt/cedula",
+          "description": "Guatemala - National ID Verification",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/hn/cedula": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "Honduras - National ID Verification",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "documentType",
+            "schema": {
+              "enum": [
+                "DNIHN"
+              ],
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentType"
+          },
+          {
+            "in": "query",
+            "name": "documentNumber",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentNumber"
+          }
+        ],
+        "description": "Verifik's Identity Verification API helps you authenticate Honduran citizens using official government data. It's designed to streamline your KYC (Know Your Customer) processes, prevent fraud, and ensure you meet all regulatory requirements effortlessly.",
+        "operationId": "honduras_api_identity_lookup",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "documentType": {
+                    "enum": [
+                      "DNIHN"
+                    ],
+                    "type": "string"
+                  },
+                  "documentNumber": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "documentType",
+                  "documentNumber"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/hn/cedula",
+          "description": "Honduras - National ID Verification",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/ip-lookup": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "IP Geolocation Lookup",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "ip",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: ip"
+          }
+        ],
+        "description": "Geolocate an IPv4 or IPv6 address. Returns country, region, city, ISP/ASN, and risk hints for fraud screening and access-control checks.",
+        "operationId": "ip-lookup",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "ip": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "ip"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/ip-lookup",
+          "description": "IP Geolocation Lookup",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/pa/cedula": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "Panama - National ID Verification",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "documentType",
+            "schema": {
+              "enum": [
+                "CCPA"
+              ],
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentType"
+          },
+          {
+            "in": "query",
+            "name": "documentNumber",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentNumber"
+          },
+          {
+            "in": "query",
+            "name": "dateOfBirth",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: dateOfBirth"
+          }
+        ],
+        "description": "Verify Panamanian CCPA (C\u00e9dula de Identidad Personal) data against official civil-registry sources. Send documentType (CCPA), a normalized documentNumber, and dateOfBirth in DD/MM/YYYY; the response confirms that the identity record is consistent for KYC, customer onboarding, and fraud controls.",
+        "operationId": "panama_api_identity_lookup",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$1.00"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "documentType": {
+                    "enum": [
+                      "CCPA"
+                    ],
+                    "type": "string"
+                  },
+                  "documentNumber": {
+                    "type": "string"
+                  },
+                  "dateOfBirth": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "documentType",
+                  "documentNumber",
+                  "dateOfBirth"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/pa/cedula",
+          "description": "Panama - National ID Verification",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "1000000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "1000000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "1000000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "1000000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/ve/cedula": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "Venezuela - National ID Verification",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "documentType",
+            "schema": {
+              "enum": [
+                "CCVE"
+              ],
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentType"
+          },
+          {
+            "in": "query",
+            "name": "documentNumber",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentNumber"
+          }
+        ],
+        "description": "This route returns identity data for Venezuelan nationals using the CCVE (C\u00e9dula de Identidad) document class. Send the c\u00e9dula number as documentNumber; the API resolves the record and returns structured name fields for KYC, onboarding, and fraud checks. For foreign residents, use GET /v2/ve/foreigner-id (CEVE) instead.",
+        "operationId": "venezuela_api_identity_lookup",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "documentType": {
+                    "enum": [
+                      "CCVE"
+                    ],
+                    "type": "string"
+                  },
+                  "documentNumber": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "documentType",
+                  "documentNumber"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/ve/cedula",
+          "description": "Venezuela - National ID Verification",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/ar/company": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "Argentina - Company Lookup",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "documentType",
+            "schema": {
+              "enum": [
+                "CUIT"
+              ],
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentType"
+          },
+          {
+            "in": "query",
+            "name": "documentNumber",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentNumber"
+          }
+        ],
+        "description": "Look up an Argentine company using documentType CUIT and documentNumber. Returns registration fields to support KYB, vendor screening, and compliance.",
+        "operationId": "argentina_api_company_lookup",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "documentType": {
+                    "enum": [
+                      "CUIT"
+                    ],
+                    "type": "string"
+                  },
+                  "documentNumber": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "documentType",
+                  "documentNumber"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/ar/company",
+          "description": "Argentina - Company Lookup",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/ar/vehicle": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "Argentina - Vehicle Verification",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "plate",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: plate"
+          }
+        ],
+        "description": "The Argentine Vehicle Information service provides detailed information about vehicles registered in Argentina using their license plate number. This service returns comprehensive vehicle data including make, model, year, engine specifications, and registration details.",
+        "operationId": "argentina_api_vehicle",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "plate": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "plate"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/ar/vehicle",
+          "description": "Argentina - Vehicle Verification",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/bo/company": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "Bolivia - Company Lookup",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "documentType",
+            "schema": {
+              "enum": [
+                "NIT"
+              ],
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentType"
+          },
+          {
+            "in": "query",
+            "name": "documentNumber",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentNumber"
+          }
+        ],
+        "description": "Look up a Bolivian company using documentType NIT and documentNumber. Returns registration fields to support KYB, vendor screening, and compliance.",
+        "operationId": "bolivia_api_business_lookup",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "documentType": {
+                    "enum": [
+                      "NIT"
+                    ],
+                    "type": "string"
+                  },
+                  "documentNumber": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "documentType",
+                  "documentNumber"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/bo/company",
+          "description": "Bolivia - Company Lookup",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/bo/vehicle": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "Bolivia - Vehicle Verification",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "plate",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: plate"
+          }
+        ],
+        "description": "Look up a vehicle by license plate (plate). Returns registration and vehicle details for verification and compliance.",
+        "operationId": "bolivia_api_vehicle",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "plate": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "plate"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/bo/vehicle",
+          "description": "Bolivia - Vehicle Verification",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/br/company": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "Brazil - Company Lookup",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "documentType",
+            "schema": {
+              "enum": [
+                "CNPJ"
+              ],
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentType"
+          },
+          {
+            "in": "query",
+            "name": "documentNumber",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentNumber"
+          }
+        ],
+        "description": "Verifies a Brazilian legal entity against official CNPJ registers. Send documentType=CNPJ and a 14-digit documentNumber with no punctuation. Typical fields include registration status, address, legal nature, and primary and secondary economic activities. Use it for KYB, vendor due diligence, and compliance programs.",
+        "operationId": "brasil_api_company_lookup",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "documentType": {
+                    "enum": [
+                      "CNPJ"
+                    ],
+                    "type": "string"
+                  },
+                  "documentNumber": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "documentType",
+                  "documentNumber"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/br/company",
+          "description": "Brazil - Company Lookup",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/br/vehicle": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "Brazil - Vehicle Verification",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "plate",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: plate"
+          }
+        ],
+        "description": "The Verifik API returns a normalized vehicle record for that plate, including plate, brand, model, model year and year of manufacture, chassis (VIN), engine, color, body type, fuel type, transmission, doors, manufacturer or plant, FIPE codes where they apply to the vehicle, and irregularity or restriction indicators when they exist for that registration. Use it to confirm the unit in front of you matches the official line before you continue.",
+        "operationId": "brasil_api_vehicle",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "plate": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "plate"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/br/vehicle",
+          "description": "Brazil - Vehicle Verification",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/ca/company": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "Canada - Company Lookup",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "province",
+            "schema": {
+              "enum": [
+                "AB",
+                "BC",
+                "MB",
+                "NS",
+                "ON",
+                "QC",
+                "SK"
+              ],
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: province"
+          },
+          {
+            "in": "query",
+            "name": "business",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: business"
+          }
+        ],
+        "description": "Look up a Canadian legal entity in provincial business registries using business (company name) and province (two-letter code). Typical fields include business number, status, registry identifiers, and address. Use for KYB, vendor due diligence, and compliance.",
+        "operationId": "canada_api_company",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "province": {
+                    "enum": [
+                      "AB",
+                      "BC",
+                      "MB",
+                      "NS",
+                      "ON",
+                      "QC",
+                      "SK"
+                    ],
+                    "type": "string"
+                  },
+                  "business": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "province",
+                  "business"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/ca/company",
+          "description": "Canada - Company Lookup",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/cl/company": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "Chile - Company Lookup",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "documentType",
+            "schema": {
+              "enum": [
+                "RUT"
+              ],
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentType"
+          },
+          {
+            "in": "query",
+            "name": "documentNumber",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentNumber"
+          }
+        ],
+        "description": "This service allows you to retrieve information about a company in Chile by providing its document type and number. The service response will contain the name of the company, its business category, subcategory, and activity. Additionally, this service will provide you with a list of services for which the company is authorized to work.",
+        "operationId": "chile_api_business_lookup",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "documentType": {
+                    "enum": [
+                      "RUT"
+                    ],
+                    "type": "string"
+                  },
+                  "documentNumber": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "documentType",
+                  "documentNumber"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/cl/company",
+          "description": "Chile - Company Lookup",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/cl/vehicle": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "Chile - Vehicle Verification",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "plate",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: plate"
+          }
+        ],
+        "description": "Query by license plate (plate, no spaces or dots). Typical fields include make, model, year, VIN/chassis, engine, color, vehicle type, fines summary, and owner RUT when the registry exposes them\u2014use for fleet onboarding, collateral checks, and claims workflows.",
+        "operationId": "chile_api_vehicle",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "plate": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "plate"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/cl/vehicle",
+          "description": "Chile - Vehicle Verification",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/cr/company": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": " - Company Lookup",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "documentType",
+            "schema": {
+              "enum": [
+                "NITE"
+              ],
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentType"
+          },
+          {
+            "in": "query",
+            "name": "documentNumber",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentNumber"
+          }
+        ],
+        "description": "Use this endpoint to confirm NITE (N\u00famero de Identificaci\u00f3n Tributaria de Empresas) records for Costa Rican legal entities. Pass documentType NITE and the company documentNumber; the response returns registered business identifiers and related fields for KYB and onboarding.",
+        "operationId": "costa_rica_api_business_lookup",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "documentType": {
+                    "enum": [
+                      "NITE"
+                    ],
+                    "type": "string"
+                  },
+                  "documentNumber": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "documentType",
+                  "documentNumber"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/cr/company",
+          "description": " - Company Lookup",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/cr/vehicle": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": " - Vehicle Verification",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "plate",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: plate"
+          }
+        ],
+        "description": "Send a GET request with the plate query parameter (no spaces or punctuation). A successful response includes structured vehicle data, owner fields, and history arrays when available.",
+        "operationId": "costa_rica_api_vehicle",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "plate": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "plate"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/cr/vehicle",
+          "description": " - Vehicle Verification",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/ec/company": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "Ecuador - Company Lookup",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "documentType",
+            "schema": {
+              "enum": [
+                "RUCEC"
+              ],
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentType"
+          },
+          {
+            "in": "query",
+            "name": "documentNumber",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentNumber"
+          }
+        ],
+        "description": "Look up an Ecuadorian company using documentType RUCEC and documentNumber (13 digits, no separators). Returns registration-oriented fields to support KYB, vendor screening, and compliance.",
+        "operationId": "ecuador_api_company_lookup",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "documentType": {
+                    "enum": [
+                      "RUCEC"
+                    ],
+                    "type": "string"
+                  },
+                  "documentNumber": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "documentType",
+                  "documentNumber"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/ec/company",
+          "description": "Ecuador - Company Lookup",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/es/company": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "Spain - Company Lookup",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "documentType",
+            "schema": {
+              "enum": [
+                "NIF"
+              ],
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentType"
+          },
+          {
+            "in": "query",
+            "name": "documentNumber",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentNumber"
+          }
+        ],
+        "description": "Look up a Spanish legal entity using documentNumber (company tax identifier, e.g. CIF). Returns core registration-oriented fields to support KYB, vendor screening, and compliance.",
+        "operationId": "spain_api_company_lookup",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "documentType": {
+                    "enum": [
+                      "NIF"
+                    ],
+                    "type": "string"
+                  },
+                  "documentNumber": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "documentType",
+                  "documentNumber"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/es/company",
+          "description": "Spain - Company Lookup",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/es/vehicle": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "Spain - Vehicle Verification",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "plate",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: plate"
+          }
+        ],
+        "description": "Returns vehicle information for a Spanish registration plate, including fields such as make, model, year, and vehicle type when a match exists.",
+        "operationId": "spain_api_vehicle_lookup",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "plate": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "plate"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/es/vehicle",
+          "description": "Spain - Vehicle Verification",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/mx/company": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "Mexico - Company Lookup",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "documentType",
+            "schema": {
+              "enum": [
+                "FME"
+              ],
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentType"
+          },
+          {
+            "in": "query",
+            "name": "documentNumber",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentNumber"
+          }
+        ],
+        "description": "This endpoint looks up a Mexican legal entity by its FME (Folio Mercantil Electr\u00f3nico) identifier. Use GET with documentType=FME and documentNumber to retrieve official registration details such as legal business name and city from government commercial registry sources.",
+        "operationId": "mexico_api_company",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "documentType": {
+                    "enum": [
+                      "FME"
+                    ],
+                    "type": "string"
+                  },
+                  "documentNumber": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "documentType",
+                  "documentNumber"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/mx/company",
+          "description": "Mexico - Company Lookup",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/pa/company": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "Panama - Company Lookup",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "documentType",
+            "schema": {
+              "enum": [
+                "RUC"
+              ],
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentType"
+          },
+          {
+            "in": "query",
+            "name": "documentNumber",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentNumber"
+          },
+          {
+            "in": "query",
+            "name": "dv",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: dv"
+          }
+        ],
+        "description": "Query Panama\u2019s RUC (Registro \u00danico de Contribuyente) registry. Send documentType (RUC), the company documentNumber, and the dv (verification digit). Typical uses include KYB, vendor onboarding, and compliance reviews when you need legal name, status, representatives, and key commercial fields in one HTTPS response.",
+        "operationId": "panama_api_business_lookup",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$1.00"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "documentType": {
+                    "enum": [
+                      "RUC"
+                    ],
+                    "type": "string"
+                  },
+                  "documentNumber": {
+                    "type": "string"
+                  },
+                  "dv": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "documentType",
+                  "documentNumber",
+                  "dv"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/pa/company",
+          "description": "Panama - Company Lookup",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "1000000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "1000000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "1000000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "1000000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/py/company": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "Paraguay - Company Lookup",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "documentType",
+            "schema": {
+              "enum": [
+                "RUC"
+              ],
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentType"
+          },
+          {
+            "in": "query",
+            "name": "documentNumber",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentNumber"
+          }
+        ],
+        "description": "Look up a Paraguayan company using documentType RUC and documentNumber. Returns registration fields to support KYB, vendor screening, and compliance.",
+        "operationId": "paraguay_api_business_lookup",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "documentType": {
+                    "enum": [
+                      "RUC"
+                    ],
+                    "type": "string"
+                  },
+                  "documentNumber": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "documentType",
+                  "documentNumber"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/py/company",
+          "description": "Paraguay - Company Lookup",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/py/vehicle": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "Paraguay - Vehicle Verification",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "plate",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: plate"
+          }
+        ],
+        "description": "Look up a vehicle by license plate (plate). Returns registration, owner, and vehicle details for verification and compliance.",
+        "operationId": "paraguay_api_vehicle",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "plate": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "plate"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/py/vehicle",
+          "description": "Paraguay - Vehicle Verification",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/cl/taxpayer": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "chile api taxpayer lookup",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "documentType",
+            "schema": {
+              "enum": [
+                "RUT"
+              ],
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentType"
+          },
+          {
+            "in": "query",
+            "name": "documentNumber",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentNumber"
+          }
+        ],
+        "description": "Returns name fields and identifiers aligned with tax registry usage\u2014ideal for KYB, supplier onboarding, and invoice validation where the RUT must match registered taxpayer data.",
+        "operationId": "chile_api_taxpayer_lookup",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "documentType": {
+                    "enum": [
+                      "RUT"
+                    ],
+                    "type": "string"
+                  },
+                  "documentNumber": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "documentType",
+                  "documentNumber"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/cl/taxpayer",
+          "description": "chile api taxpayer lookup",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/usa/company": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "USA - Company Lookup",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "business",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: business"
+          }
+        ],
+        "description": "Look up a U.S. company by full or partial business name using SEC EDGAR data. Send business in the JSON body of a POST request.",
+        "operationId": "usa_api_company",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "business": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "business"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/usa/company",
+          "description": "USA - Company Lookup",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/usa/vehicle": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "USA - Vehicle Verification",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "state",
+            "schema": {
+              "enum": [
+                "AL",
+                "AK",
+                "AZ",
+                "AR",
+                "CA",
+                "CO",
+                "CT",
+                "DE",
+                "FL",
+                "GA",
+                "HI",
+                "ID",
+                "IL",
+                "IN",
+                "IA",
+                "KS",
+                "KY",
+                "LA",
+                "ME",
+                "MD",
+                "MA",
+                "MI",
+                "MN",
+                "MS",
+                "MO",
+                "MT",
+                "NE",
+                "NV",
+                "NH",
+                "NJ",
+                "NM",
+                "NY",
+                "NC",
+                "ND",
+                "OH",
+                "OK",
+                "OR",
+                "PA",
+                "RI",
+                "SC",
+                "SD",
+                "TN",
+                "TX",
+                "UT",
+                "VT",
+                "VA",
+                "WA",
+                "WV",
+                "WI",
+                "WY"
+              ],
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: state"
+          },
+          {
+            "in": "query",
+            "name": "plate",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: plate"
+          }
+        ],
+        "description": "Retrieve U.S. vehicle details by license plate and state (NHTSA-backed decode). Use plate and state as query parameters.",
+        "operationId": "usa_api_vehicle",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "state": {
+                    "enum": [
+                      "AL",
+                      "AK",
+                      "AZ",
+                      "AR",
+                      "CA",
+                      "CO",
+                      "CT",
+                      "DE",
+                      "FL",
+                      "GA",
+                      "HI",
+                      "ID",
+                      "IL",
+                      "IN",
+                      "IA",
+                      "KS",
+                      "KY",
+                      "LA",
+                      "ME",
+                      "MD",
+                      "MA",
+                      "MI",
+                      "MN",
+                      "MS",
+                      "MO",
+                      "MT",
+                      "NE",
+                      "NV",
+                      "NH",
+                      "NJ",
+                      "NM",
+                      "NY",
+                      "NC",
+                      "ND",
+                      "OH",
+                      "OK",
+                      "OR",
+                      "PA",
+                      "RI",
+                      "SC",
+                      "SD",
+                      "TN",
+                      "TX",
+                      "UT",
+                      "VT",
+                      "VA",
+                      "WA",
+                      "WV",
+                      "WI",
+                      "WY"
+                    ],
+                    "type": "string"
+                  },
+                  "plate": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "state",
+                  "plate"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/usa/vehicle",
+          "description": "USA - Vehicle Verification",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/co/contracts": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "Colombia - Government Contracts Verification",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "documentType",
+            "schema": {
+              "enum": [
+                "NIT",
+                "CC",
+                "CE",
+                "PA",
+                "RC",
+                "TI",
+                "PEP",
+                "CCVE",
+                "CURP",
+                "DNI",
+                "CCEC"
+              ],
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentType"
+          },
+          {
+            "in": "query",
+            "name": "documentNumber",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentNumber"
+          }
+        ],
+        "description": "Verify government contracts and procurement records in Colombia.",
+        "operationId": "api_colombia_contracts",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "documentType": {
+                    "enum": [
+                      "NIT",
+                      "CC",
+                      "CE",
+                      "PA",
+                      "RC",
+                      "TI",
+                      "PEP",
+                      "CCVE",
+                      "CURP",
+                      "DNI",
+                      "CCEC"
+                    ],
+                    "type": "string"
+                  },
+                  "documentNumber": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "documentType",
+                  "documentNumber"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/co/contracts",
+          "description": "Colombia - Government Contracts Verification",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/ocr/scan-gpt": {
+      "post": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "OCR Document Scan GPT",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "description": "GPT-powered OCR for ID documents and other scans. Submit an image and receive structured fields (names, document numbers, dates) plus the raw extracted text for downstream KYC workflows.",
+        "operationId": "ocr_scan_gpt",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "documentType"
+                ],
+                "properties": {
+                  "image": {
+                    "type": "string",
+                    "description": "Parameter: image"
+                  },
+                  "country": {
+                    "type": "string",
+                    "description": "Parameter: country"
+                  },
+                  "documentType": {
+                    "type": "string",
+                    "description": "Parameter: documentType"
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.07"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "required": [
+                  "documentType"
+                ],
+                "properties": {
+                  "image": {
+                    "type": "string",
+                    "description": "Parameter: image"
+                  },
+                  "country": {
+                    "type": "string",
+                    "description": "Parameter: country"
+                  },
+                  "documentType": {
+                    "type": "string",
+                    "description": "Parameter: documentType"
+                  }
+                }
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/ocr/scan-gpt",
+          "description": "OCR Document Scan GPT",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "70000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "70000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "70000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "70000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/co/cedula/extra": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "Colombia - National ID Verification",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "documentType",
+            "schema": {
+              "enum": [
+                "CC"
+              ],
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentType"
+          },
+          {
+            "in": "query",
+            "name": "documentNumber",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentNumber"
+          },
+          {
+            "in": "query",
+            "name": "date",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: date"
+          }
+        ],
+        "description": "The same integration is available as POST with a JSON body containing the same fields. GET uses query parameters as shown below.",
+        "operationId": "colombia_api_identity_lookup_extra",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.40"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "documentType": {
+                    "enum": [
+                      "CC"
+                    ],
+                    "type": "string"
+                  },
+                  "documentNumber": {
+                    "type": "string"
+                  },
+                  "date": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "documentType",
+                  "documentNumber",
+                  "date"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/co/cedula/extra",
+          "description": "Colombia - National ID Verification",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "400000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "400000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "400000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "400000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/co/company/dian": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "Colombia - Tax Information Verification",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "documentType",
+            "schema": {
+              "enum": [
+                "NIT"
+              ],
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentType"
+          },
+          {
+            "in": "query",
+            "name": "documentNumber",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentNumber"
+          }
+        ],
+        "description": "Verify tax information through Colombia's DIAN (Direcci\u00f3n de Impuestos y Aduanas Nacionales) system. Check tax status, obligations, and compliance records. Requires document type and document number.",
+        "operationId": "colombia_api_dian",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "documentType": {
+                    "enum": [
+                      "NIT"
+                    ],
+                    "type": "string"
+                  },
+                  "documentNumber": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "documentType",
+                  "documentNumber"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/co/company/dian",
+          "description": "Colombia - Tax Information Verification",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/co/policia/rnmc": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "Colombia - Police Records Check",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "documentType",
+            "schema": {
+              "enum": [
+                "CC",
+                "CE",
+                "TI",
+                "PA"
+              ],
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentType"
+          },
+          {
+            "in": "query",
+            "name": "documentNumber",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentNumber"
+          },
+          {
+            "in": "query",
+            "name": "date",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: date"
+          }
+        ],
+        "description": "Police records verification service for Colombia citizens. Provides information about police interactions and records.",
+        "operationId": "colombia_api_police_rnmc",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "documentType": {
+                    "enum": [
+                      "CC",
+                      "CE",
+                      "TI",
+                      "PA"
+                    ],
+                    "type": "string"
+                  },
+                  "documentNumber": {
+                    "type": "string"
+                  },
+                  "date": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "documentType",
+                  "documentNumber",
+                  "date"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/co/policia/rnmc",
+          "description": "Colombia - Police Records Check",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/ocr/scan-studio": {
+      "post": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "OCR Document Scan Studio",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "description": "The Scan Studio offers a seamless and efficient solution for extracting critical information from scanned documents through state-of-the-art Optical Character Recognition (OCR) technology. To use this service, simply provide the document image in Base64-encoded format or a URL where the image is hosted, and let our system handle the rest.",
+        "operationId": "ocr_scan_studio",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "documentType"
+                ],
+                "properties": {
+                  "image": {
+                    "type": "string",
+                    "description": "Parameter: image"
+                  },
+                  "country": {
+                    "type": "string",
+                    "description": "Parameter: country"
+                  },
+                  "documentType": {
+                    "type": "string",
+                    "description": "Parameter: documentType"
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.10"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "required": [
+                  "documentType"
+                ],
+                "properties": {
+                  "image": {
+                    "type": "string",
+                    "description": "Parameter: image"
+                  },
+                  "country": {
+                    "type": "string",
+                    "description": "Parameter: country"
+                  },
+                  "documentType": {
+                    "type": "string",
+                    "description": "Parameter: documentType"
+                  }
+                }
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/ocr/scan-studio",
+          "description": "OCR Document Scan Studio",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "100000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "100000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "100000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "100000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/ve/foreigner-id": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "Venezuela - Immigration Status Verification",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "documentNumber",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentNumber"
+          }
+        ],
+        "description": "Immigration records verification service for Venezuela. Provides immigration status and foreigner registration information.",
+        "operationId": "venezuela_foreigner_api",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "documentNumber": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "documentNumber"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/ve/foreigner-id",
+          "description": "Venezuela - Immigration Status Verification",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/co/cedula/rethus": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "Colombia - Health Records Verification",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "documentType",
+            "schema": {
+              "enum": [
+                "CC"
+              ],
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentType"
+          },
+          {
+            "in": "query",
+            "name": "documentNumber",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentNumber"
+          }
+        ],
+        "description": "Access Colombian health records through Rethus system. Verify medical history, health status, and healthcare provider information. Requires document type (CC, CE, PPT) and document number.",
+        "operationId": "colombia_api_rethus",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "documentType": {
+                    "enum": [
+                      "CC"
+                    ],
+                    "type": "string"
+                  },
+                  "documentNumber": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "documentType",
+                  "documentNumber"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/co/cedula/rethus",
+          "description": "Colombia - Health Records Verification",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/co/rama/abogados": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "Colombia - Lawyers Verification",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "documentType",
+            "schema": {
+              "enum": [
+                "CC",
+                "CE",
+                "PEP"
+              ],
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentType"
+          },
+          {
+            "in": "query",
+            "name": "documentNumber",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentNumber"
+          }
+        ],
+        "description": "Verify lawyer registration and professional status with the Colombian bar.",
+        "operationId": "colombia_api_lawyers",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "documentType": {
+                    "enum": [
+                      "CC",
+                      "CE",
+                      "PEP"
+                    ],
+                    "type": "string"
+                  },
+                  "documentNumber": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "documentType",
+                  "documentNumber"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/co/rama/abogados",
+          "description": "Colombia - Lawyers Verification",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/co/runt/vehiculo": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "Colombia - Basic Vehicle Information",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "documentType",
+            "schema": {
+              "enum": [
+                "CC",
+                "TI",
+                "CE",
+                "PA",
+                "RC"
+              ],
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentType"
+          },
+          {
+            "in": "query",
+            "name": "documentNumber",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentNumber"
+          },
+          {
+            "in": "query",
+            "name": "plate",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: plate"
+          }
+        ],
+        "description": "Retrieve general registration data and basic characteristics of a Colombian vehicle by its license plate.",
+        "operationId": "colombia_api_vehicle",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "documentType": {
+                    "enum": [
+                      "CC",
+                      "TI",
+                      "CE",
+                      "PA",
+                      "RC"
+                    ],
+                    "type": "string"
+                  },
+                  "documentNumber": {
+                    "type": "string"
+                  },
+                  "plate": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "documentType",
+                  "documentNumber",
+                  "plate"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/co/runt/vehiculo",
+          "description": "Colombia - Basic Vehicle Information",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/pe/vehiculo/soat": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "Peru - Vehicle Verification",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "plate",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: plate"
+          }
+        ],
+        "description": "This service provides information on the insurance status of a vehicle in Peru. It returns details including the insurance company name, policy start and end dates, vehicle plate number, policy number, usage type, vehicle class, and policy status.",
+        "operationId": "peru_api_vehicle_soat",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.60"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "plate": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "plate"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/pe/vehiculo/soat",
+          "description": "Peru - Vehicle Verification",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "600000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "600000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "600000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "600000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/co/runt/conductor": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "Colombia - Driver License Verification (RUNT)",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "documentType",
+            "schema": {
+              "enum": [
+                "CC",
+                "CE",
+                "PA",
+                "PPT",
+                "NIT"
+              ],
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentType"
+          },
+          {
+            "in": "query",
+            "name": "documentNumber",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentNumber"
+          }
+        ],
+        "description": "Verify Colombian driver license status and validity through the RUNT system.",
+        "operationId": "colombia_api_driver",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "documentType": {
+                    "enum": [
+                      "CC",
+                      "CE",
+                      "PA",
+                      "PPT",
+                      "NIT"
+                    ],
+                    "type": "string"
+                  },
+                  "documentNumber": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "documentType",
+                  "documentNumber"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/co/runt/conductor",
+          "description": "Colombia - Driver License Verification (RUNT)",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/ec/vehiculo/placa": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "Ecuador - Vehicle Verification",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "plate",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: plate"
+          }
+        ],
+        "description": "Query an Ecuadorian vehicle by plate (no spaces or periods). Use for verification, insurance, fleet, and compliance workflows.",
+        "operationId": "ecuador_api_vehicle",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "plate": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "plate"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/ec/vehiculo/placa",
+          "description": "Ecuador - Vehicle Verification",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/mx/vehiculo/placa": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "Mexico - Vehicle Verification",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "plate",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: plate"
+          }
+        ],
+        "description": "The Vehicle Information service provides detailed information about a vehicle in Mexico based on its license plate number. This service specifically returns information about a vehicle's make, model, year, VIN, and other related details. Pass the plate in the plate query parameter on a GET request; responses include registration-oriented fields when a match is found.",
+        "operationId": "mexico_api_vehicle",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "plate": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "plate"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/mx/vehiculo/placa",
+          "description": "Mexico - Vehicle Verification",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/pe/vehiculo/placa": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "Peru - Vehicle Verification",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "plate",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: plate"
+          }
+        ],
+        "description": "The Peruvian Vehicle Information service provides detailed data about registered vehicles in Peru based on their license plate number. The response includes key details such as the vehicle's make, model, year, engine and chassis serial numbers, seating capacity, and usage type.",
+        "operationId": "peru_api_vehicle",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "plate": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "plate"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/pe/vehiculo/placa",
+          "description": "Peru - Vehicle Verification",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/co/foreigner-id/ce": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "Colombia - Immigration Status Verification",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "expeditionDate",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: expeditionDate"
+          },
+          {
+            "in": "query",
+            "name": "documentNumber",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentNumber"
+          }
+        ],
+        "description": "Immigration records verification service for Colombia. Provides immigration status and foreigner registration information.",
+        "operationId": "colombia_api_identity_ce_foreigner_id",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "expeditionDate": {
+                    "type": "string"
+                  },
+                  "documentNumber": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "expeditionDate",
+                  "documentNumber"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/co/foreigner-id/ce",
+          "description": "Colombia - Immigration Status Verification",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/co/simit/consultar": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "Colombia - SIMIT Complete Transit History",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "documentType",
+            "schema": {
+              "enum": [
+                "NIT",
+                "CC",
+                "CE",
+                "PA",
+                "RC",
+                "TI"
+              ],
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentType"
+          },
+          {
+            "in": "query",
+            "name": "documentNumber",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentNumber"
+          }
+        ],
+        "description": "Comprehensive transit background check including fines, agreements, and suspensions by ID.",
+        "operationId": "colombia_api_simit_complete",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.40"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "documentType": {
+                    "enum": [
+                      "NIT",
+                      "CC",
+                      "CE",
+                      "PA",
+                      "RC",
+                      "TI"
+                    ],
+                    "type": "string"
+                  },
+                  "documentNumber": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "documentType",
+                  "documentNumber"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/co/simit/consultar",
+          "description": "Colombia - SIMIT Complete Transit History",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "400000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "400000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "400000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "400000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/pe/foreigner-id/ce": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "Peru - Immigration Status Verification",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "documentNumber",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentNumber"
+          },
+          {
+            "in": "query",
+            "name": "dateOfBirth",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: dateOfBirth"
+          }
+        ],
+        "description": "Immigration records verification service for Peru. Provides immigration status and foreigner registration information.",
+        "operationId": "peru_api_identity_ce_foreigner_id",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "documentNumber": {
+                    "type": "string"
+                  },
+                  "dateOfBirth": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "documentNumber",
+                  "dateOfBirth"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/pe/foreigner-id/ce",
+          "description": "Peru - Immigration Status Verification",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/usa/vehicle-by-vin": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "USA - Vehicle Lookup by VIN",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "vin",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: vin"
+          }
+        ],
+        "description": "Decode a U.S. vehicle by VIN using the vin query parameter (exactly 17 characters).",
+        "operationId": "usa_api_vehicle_lookup_by_vin",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "vin": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "vin"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/usa/vehicle-by-vin",
+          "description": "USA - Vehicle Lookup by VIN",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/co/foreigner-id/pep": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "Colombia - Immigration Status Verification",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "expeditionDate",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: expeditionDate"
+          },
+          {
+            "in": "query",
+            "name": "documentNumber",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentNumber"
+          }
+        ],
+        "description": "Immigration records verification service for Colombia. Provides immigration status and foreigner registration information.",
+        "operationId": "colombia_api_identity_pep_foreigner_id",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "expeditionDate": {
+                    "type": "string"
+                  },
+                  "documentNumber": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "expeditionDate",
+                  "documentNumber"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/co/foreigner-id/pep",
+          "description": "Colombia - Immigration Status Verification",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/co/foreigner-id/ppt": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "Colombia - Immigration Status Verification",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "expeditionDate",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: expeditionDate"
+          },
+          {
+            "in": "query",
+            "name": "documentNumber",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentNumber"
+          }
+        ],
+        "description": "Immigration records verification service for Colombia. Provides immigration status and foreigner registration information.",
+        "operationId": "colombia_api_identity_ppt_foreigner_id",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "expeditionDate": {
+                    "type": "string"
+                  },
+                  "documentNumber": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "expeditionDate",
+                  "documentNumber"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/co/foreigner-id/ppt",
+          "description": "Colombia - Immigration Status Verification",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/passport/us/entries": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "United States - Identity Verification",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "passportNumber",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: passportNumber"
+          },
+          {
+            "in": "query",
+            "name": "passportCountry",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: passportCountry"
+          },
+          {
+            "in": "query",
+            "name": "firstName",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: firstName"
+          },
+          {
+            "in": "query",
+            "name": "lastName",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: lastName"
+          },
+          {
+            "in": "query",
+            "name": "dateOfBirth",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: dateOfBirth"
+          }
+        ],
+        "description": "Standard identity verification service for United States citizens. Verifies personal information and document authenticity.",
+        "operationId": "world_api_passport_entries",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.50"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "passportNumber": {
+                    "type": "string"
+                  },
+                  "passportCountry": {
+                    "type": "string"
+                  },
+                  "firstName": {
+                    "type": "string"
+                  },
+                  "lastName": {
+                    "type": "string"
+                  },
+                  "dateOfBirth": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "passportNumber",
+                  "passportCountry",
+                  "firstName",
+                  "lastName",
+                  "dateOfBirth"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/passport/us/entries",
+          "description": "United States - Identity Verification",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "500000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "500000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "500000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "500000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/co/policia/consultar": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "Colombia - Police Records Check",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "documentType",
+            "schema": {
+              "enum": [
+                "CC",
+                "NIT"
+              ],
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentType"
+          },
+          {
+            "in": "query",
+            "name": "documentNumber",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentNumber"
+          }
+        ],
+        "description": "Check police records through Colombia's National Police system. Verify interactions with law enforcement and police records. Requires document type, document number, and expedition date.",
+        "operationId": "colombia_special_api_police_identity_lookup",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.20"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "documentType": {
+                    "enum": [
+                      "CC",
+                      "NIT"
+                    ],
+                    "type": "string"
+                  },
+                  "documentNumber": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "documentType",
+                  "documentNumber"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/co/policia/consultar",
+          "description": "Colombia - Police Records Check",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "200000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "200000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "200000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "200000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/co/runt/propietarios": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "Colombia - Data Verification Service",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "plate",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: plate"
+          }
+        ],
+        "description": "General data verification service for Colombia. Provides reliable information verification and validation.",
+        "operationId": "colombia_api_runt_owners",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.20"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "plate": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "plate"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/co/runt/propietarios",
+          "description": "Colombia - Data Verification Service",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "200000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "200000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "200000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "200000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/co/situacion-militar": {
+      "post": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "Colombia - Military Service Records",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "description": "Verify military service records through Colombia's military system. Check service status, military obligations, and service records. Requires Colombian ID (CC) and document number.",
+        "operationId": "colombia_api_military_situation",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "documentType",
+                  "documentNumber"
+                ],
+                "properties": {
+                  "documentType": {
+                    "enum": [
+                      "CC"
+                    ],
+                    "type": "string",
+                    "description": "Parameter: documentType"
+                  },
+                  "documentNumber": {
+                    "type": "string",
+                    "description": "Parameter: documentNumber"
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "required": [
+                  "documentType",
+                  "documentNumber"
+                ],
+                "properties": {
+                  "documentType": {
+                    "enum": [
+                      "CC"
+                    ],
+                    "type": "string",
+                    "description": "Parameter: documentType"
+                  },
+                  "documentNumber": {
+                    "type": "string",
+                    "description": "Parameter: documentNumber"
+                  }
+                }
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/co/situacion-militar",
+          "description": "Colombia - Military Service Records",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/co/bogota/vehicle/tax": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "Colombia - Vehicle Tax Status",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "documentType",
+            "schema": {
+              "enum": [
+                "CC",
+                "NIT"
+              ],
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentType"
+          },
+          {
+            "in": "query",
+            "name": "documentNumber",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentNumber"
+          },
+          {
+            "in": "query",
+            "name": "plate",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: plate"
+          }
+        ],
+        "description": "Check the payment status and history of annual vehicular taxes (Impuesto de Veh\u00edculos).",
+        "operationId": "colombia_api_vehicle_tax",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "documentType": {
+                    "enum": [
+                      "CC",
+                      "NIT"
+                    ],
+                    "type": "string"
+                  },
+                  "documentNumber": {
+                    "type": "string"
+                  },
+                  "plate": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "documentType",
+                  "documentNumber",
+                  "plate"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/co/bogota/vehicle/tax",
+          "description": "Colombia - Vehicle Tax Status",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/co/sisconmp/trainings": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "Colombia - SISCONMP Transport Verification",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "documentType",
+            "schema": {
+              "enum": [
+                "CC",
+                "CE"
+              ],
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentType"
+          },
+          {
+            "in": "query",
+            "name": "documentNumber",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentNumber"
+          }
+        ],
+        "description": "Verify transport and cargo operator registration in the SISCONMP system.",
+        "operationId": "colombia_api_sisconmp",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "documentType": {
+                    "enum": [
+                      "CC",
+                      "CE"
+                    ],
+                    "type": "string"
+                  },
+                  "documentNumber": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "documentType",
+                  "documentNumber"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/co/sisconmp/trainings",
+          "description": "Colombia - SISCONMP Transport Verification",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/co/runt/vehicle-by-vin": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "Colombia - Complete Vehicle Report (By VIN)",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "vin",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: vin"
+          }
+        ],
+        "description": "Get an exhaustive history and technical report of a vehicle in Colombia using its Vehicle Identification Number (VIN).",
+        "operationId": "colombia_api_vehicle_complete_by_vin",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.40"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "vin": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "vin"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/co/runt/vehicle-by-vin",
+          "description": "Colombia - Complete Vehicle Report (By VIN)",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "400000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "400000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "400000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "400000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/co/bogota/vehicle/fines": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "Colombia - Bogota Transit Fines",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "plate",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: plate"
+          }
+        ],
+        "description": "Verify outstanding local traffic penalties and fines restricted to the city of Bogota.",
+        "operationId": "colombia_api_vehicle_fines_bogota",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "plate": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "plate"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/co/bogota/vehicle/fines",
+          "description": "Colombia - Bogota Transit Fines",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/co/company/dian/invoicer": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "Colombia - DIAN Electronic Invoicer Status",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "documentType",
+            "schema": {
+              "enum": [
+                "NIT"
+              ],
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentType"
+          },
+          {
+            "in": "query",
+            "name": "documentNumber",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentNumber"
+          }
+        ],
+        "description": "Verify electronic invoicing (facturaci\u00f3n electr\u00f3nica) registration status with DIAN.",
+        "operationId": "colombia_api_dian_invoicer",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "documentType": {
+                    "enum": [
+                      "NIT"
+                    ],
+                    "type": "string"
+                  },
+                  "documentNumber": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "documentType",
+                  "documentNumber"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/co/company/dian/invoicer",
+          "description": "Colombia - DIAN Electronic Invoicer Status",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/co/runt/vehicle-by-plate": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "Colombia - Complete Vehicle Report (By Plate)",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "documentType",
+            "schema": {
+              "enum": [
+                "CC",
+                "CE",
+                "PA",
+                "NIT"
+              ],
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentType"
+          },
+          {
+            "in": "query",
+            "name": "documentNumber",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentNumber"
+          },
+          {
+            "in": "query",
+            "name": "plate",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: plate"
+          }
+        ],
+        "description": "Get an exhaustive history and technical report of a vehicle in Colombia using its license plate number.",
+        "operationId": "colombia_api_vehicle_complete_by_plate",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.40"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "documentType": {
+                    "enum": [
+                      "CC",
+                      "CE",
+                      "PA",
+                      "NIT"
+                    ],
+                    "type": "string"
+                  },
+                  "documentNumber": {
+                    "type": "string"
+                  },
+                  "plate": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "documentType",
+                  "documentNumber",
+                  "plate"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/co/runt/vehicle-by-plate",
+          "description": "Colombia - Complete Vehicle Report (By Plate)",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "400000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "400000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "400000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "400000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/co/simit/consultar/placa": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "Colombia - SIMIT Fines by Plate",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "plate",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: plate"
+          }
+        ],
+        "description": "Look up traffic fines and sanctions directly associated with a specific vehicle license plate.",
+        "operationId": "colombia_api_simit_plate",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.40"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "plate": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "plate"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/co/simit/consultar/placa",
+          "description": "Colombia - SIMIT Fines by Plate",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "400000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "400000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "400000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "400000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/co/vehiculo/pico-y-placa": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "Colombia - Pico y Placa Restrictions",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "plate",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: plate"
+          }
+        ],
+        "description": "Check current transit restrictions (Pico y Placa) for a specific vehicle across various Colombian cities.",
+        "operationId": "colombia_api_pico_placa",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "plate": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "plate"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/co/vehiculo/pico-y-placa",
+          "description": "Colombia - Pico y Placa Restrictions",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/ec/vehiculo/placa/multas": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "Ecuador - Vehicle Fines",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "plate",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: plate"
+          }
+        ],
+        "description": "Look up an Ecuadorian vehicle by plate (license plate). Returns registration details and outstanding fines for compliance, fleet, and risk checks.",
+        "operationId": "ecuador_api_vehicle_fines",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "plate": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "plate"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/ec/vehiculo/placa/multas",
+          "description": "Ecuador - Vehicle Fines",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/co/medellin/vehicle/fines": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "Colombia - Medellin Transit Fines",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "plate",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: plate"
+          }
+        ],
+        "description": "Verify outstanding local traffic penalties and fines restricted to the city of Medellin.",
+        "operationId": "colombia_api_vehicle_fines_medellin",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "plate": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "plate"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/co/medellin/vehicle/fines",
+          "description": "Colombia - Medellin Transit Fines",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/co/registraduria/votacion": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "Colombia - Electoral Records Verification",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "documentNumber",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentNumber"
+          }
+        ],
+        "description": "Electoral records verification service for Colombia citizens. Provides voting status and electoral information.",
+        "operationId": "colombia_api_registraduria_voting",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "documentNumber": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "documentNumber"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/co/registraduria/votacion",
+          "description": "Colombia - Electoral Records Verification",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/usa/florida/driver-license": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "USA - Driver License Verification",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "documentNumber",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentNumber"
+          }
+        ],
+        "description": "This service allows developers to validate the status, restrictions, endorsements, and designations of Florida driver licenses. By providing a valid Florida driver license number, the service response with the license status, expiration date, restrictions, endorsements, and designations.",
+        "operationId": "usa_api_driver_license_lookup",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "documentNumber": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "documentNumber"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/usa/florida/driver-license",
+          "description": "USA - Driver License Verification",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/co/procuraduria/antecedentes": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "Colombia - Legal Background Check",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "documentType",
+            "schema": {
+              "enum": [
+                "CC",
+                "CE",
+                "PEP"
+              ],
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentType"
+          },
+          {
+            "in": "query",
+            "name": "documentNumber",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentNumber"
+          }
+        ],
+        "description": "Legal background verification service for Colombia citizens. Provides information about legal proceedings and judicial records.",
+        "operationId": "colombia_api_criminal_history",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "documentType": {
+                    "enum": [
+                      "CC",
+                      "CE",
+                      "PEP"
+                    ],
+                    "type": "string"
+                  },
+                  "documentNumber": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "documentType",
+                  "documentNumber"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/co/procuraduria/antecedentes",
+          "description": "Colombia - Legal Background Check",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/co/rama/certificado/vigencia": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "Colombia - Lawyers Verification",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "documentType",
+            "schema": {
+              "enum": [
+                "CC",
+                "NIT",
+                "CE"
+              ],
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentType"
+          },
+          {
+            "in": "query",
+            "name": "quality",
+            "schema": {
+              "enum": [
+                "ABG",
+                "JUEZPAZ",
+                "LT"
+              ],
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: quality"
+          },
+          {
+            "in": "query",
+            "name": "documentNumber",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentNumber"
+          }
+        ],
+        "description": "Obtain lawyer certification and professional status verification.",
+        "operationId": "colombia_api_lawyers_certificate",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "documentType": {
+                    "enum": [
+                      "CC",
+                      "NIT",
+                      "CE"
+                    ],
+                    "type": "string"
+                  },
+                  "quality": {
+                    "enum": [
+                      "ABG",
+                      "JUEZPAZ",
+                      "LT"
+                    ],
+                    "type": "string"
+                  },
+                  "documentNumber": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "documentType",
+                  "quality",
+                  "documentNumber"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/co/rama/certificado/vigencia",
+          "description": "Colombia - Lawyers Verification",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/co/registraduria/certificado": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "Colombia - Electoral Records Verification",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "documentType",
+            "schema": {
+              "enum": [
+                "CC"
+              ],
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentType"
+          },
+          {
+            "in": "query",
+            "name": "documentNumber",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentNumber"
+          },
+          {
+            "in": "query",
+            "name": "date",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: date"
+          }
+        ],
+        "description": "Electoral records verification service for Colombia citizens. Provides voting status and electoral information.",
+        "operationId": "colombia_api_registraduria_certificate",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "documentType": {
+                    "enum": [
+                      "CC"
+                    ],
+                    "type": "string"
+                  },
+                  "documentNumber": {
+                    "type": "string"
+                  },
+                  "date": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "documentType",
+                  "documentNumber",
+                  "date"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/co/registraduria/certificado",
+          "description": "Colombia - Electoral Records Verification",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/co/politically-exposed-persons": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "Colombia - Politically Exposed Persons (PEP) Lookup",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "documentType",
+            "schema": {
+              "enum": [
+                "CC"
+              ],
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentType"
+          },
+          {
+            "in": "query",
+            "name": "documentNumber",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentNumber"
+          }
+        ],
+        "description": "Check if a person is listed as politically exposed (PEP) for compliance purposes.",
+        "operationId": "colombia_pep_lookup",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "documentType": {
+                    "enum": [
+                      "CC"
+                    ],
+                    "type": "string"
+                  },
+                  "documentNumber": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "documentType",
+                  "documentNumber"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/co/politically-exposed-persons",
+          "description": "Colombia - Politically Exposed Persons (PEP) Lookup",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/co/bogota/vehicle/accidentality": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "Colombia - Bogota Vehicle Accidents",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "plate",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: plate"
+          }
+        ],
+        "description": "Look up accident records and traffic incidents registered specifically within the Bogota municipal transit database.",
+        "operationId": "colombia_api_vehicle_accidentality_bogota",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "plate": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "plate"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/co/bogota/vehicle/accidentality",
+          "description": "Colombia - Bogota Vehicle Accidents",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/co/runt/vehicle-by-plate-simplified": {
+      "get": {
+        "tags": [
+          "KYC",
+          "KYB",
+          "Data",
+          "LATAM"
+        ],
+        "summary": "Colombia - Simplified Vehicle Report",
+        "responses": {
+          "200": {
+            "description": "Success \u2014 proxied Verifik response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "documentType",
+            "schema": {
+              "enum": [
+                "CC",
+                "TI",
+                "CE",
+                "PA",
+                "RC"
+              ],
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentType"
+          },
+          {
+            "in": "query",
+            "name": "documentNumber",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: documentNumber"
+          },
+          {
+            "in": "query",
+            "name": "plate",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Parameter: plate"
+          }
+        ],
+        "description": "A streamlined version of the vehicle background check focusing on essential legal and physical status markers.",
+        "operationId": "colombia_api_vehicle_complete_by_plate_simplified",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {
+                  "documentType": {
+                    "enum": [
+                      "CC",
+                      "TI",
+                      "CE",
+                      "PA",
+                      "RC"
+                    ],
+                    "type": "string"
+                  },
+                  "documentNumber": {
+                    "type": "string"
+                  },
+                  "plate": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "documentType",
+                  "documentNumber",
+                  "plate"
+                ],
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/co/runt/vehicle-by-plate-simplified",
+          "description": "Colombia - Simplified Vehicle Report",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/communication/whatsapp": {
+      "get": {
+        "summary": "GET /v2/communication/whatsapp",
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.02"
+        },
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/communication/whatsapp",
+          "description": "GET /v2/communication/whatsapp",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "20000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "20000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "20000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "20000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/co/simit/acuerdos": {
+      "get": {
+        "summary": "GET /v2/co/simit/acuerdos",
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/co/simit/acuerdos",
+          "description": "GET /v2/co/simit/acuerdos",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v3/pe/company": {
+      "get": {
+        "summary": "GET /v3/pe/company",
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v3/pe/company",
+          "description": "GET /v3/pe/company",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v3/pe/cedula": {
+      "get": {
+        "summary": "GET /v3/pe/cedula",
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.50"
+        },
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v3/pe/cedula",
+          "description": "GET /v3/pe/cedula",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "500000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "500000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "500000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "500000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v3/co/rues": {
+      "get": {
+        "summary": "GET /v3/co/rues",
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v3/co/rues",
+          "description": "GET /v3/co/rues",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/appointments": {
+      "get": {
+        "summary": "GET /v2/appointments",
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.20"
+        },
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/appointments",
+          "description": "GET /v2/appointments",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "200000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "200000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "200000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "200000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/ca/quebec/driver-license": {
+      "get": {
+        "summary": "GET /v2/ca/quebec/driver-license",
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.40"
+        },
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/ca/quebec/driver-license",
+          "description": "GET /v2/ca/quebec/driver-license",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "400000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "400000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "400000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "400000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/br/background-check": {
+      "get": {
+        "summary": "GET /v2/br/background-check",
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/br/background-check",
+          "description": "GET /v2/br/background-check",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/co/deudoresmorosos": {
+      "get": {
+        "summary": "GET /v2/co/deudoresmorosos",
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/co/deudoresmorosos",
+          "description": "GET /v2/co/deudoresmorosos",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v3/pe/cedula/extra": {
+      "get": {
+        "summary": "GET /v3/pe/cedula/extra",
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.60"
+        },
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v3/pe/cedula/extra",
+          "description": "GET /v3/pe/cedula/extra",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "600000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "600000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "600000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "600000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/co/rama/proceso": {
+      "get": {
+        "summary": "GET /v2/co/rama/proceso",
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/co/rama/proceso",
+          "description": "GET /v2/co/rama/proceso",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/cl/driver-license": {
+      "get": {
+        "summary": "GET /v2/cl/driver-license",
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/cl/driver-license",
+          "description": "GET /v2/cl/driver-license",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/co/sena/certificados": {
+      "get": {
+        "summary": "GET /v2/co/sena/certificados",
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/co/sena/certificados",
+          "description": "GET /v2/co/sena/certificados",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/credit-intents": {
+      "get": {
+        "summary": "GET /v2/credit-intents",
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$1.00"
+        },
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/credit-intents",
+          "description": "GET /v2/credit-intents",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "1000000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "1000000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "1000000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "1000000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/ca/ontario/driver-license": {
+      "get": {
+        "summary": "GET /v2/ca/ontario/driver-license",
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.40"
+        },
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/ca/ontario/driver-license",
+          "description": "GET /v2/ca/ontario/driver-license",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "400000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "400000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "400000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "400000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/co/rama/procesos": {
+      "get": {
+        "summary": "GET /v2/co/rama/procesos",
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/co/rama/procesos",
+          "description": "GET /v2/co/rama/procesos",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/communication/email": {
+      "get": {
+        "summary": "GET /v2/communication/email",
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.01"
+        },
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/communication/email",
+          "description": "GET /v2/communication/email",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "10000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "10000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "10000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "10000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/communication/sms": {
+      "get": {
+        "summary": "GET /v2/communication/sms",
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.10"
+        },
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/communication/sms",
+          "description": "GET /v2/communication/sms",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "100000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "100000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "100000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "100000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/ocr/scan-pro": {
+      "post": {
+        "summary": "POST /v2/ocr/scan-pro",
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.15"
+        },
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/ocr/scan-pro",
+          "description": "POST /v2/ocr/scan-pro",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "150000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "150000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "150000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "150000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/co/fasecolda/values-by-plate": {
+      "get": {
+        "summary": "GET /v2/co/fasecolda/values-by-plate",
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.40"
+        },
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/co/fasecolda/values-by-plate",
+          "description": "GET /v2/co/fasecolda/values-by-plate",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "400000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "400000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "400000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "400000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/co/rama/juzgado/expedientes": {
+      "get": {
+        "summary": "GET /v2/co/rama/juzgado/expedientes",
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/co/rama/juzgado/expedientes",
+          "description": "GET /v2/co/rama/juzgado/expedientes",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/co/afiliaciones": {
+      "get": {
+        "summary": "GET /v2/co/afiliaciones",
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/co/afiliaciones",
+          "description": "GET /v2/co/afiliaciones",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/ca/british-columbia/driver-license": {
+      "get": {
+        "summary": "GET /v2/ca/british-columbia/driver-license",
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.010000"
+        },
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/ca/british-columbia/driver-license",
+          "description": "GET /v2/ca/british-columbia/driver-license",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "10000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "10000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "10000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "10000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/co/contraloria/certificado": {
+      "get": {
+        "summary": "GET /v2/co/contraloria/certificado",
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/co/contraloria/certificado",
+          "description": "GET /v2/co/contraloria/certificado",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v3/co/rues-complete": {
+      "get": {
+        "summary": "GET /v3/co/rues-complete",
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.40"
+        },
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v3/co/rues-complete",
+          "description": "GET /v3/co/rues-complete",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "400000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "400000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "400000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "400000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/co/fasecolda/values-by-code": {
+      "get": {
+        "summary": "GET /v2/co/fasecolda/values-by-code",
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.40"
+        },
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/co/fasecolda/values-by-code",
+          "description": "GET /v2/co/fasecolda/values-by-code",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "400000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "400000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "400000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "400000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/co/fasecolda/sinister": {
+      "get": {
+        "summary": "GET /v2/co/fasecolda/sinister",
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.40"
+        },
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/co/fasecolda/sinister",
+          "description": "GET /v2/co/fasecolda/sinister",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "400000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "400000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "400000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "400000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/cl/validate/documents": {
+      "get": {
+        "summary": "GET /v2/cl/validate/documents",
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/cl/validate/documents",
+          "description": "GET /v2/cl/validate/documents",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/co/simit/suspensiones": {
+      "get": {
+        "summary": "GET /v2/co/simit/suspensiones",
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/co/simit/suspensiones",
+          "description": "GET /v2/co/simit/suspensiones",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v3/co/ministerio-de-trabajo/certificados": {
+      "get": {
+        "summary": "GET /v3/co/ministerio-de-trabajo/certificados",
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v3/co/ministerio-de-trabajo/certificados",
+          "description": "GET /v3/co/ministerio-de-trabajo/certificados",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/autodata/selection": {
+      "get": {
+        "summary": "GET /v2/autodata/selection",
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.20"
+        },
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/autodata/selection",
+          "description": "GET /v2/autodata/selection",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "200000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "200000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "200000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "200000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/co/simit/resoluciones": {
+      "get": {
+        "summary": "GET /v2/co/simit/resoluciones",
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/co/simit/resoluciones",
+          "description": "GET /v2/co/simit/resoluciones",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    },
+    "/v2/co/simit/comparendo": {
+      "get": {
+        "summary": "GET /v2/co/simit/comparendo",
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "extensions": {
+          "bazaar": {
+            "info": {
+              "input": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": false
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.30"
+        },
+        "x402Version": 2,
+        "resource": {
+          "url": "https://verifik.x402.paysponge.com/v2/co/simit/comparendo",
+          "description": "GET /v2/co/simit/comparendo",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "eip155:8453",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:43114",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "eip155:137",
+            "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          },
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+            "asset": "usdc",
+            "amount": "300000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ]
+      }
+    }
+  },
+  "openapi": "3.0.3",
+  "servers": [
+    {
+      "url": "https://verifik.x402.paysponge.com"
+    }
+  ],
+  "x-discovery": {
+    "tags": [
+      "KYC",
+      "KYB",
+      "Data",
+      "LATAM"
+    ]
+  },
+  "x402Version": 2,
+  "resource": {
+    "url": "https://verifik.x402.paysponge.com/",
+    "description": "Verifik identity, KYC, and data verification APIs proxied through ai.verifik.co (Smart Agent). Multi-country coverage across Latin America (e.g. Colombia, Peru, Mexico, Ecuador, Argentina, Chile, Brazil, Venezuela, and others), North America, Europe, and global compliance checks (OFAC, Interpol, UN, DEA, FBI, Europol, etc.). Each gateway endpoint has its own price; Colombia c\u00e9dula is one of many routes.",
+    "mimeType": "application/json"
+  },
+  "accepts": [
+    {
+      "scheme": "exact",
+      "network": "eip155:8453",
+      "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+      "asset": "usdc",
+      "amount": "10000",
+      "maxTimeoutSeconds": 300,
+      "extra": {}
+    },
+    {
+      "scheme": "exact",
+      "network": "eip155:43114",
+      "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+      "asset": "usdc",
+      "amount": "10000",
+      "maxTimeoutSeconds": 300,
+      "extra": {}
+    },
+    {
+      "scheme": "exact",
+      "network": "eip155:137",
+      "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90",
+      "asset": "usdc",
+      "amount": "10000",
+      "maxTimeoutSeconds": 300,
+      "extra": {}
+    },
+    {
+      "scheme": "exact",
+      "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+      "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV",
+      "asset": "usdc",
+      "amount": "10000",
+      "maxTimeoutSeconds": 300,
+      "extra": {}
+    }
+  ],
+  "x-payment-accepts": [
+    {
+      "scheme": "exact",
+      "network": "eip155:8453",
+      "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90"
+    },
+    {
+      "scheme": "exact",
+      "network": "eip155:43114",
+      "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90"
+    },
+    {
+      "scheme": "exact",
+      "network": "eip155:137",
+      "payTo": "0x0dAada2f4f15b2151071CDA5fBA7b92Bb727fa90"
+    },
+    {
+      "scheme": "exact",
+      "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+      "payTo": "2xkALVxsG1cE53fxFtPTHoiQp7wDhBHyhYKedz5ikWaV"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds `providers/paysponge/verifik/` with `PAY.md` and `openapi.json`
- 122 endpoints for KYC, KYB, identity verification, sanctions screening, vehicle lookups, and OCR
- Strong Latin American coverage (Colombia, Mexico, Argentina, Brazil, Chile, Peru, Ecuador, and more)
- Global sanctions databases: OFAC, FBI, DEA, Interpol, UN, Europol
- Accepts x402 USDC on Base, Avalanche, Polygon, and Solana mainnet
- Pricing ranges from $0.01 (email/WhatsApp verification) to $1.00 (Panama ID, credit intents); most endpoints at $0.30

## Source

OpenAPI spec served live at: `https://verifik.x402.paysponge.com/openapi.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)