### PR TITLE
Add CoinStats crypto data API

### DIFF
--- a/providers/coinstats/api/PAY.md
+++ b/providers/coinstats/api/PAY.md
@@ -1,0 +1,32 @@
+---
+name: api
+title: "CoinStats"
+description: "Pay-per-request crypto market data, wallet balances, DeFi positions, news, insights, and portfolio analytics — 33 endpoints across 20,000+ coins and 70+ blockchains"
+use_case: "Use when an agent needs live cryptocurrency prices, wallet balances, DeFi protocol positions, portfolio tracking, crypto news, or market sentiment indicators"
+category: finance
+service_url: https://x402.coinstats.app
+openapi:
+  path: openapi.json
+---
+
+CoinStats provides comprehensive cryptocurrency data through 33 pay-per-request endpoints. The API covers live market data for 20,000+ coins, on-chain wallet tracking across 70+ blockchains, DeFi protocol positions, crypto news aggregation, and portfolio analytics.
+
+All endpoints accept USDC micropayments on Base via x402. After the first payment a JWT cookie is issued (1-hour TTL) so subsequent calls in the same session skip the payment flow.
+
+## Data domains
+
+- **Market data** — live prices, charts, global market cap, exchange tickers for 20,000+ cryptocurrencies
+- **Wallet tracking** — balances, transactions, DeFi positions, and portfolio charts for any address across 70+ blockchains
+- **News** — aggregated crypto news from 100+ sources with sentiment and topic filtering
+- **Insights** — Fear & Greed Index, BTC dominance, rainbow charts
+- **Portfolio** — read-only access to CoinStats user portfolios via shareToken (no account required)
+
+## Spend-aware usage
+
+- Start with `/coins` to discover coin IDs, then call `/coins/{coinId}` for details rather than paginating through the full list.
+- For wallet data, call `/wallet/blockchains` first to get connection IDs, then use `/wallet/balance` for a single chain or `/wallet/balances` for multi-chain aggregation.
+- `/wallet/defi` ($0.04) and `/portfolio/defi` ($0.04) are the most expensive endpoints — only call when DeFi positions are specifically needed.
+- `/portfolio/snapshot/items` ($0.05) returns historical snapshots — use `/portfolio/coins` ($0.001) for current holdings instead.
+- Use `/markets` for a quick global summary before drilling into per-coin data.
+- News endpoints are all $0.001 — prefer `/news/type/{type}` with a topic filter over the unfiltered `/news` feed to reduce response size.
+- Portfolio endpoints require a `sharetoken` header from a CoinStats Degen-plan user who has shared their portfolio.

--- a/providers/coinstats/api/openapi.json
+++ b/providers/coinstats/api/openapi.json
@@ -1741,16 +1741,6 @@
             }
           },
           {
-            "name": "connectionId",
-            "required": false,
-            "in": "query",
-            "description": "The identifier of connection from [/wallet/blockchains](/openapi/get-blockchains) call response. Either connectionId or blockchain must be provided. If both are provided, connectionId will be used.",
-            "schema": {
-              "example": "base-wallet",
-              "type": "string"
-            }
-          },
-          {
             "name": "blockchain",
             "required": false,
             "in": "query",
@@ -1908,7 +1898,7 @@
           },
           {
             "name": "blockchain",
-            "required": false,
+            "required": true,
             "in": "query",
             "description": "The identifier of connection from [/wallet/blockchains](/openapi/get-blockchains) call response. Specifies the blockchain networks to query for the wallet balance. Can be a single network (e.g., \"ethereum\") or a comma-separated list of networks (e.g., \"ethereum,polygon,binance_smart\"). If not provided, the default is \"all\" supported networks.",
             "schema": {
@@ -2124,16 +2114,6 @@
             }
           },
           {
-            "name": "connectionId",
-            "required": false,
-            "in": "query",
-            "description": "The identifier of connection from [/wallet/blockchains](/openapi/get-blockchains) call response. **Either connectionId or blockchain must be provided. If both are provided, connectionId will be used. Required if using address parameter.**",
-            "schema": {
-              "example": "ethereum",
-              "type": "string"
-            }
-          },
-          {
             "name": "blockchain",
             "required": false,
             "in": "query",
@@ -2307,16 +2287,6 @@
             }
           },
           {
-            "name": "connectionId",
-            "required": false,
-            "in": "query",
-            "description": "The identifier of connection from [/wallet/blockchains](/openapi/get-blockchains) call response. Either connectionId or blockchain must be provided. If both are provided, connectionId will be used.",
-            "schema": {
-              "example": "base-wallet",
-              "type": "string"
-            }
-          },
-          {
             "name": "blockchain",
             "required": false,
             "in": "query",
@@ -2474,16 +2444,6 @@
             "description": "The wallet address for which the chart is being queried.",
             "schema": {
               "example": "0x1234567890abcdef1234567890abcdef12345678",
-              "type": "string"
-            }
-          },
-          {
-            "name": "connectionId",
-            "required": false,
-            "in": "query",
-            "description": "The identifier of connection from [/wallet/blockchains](/openapi/get-blockchains) call response.  Can be a single network (e.g., \"ethereum\") or a comma-separated list of networks or \"all\" for all connections. ",
-            "schema": {
-              "example": "base-wallet",
               "type": "string"
             }
           },
@@ -2796,16 +2756,6 @@
             "description": "The wallet address for which the DeFi data is being queried. Must be a valid string representing an EVM-compatible wallet address.",
             "schema": {
               "example": "0x1234567890abcdef1234567890abcdef12345678",
-              "type": "string"
-            }
-          },
-          {
-            "name": "connectionId",
-            "required": false,
-            "in": "query",
-            "description": "Specifies the blockchain network connection ID to query for DeFi data. Can be a single network (e.g., \"ethereum\") or comma-separated list of networks (e.g., \"ethereum,polygon-wallet\") or \"all\" for all networks. Either connectionId or blockchain must be provided. If both are provided, connectionId will be used.",
-            "schema": {
-              "example": "base-wallet",
               "type": "string"
             }
           },
@@ -4452,16 +4402,6 @@
               "example": "USD",
               "type": "string"
             }
-          },
-          {
-            "name": "portfolioId",
-            "required": false,
-            "in": "query",
-            "description": "Portfolio ID for accessing a specific API-connected portfolio. Required if shareToken is not provided.",
-            "schema": {
-              "example": "abc123def456",
-              "type": "string"
-            }
           }
         ],
         "responses": {
@@ -4639,16 +4579,6 @@
                 "false"
               ]
             }
-          },
-          {
-            "name": "portfolioId",
-            "required": false,
-            "in": "query",
-            "description": "Portfolio ID for accessing a specific API-connected portfolio. Required if shareToken is not provided.",
-            "schema": {
-              "example": "abc123def456",
-              "type": "string"
-            }
           }
         ],
         "responses": {
@@ -4809,16 +4739,6 @@
                 "1y",
                 "all"
               ]
-            }
-          },
-          {
-            "name": "portfolioId",
-            "required": false,
-            "in": "query",
-            "description": "Portfolio ID for accessing a specific API-connected portfolio. Required if shareToken is not provided.",
-            "schema": {
-              "example": "abc123def456",
-              "type": "string"
             }
           }
         ],
@@ -5002,16 +4922,6 @@
               "example": "bitcoin",
               "type": "string"
             }
-          },
-          {
-            "name": "portfolioId",
-            "required": false,
-            "in": "query",
-            "description": "Portfolio ID for accessing a specific API-connected portfolio. Required if shareToken is not provided.",
-            "schema": {
-              "example": "abc123def456",
-              "type": "string"
-            }
           }
         ],
         "responses": {
@@ -5152,16 +5062,6 @@
             "description": "Passcode for accessing protected portfolio data",
             "schema": {
               "example": "123456",
-              "type": "string"
-            }
-          },
-          {
-            "name": "portfolioId",
-            "required": false,
-            "in": "query",
-            "description": "Portfolio ID for accessing a specific API-connected portfolio. Required if shareToken is not provided.",
-            "schema": {
-              "example": "abc123def456",
               "type": "string"
             }
           }
