### PR TITLE
feat: add Spraay Batch Payments (spraay/batch) - Solana-native

### DIFF
--- a/providers/spraay/batch/PAY.md
+++ b/providers/spraay/batch/PAY.md
@@ -1,0 +1,46 @@
+---
+name: batch
+title: "Spraay Batch Payments"
+description: "Native batch payments on Solana — send SOL or any SPL token to thousands of wallets in one non-custodial x402 call. The agent signs the returned transactions; the gateway never holds funds. For airdrops, stablecoin payroll, and agent disbursement."
+use_case: "Use when an agent must pay many Solana recipients at once — airdrops, SPL token distributions, stablecoin payroll, revenue splits, or paying a swarm of sub-agents — instead of sending one transfer per recipient."
+category: finance
+service_url: https://gateway-solana.spraay.app
+openapi:
+  path: openapi.json
+---
+
+Spraay is batch-payment infrastructure for the agent economy. One paid call
+fans a single token transfer out to hundreds or thousands of Solana wallets, so
+an agent that needs to *pay out* — rather than pay in — does it in one request
+instead of N.
+
+While most x402 services are things an agent **buys**, Spraay is the rail an
+agent uses to **distribute**: airdrops, stablecoin payroll, marketplace
+settlements, revenue splits, and disbursement to fleets of sub-agents. It is the
+payout complement to the pay-per-call economy.
+
+- **Native Solana execution.** Sends real SOL and any SPL token directly to
+  Solana wallets — not a wrapped or cross-chain abstraction.
+- **Non-custodial.** Endpoints return **unsigned, serialized transactions** that
+  the agent's own wallet signs and submits. Spraay never holds keys or funds.
+  The `sender` you pass is the source of funds and the fee payer.
+- **0.3% protocol fee** is included in the returned transaction as a transfer to
+  the Spraay treasury. Plus a flat x402 micro-fee per call. No accounts, no keys.
+
+## Endpoints
+
+- `GET /solana/quote` — estimate the cost of a batch by recipient count and
+  token before committing. Cheap.
+- `POST /solana/batch-send-sol` — build a batch SOL transfer to `recipients[]`,
+  funded by `sender`. Returns unsigned transaction(s) to sign and submit.
+- `POST /solana/batch-send-token` — same for any SPL token (`mint`).
+
+## Spend-aware usage
+
+- **Batch, don't loop.** Put every recipient into a single batch-send call. One
+  paid request replaces one-transfer-per-recipient — that is the entire value of
+  this skill, and the larger the list the more it saves.
+- **Quote before send.** Call `/solana/quote` to confirm recipient count and
+  cost before the priced batch-send call.
+- **Submit promptly.** Returned transactions carry a recent blockhash with a
+  short validity window — sign and submit them right away rather than holding.

--- a/providers/spraay/batch/openapi.json
+++ b/providers/spraay/batch/openapi.json
@@ -1,0 +1,151 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Spraay Batch Payments (Solana)",
+    "version": "1.0.0",
+    "description": "Native, non-custodial batch payment endpoints on Solana. Paid endpoints return HTTP 402 with an x402 challenge accepting USDC on Solana mainnet. Returns unsigned transactions for the sender to sign and submit."
+  },
+  "servers": [
+    { "url": "https://gateway-solana.spraay.app" }
+  ],
+  "paths": {
+    "/solana/quote": {
+      "get": {
+        "summary": "Estimate the cost of a batch payment",
+        "operationId": "solanaBatchQuote",
+        "parameters": [
+          { "name": "recipients", "in": "query", "required": true, "schema": { "type": "integer" }, "description": "Number of recipients in the batch" },
+          { "name": "token", "in": "query", "required": false, "schema": { "type": "string" }, "description": "Token symbol or SPL mint (default SOL)" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Cost estimate",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "recipients": { "type": "integer" },
+                    "transactions": { "type": "integer" },
+                    "estimatedFee": { "type": "string" }
+                  }
+                }
+              }
+            }
+          },
+          "402": { "description": "Payment required (x402 challenge: USDC on Solana mainnet)" }
+        }
+      }
+    },
+    "/solana/batch-send-sol": {
+      "post": {
+        "summary": "Build a non-custodial batch SOL transfer",
+        "operationId": "solanaBatchSendSol",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "sender": { "type": "string", "description": "Source / fee-payer wallet (base58). Funds the batch and signs." },
+                  "recipients": {
+                    "type": "array",
+                    "description": "Recipients and SOL amounts",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "address": { "type": "string", "description": "Recipient Solana address (base58)" },
+                        "amount": { "type": "number", "description": "Amount in SOL" }
+                      },
+                      "required": ["address", "amount"]
+                    }
+                  }
+                },
+                "required": ["sender", "recipients"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Unsigned transaction(s) for the sender to sign and submit",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "sender": { "type": "string" },
+                    "recipients": { "type": "integer" },
+                    "feeBps": { "type": "integer" },
+                    "transactions": { "type": "array", "items": { "type": "string" }, "description": "Base64 unsigned transactions" },
+                    "blockhash": { "type": "string" },
+                    "lastValidBlockHeight": { "type": "integer" }
+                  }
+                }
+              }
+            }
+          },
+          "402": { "description": "Payment required (x402 challenge: USDC on Solana mainnet)" }
+        }
+      }
+    },
+    "/solana/batch-send-token": {
+      "post": {
+        "summary": "Build a non-custodial batch SPL-token transfer",
+        "operationId": "solanaBatchSendToken",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "sender": { "type": "string", "description": "Source / fee-payer wallet (base58). Owns the source token account and signs." },
+                  "mint": { "type": "string", "description": "SPL token mint address" },
+                  "recipients": {
+                    "type": "array",
+                    "description": "Recipients and token amounts",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "address": { "type": "string", "description": "Recipient Solana address (base58)" },
+                        "amount": { "type": "number", "description": "Amount in token units" }
+                      },
+                      "required": ["address", "amount"]
+                    }
+                  }
+                },
+                "required": ["sender", "mint", "recipients"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Unsigned transaction(s) for the sender to sign and submit",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "token": { "type": "string" },
+                    "decimals": { "type": "integer" },
+                    "sender": { "type": "string" },
+                    "recipients": { "type": "integer" },
+                    "feeBps": { "type": "integer" },
+                    "atasCreated": { "type": "integer" },
+                    "transactions": { "type": "array", "items": { "type": "string" }, "description": "Base64 unsigned transactions" },
+                    "blockhash": { "type": "string" },
+                    "lastValidBlockHeight": { "type": "integer" }
+                  }
+                }
+              }
+            }
+          },
+          "402": { "description": "Payment required (x402 challenge: USDC on Solana mainnet)" }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds spraay/batch — native batch payments on Solana. One x402 call fans a single token transfer out to thousands of Solana wallets, settling in USDC on Solana mainnet. The payout/disbursement complement to the pay-per-call services in the registry: airdrops, stablecoin payroll, revenue splits, and paying out to sub-agent swarms.

- Native SOL/SPL execution to Solana wallets — non-custodial, returns unsigned transactions the agent's wallet signs.
- x402 challenge on Solana mainnet, USDC. 0.3% protocol fee included in the transaction.

Gateway: https://gateway-solana.spraay.app/ · Docs: https://docs.spraay.app/