### PR TITLE
chore: add venum/rpc provider

### DIFF
--- a/providers/venum/rpc/PAY.md
+++ b/providers/venum/rpc/PAY.md
@@ -1,8 +1,8 @@
 ---
 name: rpc
 title: "Venum RPC"
-description: "Cost-efficient Solana mainnet JSON-RPC at $0.0001 per call in USDC via Solana MPP sessions. Drop-in for any web3.js Connection URL. No signup, no API key. All JSON-RPC methods dispatched through a single POST."
-use_case: "Use for Solana JSON-RPC calls (getAccountInfo, getBalance, getProgramAccounts, getTransaction, sendTransaction), pay-as-you-go reads without API key management, and short-burst dApp backends paying micro-cents per call."
+description: "Cost-efficient Solana mainnet JSON-RPC at $0.0001 per call in USDC. Two modes: x402 per-call (no signup) and SIWX→JWT session (24h pre-paid). Drop-in for any web3.js Connection URL."
+use_case: "Use for Solana JSON-RPC calls (getAccountInfo, getBalance, getProgramAccounts, getTransaction, sendTransaction), pay-as-you-go reads without API key management, sessions for high-volume agents, short-burst dApp backends paying micro-cents per call."
 category: compute
 service_url: https://pay.rpc.venum.dev
 version: v1
@@ -10,27 +10,55 @@ openapi:
   path: openapi.json
 ---
 
-Pay-per-call Solana mainnet JSON-RPC. The endpoint accepts any standard Solana
-JSON-RPC method via `POST /` and returns the cluster response verbatim — drop
-the URL into any web3.js `Connection` constructor or `solana` CLI `--url` flag.
+Pay-per-call Solana mainnet JSON-RPC at **$0.0001 per request**, regardless of
+method or response size. Drop the URL into any web3.js `Connection` constructor
+or `solana` CLI `--url` flag.
 
-Pricing is flat: **$0.0001 per request**, regardless of method or response
-size. The 402 challenge opens a Solana MPP session with a `$25` cap and a `1h`
-TTL, so a client signs once and the gateway debits against the session until
-the cap or TTL is reached.
+Two complementary modes — the agent picks based on its workload:
+
+### x402 per-call (default, no signup)
+
+POST `/` with a standard JSON-RPC body. The gateway responds with `402 Payment
+Required` carrying a Solana payment challenge in the `www-authenticate` header.
+The client signs a USDC transfer to the recipient and retries with the proof —
+the call succeeds, the cluster response is forwarded back verbatim. Best for
+agents doing tens of calls per task; no setup, no balance, customer pays both
+the $0.0001 USDC and the ~5000-lamport SOL signature fee.
+
+### SIWX → JWT session (high-volume)
+
+POST `/auth` with a CAIP-122 SIWX message + ed25519 signature; receive a
+**24-hour JWT** (vs the 1-hour TTL most providers ship). Pre-fund with a USDC
+transfer to the recipient using memo `venum-prepay:<your-base58-pubkey>`. Reuse
+the JWT via `Authorization: Bearer <token>` on every subsequent POST `/`. No
+per-call SOL signature, no per-call x402 round-trip — pure JSON-RPC at the line
+rate of the upstream node.
+
+`GET /balance` returns the remaining pre-pay balance and top-up instructions
+so a long-running agent can preempt 402s and refill before exhaustion.
+
+### Free reads
+
+`getHealth` and `getVersion` are free in both modes — liveness/identity probes
+shouldn't burn micro-USDC.
 
 ## Spend-aware usage
 
+- For repeat callers, **prefer the SIWX→JWT session** — one signing event for
+  the whole 24h window.
 - Cache method results client-side when the answer is stable —
   `getLatestBlockhash` for batching, `getSlot` for clock reads, mint metadata
-  via `getAccountInfo` for token lists. RPC pricing assumes stateless retrieval
-  on the gateway side, so any in-flight de-dupe is straight savings.
+  via `getAccountInfo` for token lists. The gateway has no per-method cache,
+  so any in-flight de-dupe is straight savings.
 - Prefer commitment `processed` over `finalized` when the application can
-  tolerate optimistic state — same price per call but ~10× fresher data.
-- Reuse one MPP session for the full hour. Opening a new session per call
-  burns the same micro-cents but spends extra TX setup time.
+  tolerate optimistic state — same price per call, ~10× fresher data.
 - For very high-volume reads (mass `getMultipleAccounts` over thousands of
   pubkeys), prefer one batched call with 100 pubkeys per request over 100
   single-pubkey calls — same on-chain work, 100× less RPC overhead.
 - `sendTransaction` is a single call regardless of tx size; the price doesn't