@@ -5325,16 +5225,6 @@
             "schema": {
               "example": 20,
               "type": "number"
-            }
-          },
-          {
-            "name": "portfolioId",
-            "required": false,
-            "in": "query",
-            "description": "Portfolio ID for accessing a specific API-connected portfolio. Required if shareToken is not provided.",
-            "schema": {
-              "example": "abc123def456",
-              "type": "string"
             }
           },
           {

--- a/providers/coinstats/api/openapi.json
+++ b/providers/coinstats/api/openapi.json
@@ -1,0 +1,7720 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "CoinStats Crypto Data API",
+    "description": "Pay-per-request access to real-time cryptocurrency market data, wallet balances, DeFi positions, news, insights, and portfolio analytics via x402 micropayments.",
+    "version": "1.0.0",
+    "contact": {
+      "name": "CoinStats",
+      "url": "https://coinstats.app"
+    }
+  },
+  "servers": [
+    {
+      "url": "https://x402.coinstats.app"
+    }
+  ],
+  "paths": {
+    "/coins": {
+      "get": {
+        "operationId": "get-coins",
+        "parameters": [
+          {
+            "name": "page",
+            "required": false,
+            "in": "query",
+            "description": "Page number to retrieve (1-based indexing)",
+            "schema": {
+              "example": 1,
+              "type": "number"
+            }
+          },
+          {
+            "name": "limit",
+            "required": false,
+            "in": "query",
+            "description": "Number of items to return per page",
+            "schema": {
+              "example": 20,
+              "type": "number"
+            }
+          },
+          {
+            "name": "coinIds",
+            "required": false,
+            "in": "query",
+            "description": "Filter coins by specific coin IDs. Use comma-separated values to specify multiple coins. Each coin ID should be the unique identifier for the cryptocurrency.",
+            "schema": {
+              "example": "bitcoin,ethereum,solana",
+              "type": "string"
+            }
+          },
+          {
+            "name": "currency",
+            "required": false,
+            "in": "query",
+            "description": "The currency to display coin prices and market data in.",
+            "schema": {
+              "example": "USD",
+              "type": "string"
+            }
+          },
+          {
+            "name": "name",
+            "required": false,
+            "in": "query",
+            "description": "Search for coins by their name. Supports partial matching - you can search for \"bit\" to find \"Bitcoin\" and other coins containing that substring.",
+            "schema": {
+              "example": "bitcoin",
+              "type": "string"
+            }
+          },
+          {
+            "name": "symbol",
+            "required": false,
+            "in": "query",
+            "description": "Filter coins by their ticker symbol. Use the standard trading symbol for the cryptocurrency (e.g., BTC for Bitcoin, ETH for Ethereum).",
+            "schema": {
+              "example": "BTC",
+              "type": "string"
+            }
+          },
+          {
+            "name": "contractAddresses",
+            "required": false,
+            "in": "query",
+            "description": "Filter coins by smart contract addresses. Use comma-separated values to specify multiple addresses. Matching is case-insensitive.",
+            "schema": {
+              "example": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48,0xdac17f958d2ee523a2206206994597c13d831ec7",
+              "type": "string"
+            }
+          },
+          {
+            "name": "blockchains",
+            "required": false,
+            "in": "query",
+            "description": "Filter coins by blockchain networks. Use comma-separated values to specify multiple blockchains. Common values include ethereum, solana, binance-smart-chain, polygon, avalanche.",
+            "schema": {
+              "example": "ethereum,solana,binance-smart-chain",
+              "type": "string"
+            }
+          },
+          {
+            "name": "includeRiskScore",
+            "required": false,
+            "in": "query",
+            "description": "Include risk score data in the response. Set to \"true\" to include risk assessment metrics, or \"false\" to exclude them.",
+            "schema": {
+              "example": "true",
+              "type": "string"
+            }
+          },
+          {
+            "name": "categories",
+            "required": false,
+            "in": "query",
+            "description": "Filter coins by categories. Use comma-separated values to specify multiple categories. Common categories include defi, memecoins, gaming, nft, metaverse, layer-1, layer-2.",
+            "schema": {
+              "example": "defi,memecoins,gaming",
+              "type": "string"
+            }
+          },
+          {
+            "name": "sortBy",
+            "required": false,
+            "in": "query",
+            "description": "Field to sort results by.",
+            "schema": {
+              "example": "marketCap",
+              "type": "string",
+              "enum": [
+                "rank",
+                "marketCap",
+                "price",
+                "volume",
+                "priceChange1h",
+                "priceChange1d",
+                "priceChange7d",
+                "priceChange1m",
+                "name",
+                "symbol"
+              ]
+            }
+          },
+          {
+            "name": "sortDir",
+            "required": false,
+            "in": "query",
+            "description": "Sort direction for the results. Use \"asc\" for ascending order or \"desc\" for descending order.",
+            "schema": {
+              "example": "desc",
+              "type": "string",
+              "enum": [
+                "asc",
+                "desc"
+              ]
+            }
+          },
+          {
+            "name": "marketCap~greaterThan",
+            "required": false,
+            "in": "query",
+            "description": "Filter coins with market capitalization greater than the specified value (in USD). Example: 1000000000 for coins with market cap above $1 billion.",
+            "schema": {
+              "example": "1000000000",
+              "type": "number"
+            }
+          },
+          {
+            "name": "marketCap~equals",
+            "required": false,
+            "in": "query",
+            "description": "Filter coins with market capitalization equal to the specified value (in USD). Exact matches are rare due to constant price fluctuations.",
+            "schema": {
+              "example": "500000000",
+              "type": "number"
+            }
+          },
+          {
+            "name": "marketCap~lessThan",
+            "required": false,
+            "in": "query",
+            "description": "Filter coins with market capitalization less than the specified value (in USD). Example: 100000000 for coins with market cap below $100 million.",
+            "schema": {
+              "example": "100000000",
+              "type": "number"
+            }
+          },
+          {
+            "name": "fullyDilutedValuation~greaterThan",
+            "required": false,
+            "in": "query",
+            "description": "Filter coins with fully diluted valuation greater than the specified value (in USD). FDV represents the theoretical market cap if all tokens were in circulation.",
+            "schema": {
+              "example": "2000000000",
+              "type": "number"
+            }
+          },
+          {
+            "name": "fullyDilutedValuation~equals",
+            "required": false,
+            "in": "query",
+            "description": "Filter coins with fully diluted valuation equal to the specified value (in USD). FDV = total supply \u00d7 current price.",
+            "schema": {
+              "example": "1500000000",
+              "type": "number"
+            }
+          },
+          {
+            "name": "fullyDilutedValuation~lessThan",
+            "required": false,
+            "in": "query",
+            "description": "Filter coins with fully diluted valuation less than the specified value (in USD). Useful for finding smaller cap projects with growth potential.",
+            "schema": {
+              "example": "500000000",
+              "type": "number"
+            }
+          },
+          {
+            "name": "volume~greaterThan",
+            "required": false,
+            "in": "query",
+            "description": "Filter coins with 24-hour trading volume greater than the specified value (in USD). Higher volume indicates more liquidity and trading activity.",
+            "schema": {
+              "example": "10000000",
+              "type": "number"
+            }
+          },
+          {
+            "name": "volume~equals",
+            "required": false,
+            "in": "query",
+            "description": "Filter coins with 24-hour trading volume equal to the specified value (in USD). Exact matches are uncommon due to constant trading activity.",
+            "schema": {
+              "example": "5000000",
+              "type": "number"
+            }
+          },
+          {
+            "name": "volume~lessThan",
+            "required": false,
+            "in": "query",
+            "description": "Filter coins with 24-hour trading volume less than the specified value (in USD). Useful for finding less traded or emerging coins.",
+            "schema": {
+              "example": "1000000",
+              "type": "number"
+            }
+          },
+          {
+            "name": "priceChange1h~greaterThan",
+            "required": false,
+            "in": "query",
+            "description": "Filter coins with 1-hour price change greater than the specified percentage. Example: 5 for coins with more than 5% gain in the last hour.",
+            "schema": {
+              "example": "5",
+              "type": "number"
+            }
+          },
+          {
+            "name": "priceChange1h~equals",
+            "required": false,
+            "in": "query",
+            "description": "Filter coins with 1-hour price change equal to the specified percentage. Useful for finding stable coins in short timeframes.",
+            "schema": {
+              "example": "0",
+              "type": "number"
+            }
+          },
+          {
+            "name": "priceChange1h~lessThan",
+            "required": false,
+            "in": "query",
+            "description": "Filter coins with 1-hour price change less than the specified percentage. Example: -2 for coins declining more than 2% in the last hour.",
+            "schema": {
+              "example": "-2",
+              "type": "number"
+            }
+          },
+          {
+            "name": "priceChange1d~greaterThan",
+            "required": false,
+            "in": "query",
+            "description": "Filter coins with 24-hour price change greater than the specified percentage. Example: 10 for coins with more than 10% daily gain.",
+            "schema": {
+              "example": "10",
+              "type": "number"
+            }
+          },
+          {
+            "name": "priceChange1d~equals",
+            "required": false,
+            "in": "query",
+            "description": "Filter coins with 24-hour price change equal to the specified percentage. Useful for finding stable coins over a day.",
+            "schema": {
+              "example": "0",
+              "type": "number"
+            }
+          },
+          {
+            "name": "priceChange1d~lessThan",
+            "required": false,
+            "in": "query",
+            "description": "Filter coins with 24-hour price change less than the specified percentage. Example: -5 for coins declining more than 5% today.",
+            "schema": {
+              "example": "-5",
+              "type": "number"
+            }
+          },
+          {
+            "name": "priceChange7d~greaterThan",
+            "required": false,
+            "in": "query",
+            "description": "Filter coins with 7-day price change greater than the specified percentage. Example: 20 for coins with more than 20% weekly gain.",
+            "schema": {
+              "example": "20",
+              "type": "number"
+            }
+          },
+          {
+            "name": "priceChange7d~equals",
+            "required": false,
+            "in": "query",
+            "description": "Filter coins with 7-day price change equal to the specified percentage. Useful for finding coins with stable weekly performance.",
+            "schema": {
+              "example": "0",
+              "type": "number"
+            }
+          },
+          {
+            "name": "priceChange7d~lessThan",
+            "required": false,
+            "in": "query",
+            "description": "Filter coins with 7-day price change less than the specified percentage. Example: -10 for coins declining more than 10% this week.",
+            "schema": {
+              "example": "-10",
+              "type": "number"
+            }
+          },
+          {
+            "name": "priceChange1m~greaterThan",
+            "required": false,
+            "in": "query",
+            "description": "Filter coins with 1-month price change greater than the specified percentage. Example: 30 for coins with more than 30% monthly gain.",
+            "schema": {
+              "example": "30",
+              "type": "number"
+            }
+          },
+          {
+            "name": "priceChange1m~equals",
+            "required": false,
+            "in": "query",
+            "description": "Filter coins with 1-month price change equal to the specified percentage. Useful for finding coins with stable monthly performance.",
+            "schema": {
+              "example": "0",
+              "type": "number"
+            }
+          },
+          {
+            "name": "priceChange1m~lessThan",
+            "required": false,
+            "in": "query",
+            "description": "Filter coins with 1-month price change less than the specified percentage. Example: -20 for coins declining more than 20% this month.",
+            "schema": {
+              "example": "-20",
+              "type": "number"
+            }
+          },
+          {
+            "name": "availableSupply~greaterThan",
+            "required": false,
+            "in": "query",
+            "description": "Filter coins with circulating supply greater than the specified amount. This represents tokens currently available for trading in the market.",
+            "schema": {
+              "example": "1000000",
+              "type": "number"
+            }
+          },
+          {
+            "name": "availableSupply~equals",
+            "required": false,
+            "in": "query",
+            "description": "Filter coins with circulating supply equal to the specified amount. Example: 21000000 for Bitcoin's maximum supply.",
+            "schema": {
+              "example": "21000000",
+              "type": "number"
+            }
+          },
+          {
+            "name": "availableSupply~lessThan",
+            "required": false,
+            "in": "query",
+            "description": "Filter coins with circulating supply less than the specified amount. Useful for finding scarce or limited supply tokens.",
+            "schema": {
+              "example": "100000",
+              "type": "number"
+            }
+          },
+          {
+            "name": "totalSupply~greaterThan",
+            "required": false,
+            "in": "query",
+            "description": "Filter coins with total supply greater than the specified amount. Total supply includes all minted tokens, including locked and vested ones.",
+            "schema": {
+              "example": "10000000",
+              "type": "number"
+            }
+          },
+          {
+            "name": "totalSupply~equals",
+            "required": false,
+            "in": "query",
+            "description": "Filter coins with total supply equal to the specified amount. Useful for finding tokens with specific supply characteristics.",
+            "schema": {
+              "example": "1000000000",
+              "type": "number"
+            }
+          },
+          {
+            "name": "totalSupply~lessThan",
+            "required": false,
+            "in": "query",
+            "description": "Filter coins with total supply less than the specified amount. Great for finding ultra-scarce tokens with limited total supply.",
+            "schema": {
+              "example": "500000",
+              "type": "number"
+            }
+          },
+          {
+            "name": "rank~greaterThan",
+            "required": false,
+            "in": "query",
+            "description": "Filter coins with market cap rank greater than the specified number. Example: 100 to exclude top 100 coins and find smaller cap projects.",
+            "schema": {
+              "example": "100",
+              "type": "number"
+            }
+          },
+          {
+            "name": "rank~equals",
+            "required": false,
+            "in": "query",
+            "description": "Filter coins with market cap rank equal to the specified number. Example: 10 to find the 10th largest cryptocurrency by market cap.",
+            "schema": {
+              "example": "10",
+              "type": "number"
+            }
+          },
+          {
+            "name": "rank~lessThan",
+            "required": false,
+            "in": "query",
+            "description": "Filter coins with market cap rank less than the specified number. Example: 50 to show only top 50 cryptocurrencies.",
+            "schema": {
+              "example": "50",
+              "type": "number"
+            }
+          },
+          {
+            "name": "price~greaterThan",
+            "required": false,
+            "in": "query",
+            "description": "Filter coins with current price greater than the specified value (in the selected currency). Example: 100 for coins priced above $100.",
+            "schema": {
+              "example": "100",
+              "type": "number"
+            }
+          },
+          {
+            "name": "price~equals",
+            "required": false,
+            "in": "query",
+            "description": "Filter coins with current price equal to the specified value. Useful for finding stablecoins or coins at specific price points.",
+            "schema": {
+              "example": "1",
+              "type": "number"
+            }
+          },
+          {
+            "name": "price~lessThan",
+            "required": false,
+            "in": "query",
+            "description": "Filter coins with current price less than the specified value. Example: 0.01 for coins under 1 cent, often called \"penny coins\".",
+            "schema": {
+              "example": "0.01",
+              "type": "number"
+            }
+          },
+          {
+            "name": "riskScore~greaterThan",
+            "required": false,
+            "in": "query",
+            "description": "Filter coins with risk score greater than the specified value (0-100 scale). Higher scores indicate higher risk. Only available when **includeRiskScore=true**.",
+            "schema": {
+              "minimum": 0,
+              "maximum": 100,
+              "example": "70",
+              "type": "number"
+            }
+          },
+          {
+            "name": "riskScore~equals",
+            "required": false,
+            "in": "query",
+            "description": "Filter coins with risk score equal to the specified value (0-100 scale). Useful for finding coins with specific risk profiles. Only available when **includeRiskScore=true**.",
+            "schema": {
+              "minimum": 0,
+              "maximum": 100,
+              "example": "50",
+              "type": "number"
+            }
+          },
+          {
+            "name": "riskScore~lessThan",
+            "required": false,
+            "in": "query",
+            "description": "Filter coins with risk score less than the specified value (0-100 scale). Lower scores indicate lower risk investments. Only available when **includeRiskScore=true**.",
+            "schema": {
+              "minimum": 0,
+              "maximum": 100,
+              "example": "30",
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Get coins list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CoinListResponseDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 400,
+                  "message": "Bad Request",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 401,
+                  "message": "Unauthorized",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 403,
+                  "message": "Forbidden",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 404,
+                  "message": "Not Found",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict (for some endpoints)",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 409,
+                  "message": "Transactions not synced",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 429,
+                  "message": "Rate limit exceeded",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Service Unavailable",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 503,
+                  "message": "Service Unavailable. Please Contact Support"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "X-API-KEY": []
+          }
+        ],
+        "summary": "Get comprehensive data about all cryptocurrencies",
+        "tags": [
+          "Market Data"
+        ],
+        "x-mint": {
+          "content": "<Note>**2** credits per request</Note><hr/>\n    <AccordionGroup>\n<Accordion title=\"You will get\">\n- Price, market cap, and volume\n- Price changes (1h, 24h, 7d, 1m)\n- Supply information\n- Trading metrics\n- Social links and metadata\n</Accordion>\n<Accordion title=\"Optional\">\n- currency: Price display currency\n- limit & skip: Pagination controls\n- includeRiskScore: Add risk analysis data\n- categories: Filter by coin categories\n- blockchains: Filter by blockchain networks\n</Accordion>\n<Accordion title=\"Sorting Options\">\n- sortBy: rank, price, volume, etc.\n- sortDir: asc or desc\n</Accordion>\n</AccordionGroup>",
+          "metadata": {
+            "title": "Get Coins",
+            "description": "Get comprehensive data about all cryptocurrencies",
+            "og:title": "Get Coins"
+          },
+          "href": "/openapi/get-coins"
+        }
+      }
+    },
+    "/coins/{coinId}": {
+      "get": {
+        "operationId": "get-coin-by-id",
+        "parameters": [
+          {
+            "name": "currency",
+            "required": false,
+            "in": "query",
+            "description": "The currency to display coin prices and market data in.",
+            "schema": {
+              "default": "USD",
+              "example": "USD",
+              "type": "string"
+            }
+          },
+          {
+            "name": "coinId",
+            "required": true,
+            "in": "path",
+            "description": "The identifier of coin, which you received from [/coins](/openapi/get-coins) call response.",
+            "schema": {
+              "type": "string",
+              "default": "bitcoin"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Get Coin with global avg prices",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CoinListResponseItemDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 400,
+                  "message": "Bad Request",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 401,
+                  "message": "Unauthorized",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 403,
+                  "message": "Forbidden",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 404,
+                  "message": "Not Found",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict (for some endpoints)",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 409,
+                  "message": "Transactions not synced",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 429,
+                  "message": "Rate limit exceeded",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Service Unavailable",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 503,
+                  "message": "Service Unavailable. Please Contact Support"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "X-API-KEY": []
+          }
+        ],
+        "summary": "Get detailed information about a specific cryptocurrency using coinId. ",
+        "tags": [
+          "Market Data"
+        ],
+        "x-mint": {
+          "content": "<Note>**1** credit per request</Note>",
+          "metadata": {
+            "title": "Get Coin By Id",
+            "description": "Get detailed information about a specific cryptocurrency using coinId. ",
+            "og:title": "Get Coin By Id"
+          },
+          "href": "/openapi/get-coin-by-id"
+        }
+      }
+    },
+    "/coins/{coinId}/charts": {
+      "get": {
+        "operationId": "get-coin-chart-by-id",
+        "parameters": [
+          {
+            "name": "period",
+            "required": true,
+            "in": "query",
+            "description": "Time period for the chart data",
+            "schema": {
+              "example": "24h",
+              "type": "string",
+              "enum": [
+                "all",
+                "24h",
+                "1w",
+                "1m",
+                "3m",
+                "6m",
+                "1y"
+              ],
+              "default": "24h"
+            }
+          },
+          {
+            "name": "coinId",
+            "required": true,
+            "in": "path",
+            "description": "The identifier of coin, which you received from [/coins](/openapi/get-coins) call response.",
+            "schema": {
+              "type": "string",
+              "default": "bitcoin"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Get Historical global avg price chart.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "description": "Array of historical price data points. Each data point is an array containing:\n1. TIMESTAMP - Unix timestamp in seconds\n2. USD - Price in USD\n3. BTC - Price in Bitcoin\n4. ETH - Price in Ethereum",
+                    "type": "array",
+                    "items": {
+                      "type": "number"
+                    }
+                  }
+                },
+                "example": [
+                  [
+                    1438905600,
+                    2.83162,
+                    0.0101411,
+                    1
+                  ],
+                  [
+                    1438992000,
+                    2.7976,
+                    0.0100039,
+                    1
+                  ],
+                  [
+                    1439078400,
+                    0.725225,
+                    0.00278432,
+                    1
+                  ],
+                  [
+                    1439164800,
+                    0.671728,
+                    0.00252591,
+                    1
+                  ],
+                  [
+                    1439251200,
+                    0.71888,
+                    0.00271961,
+                    1
+                  ]
+                ]
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 400,
+                  "message": "Bad Request",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 401,
+                  "message": "Unauthorized",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 403,
+                  "message": "Forbidden",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 404,
+                  "message": "Not Found",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict (for some endpoints)",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 409,
+                  "message": "Transactions not synced",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 429,
+                  "message": "Rate limit exceeded",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Service Unavailable",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 503,
+                  "message": "Service Unavailable. Please Contact Support"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "X-API-KEY": []
+          }
+        ],
+        "summary": "Get historical chart data for a specific cryptocurrency using coinId.",
+        "tags": [
+          "Market Data"
+        ],
+        "x-mint": {
+          "content": "<Note>**3** credits per request</Note>",
+          "metadata": {
+            "title": "Get Coin Chart By Id",
+            "description": "Get historical chart data for a specific cryptocurrency using coinId.",
+            "og:title": "Get Coin Chart By Id"
+          },
+          "href": "/openapi/get-coin-chart-by-id"
+        }
+      }
+    },
+    "/coins/price/avg": {
+      "get": {
+        "operationId": "get-coin-avg-price",
+        "parameters": [
+          {
+            "name": "coinId",
+            "required": true,
+            "in": "query",
+            "schema": {
+              "example": "bitcoin",
+              "type": "string"
+            }
+          },
+          {
+            "name": "timestamp",
+            "required": true,
+            "in": "query",
+            "schema": {
+              "example": 1636315200,
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Get Historical global avg price",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CoinPriceResponseDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 400,
+                  "message": "Bad Request",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 401,
+                  "message": "Unauthorized",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 403,
+                  "message": "Forbidden",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 404,
+                  "message": "Not Found",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict (for some endpoints)",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 409,
+                  "message": "Transactions not synced",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 429,
+                  "message": "Rate limit exceeded",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Service Unavailable",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 503,
+                  "message": "Service Unavailable. Please Contact Support"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "X-API-KEY": []
+          }
+        ],
+        "summary": "Get the historical average price of a specific cryptocurrency for a given date. ",
+        "tags": [
+          "Market Data"
+        ],
+        "x-mint": {
+          "content": "<Note>**4** credits per request</Note>",
+          "metadata": {
+            "title": "Get Coin Avg Price",
+            "description": "Get the historical average price of a specific cryptocurrency for a given date. ",
+            "og:title": "Get Coin Avg Price"
+          },
+          "href": "/openapi/get-coin-avg-price"
+        }
+      }
+    },
+    "/coins/price/exchange": {
+      "get": {
+        "operationId": "get-coin-exchange-price",
+        "parameters": [
+          {
+            "name": "exchange",
+            "required": true,
+            "in": "query",
+            "description": "The name of the exchange to get price data from",
+            "schema": {
+              "example": "Binance",
+              "type": "string"
+            }
+          },
+          {
+            "name": "from",
+            "required": true,
+            "in": "query",
+            "description": "The base currency symbol to convert from",
+            "schema": {
+              "example": "BTC",
+              "type": "string"
+            }
+          },
+          {
+            "name": "to",
+            "required": true,
+            "in": "query",
+            "description": "The target currency symbol to convert to",
+            "schema": {
+              "example": "ETH",
+              "type": "string"
+            }
+          },
+          {
+            "name": "timestamp",
+            "required": true,
+            "in": "query",
+            "description": "Unix timestamp in seconds for the historical price lookup",
+            "schema": {
+              "example": 1636315200,
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Get Historical coin exchange price",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CoinExchangePriceResponseDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 400,
+                  "message": "Bad Request",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 401,
+                  "message": "Unauthorized",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 403,
+                  "message": "Forbidden",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 404,
+                  "message": "Not Found",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict (for some endpoints)",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 409,
+                  "message": "Transactions not synced",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 429,
+                  "message": "Rate limit exceeded",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Service Unavailable",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 503,
+                  "message": "Service Unavailable. Please Contact Support"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "X-API-KEY": []
+          }
+        ],
+        "summary": "Get historical price data for a specific cryptocurrency on a selected exchange.",
+        "tags": [
+          "Market Data"
+        ],
+        "x-mint": {
+          "content": "<Note>**5** credits per request</Note>",
+          "metadata": {
+            "title": "Get Coin Exchange Price",
+            "description": "Get historical price data for a specific cryptocurrency on a selected exchange.",
+            "og:title": "Get Coin Exchange Price"
+          },
+          "href": "/openapi/get-coin-exchange-price"
+        }
+      }
+    },
+    "/tickers/exchanges": {
+      "get": {
+        "operationId": "get-ticker-exchanges",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Returns a list of supported cryptocurrency exchanges available on CoinStats.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ExchangeCollectionEntity"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 400,
+                  "message": "Bad Request",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 401,
+                  "message": "Unauthorized",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 403,
+                  "message": "Forbidden",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 404,
+                  "message": "Not Found",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict (for some endpoints)",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 409,
+                  "message": "Transactions not synced",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 429,
+                  "message": "Rate limit exceeded",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Service Unavailable",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 503,
+                  "message": "Service Unavailable. Please Contact Support"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "X-API-KEY": []
+          }
+        ],
+        "summary": "Provides a comprehensive list of cryptocurrency exchanges supported by CoinStats.",
+        "tags": [
+          "Market Data"
+        ],
+        "x-mint": {
+          "content": "<Note>**2** credits per request</Note>",
+          "metadata": {
+            "title": "Get Ticker Exchanges",
+            "description": "Provides a comprehensive list of cryptocurrency exchanges supported by CoinStats.",
+            "og:title": "Get Ticker Exchanges"
+          },
+          "href": "/openapi/get-ticker-exchanges"
+        }
+      }
+    },
+    "/tickers/markets": {
+      "get": {
+        "operationId": "get-ticker-markets",
+        "parameters": [
+          {
+            "name": "page",
+            "required": false,
+            "in": "query",
+            "description": "Page number to retrieve (1-based indexing)",
+            "schema": {
+              "example": 1,
+              "type": "number"
+            }
+          },
+          {
+            "name": "limit",
+            "required": false,
+            "in": "query",
+            "description": "Number of items to return per page",
+            "schema": {
+              "example": 20,
+              "type": "number"
+            }
+          },
+          {
+            "name": "exchange",
+            "required": false,
+            "in": "query",
+            "description": "Filter tickers by exchange name (case-insensitive exact match)",
+            "schema": {
+              "example": "Binance",
+              "type": "string"
+            }
+          },
+          {
+            "name": "fromCoin",
+            "required": false,
+            "in": "query",
+            "description": "Filter by base currency symbol of the trading pair",
+            "schema": {
+              "example": "BTC",
+              "type": "string"
+            }
+          },
+          {
+            "name": "toCoin",
+            "required": false,
+            "in": "query",
+            "description": "Filter by quote currency symbol of the trading pair",
+            "schema": {
+              "example": "USDT",
+              "type": "string"
+            }
+          },
+          {
+            "name": "coinId",
+            "required": false,
+            "in": "query",
+            "description": "Filter by unique coin identifier (e.g., \"bitcoin\" for BTC)",
+            "schema": {
+              "example": "bitcoin",
+              "type": "string"
+            }
+          },
+          {
+            "name": "onlyVerified",
+            "required": false,
+            "in": "query",
+            "description": "When true, returns only verified tickers with recent updates and no fake volume flags",
+            "schema": {
+              "example": false,
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Get ticker market list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/TickerMarketListResponseDto"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 400,
+                  "message": "Bad Request",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 401,
+                  "message": "Unauthorized",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 403,
+                  "message": "Forbidden",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 404,
+                  "message": "Not Found",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict (for some endpoints)",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 409,
+                  "message": "Transactions not synced",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 429,
+                  "message": "Rate limit exceeded",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Service Unavailable",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 503,
+                  "message": "Service Unavailable. Please Contact Support"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "X-API-KEY": []
+          }
+        ],
+        "summary": "Returns a list of tickers for a specific cryptocurrency across multiple exchanges.",
+        "tags": [
+          "Market Data"
+        ],
+        "x-mint": {
+          "content": "<Note>**3** credits per request</Note>",
+          "metadata": {
+            "title": "Get Ticker Markets",
+            "description": "Returns a list of tickers for a specific cryptocurrency across multiple exchanges.",
+            "og:title": "Get Ticker Markets"
+          },
+          "href": "/openapi/get-ticker-markets"
+        }
+      }
+    },
+    "/wallet/blockchains": {
+      "get": {
+        "operationId": "get-blockchains",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Get list of blockchains",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/BlockchainListItemResponseDto"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 400,
+                  "message": "Bad Request",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 401,
+                  "message": "Unauthorized",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 403,
+                  "message": "Forbidden",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 404,
+                  "message": "Not Found",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict (for some endpoints)",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 409,
+                  "message": "Transactions not synced",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 429,
+                  "message": "Rate limit exceeded",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Service Unavailable",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 503,
+                  "message": "Service Unavailable. Please Contact Support"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "X-API-KEY": []
+          }
+        ],
+        "summary": "Get the list of blockchains supported by CoinStats",
+        "tags": [
+          "Wallet Data"
+        ],
+        "x-mint": {
+          "content": "<Note>**1** credit per request</Note><hr/>\n    <AccordionGroup>\n<Accordion title=\"You will get\">\n- All supported blockchains\n- Blockchain network names\n- Blockchain network icons\n</Accordion>\n<Accordion title=\"Use this data\">\n- To connect your wallet to CoinStats\n- To display blockchain network information\n- In other API endpoints\n</Accordion>\n</AccordionGroup>",
+          "metadata": {
+            "title": "Get Blockchains",
+            "description": "Get the list of blockchains supported by CoinStats",
+            "og:title": "Get Blockchains"
+          },
+          "href": "/openapi/get-blockchains"
+        }
+      }
+    },
+    "/wallet/balance": {
+      "get": {
+        "operationId": "get-wallet-balance",
+        "parameters": [
+          {
+            "name": "address",
+            "required": true,
+            "in": "query",
+            "description": "The blockchain wallet address to query balances for",
+            "schema": {
+              "example": "0x742d35Cc6634C0532925a3b844Bc454e4438f44e",
+              "type": "string"
+            }
+          },
+          {
+            "name": "connectionId",
+            "required": false,
+            "in": "query",
+            "description": "The identifier of connection from [/wallet/blockchains](/openapi/get-blockchains) call response. Either connectionId or blockchain must be provided. If both are provided, connectionId will be used.",
+            "schema": {
+              "example": "base-wallet",
+              "type": "string"
+            }
+          },
+          {
+            "name": "blockchain",
+            "required": false,
+            "in": "query",
+            "description": "The blockchain network identifier from [/wallet/blockchains](/openapi/get-blockchains) call response. Either connectionId or blockchain must be provided. If both are provided, connectionId will be used.",
+            "schema": {
+              "example": "base",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Get wallet balance",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/WalletBalanceResponseCoinDto"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 400,
+                  "message": "Bad Request",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 401,
+                  "message": "Unauthorized",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 403,
+                  "message": "Forbidden",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 404,
+                  "message": "Not Found",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict (for some endpoints)",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 409,
+                  "message": "Transactions not synced",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 429,
+                  "message": "Rate limit exceeded",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Service Unavailable",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 503,
+                  "message": "Service Unavailable. Please Contact Support"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "X-API-KEY": []
+          }
+        ],
+        "summary": "Get cryptocurrency balances for any blockchain wallet",
+        "tags": [
+          "Wallet Data"
+        ],
+        "x-mint": {
+          "content": "<Note>**40** credits per request</Note><hr/>\n    <AccordionGroup>\n<Accordion title='Details'>\n- Token balances across multiple networks\n- NFT holdings\n- Current USD values\n- Historical transactions\n</Accordion>\n<Accordion title='Required'>\n- address: Wallet address to query\n- connectionId: Blockchain network(s) to check\n  - Single network (e.g., \"ethereum\")\n  - Multiple networks (\"ethereum,polygon\")\n  - \"all\" for all supported networks\n</Accordion>\n<Accordion title='Features'>\n- Multi-chain support\n- ERC20 token detection\n- NFT balance tracking\n- Historical data access\n</Accordion>\n\n</AccordionGroup>",
+          "metadata": {
+            "title": "Get Wallet Balance",
+            "description": "Get cryptocurrency balances for any blockchain wallet",
+            "og:title": "Get Wallet Balance"
+          },
+          "href": "/openapi/get-wallet-balance"
+        }
+      }
+    },
+    "/wallet/balances": {
+      "get": {
+        "operationId": "get-wallet-balances",
+        "parameters": [
+          {
+            "name": "address",
+            "required": false,
+            "in": "query",
+            "description": "The wallet address for which the balance is being queried. Must be a valid string representing an EVM-compatible wallet address.",
+            "schema": {
+              "example": "0x1234567890abcdef1234567890abcdef12345678",
+              "type": "string"
+            }
+          },
+          {
+            "name": "networks",
+            "required": false,
+            "in": "query",
+            "description": "Use blockchain instead.",
+            "deprecated": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "blockchain",
+            "required": false,
+            "in": "query",
+            "description": "The identifier of connection from [/wallet/blockchains](/openapi/get-blockchains) call response. Specifies the blockchain networks to query for the wallet balance. Can be a single network (e.g., \"ethereum\") or a comma-separated list of networks (e.g., \"ethereum,polygon,binance_smart\"). If not provided, the default is \"all\" supported networks.",
+            "schema": {
+              "default": "all",
+              "example": "ethereum,polygon,binance_smart",
+              "type": "string"
+            }
+          },
+          {
+            "name": "wallets",
+            "required": false,
+            "in": "query",
+            "description": "Comma-separated list of wallet addresses in format \"[connectionId](/openapi/get-blockchains):address\".",
+            "schema": {
+              "example": "ethereum:0x1234567890abcdef1234567890abcdef12345678,all:0x4567890abcdef1234567890abcdef1234567890abc",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Get wallets balance",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/WalletBalancesResponse"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 400,
+                  "message": "Bad Request",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 401,
+                  "message": "Unauthorized",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 403,
+                  "message": "Forbidden",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 404,
+                  "message": "Not Found",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict (for some endpoints)",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 409,
+                  "message": "Transactions not synced",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 429,
+                  "message": "Rate limit exceeded",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Service Unavailable",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 503,
+                  "message": "Service Unavailable. Please Contact Support"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "X-API-KEY": []
+          }
+        ],
+        "summary": "Get cryptocurrency balances for multiple wallets",
+        "tags": [
+          "Wallet Data"
+        ],
+        "x-mint": {
+          "content": "<Note>**40** credits per request</Note><Accordion title=\"Multipliers\" icon=\"rectangle-history-circle-plus\" ><Note>In **Query** field **\"networks\"**: credits are multiplied by the number of values.</Note><Note>If the value of **\"networks\"** in **Query** is **\"all\"**, multiplier is **400** credits.</Note><Note>In **Query** field **\"blockchain\"**: credits are multiplied by the number of values.</Note><Note>If the value of **\"blockchain\"** in **Query** is **\"all\"**, multiplier is **400** credits.</Note><Note>In **Query** field **\"wallets\"**: credits are multiplied by the number of values.</Note><Note>If the value of **\"wallets\"** in **Query** is **\"all\"**, multiplier is **400** credits.</Note><Warning>Multipliers can be applied multiple times.</Warning><Info>[**Detailed multipliers explanation**](/multipliers)</Info></Accordion><hr/>\n    <AccordionGroup>\n<Accordion title='You will get'>\n- Token balances across multiple networks\n- Token balances across multiple addresses\n</Accordion>\n</AccordionGroup>",
+          "metadata": {
+            "title": "Get Wallet Balances",
+            "description": "Get cryptocurrency balances for multiple wallets",
+            "og:title": "Get Wallet Balances"
+          },
+          "href": "/openapi/get-wallet-balances"
+        }
+      }
+    },
+    "/wallet/transactions": {
+      "get": {
+        "operationId": "get-wallet-transactions",
+        "parameters": [
+          {
+            "name": "page",
+            "required": false,
+            "in": "query",
+            "description": "Page number to retrieve (1-based indexing)",
+            "schema": {
+              "example": 1,
+              "type": "number"
+            }
+          },
+          {
+            "name": "limit",
+            "required": false,
+            "in": "query",
+            "description": "Number of transactions to return per page. Default is 20, min is 1, max is 100.",
+            "schema": {
+              "example": 20,
+              "type": "number"
+            }
+          },
+          {
+            "name": "from",
+            "required": false,
+            "in": "query",
+            "description": "Please include the date in ISO 8601 format",
+            "schema": {
+              "format": "date-time",
+              "example": "2026-04-23T08:10:48.228Z",
+              "type": "string"
+            }
+          },
+          {
+            "name": "to",
+            "required": false,
+            "in": "query",
+            "description": "Please include the date in ISO 8601 format",
+            "schema": {
+              "format": "date-time",
+              "example": "2026-04-24T10:10:48.228Z",
+              "type": "string"
+            }
+          },
+          {
+            "name": "currency",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "example": "USD",
+              "type": "string"
+            }
+          },
+          {
+            "name": "types",
+            "required": false,
+            "in": "query",
+            "description": "Comma separated values of (deposit,withdraw,approve,executed,balance,fee)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "address",
+            "required": false,
+            "in": "query",
+            "description": "The wallet address to fetch transactions for. **Required if not using wallets parameter.**",
+            "schema": {
+              "example": "0x1234567890abcdef1234567890abcdef12345678",
+              "type": "string"
+            }
+          },
+          {
+            "name": "connectionId",
+            "required": false,
+            "in": "query",
+            "description": "The identifier of connection from [/wallet/blockchains](/openapi/get-blockchains) call response. **Either connectionId or blockchain must be provided. If both are provided, connectionId will be used. Required if using address parameter.**",
+            "schema": {
+              "example": "ethereum",
+              "type": "string"
+            }
+          },
+          {
+            "name": "blockchain",
+            "required": false,
+            "in": "query",
+            "description": "The blockchain network identifier from [/wallet/blockchains](/openapi/get-blockchains) call response. **Either connectionId or blockchain must be provided. If both are provided, connectionId will be used. Required if using address parameter.**",
+            "schema": {
+              "example": "ethereum",
+              "type": "string"
+            }
+          },
+          {
+            "name": "txId",
+            "required": false,
+            "in": "query",
+            "description": "Transaction hash to search for a specific transaction.",
+            "schema": {
+              "example": "0xc969639a5c08179c32326b5d9e8bb73f34beeb5566b7e7a6a411d38ee4c77ba4",
+              "type": "string"
+            }
+          },
+          {
+            "name": "coinId",
+            "required": false,
+            "in": "query",
+            "description": "Coin ID to search for a specific coin.",
+            "schema": {
+              "example": "bitcoin",
+              "type": "string"
+            }
+          },
+          {
+            "name": "wallets",
+            "required": false,
+            "in": "query",
+            "description": "Comma-separated list of wallet addresses in format \"[connectionId](/openapi/get-blockchains):address\". Use this for querying multiple wallets at once.",
+            "schema": {
+              "example": "ethereum:0x1234567890abcdef1234567890abcdef12345678,all:0x4567890abcdef1234567890abcdef1234567890abc",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Get wallet transactions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TransactionResponseDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 400,
+                  "message": "Bad Request",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 401,
+                  "message": "Unauthorized",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 403,
+                  "message": "Forbidden",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 404,
+                  "message": "Not Found",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Transactions not synced. Please call PATCH /transactions\n\nConflict (for some endpoints)",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 409,
+                  "message": "Transactions not synced",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 429,
+                  "message": "Rate limit exceeded",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Service Unavailable",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 503,
+                  "message": "Service Unavailable. Please Contact Support"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "X-API-KEY": []
+          }
+        ],
+        "summary": "Get transaction data for wallet addresses",
+        "tags": [
+          "Wallet Data"
+        ],
+        "x-mint": {
+          "content": "<Note>**30** credits per request</Note><Accordion title=\"Multipliers\" icon=\"rectangle-history-circle-plus\" ><Note>In **Query** field **\"wallets\"**: credits are multiplied by the number of values.</Note><Note>If the value of **\"wallets\"** in **Query** is **\"all\"**, multiplier is **300** credits.</Note><Info>[**Detailed multipliers explanation**](/multipliers)</Info></Accordion><hr/>\n    <AccordionGroup>\n<Accordion title=\"Single wallet\">\nProvide **address** and **connectionId** separately\n</Accordion>\n<Accordion title=\"Multiple wallets\">\nProvide **wallets** parameter in format \"**connectionId**:*address*,**connectionId**:*address*\"\n</Accordion>\n</AccordionGroup>",
+          "metadata": {
+            "title": "Get Wallet Transactions",
+            "description": "Get transaction data for wallet addresses",
+            "og:title": "Get Wallet Transactions"
+          },
+          "href": "/openapi/get-wallet-transactions"
+        }
+      }
+    },
+    "/wallet/status": {
+      "get": {
+        "operationId": "get-wallet-sync-status",
+        "parameters": [
+          {
+            "name": "address",
+            "required": true,
+            "in": "query",
+            "description": "The blockchain wallet address to query balances for",
+            "schema": {
+              "example": "0x742d35Cc6634C0532925a3b844Bc454e4438f44e",
+              "type": "string"
+            }
+          },
+          {
+            "name": "connectionId",
+            "required": false,
+            "in": "query",
+            "description": "The identifier of connection from [/wallet/blockchains](/openapi/get-blockchains) call response. Either connectionId or blockchain must be provided. If both are provided, connectionId will be used.",
+            "schema": {
+              "example": "base-wallet",
+              "type": "string"
+            }
+          },
+          {
+            "name": "blockchain",
+            "required": false,
+            "in": "query",
+            "description": "The blockchain network identifier from [/wallet/blockchains](/openapi/get-blockchains) call response. Either connectionId or blockchain must be provided. If both are provided, connectionId will be used.",
+            "schema": {
+              "example": "base",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Get wallet sync status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PortfolioSyncStatusResponseDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 400,
+                  "message": "Bad Request",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 401,
+                  "message": "Unauthorized",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 403,
+                  "message": "Forbidden",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 404,
+                  "message": "Not Found",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Transactions not synced. Please call PATCH /transactions\n\nConflict (for some endpoints)",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 409,
+                  "message": "Transactions not synced",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 429,
+                  "message": "Rate limit exceeded",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Service Unavailable",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 503,
+                  "message": "Service Unavailable. Please Contact Support"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "X-API-KEY": []
+          }
+        ],
+        "summary": "Get the syncing status of the provided wallet address with the blockchain network.",
+        "tags": [
+          "Wallet Data"
+        ],
+        "x-mint": {
+          "content": "<Note>**3** credits per request</Note>",
+          "metadata": {
+            "title": "Get Wallet Sync Status",
+            "description": "Get the syncing status of the provided wallet address with the blockchain network.",
+            "og:title": "Get Wallet Sync Status"
+          },
+          "href": "/openapi/get-wallet-sync-status"
+        }
+      }
+    },
+    "/wallet/chart": {
+      "get": {
+        "operationId": "wallet-chart",
+        "parameters": [
+          {
+            "name": "type",
+            "required": true,
+            "in": "query",
+            "description": "One of time periods.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "24h",
+                "1w",
+                "1m",
+                "3m",
+                "6m",
+                "1y",
+                "all"
+              ]
+            }
+          },
+          {
+            "name": "address",
+            "required": true,
+            "in": "query",
+            "description": "The wallet address for which the chart is being queried.",
+            "schema": {
+              "example": "0x1234567890abcdef1234567890abcdef12345678",
+              "type": "string"
+            }
+          },
+          {
+            "name": "connectionId",
+            "required": false,
+            "in": "query",
+            "description": "The identifier of connection from [/wallet/blockchains](/openapi/get-blockchains) call response.  Can be a single network (e.g., \"ethereum\") or a comma-separated list of networks or \"all\" for all connections. ",
+            "schema": {
+              "example": "base-wallet",
+              "type": "string"
+            }
+          },
+          {
+            "name": "blockchain",
+            "required": false,
+            "in": "query",
+            "description": "The blockchain network identifier from [/wallet/blockchains](/openapi/get-blockchains) call response. Either connectionId or blockchain must be provided. If both are provided, connectionId will be used.",
+            "schema": {
+              "example": "base",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Get Chart of Wallet",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WalletChartDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 400,
+                  "message": "Bad Request",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 401,
+                  "message": "Unauthorized",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 403,
+                  "message": "Forbidden",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 404,
+                  "message": "Not Found",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict (for some endpoints)",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 409,
+                  "message": "Transactions not synced",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 429,
+                  "message": "Rate limit exceeded",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Service Unavailable",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 503,
+                  "message": "Service Unavailable. Please Contact Support"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "X-API-KEY": []
+          }
+        ],
+        "summary": "Get wallet chart data for specific time ranges",
+        "tags": [
+          "Wallet Data"
+        ],
+        "x-mint": {
+          "content": "<Note>**40** credits per request</Note><Accordion title=\"Multipliers\" icon=\"rectangle-history-circle-plus\" ><Note>In **Query** field **\"connectionId\"**: credits are multiplied by the number of values.</Note><Note>If the value of **\"connectionId\"** in **Query** is **\"all\"**, multiplier is **400** credits.</Note><Note>In **Query** field **\"blockchain\"**: credits are multiplied by the number of values.</Note><Note>If the value of **\"blockchain\"** in **Query** is **\"all\"**, multiplier is **400** credits.</Note><Warning>Multipliers can be applied multiple times.</Warning><Info>[**Detailed multipliers explanation**](/multipliers)</Info></Accordion>",
+          "metadata": {
+            "title": "Wallet Chart",
+            "description": "Get wallet chart data for specific time ranges",
+            "og:title": "Wallet Chart"
+          },
+          "href": "/openapi/wallet-chart"
+        }
+      }
+    },
+    "/wallet/charts": {
+      "get": {
+        "operationId": "wallet-charts",
+        "parameters": [
+          {
+            "name": "type",
+            "required": true,
+            "in": "query",
+            "description": "One of time periods.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "24h",
+                "1w",
+                "1m",
+                "3m",
+                "6m",
+                "1y",
+                "all"
+              ]
+            }
+          },
+          {
+            "name": "wallets",
+            "required": true,
+            "in": "query",
+            "description": "Comma-separated list of wallet addresses in format \"**connectionId**:address\" or \"**blockchain**:address\".",
+            "schema": {
+              "example": "ethereum:0x1234567890abcdef1234567890abcdef12345678,polygon:0x4567890abcdef1234567890abcdef1234567890abc",
+              "type": "string"
+            }
+          },
+          {
+            "name": "aggregated",
+            "required": false,
+            "in": "query",
+            "description": "Whether to return aggregated data",
+            "schema": {
+              "default": "true",
+              "example": "true",
+              "type": "string",
+              "enum": [
+                "true",
+                "false"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Get Chart data for multiple wallets",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/WalletMultiChartResponseDto"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 400,
+                  "message": "Bad Request",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 401,
+                  "message": "Unauthorized",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 403,
+                  "message": "Forbidden",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 404,
+                  "message": "Not Found",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict (for some endpoints)",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 409,
+                  "message": "Transactions not synced",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 429,
+                  "message": "Rate limit exceeded",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Service Unavailable",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 503,
+                  "message": "Service Unavailable. Please Contact Support"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "X-API-KEY": []
+          }
+        ],
+        "summary": "Get chart data for multiple wallet addresses across various networks.",
+        "tags": [
+          "Wallet Data"
+        ],
+        "x-mint": {
+          "content": "<Note>**40** credits per request</Note><Accordion title=\"Multipliers\" icon=\"rectangle-history-circle-plus\" ><Note>In **Query** field **\"wallets\"**: credits are multiplied by the number of values.</Note><Note>If the value of **\"wallets\"** in **Query** is **\"all\"**, multiplier is **400** credits.</Note><Info>[**Detailed multipliers explanation**](/multipliers)</Info></Accordion><hr/>\n    <AccordionGroup>\n<Accordion title='Aggregate data'>\n- If **aggregated** is **true**, the response will include aggregated data for all wallets.\n- If **aggregated** is **false**, the response will include data for each wallet individually.\n</Accordion>\n\n</AccordionGroup>",
+          "metadata": {
+            "title": "Wallet Charts",
+            "description": "Get chart data for multiple wallet addresses across various networks.",
+            "og:title": "Wallet Charts"
+          },
+          "href": "/openapi/wallet-charts"
+        }
+      }
+    },
+    "/wallet/defi": {
+      "get": {
+        "operationId": "get-wallet-defi",
+        "parameters": [
+          {
+            "name": "address",
+            "required": true,
+            "in": "query",
+            "description": "The wallet address for which the DeFi data is being queried. Must be a valid string representing an EVM-compatible wallet address.",
+            "schema": {
+              "example": "0x1234567890abcdef1234567890abcdef12345678",
+              "type": "string"
+            }
+          },
+          {
+            "name": "connectionId",
+            "required": false,
+            "in": "query",
+            "description": "Specifies the blockchain network connection ID to query for DeFi data. Can be a single network (e.g., \"ethereum\") or comma-separated list of networks (e.g., \"ethereum,polygon-wallet\") or \"all\" for all networks. Either connectionId or blockchain must be provided. If both are provided, connectionId will be used.",
+            "schema": {
+              "example": "base-wallet",
+              "type": "string"
+            }
+          },
+          {
+            "name": "blockchain",
+            "required": false,
+            "in": "query",
+            "description": "The blockchain network identifier from [/wallet/blockchains](/openapi/get-blockchains) call response. Can be a single network (e.g., \"ethereum\") or a comma-separated list of networks (e.g., \"ethereum,polygon,binance_smart\"). Either connectionId or blockchain must be provided. If both are provided, connectionId will be used.",
+            "schema": {
+              "example": "base",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Defi Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DefiResponseDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 400,
+                  "message": "Bad Request",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 401,
+                  "message": "Unauthorized",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 403,
+                  "message": "Forbidden",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 404,
+                  "message": "Not Found",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict (for some endpoints)",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 409,
+                  "message": "Transactions not synced",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 429,
+                  "message": "Rate limit exceeded",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Service Unavailable",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 503,
+                  "message": "Service Unavailable. Please Contact Support"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "X-API-KEY": []
+          }
+        ],
+        "summary": "Retrieve comprehensive DeFi portfolio data, including staking, liquidity pool (LP), and yield farming activities",
+        "tags": [
+          "Wallet Data"
+        ],
+        "x-mint": {
+          "content": "<Warning>This endpoint is only available for OpenApi users with paid subscription.</Warning><Note>**400** credits per request</Note><Accordion title=\"Multipliers\" icon=\"rectangle-history-circle-plus\" ><Note>In **Query** field **\"connectionId\"**: credits are multiplied by the number of values.</Note><Note>If the value of **\"connectionId\"** in **Query** is **\"all\"**, multiplier is **4000** credits.</Note><Info>[**Detailed multipliers explanation**](/multipliers)</Info></Accordion><hr/>\n    <AccordionGroup>\n<Accordion title=\"You will get\">\n- Detailed breakdown of DeFi assets and protocols\n- Track staked tokens, LP positions, and earned rewards\n</Accordion>\n<Accordion title=\"Required\">\n- address and connectionId: For single wallet queries\n</Accordion>\n</AccordionGroup>",
+          "metadata": {
+            "title": "Get Wallet Defi",
+            "description": "Retrieve comprehensive DeFi portfolio data, including staking, liquidity pool (LP), and yield farming activities",
+            "og:title": "Get Wallet Defi"
+          },
+          "href": "/openapi/get-wallet-defi"
+        }
+      }
+    },
+    "/exchange/support": {
+      "get": {
+        "operationId": "get-exchanges",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Get list of exchanges",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/PortfolioExchangeListItemResponseDto"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 400,
+                  "message": "Bad Request",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 401,
+                  "message": "Unauthorized",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 403,
+                  "message": "Forbidden",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 404,
+                  "message": "Not Found",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict (for some endpoints)",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 409,
+                  "message": "Transactions not synced",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 429,
+                  "message": "Rate limit exceeded",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Service Unavailable",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 503,
+                  "message": "Service Unavailable. Please Contact Support"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "X-API-KEY": []
+          }
+        ],
+        "summary": "Get the list of exchange portfolio connections supported by CoinStats.",
+        "tags": [
+          "Exchange Connection"
+        ],
+        "x-mint": {
+          "content": "<Note>**1** credit per request</Note>",
+          "metadata": {
+            "title": "Get Exchanges",
+            "description": "Get the list of exchange portfolio connections supported by CoinStats.",
+            "og:title": "Get Exchanges"
+          },
+          "href": "/openapi/get-exchanges"
+        }
+      }
+    },
+    "/fiats": {
+      "get": {
+        "operationId": "get-fiat-currencies",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Get Fiat Currencies",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/FiatListResponseDto"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 400,
+                  "message": "Bad Request",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 401,
+                  "message": "Unauthorized",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 403,
+                  "message": "Forbidden",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 404,
+                  "message": "Not Found",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict (for some endpoints)",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 409,
+                  "message": "Transactions not synced",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 429,
+                  "message": "Rate limit exceeded",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Service Unavailable",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 503,
+                  "message": "Service Unavailable. Please Contact Support"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "X-API-KEY": []
+          }
+        ],
+        "summary": "Get detailed information about fiat currencies",
+        "tags": [
+          "Market Data"
+        ],
+        "x-mint": {
+          "content": "<Note>**1** credit per request</Note><hr/>\n    <AccordionGroup>\n<Accordion title=\"You will get\">\n- Complete list of supported fiat currencies\n- Current exchange rates\n- Currency symbols and names\n- Associated images/icons\n</Accordion>\n<Accordion title=\"Use this data to\">\n- Convert cryptocurrency values to fiat\n- Display fiat currency information\n- Access currency metadata\n</Accordion>\n</AccordionGroup>",
+          "metadata": {
+            "title": "Get Fiat Currencies",
+            "description": "Get detailed information about fiat currencies",
+            "og:title": "Get Fiat Currencies"
+          },
+          "href": "/openapi/get-fiat-currencies"
+        }
+      }
+    },
+    "/news/sources": {
+      "get": {
+        "operationId": "get-news-sources",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Get news sources",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/NewsSourceResponseItemDto"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 400,
+                  "message": "Bad Request",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 401,
+                  "message": "Unauthorized",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 403,
+                  "message": "Forbidden",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 404,
+                  "message": "Not Found",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict (for some endpoints)",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 409,
+                  "message": "Transactions not synced",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 429,
+                  "message": "Rate limit exceeded",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Service Unavailable",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 503,
+                  "message": "Service Unavailable. Please Contact Support"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "X-API-KEY": []
+          }
+        ],
+        "summary": "Get the list of news sources.",
+        "tags": [
+          "News"
+        ],
+        "x-mint": {
+          "content": "<Note>**2** credits per request</Note>",
+          "metadata": {
+            "title": "Get News Sources",
+            "description": "Get the list of news sources.",
+            "og:title": "Get News Sources"
+          },
+          "href": "/openapi/get-news-sources"
+        }
+      }
+    },
+    "/news": {
+      "get": {
+        "operationId": "get-news",
+        "parameters": [
+          {
+            "name": "page",
+            "required": false,
+            "in": "query",
+            "description": "Page number to retrieve for news (1-based indexing)",
+            "schema": {
+              "example": 1,
+              "type": "number"
+            }
+          },
+          {
+            "name": "limit",
+            "required": false,
+            "in": "query",
+            "description": "Number of news items to return per page",
+            "schema": {
+              "example": 20,
+              "type": "number"
+            }
+          },
+          {
+            "name": "from",
+            "required": false,
+            "in": "query",
+            "description": "Please include the date in ISO 8601 format",
+            "schema": {
+              "format": "date-time",
+              "example": "2026-04-23T08:10:48.234Z",
+              "type": "string"
+            }
+          },
+          {
+            "name": "to",
+            "required": false,
+            "in": "query",
+            "description": "Please include the date in ISO 8601 format",
+            "schema": {
+              "format": "date-time",
+              "example": "2026-04-24T10:10:48.234Z",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Get news list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NewsListResponseDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 400,
+                  "message": "Bad Request",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 401,
+                  "message": "Unauthorized",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 403,
+                  "message": "Forbidden",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 404,
+                  "message": "Not Found",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict (for some endpoints)",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 409,
+                  "message": "Transactions not synced",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 429,
+                  "message": "Rate limit exceeded",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Service Unavailable",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 503,
+                  "message": "Service Unavailable. Please Contact Support"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "X-API-KEY": []
+          }
+        ],
+        "summary": "Get the list of cryptocurrency news articles with pagination.",
+        "tags": [
+          "News"
+        ],
+        "x-mint": {
+          "content": "<Note>**5** credits per request</Note>",
+          "metadata": {
+            "title": "Get News",
+            "description": "Get the list of cryptocurrency news articles with pagination.",
+            "og:title": "Get News"
+          },
+          "href": "/openapi/get-news"
+        }
+      }
+    },
+    "/news/type/{type}": {
+      "get": {
+        "operationId": "get-news-by-type",
+        "parameters": [
+          {
+            "name": "type",
+            "required": true,
+            "in": "path",
+            "description": "The type of news to get",
+            "schema": {
+              "enum": [
+                "handpicked",
+                "trending",
+                "latest",
+                "bullish",
+                "bearish"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "name": "page",
+            "required": false,
+            "in": "query",
+            "description": "Page number to retrieve (1-based indexing)",
+            "schema": {
+              "example": 1,
+              "type": "number"
+            }
+          },
+          {
+            "name": "limit",
+            "required": false,
+            "in": "query",
+            "description": "Number of items to return per page",
+            "schema": {
+              "example": 20,
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Get news list by type",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/NewsFeedResponseItemDto"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 400,
+                  "message": "Bad Request",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 401,
+                  "message": "Unauthorized",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 403,
+                  "message": "Forbidden",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 404,
+                  "message": "Not Found",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict (for some endpoints)",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 409,
+                  "message": "Transactions not synced",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 429,
+                  "message": "Rate limit exceeded",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Service Unavailable",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 503,
+                  "message": "Service Unavailable. Please Contact Support"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "X-API-KEY": []
+          }
+        ],
+        "summary": "Get cryptocurrency news articles based on a specific type.",
+        "tags": [
+          "News"
+        ],
+        "x-mint": {
+          "content": "<Note>**5** credits per request</Note>",
+          "metadata": {
+            "title": "Get News By Type",
+            "description": "Get cryptocurrency news articles based on a specific type.",
+            "og:title": "Get News By Type"
+          },
+          "href": "/openapi/get-news-by-type"
+        }
+      }
+    },
+    "/news/{id}": {
+      "get": {
+        "operationId": "get-news-by-id",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "The id of the news to get",
+            "schema": {
+              "example": "376f390df50a1d44cb5593c9bff6faafabed18ee90e0d4d737d3b6d3eea50c80",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Get news by id",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NewsFeedResponseItemDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 400,
+                  "message": "Bad Request",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 401,
+                  "message": "Unauthorized",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 403,
+                  "message": "Forbidden",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 404,
+                  "message": "Not Found",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict (for some endpoints)",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 409,
+                  "message": "Transactions not synced",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 429,
+                  "message": "Rate limit exceeded",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Service Unavailable",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 503,
+                  "message": "Service Unavailable. Please Contact Support"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "X-API-KEY": []
+          }
+        ],
+        "summary": "Get a news article by id.",
+        "tags": [
+          "News"
+        ],
+        "x-mint": {
+          "content": "<Note>**1** credit per request</Note>",
+          "metadata": {
+            "title": "Get News By Id",
+            "description": "Get a news article by id.",
+            "og:title": "Get News By Id"
+          },
+          "href": "/openapi/get-news-by-id"
+        }
+      }
+    },
+    "/markets": {
+      "get": {
+        "operationId": "get-market-cap",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Get global market cap",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MarketCapResponseDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 400,
+                  "message": "Bad Request",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 401,
+                  "message": "Unauthorized",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 403,
+                  "message": "Forbidden",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 404,
+                  "message": "Not Found",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict (for some endpoints)",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 409,
+                  "message": "Transactions not synced",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 429,
+                  "message": "Rate limit exceeded",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Service Unavailable",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 503,
+                  "message": "Service Unavailable. Please Contact Support"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "X-API-KEY": []
+          }
+        ],
+        "summary": "Get current global cryptocurrency market data",
+        "tags": [
+          "Market Data"
+        ],
+        "x-mint": {
+          "content": "<Note>**1** credit per request</Note><hr/>\n    <AccordionGroup>\n<Accordion title=\"You will get\">\n- Total market capitalization\n- 24h trading volume\n- Bitcoin dominance\n- Market trends and indicators\n</Accordion>\n</AccordionGroup>",
+          "metadata": {
+            "title": "Get Market Cap",
+            "description": "Get current global cryptocurrency market data",
+            "og:title": "Get Market Cap"
+          },
+          "href": "/openapi/get-market-cap"
+        }
+      }
+    },
+    "/insights/btc-dominance": {
+      "get": {
+        "operationId": "btc-dominance",
+        "parameters": [
+          {
+            "name": "type",
+            "required": true,
+            "in": "query",
+            "description": "Time period for the data",
+            "schema": {
+              "enum": [
+                "24h",
+                "1w",
+                "1m",
+                "3m",
+                "6m",
+                "1y",
+                "all"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BtcDominanceDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 400,
+                  "message": "Bad Request",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 401,
+                  "message": "Unauthorized",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 403,
+                  "message": "Forbidden",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 404,
+                  "message": "Not Found",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict (for some endpoints)",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 409,
+                  "message": "Transactions not synced",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 429,
+                  "message": "Rate limit exceeded",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Service Unavailable",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 503,
+                  "message": "Service Unavailable. Please Contact Support"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "X-API-KEY": []
+          }
+        ],
+        "summary": "Get Bitcoin market dominance data showing BTC's percentage share of the total cryptocurrency market capitalization over a specified time period",
+        "tags": [
+          "Market Insights"
+        ],
+        "x-mint": {
+          "content": "<Note>**10** credits per request</Note><hr/>\n    <AccordionGroup>\n<Accordion title=\"Details\">\n- Supports multiple time frames: 24 hours, 1 week, 1 month, 3 months, 6 months, 1 year, or all available data.\n- Data is returned as pairs of [timestamp, percentage] values.\n- Useful for analyzing market trends and Bitcoin's relative strength in the overall crypto ecosystem.\n</Accordion>\n</AccordionGroup>",
+          "metadata": {
+            "title": "Btc Dominance",
+            "description": "Get Bitcoin market dominance data showing BTC's percentage share of the total cryptocurrency market capitalization over a specified time period",
+            "og:title": "Btc Dominance"
+          },
+          "href": "/openapi/btc-dominance"
+        }
+      }
+    },
+    "/insights/fear-and-greed": {
+      "get": {
+        "operationId": "fear-and-greed",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FearAndGreedDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 400,
+                  "message": "Bad Request",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 401,
+                  "message": "Unauthorized",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 403,
+                  "message": "Forbidden",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 404,
+                  "message": "Not Found",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict (for some endpoints)",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 409,
+                  "message": "Transactions not synced",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 429,
+                  "message": "Rate limit exceeded",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Service Unavailable",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 503,
+                  "message": "Service Unavailable. Please Contact Support"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "X-API-KEY": []
+          }
+        ],
+        "summary": "Get the Crypto Fear & Greed Index",
+        "tags": [
+          "Market Insights"
+        ],
+        "x-mint": {
+          "content": "<Note>**10** credits per request</Note><hr/>\n    <AccordionGroup>\n<Accordion title=\"You will get\">\n- Crypto Fear & Greed Index which measures market sentiment from 0 (Extreme Fear) to 100 (Extreme Greed).\n- This indicator aggregates multiple factors including volatility, market momentum, social media, and surveys to gauge investor emotional state.\n- Helps identify potential market tops (greed) and bottoms (fear).\n</Accordion>\n</AccordionGroup>",
+          "metadata": {
+            "title": "Fear And Greed",
+            "description": "Get the Crypto Fear & Greed Index",
+            "og:title": "Fear And Greed"
+          },
+          "href": "/openapi/fear-and-greed"
+        }
+      }
+    },
+    "/insights/fear-and-greed/chart": {
+      "get": {
+        "operationId": "fear-and-greed-chart",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FearAndGreedChartDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 400,
+                  "message": "Bad Request",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 401,
+                  "message": "Unauthorized",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 403,
+                  "message": "Forbidden",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 404,
+                  "message": "Not Found",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict (for some endpoints)",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 409,
+                  "message": "Transactions not synced",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 429,
+                  "message": "Rate limit exceeded",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Service Unavailable",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 503,
+                  "message": "Service Unavailable. Please Contact Support"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "X-API-KEY": []
+          }
+        ],
+        "summary": "Get historical data for the Crypto Fear & Greed Index",
+        "tags": [
+          "Market Insights"
+        ],
+        "x-mint": {
+          "content": "<Note>**10** credits per request</Note><hr/>\n    <AccordionGroup>\n<Accordion title=\"You will get\">\n- Daily values over time with timestamps, numerical values (0-100), and classifications (Extreme Fear, Fear, Neutral, Greed, Extreme Greed).\n- This historical view helps track market sentiment trends and identify potential correlation with price movements.\n</Accordion>\n</AccordionGroup>",
+          "metadata": {
+            "title": "Fear And Greed Chart",
+            "description": "Get historical data for the Crypto Fear & Greed Index",
+            "og:title": "Fear And Greed Chart"
+          },
+          "href": "/openapi/fear-and-greed-chart"
+        }
+      }
+    },
+    "/insights/rainbow-chart/{coinId}": {
+      "get": {
+        "operationId": "rainbow-chart",
+        "parameters": [
+          {
+            "name": "coinId",
+            "required": true,
+            "in": "path",
+            "description": "CoinId of the coin to return",
+            "schema": {
+              "enum": [
+                "bitcoin",
+                "ethereum"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/RainbowChartItemDto"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 400,
+                  "message": "Bad Request",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 401,
+                  "message": "Unauthorized",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 403,
+                  "message": "Forbidden",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 404,
+                  "message": "Not Found",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict (for some endpoints)",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 409,
+                  "message": "Transactions not synced",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 429,
+                  "message": "Rate limit exceeded",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Service Unavailable",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 503,
+                  "message": "Service Unavailable. Please Contact Support"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "X-API-KEY": []
+          }
+        ],
+        "summary": "Get Rainbow Chart data",
+        "tags": [
+          "Market Insights"
+        ],
+        "x-mint": {
+          "content": "<Note>**10** credits per request</Note><hr/>\n    <AccordionGroup>\n<Accordion title=\"You will get\">\n- Bitcoin or Ethereum based on the 'coinId' parameter.\n- The Rainbow Chart shows historical price data over time, which can be visualized with color bands representing different market sentiment zones.\n- An array of data points with price and time values.\n</Accordion>\n</AccordionGroup>",
+          "metadata": {
+            "title": "Rainbow Chart",
+            "description": "Get Rainbow Chart data",
+            "og:title": "Rainbow Chart"
+          },
+          "href": "/openapi/rainbow-chart"
+        }
+      }
+    },
+    "/portfolio/value": {
+      "get": {
+        "operationId": "get-portfolio-value",
+        "parameters": [
+          {
+            "name": "sharetoken",
+            "required": false,
+            "in": "header",
+            "description": "[Get Share Token](/sharetoken)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "passcode",
+            "required": false,
+            "in": "header",
+            "description": "Passcode for accessing protected portfolio data",
+            "schema": {
+              "example": "123456",
+              "type": "string"
+            }
+          },
+          {
+            "name": "currency",
+            "required": false,
+            "in": "query",
+            "description": "Currency for price values. Default is USD.",
+            "schema": {
+              "default": "USD",
+              "example": "USD",
+              "type": "string"
+            }
+          },
+          {
+            "name": "portfolioId",
+            "required": false,
+            "in": "query",
+            "description": "Portfolio ID for accessing a specific API-connected portfolio. Required if shareToken is not provided.",
+            "schema": {
+              "example": "abc123def456",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Portfolio profit/loss",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PortfolioValueResponseDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 400,
+                  "message": "Bad Request",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 401,
+                  "message": "Unauthorized",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 403,
+                  "message": "Forbidden",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 404,
+                  "message": "Not Found",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict (for some endpoints)",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 409,
+                  "message": "Transactions not synced",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 429,
+                  "message": "Rate limit exceeded",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Service Unavailable",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 503,
+                  "message": "Service Unavailable. Please Contact Support"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "X-API-KEY": []
+          }
+        ],
+        "summary": "Get detailed information about portfolio profit/loss",
+        "tags": [
+          "User Portfolio"
+        ],
+        "x-mint": {
+          "content": "<Note>**10** credits per request</Note><hr/>\n    <AccordionGroup>\n<Accordion title=\"You will get\">\n- Total value of portfolio\n- Defi value of portfolio\n- Total cost of portfolio\n- Unrealized profit/loss\n- Realized profit/loss\n- All time profit/loss\n</Accordion>\n<Accordion title=\"Required\">\n<Note>This endpoint is only available for users with a Degen plan subscription (when using shareToken).</Note>\n- shareToken OR portfolioId: Provide one of these to identify the portfolio.\n  - shareToken: Get this from your CoinStats portfolio page by clicking \"Share\"\n  - portfolioId: Use a portfolio connected via POST /portfolio/wallet or POST /portfolio/exchange\n- If neither is provided, returns aggregated data for all API-connected portfolios\n</Accordion>\n<Accordion title=\"Optional\">\n- currency: Specify the currency for price values, default is USD\n- passcode: Passcode for accessing protected portfolio data (can be passed in header or query parameter)\n</Accordion>\n</AccordionGroup>",
+          "metadata": {
+            "title": "Get Portfolio Value",
+            "description": "Get detailed information about portfolio profit/loss",
+            "og:title": "Get Portfolio Value"
+          },
+          "href": "/openapi/get-portfolio-value"
+        }
+      }
+    },
+    "/portfolio/coins": {
+      "get": {
+        "operationId": "get-portfolio-coins",
+        "parameters": [
+          {
+            "name": "sharetoken",
+            "required": false,
+            "in": "header",
+            "description": "[Get Share Token](/sharetoken)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "passcode",
+            "required": false,
+            "in": "header",
+            "description": "Passcode for accessing protected portfolio data",
+            "schema": {
+              "example": "123456",
+              "type": "string"
+            }
+          },
+          {
+            "name": "page",
+            "required": false,
+            "in": "query",
+            "description": "Page number to retrieve (1-based indexing)",
+            "schema": {
+              "example": 1,
+              "type": "number"
+            }
+          },
+          {
+            "name": "limit",
+            "required": false,
+            "in": "query",
+            "description": "Number of items to return per page",
+            "schema": {
+              "example": 20,
+              "type": "number"
+            }
+          },
+          {
+            "name": "includeRiskScore",
+            "required": false,
+            "in": "query",
+            "description": "Include Risk Score Information",
+            "schema": {
+              "default": "false",
+              "example": "true",
+              "type": "string",
+              "enum": [
+                "true",
+                "false"
+              ]
+            }
+          },
+          {
+            "name": "portfolioId",
+            "required": false,
+            "in": "query",
+            "description": "Portfolio ID for accessing a specific API-connected portfolio. Required if shareToken is not provided.",
+            "schema": {
+              "example": "abc123def456",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Portfolio coins",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PortfolioItemResponseDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 400,
+                  "message": "Bad Request",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 401,
+                  "message": "Unauthorized",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 403,
+                  "message": "Forbidden",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 404,
+                  "message": "Not Found",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict (for some endpoints)",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 409,
+                  "message": "Transactions not synced",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 429,
+                  "message": "Rate limit exceeded",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Service Unavailable",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 503,
+                  "message": "Service Unavailable. Please Contact Support"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "X-API-KEY": []
+          }
+        ],
+        "summary": "Get detailed information about all coins in your portfolio",
+        "tags": [
+          "User Portfolio"
+        ],
+        "x-mint": {
+          "content": "<Note>**8** credits per request</Note><hr/>\n    <AccordionGroup>\n<Accordion title=\"You will get\">\n- Current holdings and their USD value\n- Profit/Loss (PnL) information\n- Performance metrics and statistics\n- Risk assessment scores (optional)\n</Accordion>\n<Accordion title=\"Required\">\n<Note>This endpoint is only available for users with a Degen plan subscription (when using shareToken).</Note>\n- shareToken OR portfolioId: Provide one of these to identify the portfolio.\n  - shareToken: Get this from your CoinStats portfolio page by clicking \"Share\"\n  - portfolioId: Use a portfolio connected via POST /portfolio/wallet or POST /portfolio/exchange\n- If neither is provided, returns aggregated coins from all API-connected portfolios\n</Accordion>\n<Accordion title=\"Optional\">\n- page & limit: Control the number of results per page\n- includeRiskScore: Set to \"true\" to include risk metrics\n- passcode: Passcode for accessing protected portfolio data (can be passed in header or query parameter)\n</Accordion>\n</AccordionGroup>",
+          "metadata": {
+            "title": "Get Portfolio Coins",
+            "description": "Get detailed information about all coins in your portfolio",
+            "og:title": "Get Portfolio Coins"
+          },
+          "href": "/openapi/get-portfolio-coins"
+        }
+      }
+    },
+    "/portfolio/chart": {
+      "get": {
+        "operationId": "get-portfolio-chart",
+        "parameters": [
+          {
+            "name": "sharetoken",
+            "required": false,
+            "in": "header",
+            "description": "[Get Share Token](/sharetoken)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "passcode",
+            "required": false,
+            "in": "header",
+            "description": "Passcode for accessing protected portfolio data",
+            "schema": {
+              "example": "123456",
+              "type": "string"
+            }
+          },
+          {
+            "name": "type",
+            "required": true,
+            "in": "query",
+            "description": "One of time periods.",
+            "schema": {
+              "example": "24h",
+              "type": "string",
+              "enum": [
+                "24h",
+                "1w",
+                "1m",
+                "3m",
+                "6m",
+                "1y",
+                "all"
+              ]
+            }
+          },
+          {
+            "name": "portfolioId",
+            "required": false,
+            "in": "query",
+            "description": "Portfolio ID for accessing a specific API-connected portfolio. Required if shareToken is not provided.",
+            "schema": {
+              "example": "abc123def456",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Portfolio Chart",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PortfolioChartResponseDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 400,
+                  "message": "Bad Request",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 401,
+                  "message": "Unauthorized",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 403,
+                  "message": "Forbidden",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 404,
+                  "message": "Not Found",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict (for some endpoints)",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 409,
+                  "message": "Transactions not synced",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 429,
+                  "message": "Rate limit exceeded",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Service Unavailable",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 503,
+                  "message": "Service Unavailable. Please Contact Support"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "X-API-KEY": []
+          }
+        ],
+        "summary": "Get historical performance data to visualize your portfolio's growth over time",
+        "tags": [
+          "User Portfolio"
+        ],
+        "x-mint": {
+          "content": "<Note>**10** credits per request</Note><hr/>\n    <AccordionGroup>\n<Accordion title=\"You will get\">\n- Total portfolio value at different time points\n- Performance metrics for various time ranges\n- Historical Profit/Loss (PnL) data\n</Accordion>\n<Accordion title=\"Required\">\n<Note>This endpoint is only available for users with a Degen plan subscription (when using shareToken).</Note>\n- shareToken OR portfolioId: Provide one of these to identify the portfolio.\n  - shareToken: Get this from your CoinStats portfolio page by clicking \"Share\"\n  - portfolioId: Use a portfolio connected via POST /portfolio/wallet or POST /portfolio/exchange\n- If neither is provided, returns aggregated chart for all API-connected portfolios\n- type: Specify the time range for the chart data (e.g., \"24h\", \"1w\", \"1m\", \"1y\")\n</Accordion>\n<Accordion title=\"Optional\">\n- passcode: Passcode for accessing protected portfolio data (can be passed in header or query parameter)\n</Accordion>\n</AccordionGroup>",
+          "metadata": {
+            "title": "Get Portfolio Chart",
+            "description": "Get historical performance data to visualize your portfolio's growth over time",
+            "og:title": "Get Portfolio Chart"
+          },
+          "href": "/openapi/get-portfolio-chart"
+        }
+      }
+    },
+    "/portfolio/transactions": {
+      "get": {
+        "operationId": "get-portfolio-transactions",
+        "parameters": [
+          {
+            "name": "sharetoken",
+            "required": false,
+            "in": "header",
+            "description": "[Get Share Token](/sharetoken)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "passcode",
+            "required": false,
+            "in": "header",
+            "description": "Passcode for accessing protected portfolio data",
+            "schema": {
+              "example": "123456",
+              "type": "string"
+            }
+          },
+          {
+            "name": "page",
+            "required": false,
+            "in": "query",
+            "description": "Page number to retrieve (1-based indexing)",
+            "schema": {
+              "example": 1,
+              "type": "number"
+            }
+          },
+          {
+            "name": "limit",
+            "required": false,
+            "in": "query",
+            "description": "Number of items to return per page",
+            "schema": {
+              "example": 20,
+              "type": "number"
+            }
+          },
+          {
+            "name": "currency",
+            "required": true,
+            "in": "query",
+            "description": "The fiat currency to return values in",
+            "schema": {
+              "example": "USD",
+              "type": "string"
+            }
+          },
+          {
+            "name": "coinId",
+            "required": false,
+            "in": "query",
+            "description": "Coin ID to filter transactions for a specific coin",
+            "schema": {
+              "example": "bitcoin",
+              "type": "string"
+            }
+          },
+          {
+            "name": "portfolioId",
+            "required": false,
+            "in": "query",
+            "description": "Portfolio ID for accessing a specific API-connected portfolio. Required if shareToken is not provided.",
+            "schema": {
+              "example": "abc123def456",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Transactions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TransactionItemResponseDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 400,
+                  "message": "Bad Request",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 401,
+                  "message": "Unauthorized",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 403,
+                  "message": "Forbidden",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 404,
+                  "message": "Not Found",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict (for some endpoints)",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 409,
+                  "message": "Transactions not synced",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 429,
+                  "message": "Rate limit exceeded",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Service Unavailable",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 503,
+                  "message": "Service Unavailable. Please Contact Support"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "X-API-KEY": []
+          }
+        ],
+        "summary": "Get a detailed history of all transactions in your portfolio",
+        "tags": [
+          "User Portfolio"
+        ],
+        "x-mint": {
+          "content": "<Note>**4** credits per request</Note><hr/>\n    <AccordionGroup>\n<Accordion title=\"You will get\">\n- Complete list of buy/sell operations\n- Transaction dates and amounts\n- Price information at time of transaction\n- Supports pagination for viewing large transaction sets\n</Accordion>\n<Accordion title=\"Required\">\n<Note>This endpoint is only available for users with a Degen plan subscription (when using shareToken).</Note>\n- shareToken OR portfolioId: Provide one of these to identify the portfolio.\n  - shareToken: Get this from your CoinStats portfolio page by clicking \"Share\"\n  - portfolioId: Use a portfolio connected via POST /portfolio/wallet or POST /portfolio/exchange\n- If neither is provided, returns transactions from all API-connected portfolios\n- currency: Specify the currency for price values\n</Accordion>\n<Accordion title=\"Optional\">\n- page & limit: Control the number of transactions per page\n- from & to: Filter transactions by date range\n- passcode: Passcode for accessing protected portfolio data (can be passed in header or query parameter)\n</Accordion>\n\n</AccordionGroup>",
+          "metadata": {
+            "title": "Get Portfolio Transactions",
+            "description": "Get a detailed history of all transactions in your portfolio",
+            "og:title": "Get Portfolio Transactions"
+          },
+          "href": "/openapi/get-portfolio-transactions"
+        }
+      }
+    },
+    "/portfolio/defi": {
+      "get": {
+        "operationId": "get-portfolio-defi",
+        "parameters": [
+          {
+            "name": "sharetoken",
+            "required": false,
+            "in": "header",
+            "description": "[Get Share Token](/sharetoken)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "passcode",
+            "required": false,
+            "in": "header",
+            "description": "Passcode for accessing protected portfolio data",
+            "schema": {
+              "example": "123456",
+              "type": "string"
+            }
+          },
+          {
+            "name": "portfolioId",
+            "required": false,
+            "in": "query",
+            "description": "Portfolio ID for accessing a specific API-connected portfolio. Required if shareToken is not provided.",
+            "schema": {
+              "example": "abc123def456",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Defi Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DefiResponseDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 400,
+                  "message": "Bad Request",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 401,
+                  "message": "Unauthorized",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 403,
+                  "message": "Forbidden",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 404,
+                  "message": "Not Found",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict (for some endpoints)",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 409,
+                  "message": "Transactions not synced",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 429,
+                  "message": "Rate limit exceeded",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Service Unavailable",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 503,
+                  "message": "Service Unavailable. Please Contact Support"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "X-API-KEY": []
+          }
+        ],
+        "summary": "Retrieve comprehensive DeFi portfolio data, including staking, liquidity pool (LP), and yield farming activities",
+        "tags": [
+          "User Portfolio"
+        ],
+        "x-mint": {
+          "content": "<Note>**400** credits per request</Note><hr/>\n    <AccordionGroup>\n<Accordion title=\"You will get\">\n- Detailed breakdown of DeFi assets and protocols\n- Track staked tokens, LP positions, and earned rewards\n</Accordion>\n<Accordion title=\"Required\">\n<Note>This endpoint is only available for users with a Degen plan subscription (when using shareToken).</Note>\n- shareToken OR portfolioId: Provide one of these to identify the portfolio.\n  - shareToken: [Get Share Token](/sharetoken)\n  - portfolioId: Use a portfolio connected via POST /portfolio/wallet\n- If neither is provided, returns DeFi data for all API-connected portfolios\n</Accordion>\n<Accordion title=\"Optional\">\n- passcode: Passcode for accessing protected portfolio data (can be passed in header or query parameter)\n</Accordion>\n</AccordionGroup>",
+          "metadata": {
+            "title": "Get Portfolio Defi",
+            "description": "Retrieve comprehensive DeFi portfolio data, including staking, liquidity pool (LP), and yield farming activities",
+            "og:title": "Get Portfolio Defi"
+          },
+          "href": "/openapi/get-portfolio-defi"
+        }
+      }
+    },
+    "/portfolio/snapshot/items": {
+      "get": {
+        "operationId": "get-portfolio-snapshot-items",
+        "parameters": [
+          {
+            "name": "sharetoken",
+            "required": false,
+            "in": "header",
+            "description": "[Get Share Token](/sharetoken)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "passcode",
+            "required": false,
+            "in": "header",
+            "description": "Passcode for accessing protected portfolio data",
+            "schema": {
+              "example": "123456",
+              "type": "string"
+            }
+          },
+          {
+            "name": "page",
+            "required": false,
+            "in": "query",
+            "description": "Page number to retrieve (1-based indexing)",
+            "schema": {
+              "example": 1,
+              "type": "number"
+            }
+          },
+          {
+            "name": "limit",
+            "required": false,
+            "in": "query",
+            "description": "Number of items to return per page",
+            "schema": {
+              "example": 20,
+              "type": "number"
+            }
+          },
+          {
+            "name": "portfolioId",
+            "required": false,
+            "in": "query",
+            "description": "Portfolio ID for accessing a specific API-connected portfolio. Required if shareToken is not provided.",
+            "schema": {
+              "example": "abc123def456",
+              "type": "string"
+            }
+          },
+          {
+            "name": "from",
+            "required": false,
+            "in": "query",
+            "description": "Start date for snapshot data (YYYY-MM-DD format)",
+            "schema": {
+              "example": "2024-01-01",
+              "type": "string"
+            }
+          },
+          {
+            "name": "to",
+            "required": false,
+            "in": "query",
+            "description": "End date for snapshot data (YYYY-MM-DD format)",
+            "schema": {
+              "example": "2024-12-31",
+              "type": "string"
+            }
+          },
+          {
+            "name": "coinIds",
+            "required": false,
+            "in": "query",
+            "description": "Comma-separated list of coin IDs to filter by",
+            "schema": {
+              "example": "bitcoin,ethereum,cardano",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Portfolio Snapshot Items",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PortfolioSnapshotResponseDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 400,
+                  "message": "Bad Request",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 401,
+                  "message": "Unauthorized",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 403,
+                  "message": "Forbidden",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 404,
+                  "message": "Not Found",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict (for some endpoints)",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 409,
+                  "message": "Transactions not synced",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 429,
+                  "message": "Rate limit exceeded",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Service Unavailable",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 503,
+                  "message": "Service Unavailable. Please Contact Support"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "X-API-KEY": []
+          }
+        ],
+        "summary": "Get historical portfolio snapshot data with normalized coin balances and portfolio metrics",
+        "tags": [
+          "User Portfolio"
+        ],
+        "x-mint": {
+          "content": "<Note>**500** credits per request</Note><hr/>\n    <AccordionGroup>\n<Accordion title=\"You will get\">\n- Historical coin quantities and balances over time\n- Total portfolio balance tracking with changes\n- Price changes and quantity changes between snapshots\n- Filterable by date range and specific coins\n</Accordion>\n<Accordion title=\"Required\">\n<Note>This endpoint is only available for users with a Degen plan subscription (when using shareToken).</Note>\n- shareToken OR portfolioId: Provide one of these to identify the portfolio.\n  - shareToken: Get this from your CoinStats portfolio page by clicking \"Share\"\n  - portfolioId: Use a portfolio connected via POST /portfolio/wallet or POST /portfolio/exchange\n- If neither is provided, returns snapshot data for all API-connected portfolios\n</Accordion>\n<Accordion title=\"Optional\">\n- from & to: Date range filter (YYYY-MM-DD format)\n- coinIds: Comma-separated list of coin IDs to filter by\n- page & limit: Pagination controls\n- passcode: Passcode for accessing protected portfolio data (can be passed in header or query parameter)\n</Accordion>\n</AccordionGroup>",
+          "metadata": {
+            "title": "Get Portfolio Snapshot Items",
+            "description": "Get historical portfolio snapshot data with normalized coin balances and portfolio metrics",
+            "og:title": "Get Portfolio Snapshot Items"
+          },
+          "href": "/openapi/get-portfolio-snapshot-items"
+        }
+      }
+    },
+    "/currencies": {
+      "get": {
+        "operationId": "get-currencies",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Get currencies list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CurrenciesListResponseDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 400,
+                  "message": "Bad Request",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 401,
+                  "message": "Unauthorized",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 403,
+                  "message": "Forbidden",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 404,
+                  "message": "Not Found",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict (for some endpoints)",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 409,
+                  "message": "Transactions not synced",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 429,
+                  "message": "Rate limit exceeded",
+                  "requestId": "11111111-2222-3333-4444-555555555555",
+                  "path": "<requested-endpoint>"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Service Unavailable",
+            "content": {
+              "application/json": {
+                "example": {
+                  "statusCode": 503,
+                  "message": "Service Unavailable. Please Contact Support"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "X-API-KEY": []
+          }
+        ],
+        "summary": "Get the complete list of supported fiat currencies",
+        "tags": [
+          "Market Data"
+        ],
+        "x-mint": {
+          "content": "<Note>**1** credit per request</Note><hr/>\n    <AccordionGroup>\n<Accordion title=\"You will get\">\n- All supported fiat currencies\n- Currency codes and exchange rates\n</Accordion>\n<Accordion title=\"Use this data\">\n- To Convert cryptocurrency values to fiat\n- To Display fiat currency information\n- In other API endpoints\n</Accordion>\n\n</AccordionGroup>",
+          "metadata": {
+            "title": "Get Currencies",
+            "description": "Get the complete list of supported fiat currencies",
+            "og:title": "Get Currencies"
+          },
+          "href": "/openapi/get-currencies"
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "TransactionItemResponseDto": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "description": "Array of transaction items",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TransactionItemDto"
+            }
+          },
+          "meta": {
+            "description": "Pagination metadata",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PageMetaSimpleDto"
+              }
+            ]
+          }
+        },
+        "required": [
+          "data",
+          "meta"
+        ]
+      },
+      "ExchangeCollectionEntity": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique identifier of the exchange",
+            "example": "binance"
+          },
+          "name": {
+            "type": "string",
+            "description": "Display name of the exchange",
+            "example": "Binance"
+          },
+          "icon": {
+            "type": "string",
+            "description": "URL to the exchange logo image",
+            "example": "https://static.coinstats.app/exchanges/binance.png"
+          },
+          "rank": {
+            "type": "number",
+            "description": "Exchange rank based on trading volume",
+            "example": 1
+          },
+          "change24h": {
+            "type": "number",
+            "description": "Percentage change in trading volume over the last 24 hours",
+            "example": 5.25
+          },
+          "url": {
+            "type": "string",
+            "description": "Official website URL of the exchange",
+            "example": "https://www.binance.com"
+          },
+          "volume24h": {
+            "type": "number",
+            "description": "Total trading volume in USD over the last 24 hours",
+            "example": 12500000000
+          },
+          "volume7d": {
+            "type": "number",
+            "description": "Total trading volume in USD over the last 7 days",
+            "example": 85000000000
+          },
+          "volume1m": {
+            "type": "number",
+            "description": "Total trading volume in USD over the last 30 days",
+            "example": 350000000000
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "rank",
+          "change24h",
+          "volume24h",
+          "volume7d"
+        ]
+      },
+      "NewsSourceResponseItemDto": {
+        "type": "object",
+        "properties": {
+          "sourcename": {
+            "type": "string",
+            "description": "The name of the news source",
+            "example": "Zycrypto"
+          },
+          "coinid": {
+            "type": "string",
+            "description": "Associated coin identifier (if the news source is coin-specific)",
+            "example": "bitcoin"
+          },
+          "logo": {
+            "type": "string",
+            "description": "Filename of the news source logo image",
+            "example": "zycrypto.png"
+          },
+          "sourceImg": {
+            "type": "string",
+            "description": "Full URL to the news source image/logo",
+            "example": "https://static.coinstats.app/news/source/zycrypto_source.png"
+          },
+          "weburl": {
+            "type": "string",
+            "description": "Main website URL of the news source",
+            "example": "https://zycrypto.com"
+          },
+          "feedurl": {
+            "type": "string",
+            "description": "RSS feed URL for the news source",
+            "example": "https://zycrypto.com/feed/"
+          },
+          "_created_at": {
+            "format": "date-time",
+            "type": "string",
+            "description": "Date when the news source was created in the system",
+            "example": "2018-04-25T13:06:47.850Z"
+          },
+          "_updated_at": {
+            "format": "date-time",
+            "type": "string",
+            "description": "Date when the news source was last updated",
+            "example": "2025-03-21T13:11:07.112Z"
+          }
+        },
+        "required": [
+          "sourcename",
+          "weburl",
+          "feedurl",
+          "_created_at"
+        ]
+      },
+      "FearAndGreedChartDto": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Name of the index",
+            "example": "Fear and Greed Index"
+          },
+          "data": {
+            "description": "Array of fear and greed data points",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FearAndGreedDataPointDto"
+            }
+          }
+        },
+        "required": [
+          "name",
+          "data"
+        ]
+      },
+      "CoinListResponseDto": {
+        "type": "object",
+        "properties": {
+          "meta": {
+            "description": "Pagination metadata including page info and totals",
+            "example": {
+              "page": 1,
+              "limit": 20,
+              "itemCount": 150,
+              "pageCount": 8,
+              "hasPreviousPage": false,
+              "hasNextPage": true
+            },
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PageMetaDto"
+              }
+            ]
+          },
+          "result": {
+            "description": "Array of coin data items for the current page",
+            "example": [
+              {
+                "id": "ethereum",
+                "icon": "https://static.coinstats.app/coins/ethereum_32.png",
+                "name": "Ethereum",
+                "symbol": "ETH",
+                "rank": 2,
+                "price": 2680.45,
+                "priceBtc": 0.062,
+                "volume": 8520000000,
+                "marketCap": 322100000000,
+                "availableSupply": 120280000,
+                "totalSupply": 120280000,
+                "fullyDilutedValuation": 322100000000,
+                "priceChange1h": -0.25,
+                "priceChange1d": 1.85,
+                "priceChange1w": 3.42,
+                "priceChange1m": 7.21,
+                "websiteUrl": "https://ethereum.org",
+                "redditUrl": "https://reddit.com/r/ethereum",
+                "twitterUrl": "https://twitter.com/ethereum",
+                "contractAddress": null,
+                "contractAddresses": [],
+                "decimals": 18,
+                "explorers": [
+                  "https://etherscan.io"
+                ],
+                "liquidityScore": 88.7,
+                "volatilityScore": 38.9,
+                "marketCapScore": 92.1,
+                "riskScore": 18.5,
+                "avgChange": 2.14
+              }
+            ],
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CoinListResponseItemDto"
+            }
+          }
+        },
+        "required": [
+          "meta",
+          "result"
+        ]
+      },
+      "PortfolioValueResponseDto": {
+        "type": "object",
+        "properties": {
+          "totalValue": {
+            "type": "number",
+            "description": "Total value of portfolio",
+            "example": 12500.75
+          },
+          "defiValue": {
+            "type": "number",
+            "description": "DeFi value of portfolio",
+            "example": 2500.25
+          },
+          "totalCost": {
+            "type": "number",
+            "description": "Total cost of portfolio",
+            "example": 10000.5
+          },
+          "unrealizedProfitLoss": {
+            "type": "number",
+            "description": "Unrealized profit/loss",
+            "example": 1250.75
+          },
+          "unrealizedProfitLossPercent": {
+            "type": "number",
+            "description": "Unrealized profit/loss percentage",
+            "example": 12.5
+          },
+          "realizedProfitLoss": {
+            "type": "number",
+            "description": "Realized profit/loss",
+            "example": 500.25
+          },
+          "realizedProfitLossPercent": {
+            "type": "number",
+            "description": "Realized profit/loss percentage",
+            "example": 5
+          },
+          "allTimeProfitLoss": {
+            "type": "number",
+            "description": "All Time profit/loss",
+            "example": 1751
+          },
+          "allTimeProfitLossPercent": {
+            "type": "number",
+            "description": "All Time profit/loss percentage",
+            "example": 17.5
+          }
+        },
+        "required": [
+          "unrealizedProfitLossPercent",
+          "realizedProfitLossPercent",
+          "allTimeProfitLossPercent"
+        ]
+      },
+      "TransactionResponseDto": {
+        "type": "object",
+        "properties": {
+          "meta": {
+            "description": "Pagination metadata including total count and current page information",
+            "example": {
+              "page": 1,
+              "limit": 10
+            },
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PageMetaSimpleDto"
+              }
+            ]
+          },
+          "result": {
+            "description": "Array of transaction records",
+            "example": [
+              {
+                "type": "Sent",
+                "date": "2025-06-07T11:58:11.000Z",
+                "mainContent": {
+                  "coinIcons": [
+                    "https://static.coinstats.app/coins/1650455629727.png"
+                  ],
+                  "coinAssets": []
+                },
+                "coinData": {
+                  "count": -0.00636637,
+                  "symbol": "ETH",
+                  "currentValue": 29.21596436513665
+                },
+                "profitLoss": {
+                  "profit": -13.414468590167441,
+                  "profitPercent": -84.44241338814263,
+                  "currentValue": 29.21596436513665
+                },
+                "transactions": [
+                  {
+                    "action": "Sent",
+                    "items": [
+                      {
+                        "id": "publicApi_0_0x3f1A9B2c5E4C7d9F8E23bC19A8A6c77B10e62E5dGROUP436a0bddwithdraw",
+                        "count": -0.00636637,
+                        "totalWorth": 15.88593699768782,
+                        "coin": {
+                          "id": "ethereum",
+                          "name": "Ethereum",
+                          "symbol": "ETH",
+                          "icon": "https://static.coinstats.app/coins/1650455629727.png"
+                        }
+                      }
+                    ]
+                  }
+                ],
+                "fee": {
+                  "coin": {
+                    "id": "ethereum",
+                    "name": "Ethereum",
+                    "symbol": "ETH",
+                    "icon": "https://static.coinstats.app/coins/1650455629727.png"
+                  },
+                  "count": 3.3840249219e-05,
+                  "totalWorth": 0.08444122271861178
+                },
+                "hash": {
+                  "id": "0xc969639a5c08179c32326b5d9e8bb73f34beeb5566b7e7a6a411d38ee4c77ba4",
+                  "explorerUrl": "https://etherscan.io/tx/0xc969639a5c08179c32326b5d9e8bb73f34beeb5566b7e7a6a411d38ee4c77ba4"
+                }
+              }
+            ],
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TransactionDto"
+            }
+          }
+        },
+        "required": [
+          "meta",
+          "result"
+        ]
+      },
+      "WalletChartDto": {
+        "type": "object",
+        "properties": {
+          "result": {
+            "type": "array",
+            "items": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              }
+            },
+            "description": "Array of historical price data points. Each data point is an array containing:\n1. TIMESTAMP - Unix timestamp in seconds\n2. USD - Price in USD\n3. BTC - Price in Bitcoin\n4. ETH - Price in Ethereum",
+            "example": [
+              [
+                1735038000000,
+                8.3034,
+                8.833e-05,
+                0.00244788
+              ],
+              [
+                1735041600000,
+                8.3345,
+                8.83e-05,
+                0.00244324
+              ]
+            ]
+          }
+        },
+        "required": [
+          "result"
+        ]
+      },
+      "NewsFeedResponseItemDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique identifier for the news feed item",
+            "example": "376f390df50a1d44cb5593c9bff6faafabed18ee90e0d4d737d3b6d3eea50c80"
+          },
+          "searchKeyWords": {
+            "description": "Array of search keywords associated with this news item",
+            "example": [
+              "xrp",
+              "XRP"
+            ],
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "feedDate": {
+            "type": "number",
+            "description": "Unix timestamp (in milliseconds) when the news was published",
+            "example": 1756204736000
+          },
+          "source": {
+            "type": "string",
+            "description": "Name of the news source/publication",
+            "example": "CoinGape"
+          },
+          "title": {
+            "type": "string",
+            "description": "Title of the news article",
+            "example": "Why is XRP Price Down Even After the Ripple Lawsuit End?"
+          },
+          "isFeatured": {
+            "type": "boolean",
+            "description": "Whether this news item is featured/highlighted",
+            "example": false
+          },
+          "description": {
+            "type": "string",
+            "description": "Brief description or summary of the news article",
+            "example": "coingape.com."
+          },
+          "link": {
+            "type": "string",
+            "description": "Direct link to the full news article",
+            "example": "https://coingape.com/trending/why-is-xrp-price-down-even-after-the-ripple-lawsuit-end/?utm_medium=referral&utm_source=coinstats"
+          },
+          "sourceLink": {
+            "type": "string",
+            "description": "URL of the news source website",
+            "example": "https://coingape.com/"
+          },
+          "imgUrl": {
+            "type": "string",
+            "description": "URL of the article image",
+            "example": "https://coingape.com/wp-content/uploads/2025/08/Why-is-XRP-Price-Down.webp"
+          },
+          "reactionsCount": {
+            "type": "object",
+            "description": "Count of different reaction types on this news item, where keys are reaction type IDs and values are counts",
+            "example": {
+              "2": 13,
+              "3": 18
+            },
+            "additionalProperties": {
+              "type": "number"
+            }
+          },
+          "reactions": {
+            "description": "Array of reaction identifiers for this news item",
+            "example": [],
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "shareURL": {
+            "type": "string",
+            "description": "Shareable URL for this news item on CoinStats platform",
+            "example": "https://coinstats.app/news/376f390df50a1d44cb5593c9bff6faafabed18ee90e0d4d737d3b6d3eea50c80_Why-is-XRP-Price-Down-Even-After-the-Ripple-Lawsuit-End"
+          },
+          "relatedCoins": {
+            "description": "Array of cryptocurrency identifiers related to this news",
+            "example": [
+              "ripple",
+              "0xb9ce0dd29c91e02d4620f57a66700fc5e41d6d15_cronos"
+            ],
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "content": {
+            "type": "boolean",
+            "description": "Whether the full content of the article is available",
+            "example": true
+          },
+          "bigImg": {
+            "type": "boolean",
+            "description": "Whether this news item should display with a large image format",
+            "example": false
+          },
+          "coins": {
+            "type": "array",
+            "description": "Cryptocurrency data associated with this news",
+            "example": [
+              {
+                "coinKeyWords": "XRP",
+                "coinPercent": -5.11,
+                "coinTitleKeyWords": "XRP",
+                "coinNameKeyWords": "XRP",
+                "coinIdKeyWords": "ripple"
+              },
+              {
+                "coinKeyWords": "XRP",
+                "coinPercent": -4.67,
+                "coinTitleKeyWords": "XRP",
+                "coinNameKeyWords": "XRP",
+                "coinIdKeyWords": "0xb9ce0dd29c91e02d4620f57a66700fc5e41d6d15_cronos"
+              }
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "feedDate",
+          "source",
+          "title",
+          "isFeatured",
+          "link",
+          "sourceLink",
+          "imgUrl",
+          "reactionsCount",
+          "reactions",
+          "shareURL",
+          "relatedCoins",
+          "content",
+          "bigImg"
+        ]
+      },
+      "WalletBalancesResponse": {
+        "type": "object",
+        "properties": {
+          "blockchain": {
+            "type": "string",
+            "description": "The blockchain network name",
+            "example": "ethereum"
+          },
+          "address": {
+            "type": "string",
+            "description": "The wallet address that was queried",
+            "example": "0x742d35Cc6634C0532925a3b844Bc454e4438f44e"
+          },
+          "connectionId": {
+            "type": "string",
+            "description": "The blockchain network identifier that was used in the query",
+            "example": "ethereum"
+          },
+          "balances": {
+            "description": "Array of cryptocurrency balances found in the wallet",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/WalletBalanceResponseCoinDto"
+            }
+          }
+        },
+        "required": [
+          "blockchain",
+          "balances"
+        ]
+      },
+      "NewsListResponseDto": {
+        "type": "object",
+        "properties": {
+          "result": {
+            "description": "Array of news feed items",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/NewsFeedResponseItemDto"
+            }
+          }
+        },
+        "required": [
+          "result"
+        ]
+      },
+      "PortfolioChartResponseDto": {
+        "type": "object",
+        "properties": {
+          "result": {
+            "description": "Array of historical price data points. Each data point is an array containing:\n1. TIMESTAMP - Unix timestamp in seconds\n2. USD - Price in USD\n3. BTC - Price in Bitcoin\n4. ETH - Price in Ethereum",
+            "items": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              }
+            },
+            "example": [
+              [
+                1755864000000,
+                297711.24614580005,
+                2.65026183,
+                69.53175117
+              ],
+              [
+                1755864000000,
+                297711.24614580005,
+                2.65026183,
+                69.53175117
+              ]
+            ],
+            "type": "array"
+          }
+        },
+        "required": [
+          "result"
+        ]
+      },
+      "PortfolioItemResponseDto": {
+        "type": "object",
+        "properties": {
+          "result": {
+            "description": "Array of portfolio items containing detailed information about each held cryptocurrency including prices, profits, averages, and risk metrics",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PortfolioItemDto"
+            }
+          }
+        },
+        "required": [
+          "result"
+        ]
+      },
+      "WalletBalanceResponseCoinDto": {
+        "type": "object",
+        "properties": {
+          "chain": {
+            "type": "string",
+            "description": "The blockchain network where this token exists",
+            "example": "ethereum"
+          },
+          "coinId": {
+            "type": "string",
+            "description": "Unique identifier for the cryptocurrency",
+            "example": "ethereum"
+          },
+          "amount": {
+            "type": "number",
+            "description": "The total balance amount of this cryptocurrency in the wallet",
+            "example": 1.5
+          },
+          "name": {
+            "type": "string",
+            "description": "Full name of the cryptocurrency",
+            "example": "Ethereum"
+          },
+          "symbol": {
+            "type": "string",
+            "description": "Trading symbol of the cryptocurrency",
+            "example": "ETH"
+          },
+          "price": {
+            "type": "number",
+            "description": "Current price in USD",
+            "example": 2000.5
+          },
+          "priceBtc": {
+            "type": "number",
+            "description": "Current price in BTC",
+            "example": 0.05
+          },
+          "imgUrl": {
+            "type": "string",
+            "description": "URL of the cryptocurrency logo image",
+            "example": "https://static.coinstats.app/coins/1650455629727.png"
+          },
+          "pCh24h": {
+            "type": "number",
+            "description": "Price change percentage in the last 24 hours",
+            "example": 5.25
+          },
+          "rank": {
+            "type": "number",
+            "description": "Market cap rank of the cryptocurrency",
+            "example": 2
+          },
+          "volume": {
+            "type": "number",
+            "description": "24-hour trading volume in USD",
+            "example": 15000000000
+          },
+          "decimals": {
+            "type": "number",
+            "description": "Number of decimal places for token precision (mainly for ERC20 tokens)",
+            "example": 18
+          },
+          "contractAddress": {
+            "type": "string",
+            "description": "Smart contract address for tokens (e.g. ERC20, BEP20)",
+            "example": "0xdac17f958d2ee523a2206206994597c13d831ec7"
+          }
+        },
+        "required": [
+          "coinId",
+          "amount",
+          "name",
+          "symbol",
+          "price",
+          "priceBtc",
+          "imgUrl",
+          "pCh24h",
+          "rank",
+          "volume"
+        ]
+      },
+      "CoinPriceResponseDto": {
+        "type": "object",
+        "properties": {
+          "USD": {
+            "type": "number",
+            "description": "Price in US Dollars",
+            "example": 45123.45
+          },
+          "BTC": {
+            "type": "number",
+            "description": "Price in Bitcoin (BTC)",
+            "example": 1
+          },
+          "ETH": {
+            "type": "number",
+            "description": "Price in Ethereum (ETH)",
+            "example": 15.234
+          }
+        },
+        "required": [
+          "USD",
+          "BTC",
+          "ETH"
+        ]
+      },
+      "DefiResponseDto": {
+        "type": "object",
+        "properties": {
+          "totalAssets": {
+            "description": "Total value of all DeFi positions across all protocols",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/TotalValueDto"
+              }
+            ]
+          },
+          "protocols": {
+            "description": "List of DeFi protocols with user positions",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DefiItemDto"
+            }
+          }
+        },
+        "required": [
+          "totalAssets",
+          "protocols"
+        ]
+      },
+      "CurrenciesListResponseDto": {
+        "type": "object",
+        "properties": {
+          "result": {
+            "description": "Full list of exchange rates for various currencies relative to USD (USD = 1)",
+            "example": {
+              "USD": 1,
+              "AUD": 1.5454754068661494,
+              "BGN": 1.6841890498764196,
+              "BRL": 5.439300703523657,
+              "CAD": 1.385009899367217,
+              "CHF": 0.8062450125737061,
+              "CNY": 7.152897128536489,
+              "CZK": 21.155291093157576
+            },
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CurrencyDto"
+              }
+            ]
+          }
+        },
+        "required": [
+          "result"
+        ]
+      },
+      "CoinExchangePriceResponseDto": {
+        "type": "object",
+        "properties": {
+          "price": {
+            "type": "number",
+            "description": "The price of the cryptocurrency in the target currency",
+            "example": 15.7349
+          }
+        },
+        "required": [
+          "price"
+        ]
+      },
+      "PortfolioSyncStatusResponseDto": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": [
+              "syncing",
+              "synced"
+            ],
+            "description": "The current synchronization status of the portfolio",
+            "example": "synced"
+          }
+        },
+        "required": [
+          "status"
+        ]
+      },
+      "FiatListResponseDto": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Name of the currency",
+            "example": "USD"
+          },
+          "rate": {
+            "type": "number",
+            "description": "Current exchange rate against USD (1 USD = rate)",
+            "example": 1
+          },
+          "symbol": {
+            "type": "string",
+            "description": "Currency symbol",
+            "example": "$"
+          },
+          "imageUrl": {
+            "type": "string",
+            "description": "URL to the currency flag or icon image",
+            "example": "https://static.coinstats.app/flags/USD_r.png"
+          }
+        },
+        "required": [
+          "name",
+          "rate",
+          "symbol",
+          "imageUrl"
+        ]
+      },
+      "WalletMultiChartResponseDto": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              }
+            },
+            "example": [
+              [
+                1735038000000,
+                8.3034,
+                8.833e-05,
+                0.00244788
+              ],
+              [
+                1735041600000,
+                8.3345,
+                8.83e-05,
+                0.00244324
+              ]
+            ],
+            "description": "1. TIMESTAMP - Unix timestamp in seconds\n2. USD - Price in USD\n3. BTC - Price in Bitcoin\n4. ETH - Price in Ethereum"
+          },
+          "walletAddress": {
+            "type": "string",
+            "description": "The wallet address",
+            "example": "0x1234567890abcdef1234567890abcdef12345678"
+          },
+          "connectionId": {
+            "type": "string",
+            "description": "The identifier of connection",
+            "example": "base-wallet"
+          },
+          "blockchain": {
+            "type": "string",
+            "description": "The blockchain network identifier",
+            "example": "base"
+          },
+          "message": {
+            "type": "string",
+            "description": "Error messages for each wallet in case of errors. If a wallet encounters an error, its corresponding message will be included. If all wallets are successful, this field will be empty.",
+            "example": "An error occurred while fetching data"
+          }
+        },
+        "required": [
+          "data"
+        ]
+      },
+      "PortfolioSnapshotResponseDto": {
+        "type": "object",
+        "properties": {
+          "result": {
+            "description": "Array of portfolio snapshots ordered chronologically",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PortfolioSnapshotItemDto"
+            }
+          }
+        },
+        "required": [
+          "result"
+        ]
+      },
+      "TickerMarketListResponseDto": {
+        "type": "object",
+        "properties": {
+          "meta": {
+            "description": "Pagination metadata including total count, page number, and limit",
+            "example": {
+              "page": 1,
+              "limit": 20,
+              "itemCount": 57072,
+              "pageCount": 2854,
+              "hasPreviousPage": false,
+              "hasNextPage": true
+            },
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PageMetaDto"
+              }
+            ]
+          },
+          "result": {
+            "description": "Array of ticker market data for trading pairs",
+            "example": {
+              "_created_at": "2023-04-13T07:34:24.442Z",
+              "_updated_at": "2025-08-27T10:56:44.779Z",
+              "exchange": "BinanceFutures",
+              "from": "BTC",
+              "to": "USD",
+              "pair": "BTC/USD",
+              "price": 111014.4,
+              "pairPrice": 111014.4,
+              "volume": 1967687277427.2,
+              "pairVolume": 17724613
+            },
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TickerMarketItemDto"
+            }
+          }
+        },
+        "required": [
+          "meta",
+          "result"
+        ]
+      },
+      "PortfolioExchangeListItemResponseDto": {
+        "type": "object",
+        "properties": {
+          "connectionId": {
+            "type": "string",
+            "description": "Unique identifier for the exchange connection",
+            "example": "binance"
+          },
+          "name": {
+            "type": "string",
+            "description": "Display name of the exchange",
+            "example": "Binance"
+          },
+          "icon": {
+            "type": "string",
+            "description": "URL to the exchange icon/logo",
+            "example": "https://static.coinstats.app/portfolio_images/binance_dark.png"
+          },
+          "connectionFields": {
+            "description": "Array of required connection fields for the exchange API",
+            "example": [
+              {
+                "name": "API Key",
+                "key": "apiKey"
+              },
+              {
+                "name": "API Secret",
+                "key": "apiSecret"
+              }
+            ],
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConnectionField"
+            }
+          }
+        },
+        "required": [
+          "connectionId",
+          "name",
+          "icon",
+          "connectionFields"
+        ]
+      },
+      "FearAndGreedDto": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Name of the index",
+            "example": "Fear and Greed Index"
+          },
+          "now": {
+            "description": "Current Fear and Greed index data",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CurrentFearGreedValueDto"
+              }
+            ]
+          },
+          "yesterday": {
+            "description": "Fear and Greed index data from yesterday",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/FearGreedValueDto"
+              }
+            ]
+          },
+          "lastWeek": {
+            "description": "Fear and Greed index data from last week",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/FearGreedValueDto"
+              }
+            ]
+          }
+        },
+        "required": [
+          "name",
+          "now",
+          "yesterday",
+          "lastWeek"
+        ]
+      },
+      "RainbowChartItemDto": {
+        "type": "object",
+        "properties": {
+          "price": {
+            "type": "string",
+            "description": "Price value",
+            "example": "0.9111"
+          },
+          "time": {
+            "type": "string",
+            "description": "Date in YYYY-MM-DD format",
+            "example": "2010-09-30"
+          }
+        },
+        "required": [
+          "price",
+          "time"
+        ]
+      },
+      "CoinListResponseItemDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique identifier for the cryptocurrency",
+            "example": "bitcoin"
+          },
+          "icon": {
+            "type": "string",
+            "description": "URL to the cryptocurrency icon/logo",
+            "example": "https://static.coinstats.app/coins/1650455588819.png"
+          },
+          "name": {
+            "type": "string",
+            "description": "Full name of the cryptocurrency",
+            "example": "Bitcoin"
+          },
+          "symbol": {
+            "type": "string",
+            "description": "Trading symbol/ticker of the cryptocurrency",
+            "example": "BTC"
+          },
+          "rank": {
+            "type": "number",
+            "description": "Market capitalization rank of the cryptocurrency",
+            "example": 1
+          },
+          "price": {
+            "type": "number",
+            "description": "Current price of the cryptocurrency in USD",
+            "example": 43250.75
+          },
+          "priceBtc": {
+            "type": "number",
+            "description": "Current price of the cryptocurrency in BTC",
+            "example": 1
+          },
+          "volume": {
+            "type": "number",
+            "description": "24-hour trading volume in USD",
+            "example": 15420000000
+          },
+          "marketCap": {
+            "type": "number",
+            "description": "Market capitalization in USD",
+            "example": 847350000000
+          },
+          "availableSupply": {
+            "type": "number",
+            "description": "Number of coins currently in circulation",
+            "example": 19600000
+          },
+          "totalSupply": {
+            "type": "number",
+            "description": "Total supply of the cryptocurrency",
+            "example": 21000000
+          },
+          "fullyDilutedValuation": {
+            "type": "number",
+            "description": "Fully diluted market valuation",
+            "example": 907500000000
+          },
+          "priceChange1h": {
+            "type": "number",
+            "description": "Percentage price change in the last 1 hour",
+            "example": 0.75
+          },
+          "priceChange1d": {
+            "type": "number",
+            "description": "Percentage price change in the last 24 hours",
+            "example": 2.15
+          },
+          "priceChange1w": {
+            "type": "number",
+            "description": "Percentage price change in the last 7 days",
+            "example": -1.42
+          },
+          "priceChange1m": {
+            "type": "number",
+            "description": "Percentage price change in the last 1 month",
+            "example": 4.25
+          },
+          "websiteUrl": {
+            "type": "string",
+            "description": "Official website URL of the cryptocurrency project",
+            "example": "https://bitcoin.org"
+          },
+          "redditUrl": {
+            "type": "string",
+            "description": "Reddit community URL for the cryptocurrency",
+            "example": "https://reddit.com/r/bitcoin"
+          },
+          "twitterUrl": {
+            "type": "string",
+            "description": "Official Twitter account URL",
+            "example": "https://twitter.com/bitcoin"
+          },
+          "contractAddress": {
+            "type": "string",
+            "description": "Smart contract address for the token",
+            "example": "0xa0b86a33e6776e2e09e384b0c92fceaade8fa82f"
+          },
+          "contractAddresses": {
+            "description": "Array of contract addresses across different blockchains",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ContractAddressDto"
+            }
+          },
+          "decimals": {
+            "type": "number",
+            "description": "Number of decimal places for the token",
+            "example": 18
+          },
+          "explorers": {
+            "description": "Array of blockchain explorer URLs",
+            "example": [
+              "https://blockstream.info"
+            ],
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "liquidityScore": {
+            "type": "number",
+            "description": "Liquidity score of the cryptocurrency (0-100)",
+            "example": 85.5
+          },
+          "volatilityScore": {
+            "type": "number",
+            "description": "Volatility score of the cryptocurrency (0-100)",
+            "example": 42.3
+          },
+          "marketCapScore": {
+            "type": "number",
+            "description": "Market capitalization score (0-100)",
+            "example": 95.8
+          },
+          "riskScore": {
+            "type": "number",
+            "description": "Overall risk score of the cryptocurrency (0-100)",
+            "example": 25.7
+          },
+          "avgChange": {
+            "type": "number",
+            "description": "Average price change percentage",
+            "example": 1.25
+          },
+          "isStable": {
+            "type": "boolean",
+            "description": "Indicates if the cryptocurrency is a stablecoin. Only present for stablecoins.",
+            "example": true
+          },
+          "color": {
+            "type": "string",
+            "description": "Brand color of the cryptocurrency in hex format (without #). Only present for coins that have it defined.",
+            "example": "FF9500"
+          },
+          "slug": {
+            "type": "string",
+            "description": "URL-friendly identifier for the cryptocurrency",
+            "example": "bitcoin"
+          }
+        },
+        "required": [
+          "id",
+          "icon",
+          "name",
+          "symbol",
+          "rank",
+          "price",
+          "priceBtc",
+          "volume",
+          "marketCap",
+          "availableSupply",
+          "totalSupply",
+          "fullyDilutedValuation",
+          "priceChange1h",
+          "priceChange1d",
+          "priceChange1w",
+          "priceChange1m",
+          "websiteUrl",
+          "redditUrl",
+          "twitterUrl",
+          "explorers",
+          "slug"
+        ]
+      },
+      "BlockchainListItemResponseDto": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Human-readable name of the blockchain network",
+            "example": "BNB Smart Chain"
+          },
+          "connectionId": {
+            "type": "string",
+            "description": "Unique identifier for the blockchain connection",
+            "example": "binancesmartchain"
+          },
+          "chain": {
+            "type": "string",
+            "description": "Internal identifier for the blockchain network",
+            "example": "binance_smart"
+          },
+          "icon": {
+            "type": "string",
+            "description": "URL to the blockchain network icon",
+            "example": "https://static.coinstats.app/portfolio_images/binancesmartchain.png"
+          }
+        },
+        "required": [
+          "name",
+          "connectionId",
+          "chain",
+          "icon"
+        ]
+      },
+      "MarketCapResponseDto": {
+        "type": "object",
+        "properties": {
+          "marketCap": {
+            "type": "number",
+            "description": "Total market capitalization of all cryptocurrencies in USD",
+            "example": 4026535943695
+          },
+          "volume": {
+            "type": "number",
+            "description": "Total 24-hour trading volume across all cryptocurrencies in USD",
+            "example": 98765432101
+          },
+          "btcDominance": {
+            "type": "number",
+            "description": "Bitcoin's percentage share of the total cryptocurrency market capitalization",
+            "example": 42.5
+          },
+          "marketCapChange": {
+            "type": "number",
+            "description": "24-hour change in total market capitalization (percentage)",
+            "example": -2.34
+          },
+          "volumeChange": {
+            "type": "number",
+            "description": "24-hour change in total trading volume (percentage)",
+            "example": 5.67
+          },
+          "btcDominanceChange": {
+            "type": "number",
+            "description": "24-hour change in Bitcoin dominance (percentage points)",
+            "example": 0.89
+          }
+        },
+        "required": [
+          "marketCap",
+          "volume",
+          "btcDominance",
+          "marketCapChange",
+          "volumeChange",
+          "btcDominanceChange"
+        ]
+      },
+      "BtcDominanceDto": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "description": "Array of timestamp and BTC dominance percentage pairs\nPair structure: [timestamp, BTC dominance percentage]",
+            "example": [
+              [
+                1746441300,
+                61.59
+              ],
+              [
+                1746441400,
+                62.1
+              ],
+              [
+                1746441500,
+                61.85
+              ]
+            ],
+            "items": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              }
+            }
+          }
+        },
+        "required": [
+          "data"
+        ]
+      },
+      "FearGreedValueDto": {
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": "number",
+            "description": "Numeric value of the Fear and Greed index (0-100)",
+            "example": 73
+          },
+          "value_classification": {
+            "type": "string",
+            "description": "Classification of the value (Extreme fear, Fear, Neutral, Greed, Extreme greed)",
+            "example": "Greed"
+          },
+          "timestamp": {
+            "type": "number",
+            "description": "Unix timestamp in seconds",
+            "example": 1747052304
+          }
+        },
+        "required": [
+          "value",
+          "value_classification",
+          "timestamp"
+        ]
+      },
+      "CurrencyDto": {
+        "type": "object",
+        "properties": {}
+      },
+      "CurrentFearGreedValueDto": {
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": "number",
+            "description": "Numeric value of the Fear and Greed index (0-100)",
+            "example": 73
+          },
+          "value_classification": {
+            "type": "string",
+            "description": "Classification of the value (Extreme fear, Fear, Neutral, Greed, Extreme greed)",
+            "example": "Greed"
+          },
+          "timestamp": {
+            "type": "number",
+            "description": "Unix timestamp in seconds",
+            "example": 1747052304
+          },
+          "update_time": {
+            "type": "string",
+            "description": "ISO timestamp of when the data was last updated",
+            "example": "2025-05-12T12:08:10.020Z"
+          }
+        },
+        "required": [
+          "value",
+          "value_classification",
+          "timestamp",
+          "update_time"
+        ]
+      },
+      "PageMetaSimpleDto": {
+        "type": "object",
+        "properties": {
+          "page": {
+            "type": "number",
+            "description": "The current page number",
+            "example": 1
+          },
+          "limit": {
+            "type": "number",
+            "description": "The number of items per page",
+            "example": 10
+          }
+        },
+        "required": [
+          "page",
+          "limit"
+        ]
+      },
+      "TransactionItemDto": {
+        "type": "object",
+        "properties": {
+          "transactionType": {
+            "type": "string",
+            "description": "Type of transaction performed",
+            "example": "Roll In",
+            "enum": [
+              "Sent",
+              "Dust Convert",
+              "Roll In",
+              "Received",
+              "Swap",
+              "Buy",
+              "Sell"
+            ]
+          },
+          "date": {
+            "type": "string",
+            "description": "ISO 8601 timestamp of when the transaction occurred",
+            "example": "2025-08-28T08:35:50.384Z"
+          },
+          "coinData": {
+            "description": "Main coin data for the transaction (optional for some transaction types)",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CoinDataDto"
+              }
+            ]
+          },
+          "profitLoss": {
+            "description": "Profit and loss information for the transaction",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ProfitLossDto"
+              }
+            ]
+          },
+          "fee": {
+            "description": "Transaction fee information",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/FeeDto"
+              }
+            ]
+          },
+          "transfers": {
+            "description": "List of transfers involved in the transaction (e.g., coins received/sent)",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TransferDto"
+            }
+          },
+          "portfolioInfo": {
+            "description": "Information about the portfolio where the transaction occurred",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PortfolioInfoDto"
+              }
+            ]
+          },
+          "note": {
+            "description": "Transaction Notes",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PortfolioInfoDto"
+              }
+            ]
+          }
+        },
+        "required": [
+          "transactionType",
+          "date",
+          "profitLoss",
+          "fee",
+          "portfolioInfo"
+        ]
+      },
+      "FearAndGreedDataPointDto": {
+        "type": "object",
+        "properties": {
+          "timestamp": {
+            "type": "string",
+            "description": "Unix timestamp as string",
+            "example": "1746921600"
+          },
+          "value": {
+            "type": "number",
+            "description": "Fear and Greed index value (0-100)",
+            "example": 75
+          },
+          "value_classification": {
+            "type": "string",
+            "description": "Classification of the value",
+            "example": "Greed",
+            "enum": [
+              "Extreme fear",
+              "Fear",
+              "Neutral",
+              "Greed",
+              "Extreme greed"
+            ]
+          }
+        },
+        "required": [
+          "timestamp",
+          "value",
+          "value_classification"
+        ]
+      },
+      "PageMetaDto": {
+        "type": "object",
+        "properties": {
+          "page": {
+            "type": "number",
+            "description": "Current page number (1-based)",
+            "example": 2,
+            "minimum": 1
+          },
+          "limit": {
+            "type": "number",
+            "description": "Number of items per page",
+            "example": 20,
+            "minimum": 1,
+            "maximum": 1000
+          },
+          "itemCount": {
+            "type": "number",
+            "description": "Total number of items across all pages",
+            "example": 150,
+            "minimum": 0
+          },
+          "pageCount": {
+            "type": "number",
+            "description": "Total number of pages available",
+            "example": 8,
+            "minimum": 0
+          },
+          "hasPreviousPage": {
+            "type": "boolean",
+            "description": "Whether there is a previous page available",
+            "example": true
+          },
+          "hasNextPage": {
+            "type": "boolean",
+            "description": "Whether there is a next page available",
+            "example": true
+          }
+        },
+        "required": [
+          "page",
+          "limit",
+          "itemCount",
+          "pageCount",
+          "hasPreviousPage",
+          "hasNextPage"
+        ]
+      },
+      "ContractAddressDto": {
+        "type": "object",
+        "properties": {
+          "blockchain": {
+            "type": "string",
+            "description": "The blockchain network where the contract is deployed",
+            "example": "ethereum"
+          },
+          "contractAddress": {
+            "type": "string",
+            "description": "The smart contract address on the blockchain",
+            "example": "0xa0b86a33e6776e2e09e384b0c92fceaade8fa82f"
+          }
+        },
+        "required": [
+          "blockchain",
+          "contractAddress"
+        ]
+      },
+      "TransactionDto": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "deposit",
+              "withdraw",
+              "approve",
+              "executed",
+              "balance",
+              "fee"
+            ],
+            "description": "Type of transaction (e.g., Sent, Received, Swap)",
+            "example": "Sent"
+          },
+          "date": {
+            "format": "date-time",
+            "type": "string",
+            "description": "Timestamp of the transaction",
+            "example": "2025-06-07T11:58:11.000Z"
+          },
+          "mainContent": {
+            "description": "Visual content related to the transaction",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/TransactionMainContent"
+              }
+            ]
+          },
+          "coinData": {
+            "description": "Aggregated coin data for the transaction. Only present if transaction involves cryptocurrencies.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/TransactionCoinData"
+              }
+            ]
+          },
+          "profitLoss": {
+            "description": "Profit/loss information for the transaction. Only present if transaction involves cryptocurrencies.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/TransactionProfitLoss"
+              }
+            ]
+          },
+          "transactions": {
+            "description": "Detailed breakdown of the transaction components",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Transaction"
+            }
+          },
+          "fee": {
+            "description": "Transaction fee details if applicable",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/TransactionFee"
+              }
+            ]
+          },
+          "hash": {
+            "description": "Blockchain transaction details if applicable",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/TransactionHash"
+              }
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "date",
+          "mainContent",
+          "transactions"
+        ]
+      },
+      "ConnectionField": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Display name for the connection field",
+            "example": "API Key"
+          },
+          "key": {
+            "type": "string",
+            "description": "Key identifier for the connection field",
+            "example": "apiKey"
+          }
+        },
+        "required": [
+          "name",
+          "key"
+        ]
+      },
+      "TotalValueDto": {
+        "type": "object",
+        "properties": {
+          "USD": {
+            "type": "number",
+            "example": 46.92,
+            "description": "Value in US Dollars"
+          },
+          "ETH": {
+            "type": "number",
+            "example": 0.010799824088855844,
+            "description": "Value in Ethereum"
+          },
+          "BTC": {
+            "type": "number",
+            "example": 0.0004264134046889636,
+            "description": "Value in Bitcoin"
+          }
+        },
+        "required": [
+          "USD",
+          "ETH",
+          "BTC"
+        ]
+      },
+      "PortfolioItemDto": {
+        "type": "object",
+        "properties": {
+          "count": {
+            "type": "number",
+            "example": 44.4987,
+            "description": "Quantity of coins held in the portfolio"
+          },
+          "coin": {
+            "description": "Coin information including symbol, name, rank, and market data",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CoinDto"
+              }
+            ]
+          },
+          "price": {
+            "description": "Current market prices in multiple currencies (USD, BTC, ETH)",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PriceDto"
+              }
+            ]
+          },
+          "profit": {
+            "description": "Profit and loss data across different time periods and categories",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ProfitDto"
+              }
+            ]
+          },
+          "averageBuy": {
+            "description": "Average purchase prices across different time periods",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AverageDto"
+              }
+            ]
+          },
+          "averageSell": {
+            "description": "Average sale prices across different time periods",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AverageDto"
+              }
+            ]
+          },
+          "profitPercent": {
+            "description": "Profit/loss percentages across different time periods and categories",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ProfitPercentDto"
+              }
+            ]
+          },
+          "liquidityScore": {
+            "type": "number",
+            "example": 94.44676177373067,
+            "description": "Liquidity score indicating how easily the asset can be traded (0-100)"
+          },
+          "volatilityScore": {
+            "type": "number",
+            "example": 6.823477152064536,
+            "description": "Volatility score indicating price stability (lower = more stable)"
+          },
+          "marketCapScore": {
+            "type": "number",
+            "example": 90.15554879029162,
+            "description": "Market capitalization score relative to other assets (0-100)"
+          },
+          "riskScore": {
+            "type": "number",
+            "example": 7.407055529347417,
+            "description": "Risk score indicating investment risk level (lower = less risky)"
+          },
+          "avgChange": {
+            "type": "number",
+            "example": 2.631321607022045,
+            "description": "Average price change percentage across multiple time periods"
+          },
+          "totalCost": {
+            "type": "object",
+            "example": {
+              "USD": 160,
+              "BTC": 0.0016,
+              "ETH": 0.032
+            },
+            "description": "Current open-holdings cost basis in multiple currencies"
+          }
+        },
+        "required": [
+          "count",
+          "coin",
+          "price",
+          "profitPercent"
+        ]
+      },
+      "PortfolioSnapshotItemDto": {
+        "type": "object",
+        "properties": {
+          "date": {
+            "format": "date-time",
+            "type": "string",
+            "description": "ISO 8601 timestamp when the snapshot was taken",
+            "example": "2025-08-29T10:00:00.000Z"
+          },
+          "coinBalances": {
+            "description": "Array of individual cryptocurrency balances and their changes",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SnapshotCoinBalanceDto"
+            }
+          },
+          "totalBalance": {
+            "type": "number",
+            "description": "Total USD value of all holdings in the portfolio",
+            "example": 74.137019959
+          },
+          "totalBalanceChange": {
+            "type": "number",
+            "description": "Change in total USD balance compared to previous snapshot",
+            "example": -0.43391738
+          },
+          "totalBalancePercentChange": {
+            "type": "number",
+            "description": "Percentage change in total balance compared to previous snapshot",
+            "example": -0.58188537
+          }
+        },
+        "required": [
+          "date",
+          "coinBalances",
+          "totalBalance",
+          "totalBalanceChange",
+          "totalBalancePercentChange"
+        ]
+      },
+      "DefiItemDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "example": "pancakeswap-amm-v3",
+            "description": "Unique identifier for the DeFi protocol"
+          },
+          "name": {
+            "type": "string",
+            "example": "PancakeSwap",
+            "description": "Name of the DeFi protocol"
+          },
+          "logo": {
+            "type": "string",
+            "example": "https://icons.llama.fi/pancakeswap-amm-v3.jpg",
+            "description": "URL to the protocol logo"
+          },
+          "url": {
+            "type": "string",
+            "example": "https://pancakeswap.finance/swap",
+            "description": "Official website URL of the protocol"
+          },
+          "totalValue": {
+            "description": "Total value of all investments in this protocol",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/TotalValueDto"
+              }
+            ]
+          },
+          "blockchain": {
+            "description": "Blockchain network information",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BlockchainDto"
+              }
+            ]
+          },
+          "chain": {
+            "type": "string",
+            "example": "solana",
+            "description": "Blockchain network identifier"
+          },
+          "investments": {
+            "description": "List of investments/positions in this protocol",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/InvestmentDto"
+            }
+          },
+          "walletAddress": {
+            "type": "string",
+            "example": "wallet_address_here",
+            "description": "User wallet address holding these positions"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "logo",
+          "totalValue",
+          "blockchain",
+          "chain",
+          "investments",
+          "walletAddress"
+        ]
+      },
+      "TickerMarketItemDto": {
+        "type": "object",
+        "properties": {
+          "price": {
+            "type": "number",
+            "description": "The price in USD for the trading pair",
+            "example": 50000.25
+          },
+          "_created_at": {
+            "format": "date-time",
+            "type": "string",
+            "description": "Timestamp when this ticker was first recorded",
+            "example": "2024-01-01T00:00:00.000Z"
+          },
+          "_updated_at": {
+            "format": "date-time",
+            "type": "string",
+            "description": "Timestamp of the last update for this ticker",
+            "example": "2024-01-01T12:30:00.000Z"
+          },
+          "exchange": {
+            "type": "string",
+            "description": "Name of the exchange where this trading pair is listed",
+            "example": "Binance"
+          },
+          "pair": {
+            "type": "string",
+            "description": "Trading pair symbol in format BASE/QUOTE",
+            "example": "BTC/USDT"
+          },
+          "from": {
+            "type": "string",
+            "description": "Base currency of the trading pair",
+            "example": "BTC"
+          },
+          "to": {
+            "type": "string",
+            "description": "Quote currency of the trading pair",
+            "example": "USDT"
+          },
+          "pairPrice": {
+            "type": "number",
+            "description": "Price in the original trading pair (not converted to USD)",
+            "example": 49985.5
+          },
+          "pairVolume": {
+            "type": "number",
+            "description": "Trading volume in the original trading pair currency",
+            "example": 1250.75
+          },
+          "volume": {
+            "type": "number",
+            "description": "Trading volume converted to USD",
+            "example": 62537500
+          }
+        },
+        "required": [
+          "price",
+          "_created_at",
+          "_updated_at",
+          "exchange",
+          "pair",
+          "from",
+          "to",
+          "pairPrice",
+          "pairVolume",
+          "volume"
+        ]
+      }
+    }
+  }
+}

