### PR TITLE
Add EarnFi Agent API

### DIFF
--- a/providers/earnfi/agent-api/PAY.md
+++ b/providers/earnfi/agent-api/PAY.md
@@ -1,8 +1,8 @@
 ---
 name: agent-api
 title: "EarnFi Agent API"
-description: "Human execution API for AI agents. Fund social campaigns, contests, interrupts, and custom jobs via x402 USDC on Solana; returns job_id, secret, status URLs, and worker submissions."
-use_case: "Use for human-in-the-loop workflows, social campaigns, community growth, moderation, feedback collection, human interrupts, contests, verification tasks, and hiring humans from autonomous agents."
+description: "EarnFi human execution API for autonomous agents. Create paid social campaigns, contests, manual jobs, and human-interrupt questions via x402 USDC on Solana; returns job_id, secret, status URLs, submissions, and verification queues."
+use_case: "Use for human-in-the-loop task execution, social growth campaigns, community moderation, opinion polls, contest prize payouts, manual verification reviews, worker hiring, and agent-funded real-world coordination workflows on Solana."
 category: productivity
 service_url: https://app.earnfi.fun/api/ai-agent/v1
 version: v1

--- a/providers/earnfi/agent-api/PAY.md
+++ b/providers/earnfi/agent-api/PAY.md
@@ -1,0 +1,41 @@
+---
+name: agent-api
+title: "EarnFi Agent API"
+description: "Human execution API for AI agents. Fund social campaigns, contests, interrupts, and custom jobs via x402 USDC on Solana; returns job_id, secret, status URLs, and worker submissions."
+use_case: "Use for human-in-the-loop workflows, social campaigns, community growth, moderation, feedback collection, human interrupts, contests, verification tasks, and hiring humans from autonomous agents."
+category: productivity
+service_url: https://app.earnfi.fun/api/ai-agent/v1
+version: v1
+openapi:
+  path: openapi.json
+---
+
+EarnFi is a human execution layer for AI agents.
+
+Agents can create paid jobs, contests, social campaigns, moderation workflows, human interrupt requests, verification tasks, onboarding campaigns, and structured feedback collection using x402 payments on Solana.
+
+Unlike traditional APIs that return information, EarnFi enables agents to coordinate real human work.
+
+Supported workflows include:
+
+* Social engagement campaigns
+* Human feedback collection
+* Human interrupt escalation
+* Community growth campaigns
+* Contest execution
+* Manual review workflows
+* Verification tasks
+* Human-in-the-loop agent operations
+
+All paid job creation endpoints support x402 payments using USDC on Solana. Polling and creator routes are free with `secret` or `agent_token`.
+
+Documentation: https://docs.earnfi.fun
+
+## Spend-aware usage
+
+* Use interrupt jobs for targeted human decisions instead of large campaigns.
+* Create small test campaigns before scaling budgets.
+* Poll job status and submissions instead of creating duplicate jobs.
+* Reuse existing campaigns when possible.
+* Register once via `/register` and reuse `agent_token`.
+* Use reward amounts appropriate for the task complexity.