-  scale with the transaction's compute units.
+  scale with compute units.
+- Use `GET /balance` to detect impending exhaustion before the gateway issues
+  402; top up the same wallet (`venum-prepay:<pubkey>` memo) to extend the
+  session without re-auth.
+- Start with a small top-up (\$1 = 10,000 calls) and refill as needed —
+  there's no over-fund recovery in v1, so size the deposit to the workload.

--- a/providers/venum/rpc/PAY.md
+++ b/providers/venum/rpc/PAY.md
@@ -5,7 +5,7 @@ description: "Cost-efficient Solana mainnet JSON-RPC at $0.0001 per call in USDC
 use_case: "Use for Solana JSON-RPC calls (getAccountInfo, getBalance, getProgramAccounts, getTransaction, sendTransaction), pay-as-you-go reads without API key management, and short-burst dApp backends paying micro-cents per call."
 category: compute
 service_url: https://pay.rpc.venum.dev
-version: "1"
+version: v1
 openapi:
   path: openapi.json
 ---

--- a/providers/venum/rpc/PAY.md
+++ b/providers/venum/rpc/PAY.md
@@ -1,0 +1,36 @@
+---
+name: rpc
+title: "Venum RPC"
+description: "Cost-efficient Solana mainnet JSON-RPC at $0.0001 per call in USDC via Solana MPP sessions. Drop-in for any web3.js Connection URL. No signup, no API key. All JSON-RPC methods dispatched through a single POST."
+use_case: "Use for Solana JSON-RPC calls (getAccountInfo, getBalance, getProgramAccounts, getTransaction, sendTransaction), pay-as-you-go reads without API key management, and short-burst dApp backends paying micro-cents per call."
+category: compute
+service_url: https://pay.rpc.venum.dev
+version: "1"
+openapi:
+  path: openapi.json
+---
+
+Pay-per-call Solana mainnet JSON-RPC. The endpoint accepts any standard Solana
+JSON-RPC method via `POST /` and returns the cluster response verbatim — drop
+the URL into any web3.js `Connection` constructor or `solana` CLI `--url` flag.
+
+Pricing is flat: **$0.0001 per request**, regardless of method or response
+size. The 402 challenge opens a Solana MPP session with a `$25` cap and a `1h`
+TTL, so a client signs once and the gateway debits against the session until
+the cap or TTL is reached.
+
+## Spend-aware usage
+
+- Cache method results client-side when the answer is stable —
+  `getLatestBlockhash` for batching, `getSlot` for clock reads, mint metadata
+  via `getAccountInfo` for token lists. RPC pricing assumes stateless retrieval
+  on the gateway side, so any in-flight de-dupe is straight savings.
+- Prefer commitment `processed` over `finalized` when the application can
+  tolerate optimistic state — same price per call but ~10× fresher data.
+- Reuse one MPP session for the full hour. Opening a new session per call
+  burns the same micro-cents but spends extra TX setup time.
+- For very high-volume reads (mass `getMultipleAccounts` over thousands of
+  pubkeys), prefer one batched call with 100 pubkeys per request over 100
+  single-pubkey calls — same on-chain work, 100× less RPC overhead.
+- `sendTransaction` is a single call regardless of tx size; the price doesn't
+  scale with the transaction's compute units.

--- a/providers/venum/rpc/openapi.json
+++ b/providers/venum/rpc/openapi.json
@@ -40,7 +40,8 @@
                   },
                   "params": {
                     "type": "array",
-                    "description": "Method-specific positional parameters per the Solana JSON-RPC spec."
+                    "description": "Method-specific positional parameters per the Solana JSON-RPC spec.",
+                    "items": {}
                   }
                 }
               },