--- a/providers/coinstats/api/openapi.json
+++ b/providers/coinstats/api/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "CoinStats Crypto Data API",
-    "description": "Pay-per-request access to real-time cryptocurrency market data, wallet balances, DeFi positions, news, insights, and portfolio analytics via x402 micropayments.",
+    "description": "Pay-per-request cryptocurrency data API gated by x402 USDC micropayments on Base. Send a valid X-PAYMENT header to any endpoint; after the first payment, a JWT cookie is issued (1-hour TTL) for subsequent requests without re-payment.",
     "version": "1.0.0",
     "contact": {
       "name": "CoinStats",
@@ -621,26 +621,23 @@
                 }
               }
             }
+          },
+          "402": {
+            "description": "Payment Required \u2014 return a valid x402 USDC payment on Base in the X-PAYMENT header to proceed.",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "x402 payment challenge. Contains network, payTo address, price, and accepted token.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           }
         },
-        "security": [
-          {
-            "X-API-KEY": []
-          }
-        ],
         "summary": "Get comprehensive data about all cryptocurrencies",
         "tags": [
           "Market Data"
-        ],
-        "x-mint": {
-          "content": "<Note>**2** credits per request</Note><hr/>\n    <AccordionGroup>\n<Accordion title=\"You will get\">\n- Price, market cap, and volume\n- Price changes (1h, 24h, 7d, 1m)\n- Supply information\n- Trading metrics\n- Social links and metadata\n</Accordion>\n<Accordion title=\"Optional\">\n- currency: Price display currency\n- limit & skip: Pagination controls\n- includeRiskScore: Add risk analysis data\n- categories: Filter by coin categories\n- blockchains: Filter by blockchain networks\n</Accordion>\n<Accordion title=\"Sorting Options\">\n- sortBy: rank, price, volume, etc.\n- sortDir: asc or desc\n</Accordion>\n</AccordionGroup>",
-          "metadata": {
-            "title": "Get Coins",
-            "description": "Get comprehensive data about all cryptocurrencies",
-            "og:title": "Get Coins"
-          },
-          "href": "/openapi/get-coins"
-        }
+        ]
       }
     },
     "/coins/{coinId}": {
@@ -768,26 +765,23 @@
                 }
               }
             }
