### PR TITLE
feat(syntalic): rename crushrewards provider to syntalic

### DIFF
--- a/providers/syntalic/pricing/PAY.md
+++ b/providers/syntalic/pricing/PAY.md
@@ -1,10 +1,10 @@
 ---
 name: pricing
-title: "Crush Rewards"
+title: "Syntalic"
 description: "Track competitive retail pricing across Amazon, Walmart, Costco, Home Depot, Nordstrom, IKEA, and other US/Canadian retailers. Returns live prices, availability, deal alerts, brand positioning, inflation trends, and price-drop signals."
 use_case: "Use for comparing prices across major US and Canadian retailers, monitoring deal alerts, tracking price drops, checking product availability, analyzing brand positioning, competitive pricing research, ecommerce intelligence, and shopping recommendations."
 category: shopping
-service_url: https://api.crushrewards.dev
+service_url: https://api.syntalic.com
 openapi:
   path: openapi.json
 ---

--- a/providers/syntalic/pricing/openapi.json
+++ b/providers/syntalic/pricing/openapi.json
@@ -2,11 +2,11 @@
   "openapi": "3.1.0",
   "servers": [
     {
-      "url": "https://api.crushrewards.dev"
+      "url": "https://api.syntalic.com"
     }
   ],
   "info": {
-    "title": "Crush Rewards — Pricing Intelligence API",
+    "title": "Syntalic — Pricing Intelligence API",
     "version": "1.0.0",
     "description": "Real-time competitive pricing data across US and Canadian e-commerce retailers (Amazon, Walmart, Best Buy, Target, etc.). Serves price comparisons, deal alerts, brand tracking, promotional intelligence, and market analytics to AI agents via x402 and MPP micropayments.",
     "x-guidance": "This API has three endpoint groups organized by use case:\n\n**Shopper endpoints** ($0.01/query): Use these for price comparisons and deal hunting. Start with /v1/shopper/best-price?q=<product> to find the cheapest option across retailers. Use /v1/shopper/deal-finder?category=<category> to find discounted products. Use /v1/shopper/price-drop-alert?q=<product> to check for recent price drops.\n\n**Marketing endpoints** ($0.01/query): Use these for competitive analysis. /v1/marketing/competitive-landscape?category=<category> shows all products in a category with pricing. /v1/marketing/brand-tracker?brand=<brand> tracks a brand's pricing over time. /v1/marketing/share-of-shelf?category=<category> shows brand market share.\n\n**Analyst endpoints** ($0.02/query): Use these for market-level insights. /v1/analyst/inflation?category=<category> shows price trends over time. /v1/analyst/price-dispersion?category=<category> shows price spread across retailers.\n\nAll endpoints accept an optional 'country' parameter (us or ca, defaults to us). Query parameters use 'q' for free-text search and 'category' for category-level queries."
@@ -35,7 +35,7 @@
     "/v1/shopper/best-price": {
       "get": {
         "operationId": "getBestPrice",
-        "summary": "Find the best price for a product across retailers",
+        "summary": "Find the lowest price for a product across retailers",
         "description": "Find the lowest current price for a product across Amazon, Walmart, Costco, Home Depot, Nordstrom, and IKEA in US and Canada. Returns the cheapest option plus other retailer prices for comparison.",
         "tags": [
           "Shopper"
@@ -1164,7 +1164,7 @@
     "/v1/marketing/competitive-landscape": {
       "get": {
         "operationId": "getCompetitiveLandscape",
-        "summary": "View all products and pricing in a category",
+        "summary": "List all products and pricing in a category",
         "description": "View every product and its current pricing within a category across retailers. Sortable by price, rating, or review count for competitive benchmarking. Cursor-paginated.",
         "tags": [
           "Marketing"
@@ -1450,7 +1450,7 @@
     "/v1/marketing/brand-tracker": {
       "get": {
         "operationId": "trackBrand",
-        "summary": "Track a brand's pricing and presence over time",
+        "summary": "Summarize a brand's daily pricing and presence over time",
         "description": "Track a brand's average/min/max price, product count, in-stock count, and promo count day-by-day across a date range.",
         "tags": [
           "Marketing"
@@ -1950,7 +1950,7 @@
     "/v1/marketing/share-of-shelf": {
       "get": {
         "operationId": "getShareOfShelf",
-        "summary": "See brand market share within a category",
+        "summary": "Calculate brand market share within a category",
         "description": "Measure each brand's market share within a category by product count. Shows digital shelf dominance.",
         "tags": [
           "Marketing"
@@ -2346,7 +2346,7 @@
     "/v1/analyst/inflation": {
       "get": {
         "operationId": "getInflation",
-        "summary": "Track price inflation trends in a category or department",
+        "summary": "Analyze price inflation trends for a category or department",
         "description": "Track category-level price inflation with configurable daily, weekly, or monthly granularity. Returns period-over-period change and overall change.",
         "tags": [
           "Analyst"
@@ -2645,7 +2645,7 @@
     "/v1/analyst/price-dispersion": {
       "get": {
         "operationId": "getPriceDispersion",
-        "summary": "Analyze price spread within a category",
+        "summary": "Analyze price spread within a category or department",
         "description": "Analyze price spread within a category - mean, stddev, coefficient of variation, and percentiles (p10..p90) with IQR outlier exclusion.",
         "tags": [
           "Analyst"
@@ -2860,7 +2860,7 @@
     "/v1/analyst/retailer-index": {
       "get": {
         "operationId": "getRetailerIndex",
-        "summary": "Price index for a specific retailer over time",
+        "summary": "Calculate a price index for a retailer over time",
         "description": "Compute a normalized price index (retailer avg / category avg) for a specific retailer day-by-day versus its category baseline.",
         "tags": [
           "Analyst"
@@ -3147,7 +3147,7 @@
     "/v1/analyst/category-summary": {
       "get": {
         "operationId": "getCategorySummary",
-        "summary": "High-level summary statistics for a category or department",
+        "summary": "Summarize pricing and product statistics for a category",
         "description": "High-level category statistics - product/brand/retailer counts, pricing (avg/min/max/median), avg rating, promo rate, in-stock rate, and top brands.",
         "tags": [
           "Analyst"


### PR DESCRIPTION
Crush Rewards has rebranded to **Syntalic**. The pricing API moved to `api.syntalic.com` (the old `api.crushrewards.dev` gateway is retired), so this renames the provider and refreshes the committed OpenAPI snapshot.

### Changes
- `providers/crushrewards/pricing` → `providers/syntalic/pricing`
- `title`: "Crush Rewards" → "Syntalic"
- `service_url`: `https://api.crushrewards.dev` → `https://api.syntalic.com`
- Refreshed the committed `openapi.json` snapshot from the live spec

### Validation
`pay catalog check providers/syntalic/pricing/PAY.md` — 13/13 endpoints Solana-compatible (USDC on Solana mainnet + Base). Pricing: $0.01 shopper/marketing, $0.02 analyst.