@@ -84,6 +85,13 @@
           },
           "402": {
             "description": "Payment required. Returned when no valid Solana MPP session cookie is present. Inspect the `www-authenticate: Payment …` header for the session challenge.",
+            "headers": {
+              "WWW-Authenticate": {
+                "description": "Solana MPP session challenge — `Payment id=\"<challenge-id>\", realm=\"Venum RPC\", method=\"solana\", intent=\"session\", request=\"<base64-json>\"`. The base64 `request` decodes to JSON containing `operator`, `recipient`, `cap`, `currency` (USDC mint), `decimals`, `network`, and `recentBlockhash`.",
+                "required": true,
+                "schema": { "type": "string" }
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {

--- a/providers/venum/rpc/openapi.json
+++ b/providers/venum/rpc/openapi.json
@@ -239,7 +239,7 @@
             "content": { "application/json": { "schema": { "type": "object", "properties": { "error": { "type": "string" } } } } }
           },
           "403": {
-            "description": "JWT revoked (e.g. after a successful `/refund`).",
+            "description": "JWT explicitly revoked (operator-side revocation; v1 has no customer-facing revoke endpoint).",
             "content": { "application/json": { "schema": { "type": "object", "properties": { "error": { "type": "string" } } } } }
           }
         }

--- a/providers/venum/rpc/openapi.json
+++ b/providers/venum/rpc/openapi.json
@@ -2,109 +2,245 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Venum RPC",
-    "version": "1.0.0",
-    "description": "Pay-per-call Solana mainnet JSON-RPC endpoint. All standard Solana JSON-RPC methods are dispatched through a single POST `/`. Pricing is flat: $0.0001 per request regardless of method or response size. USDC settlement on Solana via Solana MPP sessions ($25 cap / 1h TTL).",
+    "version": "1.1.0",
+    "description": "Pay-per-call Solana mainnet JSON-RPC at $0.0001 per request. Two complementary auth paths: x402 per-call (Solana payment challenge in `WWW-Authenticate`, no signup) and SIWX → JWT session (`POST /auth` exchange, 24h Bearer reuse, pre-pay USDC with `venum-prepay:<pubkey>` memo). `getHealth` and `getVersion` are free in both modes.",
     "license": { "name": "Proprietary" }
   },
   "servers": [
     { "url": "https://pay.rpc.venum.dev" }
   ],
+  "components": {
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "JWT",
+        "description": "EdDSA-signed JWT obtained from `POST /auth`. 24h TTL. Customer pre-funds a USDC balance to the recipient with memo `venum-prepay:<base58 wallet>`, then the gateway debits 100 micro-USDC ($0.0001) per non-free call from that balance."
+      }
+    },
+    "schemas": {
+      "JsonRpcRequest": {
+        "type": "object",
+        "required": ["jsonrpc", "method"],
+        "properties": {
+          "jsonrpc": { "type": "string", "enum": ["2.0"] },
+          "id": {
+            "oneOf": [
+              { "type": "string" },
+              { "type": "integer" },
+              { "type": "null" }
+            ]
+          },
+          "method": {
+            "type": "string",
+            "description": "Any Solana JSON-RPC method name."
+          },
+          "params": {
+            "type": "array",
+            "description": "Method-specific positional parameters per the Solana JSON-RPC spec.",
+            "items": {}
+          }
+        }
+      },
+      "JsonRpcResponse": {
+        "type": "object",
+        "properties": {
+          "jsonrpc": { "type": "string" },
+          "id": {
+            "oneOf": [
+              { "type": "string" },
+              { "type": "integer" },
+              { "type": "null" }
+            ]
+          },
+          "result": {},
+          "error": {
+            "type": "object",
+            "properties": {
+              "code": { "type": "integer" },
+              "message": { "type": "string" },
+              "data": {}
+            }
+          }
+        }
+      },
+      "X402Challenge": {
+        "type": "object",
+        "description": "Body shape of the x402 / MPP-charge 402 response. The authoritative challenge lives in the `WWW-Authenticate` header — this body is a hint for clients that don't decode the header.",
+        "properties": {
+          "endpoint": { "type": "object" },
+          "error": { "type": "string" },
+          "message": { "type": "string" },
+          "pricing": { "type": "object" }
+        }
+      },
+      "BalanceExhausted": {
+        "type": "object",
+        "description": "Session-mode 402 — issued when the JWT-bearing caller has run out of pre-paid balance. Top up via the included `topUpRecipient` + `topUpMemo` and the gateway will resume.",
+        "required": ["error", "message", "topUpRecipient", "topUpMemo"],
+        "properties": {
+          "error": { "type": "string", "enum": ["balance_exhausted"] },
+          "message": { "type": "string" },
+          "topUpRecipient": { "type": "string", "description": "Solana wallet (base58) — destination of the USDC top-up." },
+          "topUpMemo": { "type": "string", "description": "Required memo on the top-up tx. Format: `venum-prepay:<base58 wallet>`. Identifies which session's balance to credit." }
+        }
+      },
+      "AuthResponse": {
+        "type": "object",
+        "required": ["token", "expiresAt", "accountId"],
+        "properties": {
+          "token": { "type": "string", "description": "EdDSA-signed JWT (header.payload.signature, base64url). Reuse via `Authorization: Bearer <token>` for 24h." },
+          "expiresAt": { "type": "string", "format": "date-time" },
+          "accountId": { "type": "string", "description": "CAIP-10 account identifier — `solana:5eykt…:<base58 pubkey>`." }
+        }
+      },
+      "BalanceResponse": {
+        "type": "object",
+        "required": ["accountId", "balanceUsdc", "callsRemaining", "jwtExpiresAt", "topUpRecipient", "topUpMemo"],
+        "properties": {
+          "accountId": { "type": "string" },
+          "balanceUsdc": { "type": "string", "description": "Human-readable USDC balance (e.g. \"0.95\")." },
+          "callsRemaining": { "type": "string", "description": "Floor(balance / per-call cost). Stringified bigint." },
+          "jwtExpiresAt": { "type": "string", "format": "date-time" },
+          "topUpRecipient": { "type": "string" },
+          "topUpMemo": { "type": "string" }
+        }
+      }
+    }
+  },
   "paths": {
     "/": {
       "post": {
-        "summary": "Solana JSON-RPC dispatch",
-        "description": "Send any Solana JSON-RPC method as a standard `{jsonrpc:\"2.0\", id, method, params}` envelope. Behaves as a drop-in for any web3.js `Connection` URL. Common methods include `getAccountInfo`, `getBalance`, `getBlock`, `getLatestBlockhash`, `getProgramAccounts`, `getSignaturesForAddress`, `getSlot`, `getTokenAccountsByOwner`, `getTransaction`, `getVersion`, and `sendTransaction`. Returns the upstream JSON-RPC response verbatim.",
+        "summary": "Solana JSON-RPC dispatch (x402 or JWT)",
+        "description": "Send any Solana JSON-RPC method as a standard `{jsonrpc:\"2.0\", id, method, params}` envelope. With no `Authorization` header the call enters the x402 per-call flow (402 with payment challenge in WWW-Authenticate). With `Authorization: Bearer <JWT>` from `POST /auth` the call is served from the pre-paid balance (200 OK or 402 `balance_exhausted`). `getHealth` and `getVersion` are free in both modes.",
         "operationId": "solanaJsonRpc",
+        "security": [
+          {},
+          { "bearerAuth": [] }
+        ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": {
-                "type": "object",
-                "required": ["jsonrpc", "method"],
-                "properties": {
-                  "jsonrpc": {
-                    "type": "string",
-                    "enum": ["2.0"]
-                  },
-                  "id": {
-                    "oneOf": [
-                      { "type": "string" },
-                      { "type": "integer" },
-                      { "type": "null" }
-                    ]
-                  },
-                  "method": {
-                    "type": "string",
-                    "description": "Any Solana JSON-RPC method name."
-                  },
-                  "params": {
-                    "type": "array",
-                    "description": "Method-specific positional parameters per the Solana JSON-RPC spec.",
-                    "items": {}
-                  }
-                }
-              },
-              "example": {
-                "jsonrpc": "2.0",
-                "id": 1,
-                "method": "getHealth"
-              }
+              "schema": { "$ref": "#/components/schemas/JsonRpcRequest" },
+              "example": { "jsonrpc": "2.0", "id": 1, "method": "getHealth" }
             }
           }
         },
         "responses": {
           "200": {
             "description": "JSON-RPC response from the Solana cluster.",
+            "headers": {
+              "X-Venum-Paid": {
+                "description": "`metered` for a billed call, `free` for the free-method carve-out (`getHealth`, `getVersion`). JWT path only.",
+                "schema": { "type": "string", "enum": ["metered", "free"] }
+              }
+            },
             "content": {
               "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "jsonrpc": { "type": "string" },
-                    "id": {
-                      "oneOf": [
-                        { "type": "string" },
-                        { "type": "integer" },
-                        { "type": "null" }
-                      ]
-                    },
-                    "result": {},
-                    "error": {
-                      "type": "object",
-                      "properties": {
-                        "code": { "type": "integer" },
-                        "message": { "type": "string" },
-                        "data": {}
-                      }
-                    }
-                  }
-                }
+                "schema": { "$ref": "#/components/schemas/JsonRpcResponse" }
               }
             }
           },
           "402": {
-            "description": "Payment required. Returned when no valid Solana MPP session cookie is present. Inspect the `www-authenticate: Payment …` header for the session challenge.",
+            "description": "Payment required. In x402 mode (no Bearer) the `WWW-Authenticate` header carries the Solana payment challenge. In JWT mode the body is a `BalanceExhausted` envelope pointing at the top-up recipient and memo.",
             "headers": {
               "WWW-Authenticate": {
-                "description": "Solana MPP session challenge — `Payment id=\"<challenge-id>\", realm=\"Venum RPC\", method=\"solana\", intent=\"session\", request=\"<base64-json>\"`. The base64 `request` decodes to JSON containing `operator`, `recipient`, `cap`, `currency` (USDC mint), `decimals`, `network`, and `recentBlockhash`.",
-                "required": true,
+                "description": "Solana MPP-charge challenge (x402 mode only) — `Payment id=\"<challenge-id>\", realm=\"Venum RPC\", method=\"solana\", intent=\"charge\", request=\"<base64-json>\"`. The base64 `request` decodes to JSON containing `recipient`, `amount`, `currency` (USDC mint), `methodDetails.network`, and `methodDetails.recentBlockhash`.",
                 "schema": { "type": "string" }
               }
             },
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "endpoint": { "type": "object" },
-                    "error": { "type": "string" },
-                    "message": { "type": "string" },
-                    "pricing": { "type": "object" }
-                  }
+                  "oneOf": [
+                    { "$ref": "#/components/schemas/X402Challenge" },
+                    { "$ref": "#/components/schemas/BalanceExhausted" }
+                  ]
                 }
               }
             }