+          },
+          "402": {
+            "description": "Payment Required \u2014 return a valid x402 USDC payment on Base in the X-PAYMENT header to proceed.",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "x402 payment challenge. Contains network, payTo address, price, and accepted token.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           }
         },
-        "security": [
-          {
-            "X-API-KEY": []
-          }
-        ],
         "summary": "Get detailed information about a specific cryptocurrency using coinId. ",
         "tags": [
           "Market Data"
-        ],
-        "x-mint": {
-          "content": "<Note>**1** credit per request</Note>",
-          "metadata": {
-            "title": "Get Coin By Id",
-            "description": "Get detailed information about a specific cryptocurrency using coinId. ",
-            "og:title": "Get Coin By Id"
-          },
-          "href": "/openapi/get-coin-by-id"
-        }
+        ]
       }
     },
     "/coins/{coinId}/charts": {
@@ -963,26 +957,23 @@
                 }
               }
             }
+          },
+          "402": {
+            "description": "Payment Required \u2014 return a valid x402 USDC payment on Base in the X-PAYMENT header to proceed.",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "x402 payment challenge. Contains network, payTo address, price, and accepted token.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           }
         },
-        "security": [
-          {
-            "X-API-KEY": []
-          }
-        ],
         "summary": "Get historical chart data for a specific cryptocurrency using coinId.",
         "tags": [
           "Market Data"
-        ],
-        "x-mint": {
-          "content": "<Note>**3** credits per request</Note>",
-          "metadata": {
-            "title": "Get Coin Chart By Id",
-            "description": "Get historical chart data for a specific cryptocurrency using coinId.",
-            "og:title": "Get Coin Chart By Id"
-          },
-          "href": "/openapi/get-coin-chart-by-id"
-        }
+        ]
       }
     },
     "/coins/price/avg": {
@@ -1107,26 +1098,23 @@
                 }
               }
             }