--- a/providers/earnfi/agent-api/openapi.json
+++ b/providers/earnfi/agent-api/openapi.json
@@ -1,0 +1,330 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "EarnFi Agent API (x402)",
+    "version": "1.0.0",
+    "description": "Machine-readable overview of the EarnFi **Agent API** (`ai-agent/v1`). **Paid** routes return HTTP **402** with a quote until you attach the **x402 payment header** shown in that response; **free** routes use `?secret=` or `?agent_token=`.\n\n**MCP:** Streamable HTTP at `{origin}/mcp` exposes the same flows via tools such as `earnfi_social_create` (optional `payment_signature` on the second call; structured JSON quotes). See `/skill.md` for the tool table.\n\n**Who can run work:** New jobs are **humans-only** (`execution_mode=human`). Other modes are reserved for a future release.\n\n**Optional audience rules:** Paid creates may request token-holder gates or verified-participant options using query parameters documented on each path. See product docs for what participants see in the app.\n\n**Where to read more:** Narrative overview at https://docs.earnfi.fun (Agent API). For Solana transaction field layout, follow this file together with the x402 SDK you use in production."
+  },
+  "servers": [
+    {
+      "url": "https://app.earnfi.fun/api/ai-agent/v1",
+      "description": "EarnFi Agent API base path for this deployment"
+    }
+  ],
+  "tags": [
+    { "name": "discovery", "description": "Catalog and registration (no job payment), plus optional `/x402` preview" },
+    { "name": "x402-paid-create", "description": "Paid job creates: 402 quote, then retry with signed USDC payment header" },
+    { "name": "polling", "description": "Free reads with job secret or agent token" },
+    { "name": "creator", "description": "Free creator actions that require agent token" }
+  ],
+  "paths": {
+    "/x402": {
+      "get": {
+        "tags": ["discovery"],
+        "summary": "Preview how paid social jobs are priced",
+        "description": "**Returns 402** with the same payment framing as `/jobs/social`, so tools can learn quote shape before you fund a real run.",
+        "responses": {
+          "402": { "description": "x402 v2 JSON plus standard payment headers" }
+        }
+      },
+      "post": {
+        "tags": ["discovery"],
+        "summary": "Same as GET",
+        "description": "Identical to GET; body is optional for discovery.",
+        "responses": {
+          "402": { "description": "Same as GET" }
+        }
+      }
+    },
+    "/catalog": {
+      "get": {
+        "tags": ["discovery"],
+        "summary": "Job types, minimum rewards, suggested sizes",
+        "description": "**Free.** Lists what kinds of quick work you can fund, minimum pay, and suggested participant counts.",
+        "responses": {
+          "200": { "description": "Catalog JSON" }
+        }
+      },
+      "post": {
+        "tags": ["discovery"],
+        "summary": "Same as GET",
+        "description": "**Free.** Same JSON as GET.",
+        "responses": {
+          "200": { "description": "Catalog JSON" }
+        }
+      }
+    },
+    "/register/challenge": {
+      "get": {
+        "tags": ["discovery"],
+        "summary": "Canonical registration message",
+        "description": "**Free.** Returns `message`, `nonce`, and expiry. Sign `message` exactly (UTF-8), then `POST /register` with the same `wallet_address`, `agent_name`, unchanged `message`, `signature`, and `nonce`. Recommended for autonomous clients.",
+        "parameters": [
+          { "name": "wallet_address", "in": "query", "required": true, "schema": { "type": "string" } },
+          { "name": "agent_name", "in": "query", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": { "description": "message, nonce, expires_at" },
+          "400": { "description": "invalid_params" },
+          "409": { "description": "wallet_reserved_for_human_user" }
+        }
+      },
+      "post": {
+        "tags": ["discovery"],
+        "summary": "Same as GET",
+        "description": "**Free.** Same parameters may be sent as JSON body (merged into request like other Agent routes).",
+        "responses": {
+          "200": { "description": "Same as GET" }
+        }
+      }
+    },
+    "/register": {
+      "post": {
+        "tags": ["discovery"],
+        "summary": "Register an agent (wallet-signed message)",
+        "description": "**Free.** Creates an **agent_token** for your machine identity. This wallet message signature is **not** the same object you use for x402 paid creates after a 402 quote.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["wallet_address", "agent_name", "message", "signature"],
+                "properties": {
+                  "wallet_address": { "type": "string" },
+                  "agent_name": { "type": "string" },
+                  "message": { "type": "string" },
+                  "signature": {},
+                  "nonce": { "type": "string", "description": "Optional; when set, must match GET /register/challenge and message must match that challenge exactly." }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": { "description": "agent_id, agent_token" },
+          "400": { "description": "invalid_params" }
+        }
+      }
+    },
+    "/jobs/social": {
+      "get": {
+        "tags": ["x402-paid-create"],
+        "summary": "Create a social or quick-engagement job (paid)",
+        "description": "**Paid (x402).** Fund follows, likes, reposts, comments, watch tasks, and similar catalog work. **Without** a completed payment you receive **402** with `accepts[]` and a human-readable `resource.description`. **With** payment, retry the **same** request including the x402 payment header. Optional **token gate** and **verified-participant** query fields are documented in the live schema.",
+        "parameters": [
+          { "name": "agent_token", "in": "query", "schema": { "type": "string" } },
+          { "name": "task_type", "in": "query", "schema": { "type": "string" } },
+          { "name": "slots", "in": "query", "schema": { "type": "integer" } },
+          { "name": "reward_per_user", "in": "query", "schema": { "type": "string" } },
+          {
+            "name": "execution_mode",
+            "in": "query",
+            "schema": { "type": "string", "enum": ["human"] },
+            "description": "Must be `human` (default). Other values are rejected until supported."
+          },
+          {
+            "name": "token_gate",
+            "in": "query",
+            "schema": { "type": "string" },
+            "description": "Optional URL-encoded JSON for token-holder rules when enabled for your deployment."
+          },
+          {
+            "name": "x_account_requirement",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": ["all", "verified_only", "verified"]
+            },
+            "description": "Optional participant filter for verified accounts."
+          },
+          {
+            "name": "requires_verified_x",
+            "in": "query",
+            "schema": { "type": "boolean" },
+            "description": "Optional shorthand for verified-only vs all participants."
+          }
+        ],
+        "responses": {
+          "402": { "description": "Quote before payment" },
+          "200": { "description": "job_id, secret, status_url — polling is free with secret" },
+          "400": { "description": "Validation errors" },
+          "403": { "description": "Gating or policy rejection" }
+        }
+      }
+    },
+    "/jobs/manual": {
+      "get": {
+        "tags": ["x402-paid-create"],
+        "summary": "Create a custom / manual job (paid)",
+        "description": "**Paid (x402).** Same quote-then-pay pattern as `/jobs/social`. You supply your own title, instructions, and verification style. Optional token and verified-participant query fields as on `/jobs/social` where supported."
+      }
+    },
+    "/jobs/contest": {
+      "get": {
+        "tags": ["x402-paid-create"],
+        "summary": "Create a contest (paid)",
+        "description": "**Paid (x402).** Prize pool contests with platform fee included in the quote. Optional gating fields as on `/jobs/social` where supported."
+      }
+    },
+    "/interrupt": {
+      "get": {
+        "tags": ["x402-paid-create"],
+        "summary": "Ask many people one question (paid)",
+        "description": "**Paid (x402).** Human answers to a single clear question—opinions, quick feedback, light tasks. Same quote-then-pay pattern; optional gating as documented."
+      }
+    },
+    "/jobs/{id}": {
+      "get": {
+        "tags": ["polling"],
+        "summary": "Poll job status",
+        "description": "**Free** with `?secret=` (recommended) or `?agent_token=`."
+      }
+    },
+    "/jobs/{id}/submissions": {
+      "get": {
+        "tags": ["polling"],
+        "summary": "List submissions",
+        "description": "**Free** — list worker submissions with the job’s secret; no second on-chain payment per read."
+      }
+    },
+    "/jobs/{id}/completions": {
+      "get": {
+        "tags": ["polling"],
+        "summary": "List completions",
+        "description": "**Free** with secret or agent_token."
+      }
+    },
+    "/jobs/{id}/pause": {
+      "get": {
+        "tags": ["creator"],
+        "summary": "Pause or resume job",
+        "description": "**Free** — requires `agent_token`. GET or POST with `agent_token` in query or JSON body."
+      },
+      "post": {
+        "tags": ["creator"],
+        "summary": "Same as GET",
+        "description": "**Free** — same as GET; body may include `agent_token`."
+      }
+    },
+    "/jobs/{id}/verifications": {
+      "get": {
+        "tags": ["creator"],
+        "summary": "List pending manual verifications",
+        "description": "**Free** — requires `agent_token` for the job owner. Returns completions awaiting approve/reject on manual-verification jobs."
+      },
+      "post": {
+        "tags": ["creator"],
+        "summary": "Same as GET",
+        "description": "**Free** — same as GET."
+      }
+    },
+    "/verifications/{id}/approve": {
+      "get": {
+        "tags": ["creator"],
+        "summary": "Approve a verification",
+        "description": "**Free** — `agent_token` required. `{id}` is the verification (completion) id."
+      },
+      "post": {
+        "tags": ["creator"],
+        "summary": "Same as GET",
+        "description": "**Free** — same as GET."
+      }
+    },
+    "/verifications/{id}/reject": {
+      "get": {
+        "tags": ["creator"],
+        "summary": "Reject a verification",
+        "description": "**Free** — `agent_token` required. Optional `reason` query/body on POST."
+      },
+      "post": {
+        "tags": ["creator"],
+        "summary": "Same as GET",
+        "description": "**Free** — same as GET."
+      }
+    },
+    "/jobs/{id}/contest/submissions": {
+      "get": {
+        "tags": ["creator"],
+        "summary": "List contest submissions",
+        "description": "**Free** — contest jobs only; requires `agent_token`."
+      },
+      "post": {
+        "tags": ["creator"],
+        "summary": "Same as GET",
+        "description": "**Free** — same as GET."
+      }
+    },
+    "/jobs/{id}/contest/mark-winner": {
+      "get": {
+        "tags": ["creator"],
+        "summary": "Mark contest winner",
+        "description": "**Free** — requires `agent_token` and submission identifiers per live API schema."
+      },
+      "post": {
+        "tags": ["creator"],
+        "summary": "Same as GET",
+        "description": "**Free** — same as GET."
+      }
+    },
+    "/jobs/{id}/detail": {
+      "get": {
+        "tags": ["creator"],
+        "summary": "Creator job detail",
+        "description": "**Free** — extended job view for the agent owner."
+      },
+      "post": {
+        "tags": ["creator"],
+        "summary": "Same as GET",
+        "description": "**Free** — same as GET."
+      }
+    },
+    "/jobs/{id}/users": {
+      "get": {
+        "tags": ["creator"],
+        "summary": "List participants",
+        "description": "**Free** — users who joined or completed the job."
+      },
+      "post": {
+        "tags": ["creator"],
+        "summary": "Same as GET",
+        "description": "**Free** — same as GET."
+      }
+    },
+    "/jobs/{id}/payments": {
+      "get": {
+        "tags": ["creator"],
+        "summary": "List job payments",
+        "description": "**Free** — payment rows linked to the job."
+      },
+      "post": {
+        "tags": ["creator"],
+        "summary": "Same as GET",
+        "description": "**Free** — same as GET."
+      }
+    },
+    "/interrupt/{id}": {
+      "get": {
+        "tags": ["polling"],
+        "summary": "Poll human-interrupt job",
+        "description": "**Free** with `secret` or `agent_token`. `{id}` is the interrupt id (e.g. EFI…)."
+      },
+      "post": {
+        "tags": ["polling"],
+        "summary": "Same as GET",
+        "description": "**Free** — same as GET."
+      }
+    }
+  },
+  "components": {
+    "parameters": {
+      "PaymentSignatureHeader": {
+        "name": "PAYMENT-SIGNATURE",
+        "in": "header",
+        "required": false,
+        "description": "x402 payment payload (base64 JSON with signed_tx + requirements). Required on the **retry** after HTTP 402 on paid create routes. Not used for registration (wallet message signature is separate).",
+        "schema": { "type": "string" }
+      }
+    }
+  }
+}

--- a/providers/earnfi/agent-api/openapi.json
+++ b/providers/earnfi/agent-api/openapi.json
@@ -57,7 +57,7 @@
         "tags": [
           "discovery"
         ],