+          }
+        }
+      }
+    },
+    "/auth": {
+      "post": {
+        "summary": "Exchange SIWX signature for JWT (session mode)",
+        "description": "CAIP-122 Sign-In-With-X exchange. Send the SIWX message string + an ed25519 signature (base58) produced by the wallet named in the message's `address` field. Returns a 24-hour EdDSA-signed JWT bound to the wallet's CAIP-10 account. The customer pre-funds a USDC balance for that account by sending USDC to the gateway's recipient with memo `venum-prepay:<base58 wallet>`; the watcher credits the balance within ~30s of confirmation.",
+        "operationId": "exchangeSiwxForJwt",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["message", "signature", "type"],
+                "properties": {
+                  "message": {
+                    "type": "string",
+                    "description": "CAIP-122 SIWX message. Must include `domain=pay.rpc.venum.dev`, `chain-id=solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d`, a fresh `Nonce` (≥8 chars, single-use), and an `Issued At` within ±5 minutes of server time."
+                  },
+                  "signature": {
+                    "type": "string",
+                    "description": "Base58-encoded ed25519 signature of the UTF-8 SIWX message bytes."
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": ["siwx"]
+                  }
+                }
+              },
+              "example": {
+                "message": "pay.rpc.venum.dev wants you to sign in with your Solana account:\n7LQXiKR6QmqmB3BwLFx6Q9o7BPxZ1DmJQoS8mtHf55fW\n\nAuthorize Venum RPC session\n\nURI: https://pay.rpc.venum.dev\nVersion: 1\nChain ID: solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d\nNonce: a1b2c3d4e5f6a1b2\nIssued At: 2026-05-30T11:00:00Z",
+                "signature": "<base58 ed25519 sig of the message>",
+                "type": "siwx"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "JWT issued.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/AuthResponse" }
+              }
+            }
+          },
+          "400": {
+            "description": "Malformed request (missing field, unparseable SIWX, wrong `type`).",
+            "content": { "application/json": { "schema": { "type": "object", "properties": { "error": { "type": "string" } } } } }
+          },
+          "401": {
+            "description": "SIWX validation or signature check failed (wrong domain, bad nonce, expired, signature mismatch, replay).",
+            "content": { "application/json": { "schema": { "type": "object", "properties": { "error": { "type": "string" }, "message": { "type": "string" } } } } }
+          }
+        }
+      }
+    },
+    "/balance": {
+      "get": {
+        "summary": "Read current pre-pay balance (session mode)",
+        "description": "Returns the JWT-bound account's remaining USDC balance + top-up instructions. Cheap, never charges.",
+        "operationId": "getBalance",
+        "security": [{ "bearerAuth": [] }],
+        "responses": {
+          "200": {
+            "description": "Current balance + top-up instructions.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/BalanceResponse" }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid Authorization header.",
+            "content": { "application/json": { "schema": { "type": "object", "properties": { "error": { "type": "string" } } } } }
+          },
+          "403": {
+            "description": "JWT revoked (e.g. after a successful `/refund`).",
+            "content": { "application/json": { "schema": { "type": "object", "properties": { "error": { "type": "string" } } } } }
           }
         }
       }