+          },
+          "402": {
+            "description": "Payment Required \u2014 return a valid x402 USDC payment on Base in the X-PAYMENT header to proceed.",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "x402 payment challenge. Contains network, payTo address, price, and accepted token.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           }
         },
-        "security": [
-          {
-            "X-API-KEY": []
-          }
-        ],
         "summary": "Get the historical average price of a specific cryptocurrency for a given date. ",
         "tags": [
           "Market Data"
-        ],
-        "x-mint": {
-          "content": "<Note>**4** credits per request</Note>",
-          "metadata": {
-            "title": "Get Coin Avg Price",
-            "description": "Get the historical average price of a specific cryptocurrency for a given date. ",
-            "og:title": "Get Coin Avg Price"
-          },
-          "href": "/openapi/get-coin-avg-price"
-        }
+        ]
       }
     },
     "/coins/price/exchange": {
@@ -1273,26 +1261,23 @@
                 }
               }
             }
+          },
+          "402": {
+            "description": "Payment Required \u2014 return a valid x402 USDC payment on Base in the X-PAYMENT header to proceed.",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "x402 payment challenge. Contains network, payTo address, price, and accepted token.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           }
         },
-        "security": [
-          {
-            "X-API-KEY": []
-          }
-        ],
         "summary": "Get historical price data for a specific cryptocurrency on a selected exchange.",
         "tags": [
           "Market Data"
-        ],
-        "x-mint": {
-          "content": "<Note>**5** credits per request</Note>",
-          "metadata": {
-            "title": "Get Coin Exchange Price",
-            "description": "Get historical price data for a specific cryptocurrency on a selected exchange.",
-            "og:title": "Get Coin Exchange Price"
-          },
-          "href": "/openapi/get-coin-exchange-price"
-        }
+        ]
       }
     },
     "/tickers/exchanges": {
@@ -1401,26 +1386,23 @@
                 }
               }
             }