-        "summary": "Same as GET",
+        "summary": "Preview x402 USDC pricing for social job creation",
         "description": "Identical to GET; body is optional for discovery.",
         "responses": {
           "402": {
@@ -93,7 +93,7 @@
         "tags": [
           "discovery"
         ],
-        "summary": "Same as GET",
+        "summary": "Return the same catalog JSON as the GET catalog route",
         "description": "**Free.** Same JSON as GET.",
         "responses": {
           "200": {
@@ -145,7 +145,7 @@
         "tags": [
           "discovery"
         ],
-        "summary": "Same as GET",
+        "summary": "Fetch canonical agent registration challenge message",
         "description": "**Free.** Same parameters may be sent as JSON body (merged into request like other Agent routes).",
         "responses": {
           "200": {
@@ -438,7 +438,7 @@
         "tags": [
           "x402-paid-create"
         ],
-        "summary": "Create a contest (paid)",
+        "summary": "Create a paid contest job returning a prize-pool quote",
         "description": "**Paid (x402).** Prize pool contests with platform fee included in the quote. Optional gating fields as on `/jobs/social` where supported.",
         "responses": {
           "200": {
@@ -582,7 +582,7 @@
         "tags": [
           "polling"
         ],
-        "summary": "Poll job status",
+        "summary": "Poll funded job status, slots filled, and payout progress",
         "description": "**Free** with `?secret=` (recommended) or `?agent_token=`.",
         "parameters": [
           {
@@ -624,7 +624,7 @@
         "tags": [
           "polling"
         ],
-        "summary": "List submissions",
+        "summary": "List worker submissions awaiting review on a job",
         "description": "**Free** — list worker submissions with the job's secret; no second on-chain payment per read.",
         "parameters": [
           {
@@ -666,7 +666,7 @@
         "tags": [
           "polling"
         ],
-        "summary": "List completions",
+        "summary": "List worker completion records for a funded job",
         "description": "**Free** with secret or agent_token.",
         "parameters": [
           {
@@ -708,7 +708,7 @@
         "tags": [
           "creator"
         ],
-        "summary": "Pause or resume job",
+        "summary": "Pause or resume an active funded job for creators",
         "description": "**Free** — requires agent_token in JSON body or Agent-Token header. Use POST for mutations.",
         "parameters": [
           {
@@ -786,7 +786,7 @@
         "tags": [
           "creator"
         ],
-        "summary": "Approve a verification",
+        "summary": "Approve a manual verification and release worker pay",
         "description": "**Free** — `agent_token` required. `{id}` is the verification (completion) id. Use POST for mutations.",
         "parameters": [
           {
@@ -830,7 +830,7 @@
         "tags": [
           "creator"
         ],
-        "summary": "Reject a verification",
+        "summary": "Reject a manual verification with optional reason text",
         "description": "**Free** — `agent_token` required. Optional `reason` in query or JSON body. Use POST for mutations.",
         "parameters": [
           {
@@ -908,7 +908,7 @@
         "tags": [
           "creator"
         ],
-        "summary": "Mark contest winner",
+        "summary": "Mark a contest submission as the prize winner",
         "description": "**Free** — requires `agent_token` and submission identifiers per live API schema. Use POST for mutations.",
         "parameters": [
           {
@@ -952,7 +952,7 @@
         "tags": [
           "creator"
         ],
-        "summary": "Creator job detail",
+        "summary": "Fetch extended creator job detail and funding stats",
         "description": "**Free** — extended job view for the agent owner.",
         "parameters": [
           {
@@ -986,7 +986,7 @@
         "tags": [
           "creator"
         ],
-        "summary": "List participants",
+        "summary": "List users who joined or completed a funded job",
         "description": "**Free** — users who joined or completed the job.",
         "parameters": [
           {
@@ -1020,7 +1020,7 @@
         "tags": [
           "creator"
         ],
-        "summary": "List job payments",
+        "summary": "List on-chain payment rows linked to a funded job",
         "description": "**Free** — payment rows linked to the job.",
         "parameters": [
           {

--- a/providers/earnfi/agent-api/openapi.json
+++ b/providers/earnfi/agent-api/openapi.json
@@ -20,6 +20,7 @@
   "paths": {
     "/x402": {
       "get": {
+        "operationId": "getX402Preview",
         "tags": ["discovery"],
         "summary": "Preview how paid social jobs are priced",
         "description": "**Returns 402** with the same payment framing as `/jobs/social`, so tools can learn quote shape before you fund a real run.",
@@ -28,6 +29,7 @@
         }
       },
       "post": {
+        "operationId": "postX402Preview",
         "tags": ["discovery"],
         "summary": "Same as GET",
         "description": "Identical to GET; body is optional for discovery.",
@@ -38,6 +40,7 @@
     },
     "/catalog": {
       "get": {
+        "operationId": "getCatalog",
         "tags": ["discovery"],
         "summary": "Job types, minimum rewards, suggested sizes",
         "description": "**Free.** Lists what kinds of quick work you can fund, minimum pay, and suggested participant counts.",
@@ -46,6 +49,7 @@
         }
       },
       "post": {
+        "operationId": "postCatalog",
         "tags": ["discovery"],
         "summary": "Same as GET",
         "description": "**Free.** Same JSON as GET.",
@@ -56,6 +60,7 @@
     },
     "/register/challenge": {
       "get": {
+        "operationId": "getRegisterChallenge",
         "tags": ["discovery"],
         "summary": "Canonical registration message",
         "description": "**Free.** Returns `message`, `nonce`, and expiry. Sign `message` exactly (UTF-8), then `POST /register` with the same `wallet_address`, `agent_name`, unchanged `message`, `signature`, and `nonce`. Recommended for autonomous clients.",
@@ -70,16 +75,20 @@
         }
       },
       "post": {
+        "operationId": "postRegisterChallenge",
         "tags": ["discovery"],
         "summary": "Same as GET",
         "description": "**Free.** Same parameters may be sent as JSON body (merged into request like other Agent routes).",
         "responses": {
-          "200": { "description": "Same as GET" }
+          "200": { "description": "Same as GET" },
+          "400": { "description": "invalid_params" },
+          "409": { "description": "wallet_reserved_for_human_user" }
         }
       }
     },
     "/register": {
       "post": {
+        "operationId": "registerAgent",
         "tags": ["discovery"],
         "summary": "Register an agent (wallet-signed message)",
         "description": "**Free.** Creates an **agent_token** for your machine identity. This wallet message signature is **not** the same object you use for x402 paid creates after a 402 quote.",
@@ -94,7 +103,10 @@
                   "wallet_address": { "type": "string" },
                   "agent_name": { "type": "string" },
                   "message": { "type": "string" },
-                  "signature": {},
+                  "signature": {
+                    "type": "string",
+                    "description": "Ed25519 wallet signature of the challenge message. Accepts base58, hex (128 chars), standard base64, or a JSON array of 64 integers (0–255)."
+                  },
                   "nonce": { "type": "string", "description": "Optional; when set, must match GET /register/challenge and message must match that challenge exactly." }
                 }
               }
@@ -103,12 +115,14 @@
         },
         "responses": {
           "200": { "description": "agent_id, agent_token" },
-          "400": { "description": "invalid_params" }
+          "400": { "description": "invalid_params" },
+          "409": { "description": "wallet_reserved_for_human_user" }
         }
       }
     },
     "/jobs/social": {
       "get": {
+        "operationId": "createSocialJob",
         "tags": ["x402-paid-create"],
         "summary": "Create a social or quick-engagement job (paid)",
         "description": "**Paid (x402).** Fund follows, likes, reposts, comments, watch tasks, and similar catalog work. **Without** a completed payment you receive **402** with `accepts[]` and a human-readable `resource.description`. **With** payment, retry the **same** request including the x402 payment header. Optional **token gate** and **verified-participant** query fields are documented in the live schema.",
@@ -151,168 +165,322 @@
           "400": { "description": "Validation errors" },
           "403": { "description": "Gating or policy rejection" }
         }
+      },
+      "post": {
+        "operationId": "createSocialJobPost",
+        "tags": ["x402-paid-create"],
+        "summary": "Create a social or quick-engagement job (paid, JSON body)",
+        "description": "**Paid (x402).** Same quote-then-pay semantics as GET; parameters may be sent as JSON body.",
+        "responses": {
+          "402": { "description": "Quote before payment" },
+          "200": { "description": "job_id, secret, status_url" },
+          "400": { "description": "Validation errors" },
+          "403": { "description": "Gating or policy rejection" }
+        }
       }
     },
     "/jobs/manual": {
       "get": {
+        "operationId": "createManualJob",
         "tags": ["x402-paid-create"],
         "summary": "Create a custom / manual job (paid)",
-        "description": "**Paid (x402).** Same quote-then-pay pattern as `/jobs/social`. You supply your own title, instructions, and verification style. Optional token and verified-participant query fields as on `/jobs/social` where supported."
+        "description": "**Paid (x402).** Same quote-then-pay pattern as `/jobs/social`. You supply your own title, instructions, and verification style. Optional token and verified-participant query fields as on `/jobs/social` where supported.",
+        "responses": {
+          "402": { "description": "Quote before payment" },
+          "200": { "description": "job_id, secret, status_url" },
+          "400": { "description": "Validation errors" },
+          "403": { "description": "Gating or policy rejection" }
+        }
+      },
+      "post": {
+        "operationId": "createManualJobPost",
+        "tags": ["x402-paid-create"],
+        "summary": "Create a custom / manual job (paid, JSON body)",
+        "description": "**Paid (x402).** Same quote-then-pay semantics as GET; parameters may be sent as JSON body.",
+        "responses": {
+          "402": { "description": "Quote before payment" },
+          "200": { "description": "job_id, secret, status_url" },
+          "400": { "description": "Validation errors" },
+          "403": { "description": "Gating or policy rejection" }
+        }
       }
     },
     "/jobs/contest": {
       "get": {
+        "operationId": "createContestJob",
         "tags": ["x402-paid-create"],
         "summary": "Create a contest (paid)",
-        "description": "**Paid (x402).** Prize pool contests with platform fee included in the quote. Optional gating fields as on `/jobs/social` where supported."
+        "description": "**Paid (x402).** Prize pool contests with platform fee included in the quote. Optional gating fields as on `/jobs/social` where supported.",
+        "responses": {
+          "402": { "description": "Quote before payment" },
+          "200": { "description": "job_id, secret, status_url" },
+          "400": { "description": "Validation errors" },
+          "403": { "description": "Gating or policy rejection" }
+        }
+      },
+      "post": {
+        "operationId": "createContestJobPost",
+        "tags": ["x402-paid-create"],
+        "summary": "Create a contest (paid, JSON body)",
+        "description": "**Paid (x402).** Same quote-then-pay semantics as GET; parameters may be sent as JSON body.",
+        "responses": {
+          "402": { "description": "Quote before payment" },
+          "200": { "description": "job_id, secret, status_url" },
+          "400": { "description": "Validation errors" },
+          "403": { "description": "Gating or policy rejection" }
+        }
       }
     },
     "/interrupt": {
       "get": {
+        "operationId": "createInterruptJob",
         "tags": ["x402-paid-create"],
         "summary": "Ask many people one question (paid)",
-        "description": "**Paid (x402).** Human answers to a single clear question—opinions, quick feedback, light tasks. Same quote-then-pay pattern; optional gating as documented."
+        "description": "**Paid (x402).** Human answers to a single clear question—opinions, quick feedback, light tasks. Same quote-then-pay pattern; optional gating as documented.",
+        "responses": {
+          "402": { "description": "Quote before payment" },
+          "200": { "description": "interrupt_id, secret, status_url" },
+          "400": { "description": "Validation errors" },
+          "403": { "description": "Gating or policy rejection" }
+        }
+      },
+      "post": {
+        "operationId": "createInterruptJobPost",
+        "tags": ["x402-paid-create"],
+        "summary": "Ask many people one question (paid, JSON body)",
+        "description": "**Paid (x402).** Same quote-then-pay semantics as GET; parameters may be sent as JSON body.",
+        "responses": {
+          "402": { "description": "Quote before payment" },
+          "200": { "description": "interrupt_id, secret, status_url" },
+          "400": { "description": "Validation errors" },
+          "403": { "description": "Gating or policy rejection" }
+        }
       }
     },
     "/jobs/{id}": {
       "get": {
+        "operationId": "getJobStatus",
         "tags": ["polling"],
         "summary": "Poll job status",
-        "description": "**Free** with `?secret=` (recommended) or `?agent_token=`."
+        "description": "**Free** with `?secret=` (recommended) or `?agent_token=`.",
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } },
+          { "name": "secret", "in": "query", "schema": { "type": "string" } },
+          { "name": "agent_token", "in": "query", "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": { "description": "Job status JSON" },
+          "401": { "description": "Missing or invalid secret/agent_token" },
+          "404": { "description": "Job not found" }
+        }
       }
     },
     "/jobs/{id}/submissions": {
       "get": {
+        "operationId": "listJobSubmissions",
         "tags": ["polling"],
         "summary": "List submissions",
-        "description": "**Free** — list worker submissions with the job’s secret; no second on-chain payment per read."
+        "description": "**Free** — list worker submissions with the job's secret; no second on-chain payment per read.",
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } },
+          { "name": "secret", "in": "query", "schema": { "type": "string" } },
+          { "name": "agent_token", "in": "query", "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": { "description": "Submission list JSON" },
+          "401": { "description": "Missing or invalid secret/agent_token" },
+          "404": { "description": "Job not found" }
+        }
       }
     },
     "/jobs/{id}/completions": {
       "get": {
+        "operationId": "listJobCompletions",
         "tags": ["polling"],
         "summary": "List completions",
-        "description": "**Free** with secret or agent_token."
+        "description": "**Free** with secret or agent_token.",
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } },
+          { "name": "secret", "in": "query", "schema": { "type": "string" } },
+          { "name": "agent_token", "in": "query", "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": { "description": "Completion list JSON" },
+          "401": { "description": "Missing or invalid secret/agent_token" },
+          "404": { "description": "Job not found" }
+        }
       }
     },
     "/jobs/{id}/pause": {
-      "get": {
+      "post": {
+        "operationId": "pauseOrResumeJob",
         "tags": ["creator"],
         "summary": "Pause or resume job",
-        "description": "**Free** — requires `agent_token`. GET or POST with `agent_token` in query or JSON body."
-      },
-      "post": {
-        "tags": ["creator"],
-        "summary": "Same as GET",
-        "description": "**Free** — same as GET; body may include `agent_token`."
+        "description": "**Free** — requires `agent_token` in query or JSON body. Use POST for mutations (GET is not documented).",
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } },
+          { "name": "agent_token", "in": "query", "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": { "description": "Updated job pause state" },
+          "401": { "description": "Missing or invalid agent_token" },
+          "404": { "description": "Job not found" }
+        }
       }
     },
     "/jobs/{id}/verifications": {
       "get": {
+        "operationId": "listPendingVerifications",
         "tags": ["creator"],
         "summary": "List pending manual verifications",
-        "description": "**Free** — requires `agent_token` for the job owner. Returns completions awaiting approve/reject on manual-verification jobs."
-      },
-      "post": {
-        "tags": ["creator"],
-        "summary": "Same as GET",
-        "description": "**Free** — same as GET."
+        "description": "**Free** — requires `agent_token` for the job owner. Returns completions awaiting approve/reject on manual-verification jobs.",
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } },
+          { "name": "agent_token", "in": "query", "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": { "description": "Pending verification list JSON" },
+          "401": { "description": "Missing or invalid agent_token" },
+          "404": { "description": "Job not found" }
+        }
       }
     },
     "/verifications/{id}/approve": {
-      "get": {
+      "post": {
+        "operationId": "approveVerification",
         "tags": ["creator"],
         "summary": "Approve a verification",
-        "description": "**Free** — `agent_token` required. `{id}` is the verification (completion) id."
-      },
-      "post": {
-        "tags": ["creator"],
-        "summary": "Same as GET",
-        "description": "**Free** — same as GET."
+        "description": "**Free** — `agent_token` required. `{id}` is the verification (completion) id. Use POST for mutations.",
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } },
+          { "name": "agent_token", "in": "query", "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": { "description": "Verification approved" },
+          "401": { "description": "Missing or invalid agent_token" },
+          "404": { "description": "Verification not found" }
+        }
       }
     },
     "/verifications/{id}/reject": {
-      "get": {
+      "post": {
+        "operationId": "rejectVerification",
         "tags": ["creator"],
         "summary": "Reject a verification",
-        "description": "**Free** — `agent_token` required. Optional `reason` query/body on POST."
-      },
-      "post": {
-        "tags": ["creator"],
-        "summary": "Same as GET",
-        "description": "**Free** — same as GET."
+        "description": "**Free** — `agent_token` required. Optional `reason` in query or JSON body. Use POST for mutations.",
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } },
+          { "name": "agent_token", "in": "query", "schema": { "type": "string" } },
+          { "name": "reason", "in": "query", "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": { "description": "Verification rejected" },
+          "401": { "description": "Missing or invalid agent_token" },
+          "404": { "description": "Verification not found" }
+        }
       }
     },
     "/jobs/{id}/contest/submissions": {
       "get": {
+        "operationId": "listContestSubmissions",
         "tags": ["creator"],
         "summary": "List contest submissions",
-        "description": "**Free** — contest jobs only; requires `agent_token`."
-      },
-      "post": {
-        "tags": ["creator"],
-        "summary": "Same as GET",
-        "description": "**Free** — same as GET."
+        "description": "**Free** — contest jobs only; requires `agent_token`.",
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } },
+          { "name": "agent_token", "in": "query", "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": { "description": "Contest submission list JSON" },
+          "401": { "description": "Missing or invalid agent_token" },
+          "404": { "description": "Job not found" }
+        }
       }
     },
     "/jobs/{id}/contest/mark-winner": {
-      "get": {
+      "post": {
+        "operationId": "markContestWinner",
         "tags": ["creator"],
         "summary": "Mark contest winner",
-        "description": "**Free** — requires `agent_token` and submission identifiers per live API schema."
-      },
-      "post": {
-        "tags": ["creator"],
-        "summary": "Same as GET",
-        "description": "**Free** — same as GET."
+        "description": "**Free** — requires `agent_token` and submission identifiers per live API schema. Use POST for mutations.",
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } },
+          { "name": "agent_token", "in": "query", "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": { "description": "Winner marked" },
+          "401": { "description": "Missing or invalid agent_token" },
+          "404": { "description": "Job or submission not found" }
+        }
       }
     },
     "/jobs/{id}/detail": {
       "get": {
+        "operationId": "getCreatorJobDetail",
         "tags": ["creator"],
         "summary": "Creator job detail",
-        "description": "**Free** — extended job view for the agent owner."
-      },
-      "post": {
-        "tags": ["creator"],
-        "summary": "Same as GET",
-        "description": "**Free** — same as GET."
+        "description": "**Free** — extended job view for the agent owner.",
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } },
+          { "name": "agent_token", "in": "query", "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": { "description": "Extended job detail JSON" },
+          "401": { "description": "Missing or invalid agent_token" },
+          "404": { "description": "Job not found" }
+        }
       }
     },
     "/jobs/{id}/users": {
       "get": {
+        "operationId": "listJobParticipants",
         "tags": ["creator"],
         "summary": "List participants",
-        "description": "**Free** — users who joined or completed the job."
-      },
-      "post": {
-        "tags": ["creator"],
-        "summary": "Same as GET",
-        "description": "**Free** — same as GET."
+        "description": "**Free** — users who joined or completed the job.",
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } },
+          { "name": "agent_token", "in": "query", "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": { "description": "Participant list JSON" },
+          "401": { "description": "Missing or invalid agent_token" },
+          "404": { "description": "Job not found" }
+        }
       }
     },
     "/jobs/{id}/payments": {
       "get": {
+        "operationId": "listJobPayments",
         "tags": ["creator"],
         "summary": "List job payments",
-        "description": "**Free** — payment rows linked to the job."
-      },
-      "post": {
-        "tags": ["creator"],
-        "summary": "Same as GET",
-        "description": "**Free** — same as GET."
+        "description": "**Free** — payment rows linked to the job.",
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } },
+          { "name": "agent_token", "in": "query", "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": { "description": "Payment list JSON" },
+          "401": { "description": "Missing or invalid agent_token" },
+          "404": { "description": "Job not found" }
+        }
       }
     },
     "/interrupt/{id}": {
       "get": {
+        "operationId": "getInterruptStatus",
         "tags": ["polling"],
         "summary": "Poll human-interrupt job",
-        "description": "**Free** with `secret` or `agent_token`. `{id}` is the interrupt id (e.g. EFI…)."
-      },
-      "post": {
-        "tags": ["polling"],
-        "summary": "Same as GET",
-        "description": "**Free** — same as GET."
+        "description": "**Free** with `secret` or `agent_token`. `{id}` is the interrupt id (e.g. EFI…).",
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } },
+          { "name": "secret", "in": "query", "schema": { "type": "string" } },
+          { "name": "agent_token", "in": "query", "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": { "description": "Interrupt status JSON" },
+          "401": { "description": "Missing or invalid secret/agent_token" },
+          "404": { "description": "Interrupt not found" }
+        }
       }
     }
   },

--- a/providers/earnfi/agent-api/openapi.json
+++ b/providers/earnfi/agent-api/openapi.json
@@ -12,84 +12,160 @@
     }
   ],
   "tags": [
-    { "name": "discovery", "description": "Catalog and registration (no job payment), plus optional `/x402` preview" },
-    { "name": "x402-paid-create", "description": "Paid job creates: 402 quote, then retry with signed USDC payment header" },
-    { "name": "polling", "description": "Free reads with job secret or agent token" },
-    { "name": "creator", "description": "Free creator actions that require agent token" }
+    {
+      "name": "discovery",
+      "description": "Catalog and registration (no job payment), plus optional `/x402` preview"
+    },
+    {
+      "name": "x402-paid-create",
+      "description": "Paid job creates: 402 quote, then retry with signed USDC payment header"
+    },
+    {
+      "name": "polling",
+      "description": "Free reads with job secret or agent token"
+    },
+    {
+      "name": "creator",
+      "description": "Free creator actions that require agent token"
+    }
   ],
   "paths": {
     "/x402": {
       "get": {
         "operationId": "getX402Preview",
-        "tags": ["discovery"],
+        "tags": [
+          "discovery"
+        ],
         "summary": "Preview how paid social jobs are priced",
         "description": "**Returns 402** with the same payment framing as `/jobs/social`, so tools can learn quote shape before you fund a real run.",
         "responses": {
-          "402": { "description": "x402 v2 JSON plus standard payment headers" }
-        }
+          "402": {
+            "description": "x402 v2 JSON plus standard payment headers"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          },
+          {
+            "$ref": "#/components/parameters/AgentTokenHeader"
+          }
+        ]
       },
       "post": {
         "operationId": "postX402Preview",
-        "tags": ["discovery"],
+        "tags": [
+          "discovery"
+        ],
         "summary": "Same as GET",
         "description": "Identical to GET; body is optional for discovery.",
         "responses": {
-          "402": { "description": "Same as GET" }
-        }
+          "402": {
+            "description": "Same as GET"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          },
+          {
+            "$ref": "#/components/parameters/AgentTokenHeader"
+          }
+        ]
       }
     },
     "/catalog": {
       "get": {
         "operationId": "getCatalog",
-        "tags": ["discovery"],
+        "tags": [
+          "discovery"
+        ],
         "summary": "Job types, minimum rewards, suggested sizes",
         "description": "**Free.** Lists what kinds of quick work you can fund, minimum pay, and suggested participant counts.",
         "responses": {
-          "200": { "description": "Catalog JSON" }
+          "200": {
+            "description": "Catalog JSON"
+          }
         }
       },
       "post": {
         "operationId": "postCatalog",
-        "tags": ["discovery"],
+        "tags": [
+          "discovery"
+        ],
         "summary": "Same as GET",
         "description": "**Free.** Same JSON as GET.",
         "responses": {
-          "200": { "description": "Catalog JSON" }
+          "200": {
+            "description": "Catalog JSON"
+          }
         }
       }
     },
     "/register/challenge": {
       "get": {
         "operationId": "getRegisterChallenge",
-        "tags": ["discovery"],
+        "tags": [
+          "discovery"
+        ],
         "summary": "Canonical registration message",
         "description": "**Free.** Returns `message`, `nonce`, and expiry. Sign `message` exactly (UTF-8), then `POST /register` with the same `wallet_address`, `agent_name`, unchanged `message`, `signature`, and `nonce`. Recommended for autonomous clients.",
         "parameters": [
-          { "name": "wallet_address", "in": "query", "required": true, "schema": { "type": "string" } },
-          { "name": "agent_name", "in": "query", "required": true, "schema": { "type": "string" } }
+          {
+            "name": "wallet_address",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "agent_name",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
         ],
         "responses": {
-          "200": { "description": "message, nonce, expires_at" },
-          "400": { "description": "invalid_params" },
-          "409": { "description": "wallet_reserved_for_human_user" }
+          "200": {
+            "description": "message, nonce, expires_at"
+          },
+          "400": {
+            "description": "invalid_params"
+          },
+          "409": {
+            "description": "wallet_reserved_for_human_user"
+          }
         }
       },
       "post": {
         "operationId": "postRegisterChallenge",
-        "tags": ["discovery"],
+        "tags": [
+          "discovery"
+        ],
         "summary": "Same as GET",
         "description": "**Free.** Same parameters may be sent as JSON body (merged into request like other Agent routes).",
         "responses": {
-          "200": { "description": "Same as GET" },
-          "400": { "description": "invalid_params" },
-          "409": { "description": "wallet_reserved_for_human_user" }
+          "200": {
+            "description": "Same as GET"
+          },
+          "400": {
+            "description": "invalid_params"
+          },
+          "409": {
+            "description": "wallet_reserved_for_human_user"
+          }
         }
       }
     },
     "/register": {
       "post": {
         "operationId": "registerAgent",
-        "tags": ["discovery"],
+        "tags": [
+          "discovery"
+        ],
         "summary": "Register an agent (wallet-signed message)",
         "description": "**Free.** Creates an **agent_token** for your machine identity. This wallet message signature is **not** the same object you use for x402 paid creates after a 402 quote.",
         "requestBody": {
@@ -98,388 +174,919 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["wallet_address", "agent_name", "message", "signature"],
+                "required": [
+                  "wallet_address",
+                  "agent_name",
+                  "message",
+                  "signature"
+                ],
                 "properties": {
-                  "wallet_address": { "type": "string" },
-                  "agent_name": { "type": "string" },
-                  "message": { "type": "string" },
+                  "wallet_address": {
+                    "type": "string"
+                  },
+                  "agent_name": {
+                    "type": "string"
+                  },
+                  "message": {
+                    "type": "string"
+                  },
                   "signature": {
                     "type": "string",
                     "description": "Ed25519 wallet signature of the challenge message. Accepts base58, hex (128 chars), standard base64, or a JSON array of 64 integers (0–255)."
                   },
-                  "nonce": { "type": "string", "description": "Optional; when set, must match GET /register/challenge and message must match that challenge exactly." }
+                  "nonce": {
+                    "type": "string",
+                    "description": "Optional; when set, must match GET /register/challenge and message must match that challenge exactly."
+                  }
                 }
               }
             }
           }
         },
         "responses": {
-          "200": { "description": "agent_id, agent_token" },
-          "400": { "description": "invalid_params" },
-          "409": { "description": "wallet_reserved_for_human_user" }
+          "200": {
+            "description": "agent_id, agent_token"
+          },
+          "400": {
+            "description": "invalid_params"
+          },
+          "409": {
+            "description": "wallet_reserved_for_human_user"
+          }
         }
       }
     },
     "/jobs/social": {
       "get": {
         "operationId": "createSocialJob",
-        "tags": ["x402-paid-create"],
+        "tags": [
+          "x402-paid-create"
+        ],
         "summary": "Create a social or quick-engagement job (paid)",
         "description": "**Paid (x402).** Fund follows, likes, reposts, comments, watch tasks, and similar catalog work. **Without** a completed payment you receive **402** with `accepts[]` and a human-readable `resource.description`. **With** payment, retry the **same** request including the x402 payment header. Optional **token gate** and **verified-participant** query fields are documented in the live schema.",
         "parameters": [
-          { "name": "agent_token", "in": "query", "schema": { "type": "string" } },
-          { "name": "task_type", "in": "query", "schema": { "type": "string" } },
-          { "name": "slots", "in": "query", "schema": { "type": "integer" } },
-          { "name": "reward_per_user", "in": "query", "schema": { "type": "string" } },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          },
+          {
+            "$ref": "#/components/parameters/AgentTokenHeader"
+          },
+          {
+            "name": "task_type",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "slots",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "reward_per_user",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
           {
             "name": "execution_mode",
             "in": "query",
-            "schema": { "type": "string", "enum": ["human"] },
-            "description": "Must be `human` (default). Other values are rejected until supported."
+            "schema": {
+              "type": "string",
+              "enum": [
+                "human"
+              ]
+            },
+            "description": "Must be human (default)."
+          },
+          {
+            "name": "content_url",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "title",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "token_gate",
             "in": "query",
-            "schema": { "type": "string" },
-            "description": "Optional URL-encoded JSON for token-holder rules when enabled for your deployment."
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "x_account_requirement",
             "in": "query",
             "schema": {
               "type": "string",
-              "enum": ["all", "verified_only", "verified"]
-            },
-            "description": "Optional participant filter for verified accounts."
+              "enum": [
+                "all",
+                "verified_only",
+                "verified"
+              ]
+            }
           },
           {
             "name": "requires_verified_x",
             "in": "query",
-            "schema": { "type": "boolean" },
-            "description": "Optional shorthand for verified-only vs all participants."
+            "schema": {
+              "type": "boolean"
+            }
           }
         ],
         "responses": {
-          "402": { "description": "Quote before payment" },
-          "200": { "description": "job_id, secret, status_url — polling is free with secret" },
-          "400": { "description": "Validation errors" },
-          "403": { "description": "Gating or policy rejection" }
+          "200": {
+            "description": "job_id, secret, status_url — polling is free with secret"
+          },
+          "400": {
+            "description": "Validation errors"
+          },
+          "402": {
+            "description": "Quote before payment"
+          },
+          "403": {
+            "description": "Gating or policy rejection"
+          }
         }
       },
       "post": {
         "operationId": "createSocialJobPost",
-        "tags": ["x402-paid-create"],
+        "tags": [
+          "x402-paid-create"
+        ],
         "summary": "Create a social or quick-engagement job (paid, JSON body)",
         "description": "**Paid (x402).** Same quote-then-pay semantics as GET; parameters may be sent as JSON body.",
         "responses": {
-          "402": { "description": "Quote before payment" },
-          "200": { "description": "job_id, secret, status_url" },
-          "400": { "description": "Validation errors" },
-          "403": { "description": "Gating or policy rejection" }
+          "200": {
+            "description": "job_id, secret, status_url — polling is free with secret"
+          },
+          "400": {
+            "description": "Validation errors"
+          },
+          "402": {
+            "description": "Quote before payment"
+          },
+          "403": {
+            "description": "Gating or policy rejection"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          },
+          {
+            "$ref": "#/components/parameters/AgentTokenHeader"
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SocialJobCreateBody"
+              }
+            }
+          }
         }
       }
     },
     "/jobs/manual": {
       "get": {
         "operationId": "createManualJob",
-        "tags": ["x402-paid-create"],
+        "tags": [
+          "x402-paid-create"
+        ],
         "summary": "Create a custom / manual job (paid)",
         "description": "**Paid (x402).** Same quote-then-pay pattern as `/jobs/social`. You supply your own title, instructions, and verification style. Optional token and verified-participant query fields as on `/jobs/social` where supported.",
         "responses": {
-          "402": { "description": "Quote before payment" },
-          "200": { "description": "job_id, secret, status_url" },
-          "400": { "description": "Validation errors" },
-          "403": { "description": "Gating or policy rejection" }
-        }
+          "200": {
+            "description": "job_id, secret, status_url — polling is free with secret"
+          },
+          "400": {
+            "description": "Validation errors"
+          },
+          "402": {
+            "description": "Quote before payment"
+          },
+          "403": {
+            "description": "Gating or policy rejection"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          },
+          {
+            "$ref": "#/components/parameters/AgentTokenHeader"
+          }
+        ]
       },
       "post": {
         "operationId": "createManualJobPost",
-        "tags": ["x402-paid-create"],
+        "tags": [
+          "x402-paid-create"
+        ],
         "summary": "Create a custom / manual job (paid, JSON body)",
         "description": "**Paid (x402).** Same quote-then-pay semantics as GET; parameters may be sent as JSON body.",
         "responses": {
-          "402": { "description": "Quote before payment" },
-          "200": { "description": "job_id, secret, status_url" },
-          "400": { "description": "Validation errors" },
-          "403": { "description": "Gating or policy rejection" }
+          "200": {
+            "description": "job_id, secret, status_url — polling is free with secret"
+          },
+          "400": {
+            "description": "Validation errors"
+          },
+          "402": {
+            "description": "Quote before payment"
+          },
+          "403": {
+            "description": "Gating or policy rejection"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          },
+          {
+            "$ref": "#/components/parameters/AgentTokenHeader"
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ManualJobCreateBody"
+              }
+            }
+          }
         }
       }
     },
     "/jobs/contest": {
       "get": {
         "operationId": "createContestJob",
-        "tags": ["x402-paid-create"],
+        "tags": [
+          "x402-paid-create"
+        ],
         "summary": "Create a contest (paid)",
         "description": "**Paid (x402).** Prize pool contests with platform fee included in the quote. Optional gating fields as on `/jobs/social` where supported.",
         "responses": {
-          "402": { "description": "Quote before payment" },
-          "200": { "description": "job_id, secret, status_url" },
-          "400": { "description": "Validation errors" },
-          "403": { "description": "Gating or policy rejection" }
-        }
+          "200": {
+            "description": "job_id, secret, status_url — polling is free with secret"
+          },
+          "400": {
+            "description": "Validation errors"
+          },
+          "402": {
+            "description": "Quote before payment"
+          },
+          "403": {
+            "description": "Gating or policy rejection"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          },
+          {
+            "$ref": "#/components/parameters/AgentTokenHeader"
+          }
+        ]
       },
       "post": {
         "operationId": "createContestJobPost",
-        "tags": ["x402-paid-create"],
+        "tags": [
+          "x402-paid-create"
+        ],
         "summary": "Create a contest (paid, JSON body)",
         "description": "**Paid (x402).** Same quote-then-pay semantics as GET; parameters may be sent as JSON body.",
         "responses": {
-          "402": { "description": "Quote before payment" },
-          "200": { "description": "job_id, secret, status_url" },
-          "400": { "description": "Validation errors" },
-          "403": { "description": "Gating or policy rejection" }
+          "200": {
+            "description": "job_id, secret, status_url — polling is free with secret"
+          },
+          "400": {
+            "description": "Validation errors"
+          },
+          "402": {
+            "description": "Quote before payment"
+          },
+          "403": {
+            "description": "Gating or policy rejection"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          },
+          {
+            "$ref": "#/components/parameters/AgentTokenHeader"
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ContestJobCreateBody"
+              }
+            }
+          }
         }
       }
     },
     "/interrupt": {
       "get": {
         "operationId": "createInterruptJob",
-        "tags": ["x402-paid-create"],
+        "tags": [
+          "x402-paid-create"
+        ],
         "summary": "Ask many people one question (paid)",
         "description": "**Paid (x402).** Human answers to a single clear question—opinions, quick feedback, light tasks. Same quote-then-pay pattern; optional gating as documented.",
         "responses": {
-          "402": { "description": "Quote before payment" },
-          "200": { "description": "interrupt_id, secret, status_url" },
-          "400": { "description": "Validation errors" },
-          "403": { "description": "Gating or policy rejection" }
-        }
+          "200": {
+            "description": "interrupt_id, secret, status_url"
+          },
+          "400": {
+            "description": "Validation errors"
+          },
+          "402": {
+            "description": "Quote before payment"
+          },
+          "403": {
+            "description": "Gating or policy rejection"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          },
+          {
+            "$ref": "#/components/parameters/AgentTokenHeader"
+          }
+        ]
       },
       "post": {
         "operationId": "createInterruptJobPost",
-        "tags": ["x402-paid-create"],
+        "tags": [
+          "x402-paid-create"
+        ],
         "summary": "Ask many people one question (paid, JSON body)",
         "description": "**Paid (x402).** Same quote-then-pay semantics as GET; parameters may be sent as JSON body.",
         "responses": {
-          "402": { "description": "Quote before payment" },
-          "200": { "description": "interrupt_id, secret, status_url" },
-          "400": { "description": "Validation errors" },
-          "403": { "description": "Gating or policy rejection" }
+          "200": {
+            "description": "interrupt_id, secret, status_url"
+          },
+          "400": {
+            "description": "Validation errors"
+          },
+          "402": {
+            "description": "Quote before payment"
+          },
+          "403": {
+            "description": "Gating or policy rejection"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          },
+          {
+            "$ref": "#/components/parameters/AgentTokenHeader"
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InterruptJobCreateBody"
+              }
+            }
+          }
         }
       }
     },
     "/jobs/{id}": {
       "get": {
         "operationId": "getJobStatus",
-        "tags": ["polling"],
+        "tags": [
+          "polling"
+        ],
         "summary": "Poll job status",
         "description": "**Free** with `?secret=` (recommended) or `?agent_token=`.",
         "parameters": [
-          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } },
-          { "name": "secret", "in": "query", "schema": { "type": "string" } },
-          { "name": "agent_token", "in": "query", "schema": { "type": "string" } }
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "secret",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Per-job secret from create response (preferred)."
+          },
+          {
+            "$ref": "#/components/parameters/AgentTokenHeader"
+          }
         ],
         "responses": {
-          "200": { "description": "Job status JSON" },
-          "401": { "description": "Missing or invalid secret/agent_token" },
-          "404": { "description": "Job not found" }
+          "200": {
+            "description": "Job status JSON"
+          },
+          "401": {
+            "description": "Missing or invalid secret/agent_token"
+          },
+          "404": {
+            "description": "Job not found"
+          }
         }
       }
     },
     "/jobs/{id}/submissions": {
       "get": {
         "operationId": "listJobSubmissions",
-        "tags": ["polling"],
+        "tags": [
+          "polling"
+        ],
         "summary": "List submissions",
         "description": "**Free** — list worker submissions with the job's secret; no second on-chain payment per read.",
         "parameters": [
-          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } },
-          { "name": "secret", "in": "query", "schema": { "type": "string" } },
-          { "name": "agent_token", "in": "query", "schema": { "type": "string" } }
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "secret",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Per-job secret from create response (preferred)."
+          },
+          {
+            "$ref": "#/components/parameters/AgentTokenHeader"
+          }
         ],
         "responses": {
-          "200": { "description": "Submission list JSON" },
-          "401": { "description": "Missing or invalid secret/agent_token" },
-          "404": { "description": "Job not found" }
+          "200": {
+            "description": "Submission list JSON"
+          },
+          "401": {
+            "description": "Missing or invalid secret/agent_token"
+          },
+          "404": {
+            "description": "Job not found"
+          }
         }
       }
     },
     "/jobs/{id}/completions": {
       "get": {
         "operationId": "listJobCompletions",
-        "tags": ["polling"],
+        "tags": [
+          "polling"
+        ],
         "summary": "List completions",
         "description": "**Free** with secret or agent_token.",
         "parameters": [
-          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } },
-          { "name": "secret", "in": "query", "schema": { "type": "string" } },
-          { "name": "agent_token", "in": "query", "schema": { "type": "string" } }
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "secret",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Per-job secret from create response (preferred)."
+          },
+          {
+            "$ref": "#/components/parameters/AgentTokenHeader"
+          }
         ],
         "responses": {
-          "200": { "description": "Completion list JSON" },
-          "401": { "description": "Missing or invalid secret/agent_token" },
-          "404": { "description": "Job not found" }
+          "200": {
+            "description": "Completion list JSON"
+          },
+          "401": {
+            "description": "Missing or invalid secret/agent_token"
+          },
+          "404": {
+            "description": "Job not found"
+          }
         }
       }
     },
     "/jobs/{id}/pause": {
       "post": {
         "operationId": "pauseOrResumeJob",
-        "tags": ["creator"],
+        "tags": [
+          "creator"
+        ],
         "summary": "Pause or resume job",
-        "description": "**Free** — requires `agent_token` in query or JSON body. Use POST for mutations (GET is not documented).",
+        "description": "**Free** — requires agent_token in JSON body or Agent-Token header. Use POST for mutations.",
         "parameters": [
-          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } },
-          { "name": "agent_token", "in": "query", "schema": { "type": "string" } }
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/AgentTokenHeader"
+          }
         ],
         "responses": {
-          "200": { "description": "Updated job pause state" },
-          "401": { "description": "Missing or invalid agent_token" },
-          "404": { "description": "Job not found" }
+          "200": {
+            "description": "Updated job pause state"
+          },
+          "401": {
+            "description": "Missing or invalid agent_token"
+          },
+          "404": {
+            "description": "Job not found"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AgentTokenBody"
+              }
+            }
+          }
         }
       }
     },
     "/jobs/{id}/verifications": {
       "get": {
         "operationId": "listPendingVerifications",
-        "tags": ["creator"],
+        "tags": [
+          "creator"
+        ],
         "summary": "List pending manual verifications",
         "description": "**Free** — requires `agent_token` for the job owner. Returns completions awaiting approve/reject on manual-verification jobs.",
         "parameters": [
-          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } },
-          { "name": "agent_token", "in": "query", "schema": { "type": "string" } }
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/AgentTokenHeader"
+          }
         ],
         "responses": {
-          "200": { "description": "Pending verification list JSON" },
-          "401": { "description": "Missing or invalid agent_token" },
-          "404": { "description": "Job not found" }
+          "200": {
+            "description": "Pending verification list JSON"
+          },
+          "401": {
+            "description": "Missing or invalid agent_token"
+          },
+          "404": {
+            "description": "Job not found"
+          }
         }
       }
     },
     "/verifications/{id}/approve": {
       "post": {
         "operationId": "approveVerification",
-        "tags": ["creator"],
+        "tags": [
+          "creator"
+        ],
         "summary": "Approve a verification",
         "description": "**Free** — `agent_token` required. `{id}` is the verification (completion) id. Use POST for mutations.",
         "parameters": [
-          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } },
-          { "name": "agent_token", "in": "query", "schema": { "type": "string" } }
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/AgentTokenHeader"
+          }
         ],
         "responses": {
-          "200": { "description": "Verification approved" },
-          "401": { "description": "Missing or invalid agent_token" },
-          "404": { "description": "Verification not found" }
+          "200": {
+            "description": "Verification approved"
+          },
+          "401": {
+            "description": "Missing or invalid agent_token"
+          },
+          "404": {
+            "description": "Verification not found"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AgentTokenBody"
+              }
+            }
+          }
         }
       }
     },
     "/verifications/{id}/reject": {
       "post": {
         "operationId": "rejectVerification",
-        "tags": ["creator"],
+        "tags": [
+          "creator"
+        ],
         "summary": "Reject a verification",
         "description": "**Free** — `agent_token` required. Optional `reason` in query or JSON body. Use POST for mutations.",
         "parameters": [
-          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } },
-          { "name": "agent_token", "in": "query", "schema": { "type": "string" } },
-          { "name": "reason", "in": "query", "schema": { "type": "string" } }
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/AgentTokenHeader"
+          }
         ],
         "responses": {
-          "200": { "description": "Verification rejected" },
-          "401": { "description": "Missing or invalid agent_token" },
-          "404": { "description": "Verification not found" }
+          "200": {
+            "description": "Verification rejected"
+          },
+          "401": {
+            "description": "Missing or invalid agent_token"
+          },
+          "404": {
+            "description": "Verification not found"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RejectVerificationBody"
+              }
+            }
+          }
         }
       }
     },
     "/jobs/{id}/contest/submissions": {
       "get": {
         "operationId": "listContestSubmissions",
-        "tags": ["creator"],
+        "tags": [
+          "creator"
+        ],
         "summary": "List contest submissions",
         "description": "**Free** — contest jobs only; requires `agent_token`.",
         "parameters": [
-          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } },
-          { "name": "agent_token", "in": "query", "schema": { "type": "string" } }
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/AgentTokenHeader"
+          }
         ],
         "responses": {
-          "200": { "description": "Contest submission list JSON" },
-          "401": { "description": "Missing or invalid agent_token" },
-          "404": { "description": "Job not found" }
+          "200": {
+            "description": "Contest submission list JSON"
+          },
+          "401": {
+            "description": "Missing or invalid agent_token"
+          },
+          "404": {
+            "description": "Job not found"
+          }
         }
       }
     },
     "/jobs/{id}/contest/mark-winner": {
       "post": {
         "operationId": "markContestWinner",
-        "tags": ["creator"],
+        "tags": [
+          "creator"
+        ],
         "summary": "Mark contest winner",
         "description": "**Free** — requires `agent_token` and submission identifiers per live API schema. Use POST for mutations.",
         "parameters": [
-          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } },
-          { "name": "agent_token", "in": "query", "schema": { "type": "string" } }
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/AgentTokenHeader"
+          }
         ],
         "responses": {
-          "200": { "description": "Winner marked" },
-          "401": { "description": "Missing or invalid agent_token" },
-          "404": { "description": "Job or submission not found" }
+          "200": {
+            "description": "Winner marked"
+          },
+          "401": {
+            "description": "Missing or invalid agent_token"
+          },
+          "404": {
+            "description": "Job or submission not found"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MarkContestWinnerBody"
+              }
+            }
+          }
         }
       }
     },
     "/jobs/{id}/detail": {
       "get": {
         "operationId": "getCreatorJobDetail",
-        "tags": ["creator"],
+        "tags": [
+          "creator"
+        ],
         "summary": "Creator job detail",
         "description": "**Free** — extended job view for the agent owner.",
         "parameters": [
-          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } },
-          { "name": "agent_token", "in": "query", "schema": { "type": "string" } }
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/AgentTokenHeader"
+          }
         ],
         "responses": {
-          "200": { "description": "Extended job detail JSON" },
-          "401": { "description": "Missing or invalid agent_token" },
-          "404": { "description": "Job not found" }
+          "200": {
+            "description": "Extended job detail JSON"
+          },
+          "401": {
+            "description": "Missing or invalid agent_token"
+          },
+          "404": {
+            "description": "Job not found"
+          }
         }
       }
     },
     "/jobs/{id}/users": {
       "get": {
         "operationId": "listJobParticipants",
-        "tags": ["creator"],
+        "tags": [
+          "creator"
+        ],
         "summary": "List participants",
         "description": "**Free** — users who joined or completed the job.",
         "parameters": [
-          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } },
-          { "name": "agent_token", "in": "query", "schema": { "type": "string" } }
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/AgentTokenHeader"
+          }
         ],
         "responses": {
-          "200": { "description": "Participant list JSON" },
-          "401": { "description": "Missing or invalid agent_token" },
-          "404": { "description": "Job not found" }
+          "200": {
+            "description": "Participant list JSON"
+          },
+          "401": {
+            "description": "Missing or invalid agent_token"
+          },
+          "404": {
+            "description": "Job not found"
+          }
         }
       }
     },
     "/jobs/{id}/payments": {
       "get": {
         "operationId": "listJobPayments",
-        "tags": ["creator"],
+        "tags": [
+          "creator"
+        ],
         "summary": "List job payments",
         "description": "**Free** — payment rows linked to the job.",
         "parameters": [
-          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } },
-          { "name": "agent_token", "in": "query", "schema": { "type": "string" } }
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/AgentTokenHeader"
+          }
         ],
         "responses": {
-          "200": { "description": "Payment list JSON" },
-          "401": { "description": "Missing or invalid agent_token" },
-          "404": { "description": "Job not found" }
+          "200": {
+            "description": "Payment list JSON"
+          },
+          "401": {
+            "description": "Missing or invalid agent_token"
+          },
+          "404": {
+            "description": "Job not found"
+          }
         }
       }
     },
     "/interrupt/{id}": {
       "get": {
         "operationId": "getInterruptStatus",
-        "tags": ["polling"],
+        "tags": [
+          "polling"
+        ],
         "summary": "Poll human-interrupt job",
         "description": "**Free** with `secret` or `agent_token`. `{id}` is the interrupt id (e.g. EFI…).",
         "parameters": [
-          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } },
-          { "name": "secret", "in": "query", "schema": { "type": "string" } },
-          { "name": "agent_token", "in": "query", "schema": { "type": "string" } }
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "secret",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Per-job secret from create response (preferred)."
+          },
+          {
+            "$ref": "#/components/parameters/AgentTokenHeader"
+          }
         ],
         "responses": {
-          "200": { "description": "Interrupt status JSON" },
-          "401": { "description": "Missing or invalid secret/agent_token" },
-          "404": { "description": "Interrupt not found" }
+          "200": {
+            "description": "Interrupt status JSON"
+          },
+          "401": {
+            "description": "Missing or invalid secret/agent_token"
+          },
+          "404": {
+            "description": "Interrupt not found"
+          }
         }
       }
     }
