### PR TITLE
feat: add TrustBoost PII Sanitizer — x402 privacy layer for AI agent pipelines

### DIFF
--- a/providers/teodorofodocrispin-cmyk/trustboost/PAY.md
+++ b/providers/teodorofodocrispin-cmyk/trustboost/PAY.md
@@ -3,7 +3,7 @@ name: trustboost
 title: "TrustBoost PII Sanitizer"
 description: "Sanitize PII from text before it reaches LLMs or external APIs. Detects and redacts emails, phone numbers, national IDs, API keys, private keys, financial data, and country-specific identifiers across 8 languages. Returns sanitized text, safety_score (0.0-1.0), and risk_category (CRITICAL/PRIVATE/SENSITIVE/CLEAN). Proof of Sanitization anchored on Solana for every paid request."
 use_case: "Use before any LLM call that processes user-generated text. Required for GDPR, LGPD, APPI, CCPA, and EU AI Act compliance (enforcement August 2, 2026). Supports LATAM PII natively: RFC, CUIT, CURP, CPF, CNPJ, DNI, Cédula. Also covers EN, DE (Personalausweis), JA (マイナンバー), FR (NIR/SIRET), IT (Codice Fiscale), KO (주민등록번호). Fail-closed by design: if unreachable, block the LLM call."
-category: ai
+category: ai_ml
 service_url: https://api.trustboost.dev
 openapi:
   path: openapi.json
@@ -44,7 +44,7 @@ Each mode applies specialized PRESERVE and REDACT rules:
   Each chunk costs 1 sanitization from quota. Use the `chunks_needed` field
   in the 413 error response to plan the split.
 - Check `quota_remaining` in each response. Initiate autonomous payment when
-  quota drops below 10: send 149 USDC to the payment address on Solana mainnet
+  quota drops below 10: send 1.49 USDC to the payment address on Solana mainnet
   and retry with the resulting tx_hash.
 - Use `/score/{wallet_address}` to verify the trust tier of any agent before
   sharing data with it. Tiers: NEW → ACTIVE → VERIFIED → TRUSTED.

--- a/providers/teodorofodocrispin-cmyk/trustboost/PAY.md
+++ b/providers/teodorofodocrispin-cmyk/trustboost/PAY.md
@@ -1,0 +1,66 @@
+---
+name: trustboost
+title: "TrustBoost PII Sanitizer"
+description: "Sanitize PII from text before it reaches LLMs or external APIs. Detects and redacts emails, phone numbers, national IDs, API keys, private keys, financial data, and country-specific identifiers across 8 languages. Returns sanitized text, safety_score (0.0-1.0), and risk_category (CRITICAL/PRIVATE/SENSITIVE/CLEAN). Proof of Sanitization anchored on Solana for every paid request."
+use_case: "Use before any LLM call that processes user-generated text. Required for GDPR, LGPD, APPI, CCPA, and EU AI Act compliance (enforcement August 2, 2026). Supports LATAM PII natively: RFC, CUIT, CURP, CPF, CNPJ, DNI, Cédula. Also covers EN, DE (Personalausweis), JA (マイナンバー), FR (NIR/SIRET), IT (Codice Fiscale), KO (주민등록번호). Fail-closed by design: if unreachable, block the LLM call."
+category: ai
+service_url: https://api.trustboost.dev
+openapi:
+  path: openapi.json
+---
+
+TrustBoost PII Sanitizer — privacy firewall for autonomous AI agent pipelines,
+exposed as a pay-compatible x402 endpoint on Solana.
+
+Send raw text to `/sanitize`. TrustBoost detects PII using GPT-4o-mini at
+temperature=0, enforces redaction server-side, and returns sanitized text with
+a structured entity list. Every paid sanitization is anchored on Solana via
+Helius — verifiable by any agent at `/verify/{anchor_tx}`.
+
+All endpoints accept x402 USDC on Solana mainnet. TRIAL mode (tx_hash=TRIAL)
+provides 50 free sanitizations per wallet — no payment required to start.
+
+## Context modes
+
+TrustBoost supports 5 domain-specific context modes via the `context` field.
+Each mode applies specialized PRESERVE and REDACT rules:
+
+- `general` — standard PII detection across all categories (default)
+- `financial` — preserves amounts and dates; redacts IBANs, account numbers, wallet addresses
+- `legal` — maximum redaction for contracts, court filings, regulatory documents
+- `medical` — HIPAA minimum-necessary principle; redacts patient identifiers, MRNs
+- `code` — targets API keys, hardcoded credentials, PEM blocks; preserves variable names
+
+## Spend-aware usage
+
+- Always pass `context` explicitly. Default is `general` — use `financial` for
+  payment payloads, `code` for source code or config files, `medical` for
+  clinical data. The right context reduces false positives and improves accuracy.
+- Use `/sanitize/preview` for free spot-checks (3 per IP per hour, 500 chars)
+  before committing quota to a full sanitization run.
+- Use `tx_hash=TRIAL` for the first 50 sanitizations. No payment required.
+  Switch to a paid Solana tx_hash only after validating the integration.
+- For texts longer than 10,000 chars, split into chunks of max 10,000 chars.
+  Each chunk costs 1 sanitization from quota. Use the `chunks_needed` field
+  in the 413 error response to plan the split.
+- Check `quota_remaining` in each response. Initiate autonomous payment when
+  quota drops below 10: send 149 USDC to the payment address on Solana mainnet
+  and retry with the resulting tx_hash.
+- Use `/score/{wallet_address}` to verify the trust tier of any agent before
+  sharing data with it. Tiers: NEW → ACTIVE → VERIFIED → TRUSTED.
+- For paid requests, call `/verify/{proof_of_sanitization.solana_tx}` to
+  confirm the on-chain proof. Store the verify_url in your audit log for
+  EU AI Act compliance documentation.
+
+## Compliance
+
+TrustBoost covers GDPR Art. 25 (Privacy by Design), EU AI Act Arts. 12/13/26
+(record keeping, transparency, deployer obligations), LGPD Art. 46, APPI,
+CCPA, and HIPAA technical safeguards. EU AI Act enforcement: August 2, 2026.
+
+## Performance
+
+F1=1.000 across all 8 languages (34 labeled test cases). Avg latency ~200ms.
+Raw input is never stored — only sanitized output logged to Supabase with
+90-day retention. Source code fully auditable at:
+https://github.com/teodorofodocrispin-cmyk/trustboost-api