+          },
+          "402": {
+            "description": "Payment Required \u2014 return a valid x402 USDC payment on Base in the X-PAYMENT header to proceed.",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "x402 payment challenge. Contains network, payTo address, price, and accepted token.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           }
         },
-        "security": [
-          {
-            "X-API-KEY": []
-          }
-        ],
         "summary": "Provides a comprehensive list of cryptocurrency exchanges supported by CoinStats.",
         "tags": [
           "Market Data"
-        ],
-        "x-mint": {
-          "content": "<Note>**2** credits per request</Note>",
-          "metadata": {
-            "title": "Get Ticker Exchanges",
-            "description": "Provides a comprehensive list of cryptocurrency exchanges supported by CoinStats.",
-            "og:title": "Get Ticker Exchanges"
-          },
-          "href": "/openapi/get-ticker-exchanges"
-        }
+        ]
       }
     },
     "/tickers/markets": {
@@ -1600,26 +1582,23 @@
                 }
               }
             }
+          },
+          "402": {
+            "description": "Payment Required \u2014 return a valid x402 USDC payment on Base in the X-PAYMENT header to proceed.",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "x402 payment challenge. Contains network, payTo address, price, and accepted token.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           }
         },
-        "security": [
-          {
-            "X-API-KEY": []
-          }
-        ],
         "summary": "Returns a list of tickers for a specific cryptocurrency across multiple exchanges.",
         "tags": [
           "Market Data"
-        ],
-        "x-mint": {
-          "content": "<Note>**3** credits per request</Note>",
-          "metadata": {
-            "title": "Get Ticker Markets",
-            "description": "Returns a list of tickers for a specific cryptocurrency across multiple exchanges.",
-            "og:title": "Get Ticker Markets"
-          },
-          "href": "/openapi/get-ticker-markets"
-        }
+        ]
       }
     },
     "/wallet/blockchains": {
@@ -1728,26 +1707,23 @@
                 }
               }
             }