@@ -490,8 +1097,182 @@
         "name": "PAYMENT-SIGNATURE",
         "in": "header",
         "required": false,
-        "description": "x402 payment payload (base64 JSON with signed_tx + requirements). Required on the **retry** after HTTP 402 on paid create routes. Not used for registration (wallet message signature is separate).",
-        "schema": { "type": "string" }
+        "description": "x402 payment payload (base64 JSON with signed_tx + requirements). Required on the retry after HTTP 402 on paid create routes. Not used for registration.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "AgentTokenHeader": {
+        "name": "Agent-Token",
+        "in": "header",
+        "required": false,
+        "description": "Agent credential from POST /register. Preferred over query string to avoid log exposure. Also accepts X-Agent-Token.",
+        "schema": {
+          "type": "string"
+        }
+      }
+    },
+    "schemas": {
+      "SocialJobCreateBody": {
+        "type": "object",
+        "properties": {
+          "agent_token": {
+            "type": "string",
+            "description": "From POST /register. Prefer Agent-Token header."
+          },
+          "task_type": {
+            "type": "string",
+            "description": "Catalog task slug, e.g. like, x_follow, repost."
+          },
+          "slots": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "reward_per_user": {
+            "type": "string",
+            "description": "USD reward per participant, e.g. 0.05"
+          },
+          "execution_mode": {
+            "type": "string",
+            "enum": [
+              "human"
+            ]
+          },
+          "content_url": {
+            "type": "string",
+            "description": "Target post, profile, or video URL."
+          },
+          "title": {
+            "type": "string"
+          },
+          "token_gate": {
+            "type": "string",
+            "description": "Optional URL-encoded JSON token-holder gate."
+          },
+          "x_account_requirement": {
+            "type": "string",
+            "enum": [
+              "all",
+              "verified_only",
+              "verified"
+            ]
+          },
+          "requires_verified_x": {
+            "type": "boolean"
+          }
+        }
+      },
+      "ManualJobCreateBody": {
+        "type": "object",
+        "properties": {
+          "agent_token": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "instructions": {
+            "type": "string"
+          },
+          "reward_per_user": {
+            "type": "string"
+          },
+          "slots": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "verification_method": {
+            "type": "string",
+            "enum": [
+              "manual",
+              "auto"
+            ]
+          },
+          "token_gate": {
+            "type": "string"
+          }
+        }
+      },
+      "ContestJobCreateBody": {
+        "type": "object",
+        "properties": {
+          "agent_token": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "instructions": {
+            "type": "string"
+          },
+          "total_prize_pool": {
+            "type": "string",
+            "description": "Total prize pool in USD."
+          }
+        }
+      },
+      "InterruptJobCreateBody": {
+        "type": "object",
+        "properties": {
+          "agent_token": {
+            "type": "string"
+          },
+          "question": {
+            "type": "string"
+          },
+          "slots": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 50
+          },
+          "reward_per_user": {
+            "type": "string"
+          }
+        }
+      },
+      "AgentTokenBody": {
+        "type": "object",
+        "required": [
+          "agent_token"
+        ],
+        "properties": {
+          "agent_token": {
+            "type": "string",
+            "description": "Agent credential from POST /register."
+          }
+        }
+      },
+      "RejectVerificationBody": {
+        "type": "object",
+        "required": [
+          "agent_token"
+        ],
+        "properties": {
+          "agent_token": {
+            "type": "string"
+          },
+          "reason": {
+            "type": "string"
+          }
+        }
+      },
+      "MarkContestWinnerBody": {
+        "type": "object",
+        "required": [
+          "agent_token",
+          "submission_id"
+        ],
+        "properties": {
+          "agent_token": {
+            "type": "string"
+          },
+          "submission_id": {
+            "type": "string"
+          },
+          "rank_position": {
+            "type": "integer"
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary
- Adds EarnFi Agent API (`earnfi/agent-api`) to the pay.sh registry.
- Human execution infrastructure for AI agents: social campaigns, contests, manual jobs, human interrupts, and verification workflows.
- Paid job creation endpoints use x402 USDC on Solana; OpenAPI spec committed as sidecar.

## Test plan
- [x] `npx @solana/pay catalog check providers/earnfi/agent-api/PAY.md` passes locally
- [ ] CI Validate providers workflow passes (402 probe on paid routes)
- [ ] After merge, `pay skills search earnfi` finds the provider