--- a/providers/teodorofodocrispin-cmyk/trustboost/openapi.json
+++ b/providers/teodorofodocrispin-cmyk/trustboost/openapi.json
@@ -49,11 +49,20 @@
                   },
                   "context": {
                     "type": "string",
-                    "enum": ["general", "legal", "financial", "medical", "code"],
+                    "enum": [
+                      "general",
+                      "legal",
+                      "financial",
+                      "medical",
+                      "code"
+                    ],
                     "description": "Domain context for specialized redaction rules.",
                     "default": "general"
                   }
-                }
+                },
+                "required": [
+                  "text"
+                ]
               }
             }
           }
@@ -83,7 +92,12 @@
                         },
                         "risk_category": {
                           "type": "string",
-                          "enum": ["CLEAN", "SENSITIVE", "PRIVATE", "CRITICAL"],
+                          "enum": [
+                            "CLEAN",
+                            "SENSITIVE",
+                            "PRIVATE",
+                            "CRITICAL"
+                          ],
                           "example": "PRIVATE"
                         },
                         "entities_removed": {
@@ -95,9 +109,19 @@
                           "items": {
                             "type": "object",
                             "properties": {
-                              "type": {"type": "string", "example": "email"},
-                              "category": {"type": "string", "example": "PRIVATE"},
-                              "redacted_text": {"type": "string", "example": "john@example.com"}
+                              "type": {
+                                "type": "string",
+                                "example": "email"
+                              },
+                              "category": {
+                                "type": "string",
+                                "example": "PRIVATE"
+                              },
+                              "redacted_text": {
+                                "type": "string",
+                                "example": "[original-value-redacted-from-response-logs]",
+                                "description": "Original value that was redacted. WARNING: contains raw PII — do not log this field for EU AI Act audit compliance. Store only sanitized_content."
+                              }
                             }
                           }
                         },
@@ -109,15 +133,25 @@
                           "type": "object",
                           "description": "Solana anchor — paid requests only",
                           "properties": {
-                            "solana_tx": {"type": "string"},
-                            "verify_url": {"type": "string"}
+                            "solana_tx": {
+                              "type": "string"
+                            },
+                            "verify_url": {
+                              "type": "string"
+                            }
                           }
                         },
                         "usage_metrics": {
                           "type": "object",
                           "properties": {
-                            "quota_remaining": {"type": "integer", "example": 49},
-                            "quota_limit": {"type": "integer", "example": 50}
+                            "quota_remaining": {
+                              "type": "integer",
+                              "example": 49
+                            },
+                            "quota_limit": {
+                              "type": "integer",
+                              "example": 50
+                            }
                           }
                         }
                       }