+          },
+          "402": {
+            "description": "Payment Required \u2014 return a valid x402 USDC payment on Base in the X-PAYMENT header to proceed.",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "x402 payment challenge. Contains network, payTo address, price, and accepted token.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           }
         },
-        "security": [
-          {
-            "X-API-KEY": []
-          }
-        ],
         "summary": "Get the list of blockchains supported by CoinStats",
         "tags": [
           "Wallet Data"
-        ],
-        "x-mint": {
-          "content": "<Note>**1** credit per request</Note><hr/>\n    <AccordionGroup>\n<Accordion title=\"You will get\">\n- All supported blockchains\n- Blockchain network names\n- Blockchain network icons\n</Accordion>\n<Accordion title=\"Use this data\">\n- To connect your wallet to CoinStats\n- To display blockchain network information\n- In other API endpoints\n</Accordion>\n</AccordionGroup>",
-          "metadata": {
-            "title": "Get Blockchains",
-            "description": "Get the list of blockchains supported by CoinStats",
-            "og:title": "Get Blockchains"
-          },
-          "href": "/openapi/get-blockchains"
-        }
+        ]
       }
     },
     "/wallet/balance": {
@@ -1887,26 +1863,23 @@
                 }
               }
             }
+          },
+          "402": {
+            "description": "Payment Required \u2014 return a valid x402 USDC payment on Base in the X-PAYMENT header to proceed.",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "x402 payment challenge. Contains network, payTo address, price, and accepted token.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           }
         },
-        "security": [
-          {
-            "X-API-KEY": []
-          }
-        ],
         "summary": "Get cryptocurrency balances for any blockchain wallet",
         "tags": [
           "Wallet Data"
-        ],
-        "x-mint": {
-          "content": "<Note>**40** credits per request</Note><hr/>\n    <AccordionGroup>\n<Accordion title='Details'>\n- Token balances across multiple networks\n- NFT holdings\n- Current USD values\n- Historical transactions\n</Accordion>\n<Accordion title='Required'>\n- address: Wallet address to query\n- connectionId: Blockchain network(s) to check\n  - Single network (e.g., \"ethereum\")\n  - Multiple networks (\"ethereum,polygon\")\n  - \"all\" for all supported networks\n</Accordion>\n<Accordion title='Features'>\n- Multi-chain support\n- ERC20 token detection\n- NFT balance tracking\n- Historical data access\n</Accordion>\n\n</AccordionGroup>",
-          "metadata": {
-            "title": "Get Wallet Balance",
-            "description": "Get cryptocurrency balances for any blockchain wallet",
-            "og:title": "Get Wallet Balance"
-          },
-          "href": "/openapi/get-wallet-balance"
-        }
+        ]
       }
     },
     "/wallet/balances": {
@@ -2057,26 +2030,23 @@
                 }
               }
             }
+          },
+          "402": {
+            "description": "Payment Required \u2014 return a valid x402 USDC payment on Base in the X-PAYMENT header to proceed.",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "x402 payment challenge. Contains network, payTo address, price, and accepted token.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           }
         },
-        "security": [
-          {
-            "X-API-KEY": []
-          }
-        ],
         "summary": "Get cryptocurrency balances for multiple wallets",
         "tags": [
           "Wallet Data"
-        ],
-        "x-mint": {
-          "content": "<Note>**40** credits per request</Note><Accordion title=\"Multipliers\" icon=\"rectangle-history-circle-plus\" ><Note>In **Query** field **\"networks\"**: credits are multiplied by the number of values.</Note><Note>If the value of **\"networks\"** in **Query** is **\"all\"**, multiplier is **400** credits.</Note><Note>In **Query** field **\"blockchain\"**: credits are multiplied by the number of values.</Note><Note>If the value of **\"blockchain\"** in **Query** is **\"all\"**, multiplier is **400** credits.</Note><Note>In **Query** field **\"wallets\"**: credits are multiplied by the number of values.</Note><Note>If the value of **\"wallets\"** in **Query** is **\"all\"**, multiplier is **400** credits.</Note><Warning>Multipliers can be applied multiple times.</Warning><Info>[**Detailed multipliers explanation**](/multipliers)</Info></Accordion><hr/>\n    <AccordionGroup>\n<Accordion title='You will get'>\n- Token balances across multiple networks\n- Token balances across multiple addresses\n</Accordion>\n</AccordionGroup>",
-          "metadata": {
-            "title": "Get Wallet Balances",
-            "description": "Get cryptocurrency balances for multiple wallets",
-            "og:title": "Get Wallet Balances"
-          },
-          "href": "/openapi/get-wallet-balances"
-        }
+        ]
       }
     },
     "/wallet/transactions": {
@@ -2303,26 +2273,23 @@
                 }
               }
             }
+          },
+          "402": {
+            "description": "Payment Required \u2014 return a valid x402 USDC payment on Base in the X-PAYMENT header to proceed.",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "x402 payment challenge. Contains network, payTo address, price, and accepted token.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           }
         },
-        "security": [
-          {
-            "X-API-KEY": []
-          }
-        ],
         "summary": "Get transaction data for wallet addresses",
         "tags": [
           "Wallet Data"
-        ],
-        "x-mint": {
-          "content": "<Note>**30** credits per request</Note><Accordion title=\"Multipliers\" icon=\"rectangle-history-circle-plus\" ><Note>In **Query** field **\"wallets\"**: credits are multiplied by the number of values.</Note><Note>If the value of **\"wallets\"** in **Query** is **\"all\"**, multiplier is **300** credits.</Note><Info>[**Detailed multipliers explanation**](/multipliers)</Info></Accordion><hr/>\n    <AccordionGroup>\n<Accordion title=\"Single wallet\">\nProvide **address** and **connectionId** separately\n</Accordion>\n<Accordion title=\"Multiple wallets\">\nProvide **wallets** parameter in format \"**connectionId**:*address*,**connectionId**:*address*\"\n</Accordion>\n</AccordionGroup>",
-          "metadata": {
-            "title": "Get Wallet Transactions",
-            "description": "Get transaction data for wallet addresses",
-            "og:title": "Get Wallet Transactions"
-          },
-          "href": "/openapi/get-wallet-transactions"
-        }
+        ]
       }
     },
     "/wallet/status": {
@@ -2459,26 +2426,23 @@
                 }
               }
             }
+          },
+          "402": {
+            "description": "Payment Required \u2014 return a valid x402 USDC payment on Base in the X-PAYMENT header to proceed.",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "x402 payment challenge. Contains network, payTo address, price, and accepted token.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           }
         },
-        "security": [
-          {
-            "X-API-KEY": []
-          }
-        ],
         "summary": "Get the syncing status of the provided wallet address with the blockchain network.",
         "tags": [
           "Wallet Data"
-        ],
-        "x-mint": {
-          "content": "<Note>**3** credits per request</Note>",
-          "metadata": {
-            "title": "Get Wallet Sync Status",
-            "description": "Get the syncing status of the provided wallet address with the blockchain network.",
-            "og:title": "Get Wallet Sync Status"
-          },
-          "href": "/openapi/get-wallet-sync-status"
-        }
+        ]
       }
     },
     "/wallet/chart": {
@@ -2633,26 +2597,23 @@
                 }
               }
             }
+          },
+          "402": {
+            "description": "Payment Required \u2014 return a valid x402 USDC payment on Base in the X-PAYMENT header to proceed.",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "x402 payment challenge. Contains network, payTo address, price, and accepted token.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           }
         },
-        "security": [
-          {
-            "X-API-KEY": []
-          }
-        ],
         "summary": "Get wallet chart data for specific time ranges",
         "tags": [
           "Wallet Data"
-        ],
-        "x-mint": {
-          "content": "<Note>**40** credits per request</Note><Accordion title=\"Multipliers\" icon=\"rectangle-history-circle-plus\" ><Note>In **Query** field **\"connectionId\"**: credits are multiplied by the number of values.</Note><Note>If the value of **\"connectionId\"** in **Query** is **\"all\"**, multiplier is **400** credits.</Note><Note>In **Query** field **\"blockchain\"**: credits are multiplied by the number of values.</Note><Note>If the value of **\"blockchain\"** in **Query** is **\"all\"**, multiplier is **400** credits.</Note><Warning>Multipliers can be applied multiple times.</Warning><Info>[**Detailed multipliers explanation**](/multipliers)</Info></Accordion>",
-          "metadata": {
-            "title": "Wallet Chart",
-            "description": "Get wallet chart data for specific time ranges",
-            "og:title": "Wallet Chart"
-          },
-          "href": "/openapi/wallet-chart"
-        }
+        ]
       }
     },
     "/wallet/charts": {
@@ -2805,26 +2766,23 @@
                 }
               }
             }
+          },
+          "402": {
+            "description": "Payment Required \u2014 return a valid x402 USDC payment on Base in the X-PAYMENT header to proceed.",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "x402 payment challenge. Contains network, payTo address, price, and accepted token.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           }
         },
-        "security": [
-          {
-            "X-API-KEY": []
-          }
-        ],
         "summary": "Get chart data for multiple wallet addresses across various networks.",
         "tags": [
           "Wallet Data"
-        ],
-        "x-mint": {
-          "content": "<Note>**40** credits per request</Note><Accordion title=\"Multipliers\" icon=\"rectangle-history-circle-plus\" ><Note>In **Query** field **\"wallets\"**: credits are multiplied by the number of values.</Note><Note>If the value of **\"wallets\"** in **Query** is **\"all\"**, multiplier is **400** credits.</Note><Info>[**Detailed multipliers explanation**](/multipliers)</Info></Accordion><hr/>\n    <AccordionGroup>\n<Accordion title='Aggregate data'>\n- If **aggregated** is **true**, the response will include aggregated data for all wallets.\n- If **aggregated** is **false**, the response will include data for each wallet individually.\n</Accordion>\n\n</AccordionGroup>",
-          "metadata": {
-            "title": "Wallet Charts",
-            "description": "Get chart data for multiple wallet addresses across various networks.",
-            "og:title": "Wallet Charts"
-          },
-          "href": "/openapi/wallet-charts"
-        }
+        ]
       }
     },
     "/wallet/defi": {
@@ -2961,26 +2919,23 @@
                 }
               }
             }
+          },
+          "402": {
+            "description": "Payment Required \u2014 return a valid x402 USDC payment on Base in the X-PAYMENT header to proceed.",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "x402 payment challenge. Contains network, payTo address, price, and accepted token.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           }
         },
-        "security": [
-          {
-            "X-API-KEY": []
-          }
-        ],
         "summary": "Retrieve comprehensive DeFi portfolio data, including staking, liquidity pool (LP), and yield farming activities",
         "tags": [
           "Wallet Data"
-        ],
-        "x-mint": {
-          "content": "<Warning>This endpoint is only available for OpenApi users with paid subscription.</Warning><Note>**400** credits per request</Note><Accordion title=\"Multipliers\" icon=\"rectangle-history-circle-plus\" ><Note>In **Query** field **\"connectionId\"**: credits are multiplied by the number of values.</Note><Note>If the value of **\"connectionId\"** in **Query** is **\"all\"**, multiplier is **4000** credits.</Note><Info>[**Detailed multipliers explanation**](/multipliers)</Info></Accordion><hr/>\n    <AccordionGroup>\n<Accordion title=\"You will get\">\n- Detailed breakdown of DeFi assets and protocols\n- Track staked tokens, LP positions, and earned rewards\n</Accordion>\n<Accordion title=\"Required\">\n- address and connectionId: For single wallet queries\n</Accordion>\n</AccordionGroup>",
-          "metadata": {
-            "title": "Get Wallet Defi",
-            "description": "Retrieve comprehensive DeFi portfolio data, including staking, liquidity pool (LP), and yield farming activities",
-            "og:title": "Get Wallet Defi"
-          },
-          "href": "/openapi/get-wallet-defi"
-        }
+        ]
       }
     },
     "/exchange/support": {
@@ -3089,26 +3044,23 @@
                 }
               }
             }
+          },
+          "402": {
+            "description": "Payment Required \u2014 return a valid x402 USDC payment on Base in the X-PAYMENT header to proceed.",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "x402 payment challenge. Contains network, payTo address, price, and accepted token.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           }
         },
-        "security": [
-          {
-            "X-API-KEY": []
-          }
-        ],
         "summary": "Get the list of exchange portfolio connections supported by CoinStats.",
         "tags": [
           "Exchange Connection"
-        ],
-        "x-mint": {
-          "content": "<Note>**1** credit per request</Note>",
-          "metadata": {
-            "title": "Get Exchanges",
-            "description": "Get the list of exchange portfolio connections supported by CoinStats.",
-            "og:title": "Get Exchanges"
-          },
-          "href": "/openapi/get-exchanges"
-        }
+        ]
       }
     },
     "/fiats": {
@@ -3217,26 +3169,23 @@
                 }
               }
             }
+          },
+          "402": {
+            "description": "Payment Required \u2014 return a valid x402 USDC payment on Base in the X-PAYMENT header to proceed.",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "x402 payment challenge. Contains network, payTo address, price, and accepted token.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           }
         },
-        "security": [
-          {
-            "X-API-KEY": []
-          }
-        ],
         "summary": "Get detailed information about fiat currencies",
         "tags": [
           "Market Data"
-        ],
-        "x-mint": {
-          "content": "<Note>**1** credit per request</Note><hr/>\n    <AccordionGroup>\n<Accordion title=\"You will get\">\n- Complete list of supported fiat currencies\n- Current exchange rates\n- Currency symbols and names\n- Associated images/icons\n</Accordion>\n<Accordion title=\"Use this data to\">\n- Convert cryptocurrency values to fiat\n- Display fiat currency information\n- Access currency metadata\n</Accordion>\n</AccordionGroup>",
-          "metadata": {
-            "title": "Get Fiat Currencies",
-            "description": "Get detailed information about fiat currencies",
-            "og:title": "Get Fiat Currencies"
-          },
-          "href": "/openapi/get-fiat-currencies"
-        }
+        ]
       }
     },
     "/news/sources": {
@@ -3345,26 +3294,23 @@
                 }
               }
             }
+          },
+          "402": {
+            "description": "Payment Required \u2014 return a valid x402 USDC payment on Base in the X-PAYMENT header to proceed.",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "x402 payment challenge. Contains network, payTo address, price, and accepted token.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           }
         },