--- a/providers/venum/rpc/openapi.json
+++ b/providers/venum/rpc/openapi.json
@@ -1,0 +1,105 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Venum RPC",
+    "version": "1.0.0",
+    "description": "Pay-per-call Solana mainnet JSON-RPC endpoint. All standard Solana JSON-RPC methods are dispatched through a single POST `/`. Pricing is flat: $0.0001 per request regardless of method or response size. USDC settlement on Solana via Solana MPP sessions ($25 cap / 1h TTL).",
+    "license": { "name": "Proprietary" }
+  },
+  "servers": [
+    { "url": "https://pay.rpc.venum.dev" }
+  ],
+  "paths": {
+    "/": {
+      "post": {
+        "summary": "Solana JSON-RPC dispatch",
+        "description": "Send any Solana JSON-RPC method as a standard `{jsonrpc:\"2.0\", id, method, params}` envelope. Behaves as a drop-in for any web3.js `Connection` URL. Common methods include `getAccountInfo`, `getBalance`, `getBlock`, `getLatestBlockhash`, `getProgramAccounts`, `getSignaturesForAddress`, `getSlot`, `getTokenAccountsByOwner`, `getTransaction`, `getVersion`, and `sendTransaction`. Returns the upstream JSON-RPC response verbatim.",
+        "operationId": "solanaJsonRpc",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["jsonrpc", "method"],
+                "properties": {
+                  "jsonrpc": {
+                    "type": "string",
+                    "enum": ["2.0"]
+                  },
+                  "id": {
+                    "oneOf": [
+                      { "type": "string" },
+                      { "type": "integer" },
+                      { "type": "null" }
+                    ]
+                  },
+                  "method": {
+                    "type": "string",
+                    "description": "Any Solana JSON-RPC method name."
+                  },
+                  "params": {
+                    "type": "array",
+                    "description": "Method-specific positional parameters per the Solana JSON-RPC spec."
+                  }
+                }
+              },
+              "example": {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "getHealth"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "JSON-RPC response from the Solana cluster.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "jsonrpc": { "type": "string" },
+                    "id": {
+                      "oneOf": [
+                        { "type": "string" },
+                        { "type": "integer" },
+                        { "type": "null" }
+                      ]
+                    },
+                    "result": {},
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": { "type": "integer" },
+                        "message": { "type": "string" },
+                        "data": {}
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required. Returned when no valid Solana MPP session cookie is present. Inspect the `www-authenticate: Payment …` header for the session challenge.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "endpoint": { "type": "object" },
+                    "error": { "type": "string" },
+                    "message": { "type": "string" },
+                    "pricing": { "type": "object" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds Venum RPC under `providers/venum/rpc` per the intake-form invitation.

Pay-per-call Solana mainnet JSON-RPC at https://pay.rpc.venum.dev, **$0.0001 per request in USDC**. Two auth paths:

- **x402 per-call** — no signup, customer signs each call inline
- **SIWX → JWT session** — `POST /auth` exchanges a CAIP-122 SIWX signature for a **24-hour JWT**. Customer pre-funds a USDC balance with memo `venum-prepay:<pubkey>`; on-chain watcher credits within ~30s. Reuse via `Authorization: Bearer <token>`.
  
`getHealth` + `getVersion` are free in both modes. Other methods flat $0.0001 (no dynamic per-method pricing).
 
Three paths in `openapi.json`: `POST /` (JSON-RPC), `POST /auth`, `GET /balance`.

  $ npx @solana/pay catalog check providers/venum/rpc/PAY.md
  │ PAY.md check successful
  │ 3 endpoints tested across 1 provider
  │ 1/1 gates compatible with Solana
  
End-to-end verified on Solana mainnet: real USDC pre-pay → JWT → paid call → exact $0.0001 debit observed on-chain.