@@ -134,8 +168,13 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "status": {"type": "string", "example": "payment_required"},
-                    "x402": {"type": "object"}
+                    "status": {
+                      "type": "string",
+                      "example": "payment_required"
+                    },
+                    "x402": {
+                      "type": "object"
+                    }
                   }
                 }
               }
@@ -152,7 +191,9 @@
             "headers": {
               "PAYMENT-REQUIRED": {
                 "description": "Base64-encoded x402 v2 payment requirements",
-                "schema": {"type": "string"}
+                "schema": {
+                  "type": "string"
+                }
               }
             }
           }
@@ -193,11 +234,26 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "sanitized_content": {"type": "string", "example": "My email is [REDACTED]"},
-                    "safety_score": {"type": "number", "example": 0.2},
-                    "risk_category": {"type": "string", "example": "PRIVATE"},
-                    "demo": {"type": "boolean", "example": true},
-                    "requests_remaining": {"type": "integer", "example": 2}
+                    "sanitized_content": {
+                      "type": "string",
+                      "example": "My email is [REDACTED]"
+                    },
+                    "safety_score": {
+                      "type": "number",
+                      "example": 0.2
+                    },
+                    "risk_category": {
+                      "type": "string",
+                      "example": "PRIVATE"
+                    },
+                    "demo": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "requests_remaining": {
+                      "type": "integer",
+                      "example": 2
+                    }
                   }
                 }
               }
@@ -220,7 +276,9 @@
             "name": "wallet_address",
             "in": "path",
             "required": true,
-            "schema": {"type": "string"},
+            "schema": {
+              "type": "string"
+            },
             "example": "your-agent-wallet"
           }
         ],
@@ -232,8 +290,14 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "trust_tier": {"type": "string", "example": "ACTIVE"},
-                    "trustboost_score": {"type": "number", "example": 0.74}
+                    "trust_tier": {
+                      "type": "string",
+                      "example": "ACTIVE"
+                    },
+                    "trustboost_score": {
+                      "type": "number",
+                      "example": 0.74
+                    }
                   }
                 }
               }
@@ -256,7 +320,9 @@
             "name": "anchor_tx",
             "in": "path",
             "required": true,
-            "schema": {"type": "string"},
+            "schema": {
+              "type": "string"
+            },
             "example": "solana-tx-signature"
           }
         ],
@@ -268,8 +334,13 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "status": {"type": "string", "example": "verified"},
-                    "proof": {"type": "object"}
+                    "status": {
+                      "type": "string",
+                      "example": "verified"
+                    },
+                    "proof": {
+                      "type": "object"
+                    }
                   }
                 }
               }
@@ -295,8 +366,14 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "status": {"type": "string", "example": "ok"},
-                    "version": {"type": "string", "example": "2.6.0"}
+                    "status": {
+                      "type": "string",
+                      "example": "ok"
+                    },
+                    "version": {
+                      "type": "string",
+                      "example": "2.6.0"
+                    }
                   }
                 }
               }