-        "security": [
-          {
-            "X-API-KEY": []
-          }
-        ],
         "summary": "Get the list of news sources.",
         "tags": [
           "News"
-        ],
-        "x-mint": {
-          "content": "<Note>**2** credits per request</Note>",
-          "metadata": {
-            "title": "Get News Sources",
-            "description": "Get the list of news sources.",
-            "og:title": "Get News Sources"
-          },
-          "href": "/openapi/get-news-sources"
-        }
+        ]
       }
     },
     "/news": {
@@ -3513,26 +3459,23 @@
                 }
               }
             }
+          },
+          "402": {
+            "description": "Payment Required \u2014 return a valid x402 USDC payment on Base in the X-PAYMENT header to proceed.",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "x402 payment challenge. Contains network, payTo address, price, and accepted token.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           }
         },
-        "security": [
-          {
-            "X-API-KEY": []
-          }
-        ],
         "summary": "Get the list of cryptocurrency news articles with pagination.",
         "tags": [
           "News"
-        ],
-        "x-mint": {
-          "content": "<Note>**5** credits per request</Note>",
-          "metadata": {
-            "title": "Get News",
-            "description": "Get the list of cryptocurrency news articles with pagination.",
-            "og:title": "Get News"
-          },
-          "href": "/openapi/get-news"
-        }
+        ]
       }
     },
     "/news/type/{type}": {
@@ -3678,26 +3621,23 @@
                 }
               }
             }
+          },
+          "402": {
+            "description": "Payment Required \u2014 return a valid x402 USDC payment on Base in the X-PAYMENT header to proceed.",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "x402 payment challenge. Contains network, payTo address, price, and accepted token.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           }
         },
-        "security": [
-          {
-            "X-API-KEY": []
-          }
-        ],
         "summary": "Get cryptocurrency news articles based on a specific type.",
         "tags": [
           "News"
-        ],
-        "x-mint": {
-          "content": "<Note>**5** credits per request</Note>",
-          "metadata": {
-            "title": "Get News By Type",
-            "description": "Get cryptocurrency news articles based on a specific type.",
-            "og:title": "Get News By Type"
-          },
-          "href": "/openapi/get-news-by-type"
-        }
+        ]
       }
     },
     "/news/{id}": {
@@ -3814,26 +3754,23 @@
                 }
               }
             }
+          },
+          "402": {
+            "description": "Payment Required \u2014 return a valid x402 USDC payment on Base in the X-PAYMENT header to proceed.",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "x402 payment challenge. Contains network, payTo address, price, and accepted token.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           }
         },
-        "security": [
-          {
-            "X-API-KEY": []
-          }
-        ],
         "summary": "Get a news article by id.",
         "tags": [
           "News"
-        ],
-        "x-mint": {
-          "content": "<Note>**1** credit per request</Note>",
-          "metadata": {
-            "title": "Get News By Id",
-            "description": "Get a news article by id.",
-            "og:title": "Get News By Id"
-          },
-          "href": "/openapi/get-news-by-id"
-        }
+        ]
       }
     },
     "/markets": {
@@ -3939,26 +3876,23 @@
                 }
               }
             }
+          },
+          "402": {
+            "description": "Payment Required \u2014 return a valid x402 USDC payment on Base in the X-PAYMENT header to proceed.",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "x402 payment challenge. Contains network, payTo address, price, and accepted token.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           }
         },
-        "security": [
-          {
-            "X-API-KEY": []
-          }
-        ],
         "summary": "Get current global cryptocurrency market data",
         "tags": [
           "Market Data"
-        ],
-        "x-mint": {
-          "content": "<Note>**1** credit per request</Note><hr/>\n    <AccordionGroup>\n<Accordion title=\"You will get\">\n- Total market capitalization\n- 24h trading volume\n- Bitcoin dominance\n- Market trends and indicators\n</Accordion>\n</AccordionGroup>",
-          "metadata": {
-            "title": "Get Market Cap",
-            "description": "Get current global cryptocurrency market data",
-            "og:title": "Get Market Cap"
-          },
-          "href": "/openapi/get-market-cap"
-        }
+        ]
       }
     },
     "/insights/btc-dominance": {
@@ -4083,26 +4017,23 @@
                 }
               }
             }
+          },
+          "402": {
+            "description": "Payment Required \u2014 return a valid x402 USDC payment on Base in the X-PAYMENT header to proceed.",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "x402 payment challenge. Contains network, payTo address, price, and accepted token.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           }
         },
-        "security": [
-          {
-            "X-API-KEY": []
-          }
-        ],
         "summary": "Get Bitcoin market dominance data showing BTC's percentage share of the total cryptocurrency market capitalization over a specified time period",
         "tags": [
           "Market Insights"
-        ],
-        "x-mint": {
-          "content": "<Note>**10** credits per request</Note><hr/>\n    <AccordionGroup>\n<Accordion title=\"Details\">\n- Supports multiple time frames: 24 hours, 1 week, 1 month, 3 months, 6 months, 1 year, or all available data.\n- Data is returned as pairs of [timestamp, percentage] values.\n- Useful for analyzing market trends and Bitcoin's relative strength in the overall crypto ecosystem.\n</Accordion>\n</AccordionGroup>",
-          "metadata": {
-            "title": "Btc Dominance",
-            "description": "Get Bitcoin market dominance data showing BTC's percentage share of the total cryptocurrency market capitalization over a specified time period",
-            "og:title": "Btc Dominance"
-          },
-          "href": "/openapi/btc-dominance"
-        }
+        ]
       }
     },
     "/insights/fear-and-greed": {
@@ -4208,26 +4139,23 @@
                 }
               }
             }
+          },
+          "402": {
+            "description": "Payment Required \u2014 return a valid x402 USDC payment on Base in the X-PAYMENT header to proceed.",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "x402 payment challenge. Contains network, payTo address, price, and accepted token.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           }
         },
-        "security": [
-          {
-            "X-API-KEY": []
-          }
-        ],
         "summary": "Get the Crypto Fear & Greed Index",
         "tags": [
           "Market Insights"
-        ],
-        "x-mint": {
-          "content": "<Note>**10** credits per request</Note><hr/>\n    <AccordionGroup>\n<Accordion title=\"You will get\">\n- Crypto Fear & Greed Index which measures market sentiment from 0 (Extreme Fear) to 100 (Extreme Greed).\n- This indicator aggregates multiple factors including volatility, market momentum, social media, and surveys to gauge investor emotional state.\n- Helps identify potential market tops (greed) and bottoms (fear).\n</Accordion>\n</AccordionGroup>",
-          "metadata": {
-            "title": "Fear And Greed",
-            "description": "Get the Crypto Fear & Greed Index",
-            "og:title": "Fear And Greed"
-          },
-          "href": "/openapi/fear-and-greed"
-        }
+        ]
       }
     },
     "/insights/fear-and-greed/chart": {
@@ -4333,26 +4261,23 @@
                 }
               }
             }
+          },
+          "402": {
+            "description": "Payment Required \u2014 return a valid x402 USDC payment on Base in the X-PAYMENT header to proceed.",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "x402 payment challenge. Contains network, payTo address, price, and accepted token.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           }
         },
-        "security": [
-          {
-            "X-API-KEY": []
-          }
-        ],
         "summary": "Get historical data for the Crypto Fear & Greed Index",
         "tags": [
           "Market Insights"
-        ],
-        "x-mint": {
-          "content": "<Note>**10** credits per request</Note><hr/>\n    <AccordionGroup>\n<Accordion title=\"You will get\">\n- Daily values over time with timestamps, numerical values (0-100), and classifications (Extreme Fear, Fear, Neutral, Greed, Extreme Greed).\n- This historical view helps track market sentiment trends and identify potential correlation with price movements.\n</Accordion>\n</AccordionGroup>",
-          "metadata": {
-            "title": "Fear And Greed Chart",
-            "description": "Get historical data for the Crypto Fear & Greed Index",
-            "og:title": "Fear And Greed Chart"
-          },
-          "href": "/openapi/fear-and-greed-chart"
-        }
+        ]
       }
     },
     "/insights/rainbow-chart/{coinId}": {
@@ -4475,26 +4400,23 @@
                 }
               }
             }
+          },
+          "402": {
+            "description": "Payment Required \u2014 return a valid x402 USDC payment on Base in the X-PAYMENT header to proceed.",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "x402 payment challenge. Contains network, payTo address, price, and accepted token.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           }
         },
-        "security": [
-          {
-            "X-API-KEY": []
-          }
-        ],
         "summary": "Get Rainbow Chart data",
         "tags": [
           "Market Insights"
-        ],
-        "x-mint": {
-          "content": "<Note>**10** credits per request</Note><hr/>\n    <AccordionGroup>\n<Accordion title=\"You will get\">\n- Bitcoin or Ethereum based on the 'coinId' parameter.\n- The Rainbow Chart shows historical price data over time, which can be visualized with color bands representing different market sentiment zones.\n- An array of data points with price and time values.\n</Accordion>\n</AccordionGroup>",
-          "metadata": {
-            "title": "Rainbow Chart",
-            "description": "Get Rainbow Chart data",
-            "og:title": "Rainbow Chart"
-          },
-          "href": "/openapi/rainbow-chart"
-        }
+        ]
       }
     },
     "/portfolio/value": {
@@ -4503,7 +4425,7 @@
         "parameters": [
           {
             "name": "sharetoken",
-            "required": false,
+            "required": true,
             "in": "header",
             "description": "[Get Share Token](/sharetoken)",
             "schema": {
@@ -4641,26 +4563,23 @@
                 }
               }
             }
+          },
+          "402": {
+            "description": "Payment Required \u2014 return a valid x402 USDC payment on Base in the X-PAYMENT header to proceed.",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "x402 payment challenge. Contains network, payTo address, price, and accepted token.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           }
         },
-        "security": [
-          {
-            "X-API-KEY": []
-          }
-        ],
         "summary": "Get detailed information about portfolio profit/loss",
         "tags": [
           "User Portfolio"
-        ],
-        "x-mint": {
-          "content": "<Note>**10** credits per request</Note><hr/>\n    <AccordionGroup>\n<Accordion title=\"You will get\">\n- Total value of portfolio\n- Defi value of portfolio\n- Total cost of portfolio\n- Unrealized profit/loss\n- Realized profit/loss\n- All time profit/loss\n</Accordion>\n<Accordion title=\"Required\">\n<Note>This endpoint is only available for users with a Degen plan subscription (when using shareToken).</Note>\n- shareToken OR portfolioId: Provide one of these to identify the portfolio.\n  - shareToken: Get this from your CoinStats portfolio page by clicking \"Share\"\n  - portfolioId: Use a portfolio connected via POST /portfolio/wallet or POST /portfolio/exchange\n- If neither is provided, returns aggregated data for all API-connected portfolios\n</Accordion>\n<Accordion title=\"Optional\">\n- currency: Specify the currency for price values, default is USD\n- passcode: Passcode for accessing protected portfolio data (can be passed in header or query parameter)\n</Accordion>\n</AccordionGroup>",
-          "metadata": {
-            "title": "Get Portfolio Value",
-            "description": "Get detailed information about portfolio profit/loss",
-            "og:title": "Get Portfolio Value"
-          },
-          "href": "/openapi/get-portfolio-value"
-        }
+        ]
       }
     },
     "/portfolio/coins": {
@@ -4669,7 +4588,7 @@
         "parameters": [
           {
             "name": "sharetoken",
-            "required": false,
+            "required": true,
             "in": "header",
             "description": "[Get Share Token](/sharetoken)",
             "schema": {
@@ -4831,26 +4750,23 @@
                 }
               }
             }
+          },
+          "402": {
+            "description": "Payment Required \u2014 return a valid x402 USDC payment on Base in the X-PAYMENT header to proceed.",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "x402 payment challenge. Contains network, payTo address, price, and accepted token.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           }
         },
-        "security": [
-          {
-            "X-API-KEY": []
-          }
-        ],
         "summary": "Get detailed information about all coins in your portfolio",
         "tags": [
           "User Portfolio"
-        ],
-        "x-mint": {
-          "content": "<Note>**8** credits per request</Note><hr/>\n    <AccordionGroup>\n<Accordion title=\"You will get\">\n- Current holdings and their USD value\n- Profit/Loss (PnL) information\n- Performance metrics and statistics\n- Risk assessment scores (optional)\n</Accordion>\n<Accordion title=\"Required\">\n<Note>This endpoint is only available for users with a Degen plan subscription (when using shareToken).</Note>\n- shareToken OR portfolioId: Provide one of these to identify the portfolio.\n  - shareToken: Get this from your CoinStats portfolio page by clicking \"Share\"\n  - portfolioId: Use a portfolio connected via POST /portfolio/wallet or POST /portfolio/exchange\n- If neither is provided, returns aggregated coins from all API-connected portfolios\n</Accordion>\n<Accordion title=\"Optional\">\n- page & limit: Control the number of results per page\n- includeRiskScore: Set to \"true\" to include risk metrics\n- passcode: Passcode for accessing protected portfolio data (can be passed in header or query parameter)\n</Accordion>\n</AccordionGroup>",
-          "metadata": {
-            "title": "Get Portfolio Coins",
-            "description": "Get detailed information about all coins in your portfolio",
-            "og:title": "Get Portfolio Coins"
-          },
-          "href": "/openapi/get-portfolio-coins"
-        }
+        ]
       }
     },
     "/portfolio/chart": {
@@ -4859,7 +4775,7 @@
         "parameters": [
           {
             "name": "sharetoken",
-            "required": false,
+            "required": true,
             "in": "header",
             "description": "[Get Share Token](/sharetoken)",
             "schema": {
@@ -5005,26 +4921,23 @@
                 }
               }
             }
+          },
+          "402": {
+            "description": "Payment Required \u2014 return a valid x402 USDC payment on Base in the X-PAYMENT header to proceed.",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "x402 payment challenge. Contains network, payTo address, price, and accepted token.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           }
         },
-        "security": [
-          {
-            "X-API-KEY": []
-          }
-        ],
         "summary": "Get historical performance data to visualize your portfolio's growth over time",
         "tags": [
           "User Portfolio"
-        ],
-        "x-mint": {
-          "content": "<Note>**10** credits per request</Note><hr/>\n    <AccordionGroup>\n<Accordion title=\"You will get\">\n- Total portfolio value at different time points\n- Performance metrics for various time ranges\n- Historical Profit/Loss (PnL) data\n</Accordion>\n<Accordion title=\"Required\">\n<Note>This endpoint is only available for users with a Degen plan subscription (when using shareToken).</Note>\n- shareToken OR portfolioId: Provide one of these to identify the portfolio.\n  - shareToken: Get this from your CoinStats portfolio page by clicking \"Share\"\n  - portfolioId: Use a portfolio connected via POST /portfolio/wallet or POST /portfolio/exchange\n- If neither is provided, returns aggregated chart for all API-connected portfolios\n- type: Specify the time range for the chart data (e.g., \"24h\", \"1w\", \"1m\", \"1y\")\n</Accordion>\n<Accordion title=\"Optional\">\n- passcode: Passcode for accessing protected portfolio data (can be passed in header or query parameter)\n</Accordion>\n</AccordionGroup>",
-          "metadata": {
-            "title": "Get Portfolio Chart",
-            "description": "Get historical performance data to visualize your portfolio's growth over time",
-            "og:title": "Get Portfolio Chart"
-          },
-          "href": "/openapi/get-portfolio-chart"
-        }
+        ]
       }
     },
     "/portfolio/transactions": {
@@ -5033,7 +4946,7 @@
         "parameters": [
           {
             "name": "sharetoken",
-            "required": false,
+            "required": true,
             "in": "header",
             "description": "[Get Share Token](/sharetoken)",
             "schema": {
@@ -5200,26 +5113,23 @@
                 }
               }
             }
+          },
+          "402": {
+            "description": "Payment Required \u2014 return a valid x402 USDC payment on Base in the X-PAYMENT header to proceed.",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "x402 payment challenge. Contains network, payTo address, price, and accepted token.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           }
         },
-        "security": [
-          {
-            "X-API-KEY": []
-          }
-        ],
         "summary": "Get a detailed history of all transactions in your portfolio",
         "tags": [
           "User Portfolio"
-        ],
-        "x-mint": {
-          "content": "<Note>**4** credits per request</Note><hr/>\n    <AccordionGroup>\n<Accordion title=\"You will get\">\n- Complete list of buy/sell operations\n- Transaction dates and amounts\n- Price information at time of transaction\n- Supports pagination for viewing large transaction sets\n</Accordion>\n<Accordion title=\"Required\">\n<Note>This endpoint is only available for users with a Degen plan subscription (when using shareToken).</Note>\n- shareToken OR portfolioId: Provide one of these to identify the portfolio.\n  - shareToken: Get this from your CoinStats portfolio page by clicking \"Share\"\n  - portfolioId: Use a portfolio connected via POST /portfolio/wallet or POST /portfolio/exchange\n- If neither is provided, returns transactions from all API-connected portfolios\n- currency: Specify the currency for price values\n</Accordion>\n<Accordion title=\"Optional\">\n- page & limit: Control the number of transactions per page\n- from & to: Filter transactions by date range\n- passcode: Passcode for accessing protected portfolio data (can be passed in header or query parameter)\n</Accordion>\n\n</AccordionGroup>",
-          "metadata": {
-            "title": "Get Portfolio Transactions",
-            "description": "Get a detailed history of all transactions in your portfolio",
-            "og:title": "Get Portfolio Transactions"
-          },
-          "href": "/openapi/get-portfolio-transactions"
-        }
+        ]
       }
     },
     "/portfolio/defi": {
@@ -5228,7 +5138,7 @@
         "parameters": [
           {
             "name": "sharetoken",
-            "required": false,
+            "required": true,
             "in": "header",
             "description": "[Get Share Token](/sharetoken)",
             "schema": {
@@ -5355,26 +5265,23 @@
                 }
               }
             }
+          },
+          "402": {
+            "description": "Payment Required \u2014 return a valid x402 USDC payment on Base in the X-PAYMENT header to proceed.",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "x402 payment challenge. Contains network, payTo address, price, and accepted token.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           }
         },
-        "security": [
-          {
-            "X-API-KEY": []
-          }
-        ],
         "summary": "Retrieve comprehensive DeFi portfolio data, including staking, liquidity pool (LP), and yield farming activities",
         "tags": [
           "User Portfolio"
-        ],
-        "x-mint": {
-          "content": "<Note>**400** credits per request</Note><hr/>\n    <AccordionGroup>\n<Accordion title=\"You will get\">\n- Detailed breakdown of DeFi assets and protocols\n- Track staked tokens, LP positions, and earned rewards\n</Accordion>\n<Accordion title=\"Required\">\n<Note>This endpoint is only available for users with a Degen plan subscription (when using shareToken).</Note>\n- shareToken OR portfolioId: Provide one of these to identify the portfolio.\n  - shareToken: [Get Share Token](/sharetoken)\n  - portfolioId: Use a portfolio connected via POST /portfolio/wallet\n- If neither is provided, returns DeFi data for all API-connected portfolios\n</Accordion>\n<Accordion title=\"Optional\">\n- passcode: Passcode for accessing protected portfolio data (can be passed in header or query parameter)\n</Accordion>\n</AccordionGroup>",
-          "metadata": {
-            "title": "Get Portfolio Defi",
-            "description": "Retrieve comprehensive DeFi portfolio data, including staking, liquidity pool (LP), and yield farming activities",
-            "og:title": "Get Portfolio Defi"
-          },
-          "href": "/openapi/get-portfolio-defi"
-        }
+        ]
       }
     },
     "/portfolio/snapshot/items": {
@@ -5383,7 +5290,7 @@
         "parameters": [
           {
             "name": "sharetoken",
-            "required": false,
+            "required": true,
             "in": "header",
             "description": "[Get Share Token](/sharetoken)",
             "schema": {
@@ -5560,26 +5467,23 @@
                 }
               }
             }
+          },
+          "402": {
+            "description": "Payment Required \u2014 return a valid x402 USDC payment on Base in the X-PAYMENT header to proceed.",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "x402 payment challenge. Contains network, payTo address, price, and accepted token.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           }
         },
-        "security": [
-          {
-            "X-API-KEY": []
-          }
-        ],
         "summary": "Get historical portfolio snapshot data with normalized coin balances and portfolio metrics",
         "tags": [
           "User Portfolio"
-        ],
-        "x-mint": {
-          "content": "<Note>**500** credits per request</Note><hr/>\n    <AccordionGroup>\n<Accordion title=\"You will get\">\n- Historical coin quantities and balances over time\n- Total portfolio balance tracking with changes\n- Price changes and quantity changes between snapshots\n- Filterable by date range and specific coins\n</Accordion>\n<Accordion title=\"Required\">\n<Note>This endpoint is only available for users with a Degen plan subscription (when using shareToken).</Note>\n- shareToken OR portfolioId: Provide one of these to identify the portfolio.\n  - shareToken: Get this from your CoinStats portfolio page by clicking \"Share\"\n  - portfolioId: Use a portfolio connected via POST /portfolio/wallet or POST /portfolio/exchange\n- If neither is provided, returns snapshot data for all API-connected portfolios\n</Accordion>\n<Accordion title=\"Optional\">\n- from & to: Date range filter (YYYY-MM-DD format)\n- coinIds: Comma-separated list of coin IDs to filter by\n- page & limit: Pagination controls\n- passcode: Passcode for accessing protected portfolio data (can be passed in header or query parameter)\n</Accordion>\n</AccordionGroup>",
-          "metadata": {
-            "title": "Get Portfolio Snapshot Items",
-            "description": "Get historical portfolio snapshot data with normalized coin balances and portfolio metrics",
-            "og:title": "Get Portfolio Snapshot Items"
-          },
-          "href": "/openapi/get-portfolio-snapshot-items"
-        }
+        ]
       }
     },
     "/currencies": {
@@ -5685,26 +5589,23 @@
                 }
               }
             }
+          },
+          "402": {
+            "description": "Payment Required \u2014 return a valid x402 USDC payment on Base in the X-PAYMENT header to proceed.",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "x402 payment challenge. Contains network, payTo address, price, and accepted token.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           }
         },
-        "security": [
-          {
-            "X-API-KEY": []
-          }
-        ],
         "summary": "Get the complete list of supported fiat currencies",
         "tags": [
           "Market Data"
-        ],
-        "x-mint": {
-          "content": "<Note>**1** credit per request</Note><hr/>\n    <AccordionGroup>\n<Accordion title=\"You will get\">\n- All supported fiat currencies\n- Currency codes and exchange rates\n</Accordion>\n<Accordion title=\"Use this data\">\n- To Convert cryptocurrency values to fiat\n- To Display fiat currency information\n- In other API endpoints\n</Accordion>\n\n</AccordionGroup>",
-          "metadata": {
-            "title": "Get Currencies",
-            "description": "Get the complete list of supported fiat currencies",
-            "og:title": "Get Currencies"
-          },
-          "href": "/openapi/get-currencies"
-        }
+        ]
       }
     }
   },


### PR DESCRIPTION
## Summary

- Adds CoinStats as a finance provider with 33 x402-gated endpoints
- Covers live market data (20,000+ coins), on-chain wallet tracking (70+ blockchains), DeFi positions, crypto news, market insights, and portfolio analytics
- Pricing ranges from $0.001 (market data, news) to $0.05 (portfolio snapshots), with USDC micropayments on Base
- Includes committed OpenAPI 3.0 spec subset covering only the x402-protected surface
- Production endpoint: https://x402.coinstats.app

## Test plan

- [ ] CI syntax check passes (PAY.md frontmatter, description/use_case length, no TODOs)
- [ ] Live 402 probe succeeds against https://x402.coinstats.app (returns HTTP 402 with PAYMENT-REQUIRED header)
- [ ] OpenAPI spec validates and matches the 33 endpoint paths in PAY.md