--- a/providers/teodorofodocrispin-cmyk/trustboost/openapi.json
+++ b/providers/teodorofodocrispin-cmyk/trustboost/openapi.json
@@ -203,7 +203,7 @@
     "/sanitize/preview": {
       "post": {
         "summary": "Free PII preview — no wallet required",
-        "description": "3 free sanitizations per IP per hour. Max 500 chars. No tx_hash or wallet required.",
+        "description": "3 free sanitizations per IP per hour. Max 500 chars. No tx_hash or wallet required. Response is a flat object (no data wrapper) — see POST /sanitize for the full paid envelope.",
         "x-pay": {
           "price": 0,
           "currency": "USDC",

--- a/providers/teodorofodocrispin-cmyk/trustboost/openapi.json
+++ b/providers/teodorofodocrispin-cmyk/trustboost/openapi.json
@@ -1,0 +1,309 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "TrustBoost PII Sanitizer",
+    "version": "2.6.0",
+    "description": "Privacy firewall for autonomous AI agent pipelines. Sanitizes PII before text reaches LLMs. Every paid sanitization anchored on Solana.",
+    "x-agentcash-auth": {
+      "mode": "paid"
+    }
+  },
+  "servers": [
+    {
+      "url": "https://api.trustboost.dev",
+      "description": "TrustBoost production API"
+    }
+  ],
+  "paths": {
+    "/sanitize": {
+      "post": {
+        "summary": "Sanitize PII from text",
+        "description": "Detects and redacts PII from text before it reaches an LLM. Supports 8 languages and 5 context modes. Returns sanitized_content, safety_score, risk_category, and entities[]. Proof of Sanitization anchored on Solana for paid requests.",
+        "x-pay": {
+          "price": 0.0149,
+          "currency": "USDC",
+          "network": "solana",
+          "trial": "tx_hash=TRIAL for 50 free sanitizations per wallet"
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "text": {
+                    "type": "string",
+                    "description": "Text to sanitize. Max 10,000 chars.",
+                    "example": "Contact John at john@example.com, SSN 123-45-6789"
+                  },
+                  "tx_hash": {
+                    "type": "string",
+                    "description": "Solana tx_hash for paid access. Use TRIAL for 50 free sanitizations.",
+                    "example": "TRIAL"
+                  },
+                  "wallet_address": {
+                    "type": "string",
+                    "description": "Agent wallet identifier for quota tracking.",
+                    "example": "your-agent-wallet"
+                  },
+                  "context": {
+                    "type": "string",
+                    "enum": ["general", "legal", "financial", "medical", "code"],
+                    "description": "Domain context for specialized redaction rules.",
+                    "default": "general"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Sanitization successful",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "example": "success"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "sanitized_content": {
+                          "type": "string",
+                          "example": "Contact [REDACTED] at [REDACTED], SSN [REDACTED]"
+                        },
+                        "safety_score": {
+                          "type": "number",
+                          "example": 0.6
+                        },
+                        "risk_category": {
+                          "type": "string",
+                          "enum": ["CLEAN", "SENSITIVE", "PRIVATE", "CRITICAL"],
+                          "example": "PRIVATE"
+                        },
+                        "entities_removed": {
+                          "type": "boolean",
+                          "example": true
+                        },
+                        "entities": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "type": {"type": "string", "example": "email"},
+                              "category": {"type": "string", "example": "PRIVATE"},
+                              "redacted_text": {"type": "string", "example": "john@example.com"}
+                            }
+                          }
+                        },
+                        "context_applied": {
+                          "type": "string",
+                          "example": "general"
+                        },
+                        "proof_of_sanitization": {
+                          "type": "object",
+                          "description": "Solana anchor — paid requests only",
+                          "properties": {
+                            "solana_tx": {"type": "string"},
+                            "verify_url": {"type": "string"}
+                          }
+                        },
+                        "usage_metrics": {
+                          "type": "object",
+                          "properties": {
+                            "quota_remaining": {"type": "integer", "example": 49},
+                            "quota_limit": {"type": "integer", "example": 50}
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required — x402 payment info returned",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {"type": "string", "example": "payment_required"},
+                    "x402": {"type": "object"}
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "summary": "x402 discovery — returns payment requirements",
+        "description": "Returns HTTP 402 with PAYMENT-REQUIRED header for x402 validator crawlers and agent discovery.",
+        "responses": {
+          "402": {
+            "description": "Payment required — x402 v2 discovery response",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "Base64-encoded x402 v2 payment requirements",
+                "schema": {"type": "string"}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/sanitize/preview": {
+      "post": {
+        "summary": "Free PII preview — no wallet required",
+        "description": "3 free sanitizations per IP per hour. Max 500 chars. No tx_hash or wallet required.",
+        "x-pay": {
+          "price": 0,
+          "currency": "USDC",
+          "mode": "free"
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "text": {
+                    "type": "string",
+                    "description": "Text to sanitize. Max 500 chars.",
+                    "example": "My email is john@example.com"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Preview sanitization result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "sanitized_content": {"type": "string", "example": "My email is [REDACTED]"},
+                    "safety_score": {"type": "number", "example": 0.2},
+                    "risk_category": {"type": "string", "example": "PRIVATE"},
+                    "demo": {"type": "boolean", "example": true},
+                    "requests_remaining": {"type": "integer", "example": 2}
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/score/{wallet_address}": {
+      "get": {
+        "summary": "TrustBoost Score — M2M trust verification",
+        "description": "Returns trust tier and score for a wallet/agent based on sanitization history. Tiers: NEW, ACTIVE, VERIFIED, TRUSTED.",
+        "x-pay": {
+          "price": 0,
+          "currency": "USDC",
+          "mode": "free"
+        },
+        "parameters": [
+          {
+            "name": "wallet_address",
+            "in": "path",
+            "required": true,
+            "schema": {"type": "string"},
+            "example": "your-agent-wallet"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Trust score and tier",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "trust_tier": {"type": "string", "example": "ACTIVE"},
+                    "trustboost_score": {"type": "number", "example": 0.74}
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/verify/{anchor_tx}": {
+      "get": {
+        "summary": "Verify Proof of Sanitization on Solana",
+        "description": "Verifies a paid sanitization proof anchored on Solana. Returns immutable audit trail for EU AI Act compliance.",
+        "x-pay": {
+          "price": 0,
+          "currency": "USDC",
+          "mode": "free"
+        },
+        "parameters": [
+          {
+            "name": "anchor_tx",
+            "in": "path",
+            "required": true,
+            "schema": {"type": "string"},
+            "example": "solana-tx-signature"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Proof verified",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {"type": "string", "example": "verified"},
+                    "proof": {"type": "object"}
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/health": {
+      "get": {
+        "summary": "Service health check",
+        "description": "Returns service status and version.",
+        "x-pay": {
+          "price": 0,
+          "currency": "USDC",
+          "mode": "free"
+        },
+        "responses": {
+          "200": {
+            "description": "Service is healthy",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {"type": "string", "example": "ok"},
+                    "version": {"type": "string", "example": "2.6.0"}
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/providers/teodorofodocrispin-cmyk/trustboost/openapi.json
+++ b/providers/teodorofodocrispin-cmyk/trustboost/openapi.json
@@ -179,6 +179,60 @@
                 }
               }
             }
+          },
+          "413": {
+            "description": "Text too long — split into chunks and retry",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "example": "error"
+                    },
+                    "code": {
+                      "type": "string",
+                      "example": "TEXT_TOO_LONG"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Text is 15,000 chars. Maximum is 10,000 chars per request."
+                    },
+                    "split": {
+                      "type": "object",
+                      "properties": {
+                        "max_chars_per_chunk": {
+                          "type": "integer",
+                          "example": 10000
+                        },
+                        "chunks_needed": {
+                          "type": "integer",
+                          "example": 2
+                        },
+                        "sanitizations_needed": {
+                          "type": "integer",
+                          "example": 2
+                        },
+                        "quota_cost": {
+                          "type": "string",
+                          "example": "2 sanitizations from your quota"
+                        }
+                      }
+                    },
+                    "how_to_split": {
+                      "type": "object",
+                      "properties": {
+                        "example_python": {
+                          "type": "string",
+                          "example": "chunks = [text[i:i+10000] for i in range(0, len(text), 10000)]"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
           }
         }
       },


### PR DESCRIPTION
## What this adds

A new provider entry for TrustBoost PII Sanitizer — the only privacy/PII service in the pay-skills catalog.

## Why it belongs here

pay enables agents to call paid APIs autonomously. But the request payload travels as-is — no PII filter exists before the data reaches the target API. TrustBoost fills that gap:

Agent → pay proxy → TrustBoost /sanitize → paid API endpoint

## Provider details

- **Endpoint:** `https://api.trustboost.dev/sanitize`
- **Price:** $0.0149 USDC per sanitization on Solana mainnet
- **Trial:** `tx_hash=TRIAL` — 50 free sanitizations per wallet, no payment required
- **Category:** ai
- **x402 compatible:** HTTP 402 with PAYMENT-REQUIRED header (v2 spec)

## Key capabilities

- 8 languages: EN, ES-LATAM (RFC/CUIT/CURP), PT-BR (CPF/CNPJ), DE (Personalausweis), JA (マイナンバー), FR (NIR/SIRET), IT (Codice Fiscale), KO (주민등록번호)
- 5 context modes: general / legal / financial / medical / code
- Proof of Sanitization anchored on Solana via Helius — verifiable at `/verify/{anchor_tx}`
- TrustBoost Score M2M trust tiers: NEW → ACTIVE → VERIFIED → TRUSTED
- F1=1.000 across all 8 languages (34 labeled test cases)
- Fail-closed by design

## Compliance

GDPR · LGPD · APPI · CCPA · EU AI Act (enforcement August 2, 2026)

## Related

- Issue: solana-foundation/pay#352
- Source: https://github.com/teodorofodocrispin-cmyk/trustboost-api
- Health: https://api.trustboost.dev/health