### PR TITLE
Add Syra intelligence provider to pay-skills

### DIFF
--- a/providers/syra/intelligence/PAY.md
+++ b/providers/syra/intelligence/PAY.md
@@ -1,8 +1,8 @@
 ---
 name: intelligence
 title: "Syra"
-description: "Crypto intelligence API for trading workflows with technical signals, market news, sentiment, event feeds, cross-CEX arbitrage snapshots, and X profile analysis, delivered through x402 pay-per-call access."
-use_case: "Use for trading signal checks, sentiment and news validation, event-driven market context, arbitrage scanning across exchanges, X project credibility scoring, and AI-assisted market research before execution."
+description: "Crypto intelligence API for trading signals, indicators, news, sentiment, events, arbitrage, pump.fun scouting, Solana insights, Jupiter quotes, RugCheck reports, and X profile analysis via x402 pay-per-call."
+use_case: "Use for trading signals, technical indicators, memecoin due diligence, sentiment and news checks, arbitrage scans, Solana network insights, swap quotes, token risk reports, and AI-assisted market research before execution."
 category: finance
 service_url: https://api.syraa.fun
 version: v1
@@ -11,22 +11,23 @@ openapi:
 ---
 
 Syra provides trader-focused crypto intelligence endpoints through x402 payment
-gating. It combines structured market signals (RSI, MACD, trend context),
-news and sentiment feeds, event tracking, cross-exchange arbitrage snapshots,
-X project analysis, and AI-assisted research output for decision support.
+gating. It covers technical signals and multi-indicator analysis, news and
+sentiment, event calendars, cross-CEX arbitrage, pump.fun scouting and mint
+due diligence, Solana network/market insights, Jupiter quotes, RugCheck risk
+reports, equity/SPCX spreads, X project scoring, and AI-assisted research.
 
 Paid endpoints return HTTP `402` and accept Solana USDC settlement via x402.
-Free preview and info routes are available for lightweight discovery.
+Free discovery routes such as `/info` and `/prediction-game/health` stay ungated.
 
 ## Spend-aware usage
 
-- Start with preview or low-cost context endpoints (such as `/preview/*`,
-  `/info`, and `/info/stats`) before triggering paid workflows.
-- Use `/signal` or `/api/signal` to validate momentum and trend setup first,
-  then call heavier AI routes like `/brain` only when synthesis is required.
-- Query scoped symbols (`ticker`, `token`, `instId`) to avoid broad requests
-  and unnecessary paid retries.
-- Use `/arbitrage` with a small `limit` first, then increase only when the
-  task needs deeper candidate coverage.
-- Call `/x-analyzer` for focused project checks and avoid batch or repeated
-  polling unless the user explicitly asks for monitoring.
+- Start with low-cost context (`/info`, `/info/stats`, `/insights/*`) before
+  heavier paid workflows.
+- Use `/signal` or `/indicator` to validate momentum and setup first, then call
+  `/brain` only when synthesis is required.
+- Prefer scoped inputs (`ticker`, `symbol`, `mint`, `instId`) to avoid broad
+  paid retries.
+- Use `/arbitrage` and `/pumpfun/*` with small `limit` values first, then widen
+  only when the task needs deeper coverage.
+- Call `/x-analyzer`, `/rugcheck/report`, and `/pumpfun/analyzer` for focused
+  project checks; avoid batch polling unless the user asks for monitoring.

--- a/providers/syra/intelligence/PAY.md
+++ b/providers/syra/intelligence/PAY.md
@@ -1,0 +1,32 @@
+---
+name: intelligence
+title: "Syra"
+description: "Crypto intelligence API for trading workflows with technical signals, market news, sentiment, event feeds, cross-CEX arbitrage snapshots, and X profile analysis, delivered through x402 pay-per-call access."
+use_case: "Use for trading signal checks, sentiment and news validation, event-driven market context, arbitrage scanning across exchanges, X project credibility scoring, and AI-assisted market research before execution."
+category: finance
+service_url: https://api.syraa.fun
+version: v1
+openapi:
+  path: openapi.json
+---
+
+Syra provides trader-focused crypto intelligence endpoints through x402 payment
+gating. It combines structured market signals (RSI, MACD, trend context),
+news and sentiment feeds, event tracking, cross-exchange arbitrage snapshots,
+X project analysis, and AI-assisted research output for decision support.
+
+Paid endpoints return HTTP `402` and accept Solana USDC settlement via x402.
+Free preview and info routes are available for lightweight discovery.
+
+## Spend-aware usage
+
+- Start with preview or low-cost context endpoints (such as `/preview/*`,
+  `/info`, and `/info/stats`) before triggering paid workflows.
+- Use `/signal` or `/api/signal` to validate momentum and trend setup first,
+  then call heavier AI routes like `/brain` only when synthesis is required.
+- Query scoped symbols (`ticker`, `token`, `instId`) to avoid broad requests
+  and unnecessary paid retries.
+- Use `/arbitrage` with a small `limit` first, then increase only when the
+  task needs deeper candidate coverage.
+- Call `/x-analyzer` for focused project checks and avoid batch or repeated
+  polling unless the user explicitly asks for monitoring.

--- a/providers/syra/intelligence/openapi.json
+++ b/providers/syra/intelligence/openapi.json
@@ -101,7 +101,7 @@
         "tags": [
           "Signal"
         ],
-        "summary": "Public signal (no x402)",
+        "summary": "Fetch public trading signal without x402 payment",
         "description": "Same engine as /signal without micropayment. API key if server sets API_KEY.",
         "operationId": "getPublicSignal",
         "parameters": [
@@ -213,7 +213,7 @@
         "tags": [
           "Signal"
         ],
-        "summary": "Public signal via JSON body",
+        "summary": "Fetch public trading signal via JSON request body",
         "operationId": "postPublicSignal",
         "requestBody": {
           "required": false,
@@ -306,7 +306,7 @@
         "tags": [
           "Info"
         ],
-        "summary": "Gateway info",
+        "summary": "Get Syra gateway info and service metadata",
         "operationId": "getInfo",
         "responses": {
           "200": {
@@ -362,7 +362,7 @@
         "tags": [
           "Info"
         ],
-        "summary": "Public usage stats",
+        "summary": "Get public API usage stats and rate limits",
         "operationId": "getInfoStats",
         "responses": {
           "200": {
@@ -418,7 +418,7 @@
         "tags": [
           "Preview"
         ],
-        "summary": "News preview (no x402)",
+        "summary": "Preview crypto news headlines without payment",
         "operationId": "getPreviewNews",
         "parameters": [
           {
@@ -486,7 +486,7 @@
         "tags": [
           "Preview"
         ],
-        "summary": "Sentiment preview (no x402)",
+        "summary": "Preview market sentiment scores without payment",
         "operationId": "getPreviewSentiment",
         "parameters": [
           {
@@ -554,7 +554,7 @@
         "tags": [
           "Preview"
         ],
-        "summary": "Signal preview (no x402)",
+        "summary": "Preview trading signal output without payment",
         "operationId": "getPreviewSignal",
         "parameters": [
           {
@@ -658,7 +658,7 @@
         "tags": [
           "Dashboard"
         ],
-        "summary": "Dashboard KPI summary",
+        "summary": "Get dashboard KPI summary for Syra markets",
         "operationId": "getDashboardSummary",
         "responses": {
           "200": {
@@ -719,7 +719,7 @@
         "tags": [
           "Dashboard"
         ],
-        "summary": "Binance ticker prices",
+        "summary": "Get Binance spot ticker prices for symbols",
         "operationId": "getBinanceTicker",
         "responses": {
           "200": {
@@ -780,7 +780,7 @@
         "tags": [
           "Prediction game"
         ],
-        "summary": "Prediction game health",
+        "summary": "Check prediction game API health and status",
         "operationId": "getPredictionGameHealth",
         "responses": {
           "200": {
@@ -836,7 +836,7 @@
         "tags": [
           "Market data (x402)"
         ],
-        "summary": "Trading signal (x402)",
+        "summary": "Get paid trading signal with RSI and MACD context",
         "description": "Paid trading signal endpoint gated by x402.",
         "operationId": "getSignal",
         "parameters": [
@@ -966,7 +966,7 @@
         "tags": [
           "Market data (x402)"
         ],
-        "summary": "Trading signal via JSON body (x402)",
+        "summary": "Get paid trading signal via JSON request body",
         "operationId": "postSignal",
         "requestBody": {
           "required": false,
@@ -1077,7 +1077,7 @@
         "tags": [
           "Market data (x402)"
         ],
-        "summary": "Crypto news",
+        "summary": "Fetch curated crypto news headlines by ticker",
         "operationId": "getNews",
         "parameters": [
           {
@@ -1146,7 +1146,7 @@
         "tags": [
           "Market data (x402)"
         ],
-        "summary": "Crypto news (POST)",
+        "summary": "Fetch curated crypto news via JSON request body",
         "operationId": "postNews",
         "requestBody": {
           "required": false,
@@ -1217,7 +1217,7 @@
         "tags": [
           "Market data (x402)"
         ],
-        "summary": "Sentiment",
+        "summary": "Fetch 30-day crypto market sentiment by ticker",
         "operationId": "getSentiment",
         "parameters": [
           {
@@ -1286,7 +1286,7 @@
         "tags": [
           "Market data (x402)"
         ],
-        "summary": "Sentiment (POST)",
+        "summary": "Fetch market sentiment via JSON request body",
         "operationId": "postSentiment",
         "requestBody": {
           "required": false,
@@ -1357,7 +1357,7 @@
         "tags": [
           "Market data (x402)"
         ],
-        "summary": "Crypto events",
+        "summary": "Fetch upcoming and recent crypto event calendar",
         "operationId": "getEvent",
         "parameters": [
           {
@@ -1426,7 +1426,7 @@
         "tags": [
           "Market data (x402)"
         ],
-        "summary": "Crypto events (POST)",
+        "summary": "Fetch crypto events via JSON request body",
         "operationId": "postEvent",
         "requestBody": {
           "required": false,
@@ -1497,7 +1497,7 @@
         "tags": [
           "Gateway (x402)"
         ],
-        "summary": "API health (x402 liveness)",
+        "summary": "Check Syra API health and x402 liveness probe",
         "operationId": "getHealth",
         "responses": {
           "200": {
@@ -1554,7 +1554,7 @@
         "tags": [
           "Gateway (x402)"
         ],
-        "summary": "API health (POST)",
+        "summary": "Check API health via JSON POST liveness probe",
         "operationId": "postHealth",
         "requestBody": {
           "required": false,
@@ -1625,7 +1625,7 @@
         "tags": [
           "AI (x402)"
         ],
-        "summary": "Syra Brain (GET)",
+        "summary": "Answer crypto questions with Syra Brain tools",
         "operationId": "getBrain",
         "parameters": [
           {
@@ -1693,7 +1693,7 @@
         "tags": [
           "AI (x402)"
         ],
-        "summary": "Syra Brain (POST)",
+        "summary": "Answer crypto questions via Syra Brain POST body",
         "operationId": "postBrain",
         "requestBody": {
           "required": false,
@@ -1764,7 +1764,7 @@
         "tags": [
           "Market data (x402)"
         ],
-        "summary": "Arbitrage — CMC top + cross-CEX snapshots + ranked routes (x402)",
+        "summary": "Get cross-CEX arbitrage snapshots and ranked routes",
         "operationId": "getArbitrage",
         "parameters": [
           {
@@ -1835,7 +1835,7 @@
         "tags": [
           "Market data (x402)"
         ],
-        "summary": "Arbitrage — POST body may include { limit } (x402)",
+        "summary": "Get arbitrage routes with optional limit in body",
         "operationId": "postArbitrage",
         "requestBody": {
           "required": false,
@@ -1906,7 +1906,7 @@
         "tags": [
           "Social (x402)"
         ],
-        "summary": "X Project Analyzer — profile + tweets + score (x402)",
+        "summary": "Analyze X project profile, tweets, and score",
         "description": "Micropayment via x402. Returns deterministic 0–100 score, category breakdown, signals, red flags; optional `includeAiSummary` adds grounded LLM bullets. Example `200` body is maintained at `api/docs/examples/x-analyzer-response.example.json`.",
         "operationId": "getXAnalyzer",
         "parameters": [
@@ -2078,7 +2078,7 @@
         "tags": [
           "Social (x402)"
         ],
-        "summary": "X Project Analyzer — POST body (x402)",
+        "summary": "Analyze X project profile via JSON request body",
         "description": "Same as GET; body may include `username`, `max_results`, `includeAiSummary`. Example response identical to GET.",
         "operationId": "postXAnalyzer",
         "requestBody": {
@@ -2275,7 +2275,7 @@
         "tags": [
           "Social (batch)"
         ],
-        "summary": "Single-account Alpha analysis (allowlisted)",
+        "summary": "Analyze single allowlisted X account Alpha signals",
         "description": "`username` must belong to the configured `type` handle list. Returns full score payload, optional AI summary (default on), and `recentTweets` sample. API key when API_KEY is set.",
         "operationId": "getXProjectsAnalyzeAccount",
         "parameters": [
@@ -2390,7 +2390,7 @@
         "tags": [
           "Social (batch)"
         ],
-        "summary": "Single-account Alpha analysis — POST",
+        "summary": "Analyze allowlisted X account via JSON body",
         "operationId": "postXProjectsAnalyzeAccount",
         "requestBody": {
           "required": false,
@@ -2493,7 +2493,7 @@
         "tags": [
           "Social (batch)"
         ],
-        "summary": "Batch X project analyzer (no x402)",
+        "summary": "Run batch X project analyzer without payment",
         "description": "Runs the same deterministic analysis as /x-analyzer for all X handles configured for `type` (default `x402`). Handles are not client-supplied. See GET /x-projects-analyze/types.",
         "operationId": "getXProjectsAnalyze",
         "parameters": [
@@ -2587,7 +2587,7 @@
         "tags": [
           "Social (batch)"
         ],
-        "summary": "Batch X project analyzer — POST body",
+        "summary": "Run batch X project analyzer via JSON body",
         "operationId": "postXProjectsAnalyze",
         "requestBody": {
           "required": false,

--- a/providers/syra/intelligence/openapi.json
+++ b/providers/syra/intelligence/openapi.json
@@ -1,0 +1,2447 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Syra API",
+    "version": "1.0.0",
+    "description": "Syra gateway: preview and dashboard routes may require `X-API-Key` / Bearer when the server sets `API_KEY`.\n\n**x402** routes return **HTTP 402** until paid (Solana/Base USDC). The full payment offer (network, asset, price in micro-USDC, `payTo`, etc.) is returned at runtime in the 402 response body's `accepts` array — that is the canonical x402 V1 wire spec; pay one offer and retry with `X-PAYMENT`. See https://docs.syraa.fun/docs/api/x402-api-standard for the wire format and signing examples.\n\nSome x402 ecosystems (MPP / AgentCash registries) expect a per-operation OpenAPI extension named `x-payment-info` carrying registry metadata (protocols, pricingMode, price). This **gateway** spec deliberately omits it for strict-schema friendliness; the **MPP discovery** document at `GET /mpp-openapi.json` emits it on every paid operation. The exact shape Syra uses is described in the `x-payment-info-spec` extension at the root of this document.\n\n**Rate limits** (per IP, applied to every non-x402 / non-cron route): burst **25 req / 10s** + sustained **100 req / 60s**. Exceeding either returns **HTTP 429** with `Retry-After: <seconds>` and `{ success: false, message }`. x402 paid routes are gated by HTTP 402 instead and bypass this throttle. See the `x-ratelimit` extension below for the machine-readable spec."
+  },
+  "servers": [
+    {
+      "url": "https://api.syraa.fun"
+    }
+  ],
+  "x-payment-info-spec": {
+    "emittedHere": false,
+    "reason": "Strict-schema friendly. Canonical payment metadata for paid (x402) routes is returned at runtime in the 402 response body's `accepts` array (V1 wire format: scheme, network, asset, maxAmountRequired in micro-USDC, payTo, resource, maxTimeoutSeconds, outputSchema). Pay one of those offers and retry with `X-PAYMENT`. See: https://docs.syraa.fun/docs/api/x402-api-standard",
+    "alsoEmittedAt": {
+      "document": "https://api.syraa.fun/mpp-openapi.json",
+      "description": "MPP / AgentCash discovery document. Each paid operation includes an `x-payment-info` extension with the shape below. Settlement is still x402 V1 (HTTP 402 + `accepts`); `x-payment-info` is registry metadata only."
+    },
+    "shape": {
+      "type": "object",
+      "required": [
+        "protocols",
+        "pricingMode",
+        "price"
+      ],
+      "properties": {
+        "protocols": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Supported payment protocols. Syra emits `[\"mpp\"]` in the MPP doc.",
+          "example": [
+            "mpp"
+          ]
+        },
+        "pricingMode": {
+          "type": "string",
+          "description": "Always `\"fixed\"` for Syra (per-call USD price, no auction or tiering).",
+          "enum": [
+            "fixed"
+          ]
+        },
+        "price": {
+          "type": "string",
+          "description": "USD price as a decimal string (e.g. \"0.01\"). The runtime 402 response converts this to USDC micro-units (USDC has 6 decimals) and exposes it as `accepts[i].maxAmountRequired`.",
+          "example": "0.01"
+        }
+      },
+      "additionalProperties": true
+    },
+    "example": {
+      "x-payment-info": {
+        "protocols": [
+          "mpp"
+        ],
+        "pricingMode": "fixed",
+        "price": "0.01"
+      }
+    }
+  },
+  "x-ratelimit": {
+    "scope": "per-ip",
+    "windows": [
+      {
+        "type": "burst",
+        "maxRequests": 25,
+        "windowSeconds": 10,
+        "description": "Mitigates short bursts and DDoS attempts."
+      },
+      {
+        "type": "sustained",
+        "maxRequests": 100,
+        "windowSeconds": 60,
+        "description": "Mitigates sustained spam."
+      }
+    ],
+    "status": 429,
+    "retryAfterHeader": "Retry-After",
+    "responseBody": {
+      "success": false,
+      "message": "Too many requests. Please slow down."
+    },
+    "skip": {
+      "description": "Routes excluded from this throttle. x402 paid routes (`/news`, `/signal`, `/sentiment`, `/event`, `/health`, `/brain`, `/x*`, `/8004*`, etc.) are gated by HTTP 402 instead. Internal cron paths require a shared secret. RISE proxies are skipped because one user session can fan out across many list pages.",
+      "paths": [
+        "all x402 routes (see GET /.well-known/x402)",
+        "/internal/tester-agent*",
+        "/internal/trend-scout/run",
+        "/internal/partnership-scout/run",
+        "/internal/hackathon-scout/run",
+        "/uponly-rise-market*",
+        "/uponly-rise-portfolio*"
+      ]
+    }
+  },
+  "paths": {
+    "/api/signal": {
+      "get": {
+        "tags": [
+          "Signal"
+        ],
+        "summary": "Public signal (no x402)",
+        "description": "Same engine as /signal without micropayment. API key if server sets API_KEY.",
+        "operationId": "getPublicSignal",
+        "parameters": [
+          {
+            "name": "token",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "bitcoin"
+            },
+            "description": "Asset name for signal routing (e.g. bitcoin, solana)."
+          },
+          {
+            "name": "source",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Data source. Default: binance. CEX: binance, coinbase, coingecko, okx, bybit, kraken, bitget, kucoin, upbit, cryptocom (alias: crypto.com → cryptocom). n8n | webhook for legacy webhook."
+          },
+          {
+            "name": "instId",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Venue symbol override (e.g. BTCUSDT, BTC-USDT)."
+          },
+          {
+            "name": "bar",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Candle interval (e.g. 1m, 1h, 4h, 1d)."
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Candle count (default ~200)."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Signal result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "signal": {
+                          "type": "object",
+                          "additionalProperties": true
+                        }
+                      }
+                    },
+                    "meta": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Upstream or configuration error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Signal"
+        ],
+        "summary": "Public signal via JSON body",
+        "operationId": "postPublicSignal",
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "token": {
+                    "type": "string"
+                  },
+                  "source": {
+                    "type": "string"
+                  },
+                  "instId": {
+                    "type": "string"
+                  },
+                  "bar": {
+                    "type": "string"
+                  },
+                  "limit": {
+                    "type": "number"
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Signal result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "signal": {
+                          "type": "object",
+                          "additionalProperties": true
+                        }
+                      }
+                    },
+                    "meta": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/info": {
+      "get": {
+        "tags": [
+          "Info"
+        ],
+        "summary": "Gateway info",
+        "operationId": "getInfo",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds the client must wait before retrying.",
+                "schema": {
+                  "type": "integer",
+                  "minimum": 1
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "message"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Too many requests. Please slow down."
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/info/stats": {
+      "get": {
+        "tags": [
+          "Info"
+        ],
+        "summary": "Public usage stats",
+        "operationId": "getInfoStats",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds the client must wait before retrying.",
+                "schema": {
+                  "type": "integer",
+                  "minimum": 1
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "message"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Too many requests. Please slow down."
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/preview/news": {
+      "get": {
+        "tags": [
+          "Preview"
+        ],
+        "summary": "News preview (no x402)",
+        "operationId": "getPreviewNews",
+        "parameters": [
+          {
+            "name": "ticker",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "general"
+            },
+            "description": "Ticker symbol or general for broad feed."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds the client must wait before retrying.",
+                "schema": {
+                  "type": "integer",
+                  "minimum": 1
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "message"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Too many requests. Please slow down."
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/preview/sentiment": {
+      "get": {
+        "tags": [
+          "Preview"
+        ],
+        "summary": "Sentiment preview (no x402)",
+        "operationId": "getPreviewSentiment",
+        "parameters": [
+          {
+            "name": "ticker",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "general"
+            },
+            "description": "Ticker symbol or general for broad feed."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds the client must wait before retrying.",
+                "schema": {
+                  "type": "integer",
+                  "minimum": 1
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "message"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Too many requests. Please slow down."
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/preview/signal": {
+      "get": {
+        "tags": [
+          "Preview"
+        ],
+        "summary": "Signal preview (no x402)",
+        "operationId": "getPreviewSignal",
+        "parameters": [
+          {
+            "name": "token",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "bitcoin"
+            },
+            "description": "Asset name for signal routing (e.g. bitcoin, solana)."
+          },
+          {
+            "name": "source",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Data source. Default: binance. CEX: binance, coinbase, coingecko, okx, bybit, kraken, bitget, kucoin, upbit, cryptocom (alias: crypto.com → cryptocom). n8n | webhook for legacy webhook."
+          },
+          {
+            "name": "instId",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Venue symbol override (e.g. BTCUSDT, BTC-USDT)."
+          },
+          {
+            "name": "bar",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Candle interval (e.g. 1m, 1h, 4h, 1d)."
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Candle count (default ~200)."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds the client must wait before retrying.",
+                "schema": {
+                  "type": "integer",
+                  "minimum": 1
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "message"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Too many requests. Please slow down."
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/dashboard-summary": {
+      "get": {
+        "tags": [
+          "Dashboard"
+        ],
+        "summary": "Dashboard KPI summary",
+        "operationId": "getDashboardSummary",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds the client must wait before retrying.",
+                "schema": {
+                  "type": "integer",
+                  "minimum": 1
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "message"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Too many requests. Please slow down."
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/binance-ticker": {
+      "get": {
+        "tags": [
+          "Dashboard"
+        ],
+        "summary": "Binance ticker prices",
+        "operationId": "getBinanceTicker",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds the client must wait before retrying.",
+                "schema": {
+                  "type": "integer",
+                  "minimum": 1
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "message"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Too many requests. Please slow down."
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/prediction-game/health": {
+      "get": {
+        "tags": [
+          "Prediction game"
+        ],
+        "summary": "Prediction game health",
+        "operationId": "getPredictionGameHealth",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds the client must wait before retrying.",
+                "schema": {
+                  "type": "integer",
+                  "minimum": 1
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "message"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Too many requests. Please slow down."
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/news": {
+      "get": {
+        "tags": [
+          "Market data (x402)"
+        ],
+        "summary": "Crypto news",
+        "operationId": "getNews",
+        "parameters": [
+          {
+            "name": "ticker",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "general"
+            },
+            "description": "Ticker symbol or general for broad feed."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required — x402 (Solana/Base USDC). Retry with payment proof per response body."
+          },
+          "429": {
+            "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds the client must wait before retrying.",
+                "schema": {
+                  "type": "integer",
+                  "minimum": 1
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "message"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Too many requests. Please slow down."
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Market data (x402)"
+        ],
+        "summary": "Crypto news (POST)",
+        "operationId": "postNews",
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "description": "Request body — see https://docs.syraa.fun for fields."
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required — x402 (Solana/Base USDC). Retry with payment proof per response body."
+          },
+          "429": {
+            "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds the client must wait before retrying.",
+                "schema": {
+                  "type": "integer",
+                  "minimum": 1
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "message"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Too many requests. Please slow down."
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/sentiment": {
+      "get": {
+        "tags": [
+          "Market data (x402)"
+        ],
+        "summary": "Sentiment",
+        "operationId": "getSentiment",
+        "parameters": [
+          {
+            "name": "ticker",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "general"
+            },
+            "description": "Ticker symbol or general for broad feed."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required — x402 (Solana/Base USDC). Retry with payment proof per response body."
+          },
+          "429": {
+            "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds the client must wait before retrying.",
+                "schema": {
+                  "type": "integer",
+                  "minimum": 1
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "message"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Too many requests. Please slow down."
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Market data (x402)"
+        ],
+        "summary": "Sentiment (POST)",
+        "operationId": "postSentiment",
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "description": "Request body — see https://docs.syraa.fun for fields."
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required — x402 (Solana/Base USDC). Retry with payment proof per response body."
+          },
+          "429": {
+            "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds the client must wait before retrying.",
+                "schema": {
+                  "type": "integer",
+                  "minimum": 1
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "message"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Too many requests. Please slow down."
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/event": {
+      "get": {
+        "tags": [
+          "Market data (x402)"
+        ],
+        "summary": "Crypto events",
+        "operationId": "getEvent",
+        "parameters": [
+          {
+            "name": "ticker",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "general"
+            },
+            "description": "Ticker symbol or general for broad feed."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required — x402 (Solana/Base USDC). Retry with payment proof per response body."
+          },
+          "429": {
+            "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds the client must wait before retrying.",
+                "schema": {
+                  "type": "integer",
+                  "minimum": 1
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "message"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Too many requests. Please slow down."
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Market data (x402)"
+        ],
+        "summary": "Crypto events (POST)",
+        "operationId": "postEvent",
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "description": "Request body — see https://docs.syraa.fun for fields."
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required — x402 (Solana/Base USDC). Retry with payment proof per response body."
+          },
+          "429": {
+            "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds the client must wait before retrying.",
+                "schema": {
+                  "type": "integer",
+                  "minimum": 1
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "message"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Too many requests. Please slow down."
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/health": {
+      "get": {
+        "tags": [
+          "Gateway (x402)"
+        ],
+        "summary": "API health (x402 liveness)",
+        "operationId": "getHealth",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required — x402 (Solana/Base USDC). Retry with payment proof per response body."
+          },
+          "429": {
+            "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds the client must wait before retrying.",
+                "schema": {
+                  "type": "integer",
+                  "minimum": 1
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "message"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Too many requests. Please slow down."
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Gateway (x402)"
+        ],
+        "summary": "API health (POST)",
+        "operationId": "postHealth",
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "description": "Request body — see https://docs.syraa.fun for fields."
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required — x402 (Solana/Base USDC). Retry with payment proof per response body."
+          },
+          "429": {
+            "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds the client must wait before retrying.",
+                "schema": {
+                  "type": "integer",
+                  "minimum": 1
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "message"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Too many requests. Please slow down."
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/brain": {
+      "get": {
+        "tags": [
+          "AI (x402)"
+        ],
+        "summary": "Syra Brain (GET)",
+        "operationId": "getBrain",
+        "parameters": [
+          {
+            "name": "question",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Natural language question."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required — x402 (Solana/Base USDC). Retry with payment proof per response body."
+          },
+          "429": {
+            "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds the client must wait before retrying.",
+                "schema": {
+                  "type": "integer",
+                  "minimum": 1
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "message"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Too many requests. Please slow down."
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "AI (x402)"
+        ],
+        "summary": "Syra Brain (POST)",
+        "operationId": "postBrain",
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "description": "Request body — see https://docs.syraa.fun for fields."
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required — x402 (Solana/Base USDC). Retry with payment proof per response body."
+          },
+          "429": {
+            "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds the client must wait before retrying.",
+                "schema": {
+                  "type": "integer",
+                  "minimum": 1
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "message"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Too many requests. Please slow down."
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/arbitrage": {
+      "get": {
+        "tags": [
+          "Market data (x402)"
+        ],
+        "summary": "Arbitrage — CMC top + cross-CEX snapshots + ranked routes (x402)",
+        "operationId": "getArbitrage",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 25,
+              "default": 10
+            },
+            "description": "Number of top tradable assets to include (default 10, max 25)."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required — x402 (Solana/Base USDC). Retry with payment proof per response body."
+          },
+          "429": {
+            "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds the client must wait before retrying.",
+                "schema": {
+                  "type": "integer",
+                  "minimum": 1
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "message"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Too many requests. Please slow down."
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Market data (x402)"
+        ],
+        "summary": "Arbitrage — POST body may include { limit } (x402)",
+        "operationId": "postArbitrage",
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "description": "Request body — see https://docs.syraa.fun for fields."
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required — x402 (Solana/Base USDC). Retry with payment proof per response body."
+          },
+          "429": {
+            "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds the client must wait before retrying.",
+                "schema": {
+                  "type": "integer",
+                  "minimum": 1
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "message"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Too many requests. Please slow down."
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/x-analyzer": {
+      "get": {
+        "tags": [
+          "Social (x402)"
+        ],
+        "summary": "X Project Analyzer — profile + tweets + score (x402)",
+        "description": "Micropayment via x402. Returns deterministic 0–100 score, category breakdown, signals, red flags; optional `includeAiSummary` adds grounded LLM bullets. Example `200` body is maintained at `api/docs/examples/x-analyzer-response.example.json`.",
+        "operationId": "getXAnalyzer",
+        "parameters": [
+          {
+            "name": "username",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "syra_agent"
+            },
+            "description": "X handle without @."
+          },
+          {
+            "name": "max_results",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 5,
+              "maximum": 50,
+              "default": 20
+            },
+            "description": "Recent tweets sampled for scoring."
+          },
+          {
+            "name": "includeAiSummary",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false
+            },
+            "description": "If true, append optional LLM summary (still grounded on returned metrics)."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success — `success: true` and `data` (shape matches checked-in example file).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "example": {
+                  "success": true,
+                  "data": {
+                    "username": "syra_agent",
+                    "user": {
+                      "id": "1983380098406592515",
+                      "username": "syra_agent",
+                      "name": "Syra",
+                      "description": "Smart Intelligence Agent for Traders on Solana. https://t.co/9hRxUXzQFD",
+                      "url": "https://t.co/3Z1z9rVl2p",
+                      "created_at": "2025-10-29T03:47:33.000Z",
+                      "verified": true,
+                      "verified_type": "blue",
+                      "public_metrics": {
+                        "followers_count": 2177,
+                        "following_count": 158,
+                        "tweet_count": 1276,
+                        "listed_count": 8,
+                        "like_count": 1985,
+                        "media_count": 285
+                      }
+                    },
+                    "score": 53,
+                    "grade": "F",
+                    "breakdown": {
+                      "identity": {
+                        "score": 8.35,
+                        "max": 15,
+                        "details": {
+                          "verifiedBonus": 5,
+                          "ageYears": 0.51,
+                          "agePoints": 0.35,
+                          "bioLengthBonus": 2,
+                          "urlBonus": 1
+                        }
+                      },
+                      "reach": {
+                        "score": 14.05,
+                        "max": 25,
+                        "details": {
+                          "followersCount": 2177,
+                          "followingCount": 158,
+                          "log10Followers": 3.338,
+                          "logMappedPoints": 11.13,
+                          "ratioBonus": 2.92
+                        }
+                      },
+                      "engagement": {
+                        "score": 6.78,
+                        "max": 30,
+                        "details": {
+                          "avgEngagementRatePct": 0.3768,
+                          "tweetsAnalyzed": 14
+                        }
+                      },
+                      "cadence": {
+                        "score": 14.15,
+                        "max": 15,
+                        "details": {
+                          "tweetsPerDay": 5.41521244380721,
+                          "lastTweetDaysAgo": 0,
+                          "idealBand": "0.5-3/day",
+                          "recentActivityBonus": true
+                        }
+                      },
+                      "contentDiversity": {
+                        "score": 9.66,
+                        "max": 15,
+                        "details": {
+                          "dominanceRatio": 0.344,
+                          "spreadPoints": 6.56,
+                          "volumePoints": 3.11,
+                          "profileTweetCount": 1276
+                        }
+                      }
+                    },
+                    "signals": {
+                      "followersCount": 2177,
+                      "followingCount": 158,
+                      "tweetsAnalyzed": 14,
+                      "profileTweetCount": 1276,
+                      "avgEngagementRatePct": 0.3768,
+                      "tweetsPerDay": 5.4152,
+                      "lastTweetDaysAgo": 0,
+                      "accountAgeDays": 185
+                    },
+                    "redFlags": [],
+                    "aiSummary": null,
+                    "updatedAt": "2026-05-02T14:33:46.739Z"
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required — x402 (Solana/Base USDC). Retry with payment proof per response body."
+          },
+          "404": {
+            "description": "X user not found"
+          },
+          "502": {
+            "description": "X API upstream error"
+          },
+          "503": {
+            "description": "Server missing X_BEARER_TOKEN"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Social (x402)"
+        ],
+        "summary": "X Project Analyzer — POST body (x402)",
+        "description": "Same as GET; body may include `username`, `max_results`, `includeAiSummary`. Example response identical to GET.",
+        "operationId": "postXAnalyzer",
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "username": {
+                    "type": "string",
+                    "description": "Default syra_agent"
+                  },
+                  "max_results": {
+                    "type": "integer",
+                    "minimum": 5,
+                    "maximum": 50
+                  },
+                  "includeAiSummary": {
+                    "type": "boolean"
+                  }
+                }
+              },
+              "example": {
+                "username": "syra_agent",
+                "max_results": 20,
+                "includeAiSummary": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — same shape as GET; see example file and GET operation example.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "example": {
+                  "success": true,
+                  "data": {
+                    "username": "syra_agent",
+                    "user": {
+                      "id": "1983380098406592515",
+                      "username": "syra_agent",
+                      "name": "Syra",
+                      "description": "Smart Intelligence Agent for Traders on Solana. https://t.co/9hRxUXzQFD",
+                      "url": "https://t.co/3Z1z9rVl2p",
+                      "created_at": "2025-10-29T03:47:33.000Z",
+                      "verified": true,
+                      "verified_type": "blue",
+                      "public_metrics": {
+                        "followers_count": 2177,
+                        "following_count": 158,
+                        "tweet_count": 1276,
+                        "listed_count": 8,
+                        "like_count": 1985,
+                        "media_count": 285
+                      }
+                    },
+                    "score": 53,
+                    "grade": "F",
+                    "breakdown": {
+                      "identity": {
+                        "score": 8.35,
+                        "max": 15,
+                        "details": {
+                          "verifiedBonus": 5,
+                          "ageYears": 0.51,
+                          "agePoints": 0.35,
+                          "bioLengthBonus": 2,
+                          "urlBonus": 1
+                        }
+                      },
+                      "reach": {
+                        "score": 14.05,
+                        "max": 25,
+                        "details": {
+                          "followersCount": 2177,
+                          "followingCount": 158,
+                          "log10Followers": 3.338,
+                          "logMappedPoints": 11.13,
+                          "ratioBonus": 2.92
+                        }
+                      },
+                      "engagement": {
+                        "score": 6.78,
+                        "max": 30,
+                        "details": {
+                          "avgEngagementRatePct": 0.3768,
+                          "tweetsAnalyzed": 14
+                        }
+                      },
+                      "cadence": {
+                        "score": 14.15,
+                        "max": 15,
+                        "details": {
+                          "tweetsPerDay": 5.41521244380721,
+                          "lastTweetDaysAgo": 0,
+                          "idealBand": "0.5-3/day",
+                          "recentActivityBonus": true
+                        }
+                      },
+                      "contentDiversity": {
+                        "score": 9.66,
+                        "max": 15,
+                        "details": {
+                          "dominanceRatio": 0.344,
+                          "spreadPoints": 6.56,
+                          "volumePoints": 3.11,
+                          "profileTweetCount": 1276
+                        }
+                      }
+                    },
+                    "signals": {
+                      "followersCount": 2177,
+                      "followingCount": 158,
+                      "tweetsAnalyzed": 14,
+                      "profileTweetCount": 1276,
+                      "avgEngagementRatePct": 0.3768,
+                      "tweetsPerDay": 5.4152,
+                      "lastTweetDaysAgo": 0,
+                      "accountAgeDays": 185
+                    },
+                    "redFlags": [],
+                    "aiSummary": null,
+                    "updatedAt": "2026-05-02T14:33:46.739Z"
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required — x402 (Solana/Base USDC). Retry with payment proof per response body."
+          },
+          "404": {
+            "description": "X user not found"
+          },
+          "502": {
+            "description": "X API upstream error"
+          },
+          "503": {
+            "description": "Server missing X_BEARER_TOKEN"
+          }
+        }
+      }
+    },
+    "/x-projects-analyze/types": {
+      "get": {
+        "tags": [
+          "Social (batch)"
+        ],
+        "summary": "List batch analyzer types",
+        "description": "Returns configured `type` ids (labels, provider). X accounts per type are fixed server-side. No X API calls. API key when server sets API_KEY.",
+        "operationId": "getXProjectsAnalyzeTypes",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/x-projects-analyze/account": {
+      "get": {
+        "tags": [
+          "Social (batch)"
+        ],
+        "summary": "Single-account Alpha analysis (allowlisted)",
+        "description": "`username` must belong to the configured `type` handle list. Returns full score payload, optional AI summary (default on), and `recentTweets` sample. API key when API_KEY is set.",
+        "operationId": "getXProjectsAnalyzeAccount",
+        "parameters": [
+          {
+            "name": "username",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "X handle without @."
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "x402"
+            },
+            "description": "Feed type key."
+          },
+          {
+            "name": "max_results",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 10,
+              "maximum": 50,
+              "default": 35
+            },
+            "description": "Tweet sample size."
+          },
+          {
+            "name": "includeAiSummary",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": true
+            },
+            "description": "Grounded LLM bullets (OpenRouter)."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Username not in feed type allowlist"
+          },
+          "404": {
+            "description": "X user not found"
+          },
+          "429": {
+            "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds the client must wait before retrying.",
+                "schema": {
+                  "type": "integer",
+                  "minimum": 1
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "message"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Too many requests. Please slow down."
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "X API upstream error"
+          },
+          "503": {
+            "description": "Server missing X_BEARER_TOKEN"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Social (batch)"
+        ],
+        "summary": "Single-account Alpha analysis — POST",
+        "operationId": "postXProjectsAnalyzeAccount",
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "username": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string",
+                    "default": "x402"
+                  },
+                  "max_results": {
+                    "type": "integer",
+                    "minimum": 10,
+                    "maximum": 50
+                  },
+                  "includeAiSummary": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "username"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Username not in feed type allowlist"
+          },
+          "404": {
+            "description": "X user not found"
+          },
+          "429": {
+            "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds the client must wait before retrying.",
+                "schema": {
+                  "type": "integer",
+                  "minimum": 1
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "message"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Too many requests. Please slow down."
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "X API upstream error"
+          },
+          "503": {
+            "description": "Server missing X_BEARER_TOKEN"
+          }
+        }
+      }
+    },
+    "/x-projects-analyze": {
+      "get": {
+        "tags": [
+          "Social (batch)"
+        ],
+        "summary": "Batch X project analyzer (no x402)",
+        "description": "Runs the same deterministic analysis as /x-analyzer for all X handles configured for `type` (default `x402`). Handles are not client-supplied. See GET /x-projects-analyze/types.",
+        "operationId": "getXProjectsAnalyze",
+        "parameters": [
+          {
+            "name": "type",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "x402"
+            },
+            "description": "Analyzer type key (e.g. x402)."
+          },
+          {
+            "name": "max_results",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 5,
+              "maximum": 50,
+              "default": 20
+            },
+            "description": "Tweet sample per account."
+          },
+          {
+            "name": "includeAiSummary",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false
+            },
+            "description": "Optional grounded LLM summary per account (OpenRouter)."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds the client must wait before retrying.",
+                "schema": {
+                  "type": "integer",
+                  "minimum": 1
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "message"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Too many requests. Please slow down."
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Social (batch)"
+        ],
+        "summary": "Batch X project analyzer — POST body",
+        "operationId": "postXProjectsAnalyze",
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "default": "x402"
+                  },
+                  "max_results": {
+                    "type": "integer",
+                    "minimum": 5,
+                    "maximum": 50
+                  },
+                  "includeAiSummary": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds the client must wait before retrying.",
+                "schema": {
+                  "type": "integer",
+                  "minimum": 1
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "message"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Too many requests. Please slow down."
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Signal",
+      "description": "GET/POST /api/signal — no x402"
+    },
+    {
+      "name": "Info",
+      "description": "Public info"
+    },
+    {
+      "name": "Preview",
+      "description": "No x402 mirrors of news/sentiment/signal"
+    },
+    {
+      "name": "Dashboard",
+      "description": "Dashboard helpers"
+    },
+    {
+      "name": "Prediction game",
+      "description": "Prediction game API"
+    },
+    {
+      "name": "Market data (x402)",
+      "description": "Cryptonews-backed; payment via x402"
+    },
+    {
+      "name": "Gateway (x402)",
+      "description": "Health and gateway checks"
+    },
+    {
+      "name": "AI (x402)",
+      "description": "Syra Brain Q&A"
+    },
+    {
+      "name": "Social (x402)",
+      "description": "X (Twitter) analysis — pay-per-call via x402"
+    },
+    {
+      "name": "Social (batch)",
+      "description": "Batch X project analysis — API key when configured; no x402"
+    }
+  ],
+  "components": {
+    "securitySchemes": {
+      "SyraApiKey": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-API-Key",
+        "description": "When API_KEY is set: also `api-key` or `Authorization: Bearer`. x402 routes do not use this."
+      }
+    }
+  }
+}

--- a/providers/syra/intelligence/openapi.json
+++ b/providers/syra/intelligence/openapi.json
@@ -706,7 +706,12 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "SyraApiKey": []
+          }
+        ]
       }
     },
     "/binance-ticker": {
@@ -762,7 +767,12 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "SyraApiKey": []
+          }
+        ]
       }
     },
     "/prediction-game/health": {
@@ -783,6 +793,247 @@
                 }
               }
             }
+          },
+          "429": {
+            "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds the client must wait before retrying.",
+                "schema": {
+                  "type": "integer",
+                  "minimum": 1
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "message"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Too many requests. Please slow down."
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/signal": {
+      "get": {
+        "tags": [
+          "Market data (x402)"
+        ],
+        "summary": "Trading signal (x402)",
+        "description": "Paid trading signal endpoint gated by x402.",
+        "operationId": "getSignal",
+        "parameters": [
+          {
+            "name": "token",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "bitcoin"
+            },
+            "description": "Asset name for signal routing (e.g. bitcoin, solana)."
+          },
+          {
+            "name": "source",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Data source. Default: binance. CEX: binance, coinbase, coingecko, okx, bybit, kraken, bitget, kucoin, upbit, cryptocom (alias: crypto.com → cryptocom). n8n | webhook for legacy webhook."
+          },
+          {
+            "name": "instId",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Venue symbol override (e.g. BTCUSDT, BTC-USDT)."
+          },
+          {
+            "name": "bar",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Candle interval (e.g. 1m, 1h, 4h, 1d)."
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Candle count (default ~200)."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Signal result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "signal": {
+                          "type": "object",
+                          "additionalProperties": true
+                        }
+                      }
+                    },
+                    "meta": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "$ref": "#/components/responses/X402PaymentRequired"
+          },
+          "429": {
+            "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds the client must wait before retrying.",
+                "schema": {
+                  "type": "integer",
+                  "minimum": 1
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "message"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Too many requests. Please slow down."
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Market data (x402)"
+        ],
+        "summary": "Trading signal via JSON body (x402)",
+        "operationId": "postSignal",
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "token": {
+                    "type": "string"
+                  },
+                  "source": {
+                    "type": "string"
+                  },
+                  "instId": {
+                    "type": "string"
+                  },
+                  "bar": {
+                    "type": "string"
+                  },
+                  "limit": {
+                    "type": "number"
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Signal result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "signal": {
+                          "type": "object",
+                          "additionalProperties": true
+                        }
+                      }
+                    },
+                    "meta": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "$ref": "#/components/responses/X402PaymentRequired"
           },
           "429": {
             "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
@@ -853,7 +1104,7 @@
             }
           },
           "402": {
-            "description": "Payment required — x402 (Solana/Base USDC). Retry with payment proof per response body."
+            "$ref": "#/components/responses/X402PaymentRequired"
           },
           "429": {
             "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
@@ -922,7 +1173,7 @@
             }
           },
           "402": {
-            "description": "Payment required — x402 (Solana/Base USDC). Retry with payment proof per response body."
+            "$ref": "#/components/responses/X402PaymentRequired"
           },
           "429": {
             "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
@@ -993,7 +1244,7 @@
             }
           },
           "402": {
-            "description": "Payment required — x402 (Solana/Base USDC). Retry with payment proof per response body."
+            "$ref": "#/components/responses/X402PaymentRequired"
           },
           "429": {
             "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
@@ -1062,7 +1313,7 @@
             }
           },
           "402": {
-            "description": "Payment required — x402 (Solana/Base USDC). Retry with payment proof per response body."
+            "$ref": "#/components/responses/X402PaymentRequired"
           },
           "429": {
             "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
@@ -1133,7 +1384,7 @@
             }
           },
           "402": {
-            "description": "Payment required — x402 (Solana/Base USDC). Retry with payment proof per response body."
+            "$ref": "#/components/responses/X402PaymentRequired"
           },
           "429": {
             "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
@@ -1202,7 +1453,7 @@
             }
           },
           "402": {
-            "description": "Payment required — x402 (Solana/Base USDC). Retry with payment proof per response body."
+            "$ref": "#/components/responses/X402PaymentRequired"
           },
           "429": {
             "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
@@ -1261,7 +1512,7 @@
             }
           },
           "402": {
-            "description": "Payment required — x402 (Solana/Base USDC). Retry with payment proof per response body."
+            "$ref": "#/components/responses/X402PaymentRequired"
           },
           "429": {
             "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
@@ -1330,7 +1581,7 @@
             }
           },
           "402": {
-            "description": "Payment required — x402 (Solana/Base USDC). Retry with payment proof per response body."
+            "$ref": "#/components/responses/X402PaymentRequired"
           },
           "429": {
             "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
@@ -1400,7 +1651,7 @@
             }
           },
           "402": {
-            "description": "Payment required — x402 (Solana/Base USDC). Retry with payment proof per response body."
+            "$ref": "#/components/responses/X402PaymentRequired"
           },
           "429": {
             "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
@@ -1469,7 +1720,7 @@
             }
           },
           "402": {
-            "description": "Payment required — x402 (Solana/Base USDC). Retry with payment proof per response body."
+            "$ref": "#/components/responses/X402PaymentRequired"
           },
           "429": {
             "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
@@ -1542,7 +1793,7 @@
             }
           },
           "402": {
-            "description": "Payment required — x402 (Solana/Base USDC). Retry with payment proof per response body."
+            "$ref": "#/components/responses/X402PaymentRequired"
           },
           "429": {
             "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
@@ -1611,7 +1862,7 @@
             }
           },
           "402": {
-            "description": "Payment required — x402 (Solana/Base USDC). Retry with payment proof per response body."
+            "$ref": "#/components/responses/X402PaymentRequired"
           },
           "429": {
             "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
@@ -1810,7 +2061,7 @@
             }
           },
           "402": {
-            "description": "Payment required — x402 (Solana/Base USDC). Retry with payment proof per response body."
+            "$ref": "#/components/responses/X402PaymentRequired"
           },
           "404": {
             "description": "X user not found"
@@ -1977,7 +2228,7 @@
             }
           },
           "402": {
-            "description": "Payment required — x402 (Solana/Base USDC). Retry with payment proof per response body."
+            "$ref": "#/components/responses/X402PaymentRequired"
           },
           "404": {
             "description": "X user not found"
@@ -2011,7 +2262,12 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "SyraApiKey": []
+          }
+        ]
       }
     },
     "/x-projects-analyze/account": {
@@ -2123,7 +2379,12 @@
           "503": {
             "description": "Server missing X_BEARER_TOKEN"
           }
-        }
+        },
+        "security": [
+          {
+            "SyraApiKey": []
+          }
+        ]
       },
       "post": {
         "tags": [
@@ -2219,7 +2480,12 @@
           "503": {
             "description": "Server missing X_BEARER_TOKEN"
           }
-        }
+        },
+        "security": [
+          {
+            "SyraApiKey": []
+          }
+        ]
       }
     },
     "/x-projects-analyze": {
@@ -2310,7 +2576,12 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "SyraApiKey": []
+          }
+        ]
       },
       "post": {
         "tags": [
@@ -2388,7 +2659,12 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "SyraApiKey": []
+          }
+        ]
       }
     }
   },
@@ -2441,6 +2717,92 @@
         "in": "header",
         "name": "X-API-Key",
         "description": "When API_KEY is set: also `api-key` or `Authorization: Bearer`. x402 routes do not use this."
+      }
+    },
+    "schemas": {
+      "X402AcceptOffer": {
+        "type": "object",
+        "required": [
+          "scheme",
+          "network",
+          "asset",
+          "maxAmountRequired",
+          "payTo",
+          "resource"
+        ],
+        "properties": {
+          "scheme": {
+            "type": "string",
+            "example": "exact"
+          },
+          "network": {
+            "type": "string",
+            "example": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
+          },
+          "asset": {
+            "type": "string",
+            "example": "USDC"
+          },
+          "maxAmountRequired": {
+            "type": "string",
+            "description": "Price in micro-USDC units.",
+            "example": "10000"
+          },
+          "payTo": {
+            "type": "string",
+            "example": "7YfD...TreasuryAddress"
+          },
+          "resource": {
+            "type": "string",
+            "example": "https://api.syraa.fun/signal"
+          },
+          "maxTimeoutSeconds": {
+            "type": "integer",
+            "minimum": 1,
+            "example": 300
+          },
+          "outputSchema": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        },
+        "additionalProperties": true
+      },
+      "X402PaymentRequiredResponse": {
+        "type": "object",
+        "required": [
+          "accepts"
+        ],
+        "properties": {
+          "accepts": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "$ref": "#/components/schemas/X402AcceptOffer"
+            }
+          },
+          "error": {
+            "type": "string",
+            "example": "payment_required"
+          },
+          "message": {
+            "type": "string",
+            "example": "Payment required to access this resource."
+          }
+        },
+        "additionalProperties": true
+      }
+    },
+    "responses": {
+      "X402PaymentRequired": {
+        "description": "Payment required - x402 (Solana/Base USDC). Retry with payment proof per response body.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/X402PaymentRequiredResponse"
+            }
+          }
+        }
       }
     }
   }

--- a/providers/syra/intelligence/openapi.json
+++ b/providers/syra/intelligence/openapi.json
@@ -418,7 +418,7 @@
         "tags": [
           "Preview"
         ],
-        "summary": "Preview crypto news headlines without payment",
+        "summary": "Fetch sample crypto news headlines without payment",
         "operationId": "getPreviewNews",
         "parameters": [
           {
@@ -486,7 +486,7 @@
         "tags": [
           "Preview"
         ],
-        "summary": "Preview market sentiment scores without payment",
+        "summary": "Fetch sample market sentiment without payment",
         "operationId": "getPreviewSentiment",
         "parameters": [
           {
@@ -554,7 +554,7 @@
         "tags": [
           "Preview"
         ],
-        "summary": "Preview trading signal output without payment",
+        "summary": "Fetch sample trading signal without payment",
         "operationId": "getPreviewSignal",
         "parameters": [
           {
@@ -1625,7 +1625,7 @@
         "tags": [
           "AI (x402)"
         ],
-        "summary": "Answer crypto questions with Syra Brain tools",
+        "summary": "Generate crypto answers with Syra Brain tools",
         "operationId": "getBrain",
         "parameters": [
           {
@@ -1693,7 +1693,7 @@
         "tags": [
           "AI (x402)"
         ],
-        "summary": "Answer crypto questions via Syra Brain POST body",
+        "summary": "Generate crypto answers via Syra Brain POST body",
         "operationId": "postBrain",
         "requestBody": {
           "required": false,
@@ -2400,19 +2400,23 @@
                 "type": "object",
                 "properties": {
                   "username": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "X handle without @; must be on the allowlist for the selected type."
                   },
                   "type": {
                     "type": "string",
-                    "default": "x402"
+                    "default": "x402",
+                    "description": "Feed type key that owns the allowlisted handle list."
                   },
                   "max_results": {
                     "type": "integer",
                     "minimum": 10,
-                    "maximum": 50
+                    "maximum": 50,
+                    "description": "Tweet sample size for scoring."
                   },
                   "includeAiSummary": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "When true, include grounded LLM summary bullets."
                   }
                 },
                 "required": [

--- a/providers/syra/intelligence/openapi.json
+++ b/providers/syra/intelligence/openapi.json
@@ -3,7 +3,11 @@
   "info": {
     "title": "Syra API",
     "version": "1.0.0",
-    "description": "Syra gateway: preview and dashboard routes may require `X-API-Key` / Bearer when the server sets `API_KEY`.\n\n**x402** routes return **HTTP 402** until paid (Solana/Base USDC). The full payment offer (network, asset, price in micro-USDC, `payTo`, etc.) is returned at runtime in the 402 response body's `accepts` array — that is the canonical x402 V1 wire spec; pay one offer and retry with `X-PAYMENT`. See https://docs.syraa.fun/docs/api/x402-api-standard for the wire format and signing examples.\n\nSome x402 ecosystems (MPP / AgentCash registries) expect a per-operation OpenAPI extension named `x-payment-info` carrying registry metadata (protocols, pricingMode, price). This **gateway** spec deliberately omits it for strict-schema friendliness; the **MPP discovery** document at `GET /mpp-openapi.json` emits it on every paid operation. The exact shape Syra uses is described in the `x-payment-info-spec` extension at the root of this document.\n\n**Rate limits** (per IP, applied to every non-x402 / non-cron route): burst **25 req / 10s** + sustained **100 req / 60s**. Exceeding either returns **HTTP 429** with `Retry-After: <seconds>` and `{ success: false, message }`. x402 paid routes are gated by HTTP 402 instead and bypass this throttle. See the `x-ratelimit` extension below for the machine-readable spec."
+    "contact": {
+      "email": "support@syraa.fun"
+    },
+    "x-guidance": "Free routes (security: []) include /info and /prediction-game/health. Paid routes return HTTP 402 until settled via x402 (Solana/Base USDC) — pay an offer from the 402 body accepts array and retry with PAYMENT-SIGNATURE or X-PAYMENT. Docs: https://docs.syraa.fun",
+    "description": "Syra gateway: routes with `security: []` are free (no payment). Trading signals are at **GET/POST /signal** (x402).\n\n**x402** routes return **HTTP 402** until paid (Solana/Base USDC). The full payment offer (network, asset, price in micro-USDC, `payTo`, etc.) is returned at runtime in the 402 response body's `accepts` array and the `Payment-Required` header (x402 v2). Pay one offer and retry with `PAYMENT-SIGNATURE` or `X-PAYMENT`. See https://docs.syraa.fun/docs/api/x402-api-standard for the wire format and signing examples.\n\nPaid operations declare `x-payment-info` (catalog hint) and `security: [{ x402: [] }]`. The **MPP discovery** document at `GET /mpp-openapi.json` mirrors the full x402 catalog.\n\n**Rate limits** (per IP, applied to non-x402 / non-cron routes not listed as free in this spec): burst **25 req / 10s** + sustained **100 req / 60s**. Exceeding either returns **HTTP 429** with `Retry-After: <seconds>` and `{ success: false, message }`. x402 paid routes and openapi free routes bypass this throttle. See the `x-ratelimit` extension below."
   },
   "servers": [
     {
@@ -11,41 +15,62 @@
     }
   ],
   "x-payment-info-spec": {
-    "emittedHere": false,
-    "reason": "Strict-schema friendly. Canonical payment metadata for paid (x402) routes is returned at runtime in the 402 response body's `accepts` array (V1 wire format: scheme, network, asset, maxAmountRequired in micro-USDC, payTo, resource, maxTimeoutSeconds, outputSchema). Pay one of those offers and retry with `X-PAYMENT`. See: https://docs.syraa.fun/docs/api/x402-api-standard",
+    "emittedHere": true,
+    "reason": "Each paid operation in this document includes x-payment-info (catalog hint for x402scan / tryponcho). Canonical payment metadata is still returned at runtime in the HTTP 402 response body `accepts` array and the Payment-Required header (x402 v2). Pay one offer and retry with PAYMENT-SIGNATURE or X-PAYMENT. See: https://docs.syraa.fun/docs/api/x402-api-standard",
     "alsoEmittedAt": {
       "document": "https://api.syraa.fun/mpp-openapi.json",
-      "description": "MPP / AgentCash discovery document. Each paid operation includes an `x-payment-info` extension with the shape below. Settlement is still x402 V1 (HTTP 402 + `accepts`); `x-payment-info` is registry metadata only."
+      "description": "MPP / AgentCash discovery document with the full x402 catalog. Settlement is x402 v2 (HTTP 402 + accepts); x-payment-info is registry metadata."
     },
     "shape": {
       "type": "object",
       "required": [
         "protocols",
-        "pricingMode",
         "price"
       ],
       "properties": {
         "protocols": {
           "type": "array",
           "items": {
-            "type": "string"
+            "type": "object"
           },
-          "description": "Supported payment protocols. Syra emits `[\"mpp\"]` in the MPP doc.",
+          "description": "Protocol objects, e.g. [{ \"x402\": {} }, { \"mpp\": { ... } }].",
           "example": [
-            "mpp"
-          ]
-        },
-        "pricingMode": {
-          "type": "string",
-          "description": "Always `\"fixed\"` for Syra (per-call USD price, no auction or tiering).",
-          "enum": [
-            "fixed"
+            {
+              "x402": {}
+            },
+            {
+              "mpp": {
+                "method": "",
+                "intent": "",
+                "currency": ""
+              }
+            }
           ]
         },
         "price": {
-          "type": "string",
-          "description": "USD price as a decimal string (e.g. \"0.01\"). The runtime 402 response converts this to USDC micro-units (USDC has 6 decimals) and exposes it as `accepts[i].maxAmountRequired`.",
-          "example": "0.01"
+          "type": "object",
+          "required": [
+            "mode",
+            "currency",
+            "amount"
+          ],
+          "properties": {
+            "mode": {
+              "type": "string",
+              "enum": [
+                "fixed"
+              ]
+            },
+            "currency": {
+              "type": "string",
+              "example": "USD"
+            },
+            "amount": {
+              "type": "string",
+              "description": "USD price as decimal string",
+              "example": "0.01"
+            }
+          }
         }
       },
       "additionalProperties": true
@@ -53,10 +78,22 @@
     "example": {
       "x-payment-info": {
         "protocols": [
-          "mpp"
+          {
+            "x402": {}
+          },
+          {
+            "mpp": {
+              "method": "",
+              "intent": "",
+              "currency": ""
+            }
+          }
         ],
-        "pricingMode": "fixed",
-        "price": "0.01"
+        "price": {
+          "mode": "fixed",
+          "currency": "USD",
+          "amount": "0.01"
+        }
       }
     }
   },
@@ -83,27 +120,54 @@
       "message": "Too many requests. Please slow down."
     },
     "skip": {
-      "description": "Routes excluded from this throttle. x402 paid routes (`/news`, `/signal`, `/sentiment`, `/event`, `/health`, `/brain`, `/x*`, `/8004*`, etc.) are gated by HTTP 402 instead. Internal cron paths require a shared secret. RISE proxies are skipped because one user session can fan out across many list pages.",
+      "description": "Routes excluded from this throttle. x402 paid routes are gated by HTTP 402 instead. OpenAPI free routes (/info, /prediction-game/health) are public for discovery. Internal cron paths require a shared secret. RISE proxies are skipped because one user session can fan out across many list pages.",
       "paths": [
         "all x402 routes (see GET /.well-known/x402)",
+        "/info",
+        "/info/*",
+        "/prediction-game/health",
         "/internal/tester-agent*",
         "/internal/trend-scout/run",
+        "/internal/growth-scout/run",
         "/internal/partnership-scout/run",
-        "/internal/hackathon-scout/run",
         "/uponly-rise-market*",
         "/uponly-rise-portfolio*"
       ]
     }
   },
   "paths": {
-    "/api/signal": {
+    "/signal": {
       "get": {
         "tags": [
-          "Signal"
+          "Market data (x402)"
         ],
-        "summary": "Fetch public trading signal without x402 payment",
-        "description": "Same engine as /signal without micropayment. API key if server sets API_KEY.",
-        "operationId": "getPublicSignal",
+        "summary": "Get paid trading signal with RSI and MACD context",
+        "description": "Generates a directional trading signal with bias, confidence, entry context, and reasoning from OHLCV candles. Use when an agent needs a technical read on BTC, ETH, SOL, or other supported assets before sizing a trade. Inputs: token (e.g. solana, bitcoin), source (binance default; coingecko if CEX blocked), interval, limit. Returns signal object with recommendation and analysis — probabilistic, not execution.",
+        "operationId": "getSignal",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "protocols": [
+            {
+              "x402": {}
+            },
+            {
+              "mpp": {
+                "method": "",
+                "intent": "",
+                "currency": ""
+              }
+            }
+          ],
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.005"
+          }
+        },
         "parameters": [
           {
             "name": "token",
@@ -159,31 +223,58 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": [
-                    "success"
-                  ],
                   "properties": {
-                    "success": {
-                      "type": "boolean"
-                    },
-                    "data": {
-                      "type": "object",
-                      "properties": {
-                        "signal": {
-                          "type": "object",
-                          "additionalProperties": true
-                        }
-                      }
-                    },
-                    "meta": {
+                    "signal": {
                       "type": "object",
                       "additionalProperties": true
-                    },
-                    "error": {
-                      "type": "string"
                     }
                   },
                   "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required — x402 v2 (Payment-Required header + JSON body with accepts). Retry with PAYMENT-SIGNATURE or X-PAYMENT.",
+            "headers": {
+              "Payment-Required": {
+                "description": "x402 v2 encoded payment requirements",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds the client must wait before retrying.",
+                "schema": {
+                  "type": "integer",
+                  "minimum": 1
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "message"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Too many requests. Please slow down."
+                    }
+                  },
+                  "additionalProperties": false
                 }
               }
             }
@@ -195,10 +286,6 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "success": {
-                      "type": "boolean",
-                      "const": false
-                    },
                     "error": {
                       "type": "string"
                     }
@@ -207,14 +294,40 @@
               }
             }
           }
-        }
+        },
+        "x-syra-pillar": "spend"
       },
       "post": {
         "tags": [
-          "Signal"
+          "Market data (x402)"
         ],
-        "summary": "Fetch public trading signal via JSON request body",
-        "operationId": "postPublicSignal",
+        "summary": "Get paid trading signal via JSON request body",
+        "description": "Generates a directional trading signal with bias, confidence, entry context, and reasoning from OHLCV candles. Use when an agent needs a technical read on BTC, ETH, SOL, or other supported assets before sizing a trade. Inputs: token (e.g. solana, bitcoin), source (binance default; coingecko if CEX blocked), interval, limit. Returns signal object with recommendation and analysis — probabilistic, not execution.",
+        "operationId": "postSignal",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "protocols": [
+            {
+              "x402": {}
+            },
+            {
+              "mpp": {
+                "method": "",
+                "intent": "",
+                "currency": ""
+              }
+            }
+          ],
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.005"
+          }
+        },
         "requestBody": {
           "required": false,
           "content": {
@@ -250,31 +363,58 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": [
-                    "success"
-                  ],
                   "properties": {
-                    "success": {
-                      "type": "boolean"
-                    },
-                    "data": {
-                      "type": "object",
-                      "properties": {
-                        "signal": {
-                          "type": "object",
-                          "additionalProperties": true
-                        }
-                      }
-                    },
-                    "meta": {
+                    "signal": {
                       "type": "object",
                       "additionalProperties": true
-                    },
-                    "error": {
-                      "type": "string"
                     }
                   },
                   "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required — x402 v2 (Payment-Required header + JSON body with accepts). Retry with PAYMENT-SIGNATURE or X-PAYMENT.",
+            "headers": {
+              "Payment-Required": {
+                "description": "x402 v2 encoded payment requirements",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds the client must wait before retrying.",
+                "schema": {
+                  "type": "integer",
+                  "minimum": 1
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "message"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Too many requests. Please slow down."
+                    }
+                  },
+                  "additionalProperties": false
                 }
               }
             }
@@ -286,10 +426,6 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "success": {
-                      "type": "boolean",
-                      "const": false
-                    },
                     "error": {
                       "type": "string"
                     }
@@ -298,7 +434,8 @@
               }
             }
           }
-        }
+        },
+        "x-syra-pillar": "spend"
       }
     },
     "/info": {
@@ -308,6 +445,7 @@
         ],
         "summary": "Get Syra gateway info and service metadata",
         "operationId": "getInfo",
+        "security": [],
         "responses": {
           "200": {
             "description": "OK",
@@ -354,7 +492,8 @@
               }
             }
           }
-        }
+        },
+        "x-syra-pillar": "spend"
       }
     },
     "/info/stats": {
@@ -364,302 +503,7 @@
         ],
         "summary": "Get public API usage stats and rate limits",
         "operationId": "getInfoStats",
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": true
-                }
-              }
-            }
-          },
-          "429": {
-            "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
-            "headers": {
-              "Retry-After": {
-                "description": "Seconds the client must wait before retrying.",
-                "schema": {
-                  "type": "integer",
-                  "minimum": 1
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "required": [
-                    "success",
-                    "message"
-                  ],
-                  "properties": {
-                    "success": {
-                      "type": "boolean",
-                      "const": false
-                    },
-                    "message": {
-                      "type": "string",
-                      "example": "Too many requests. Please slow down."
-                    }
-                  },
-                  "additionalProperties": false
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/preview/news": {
-      "get": {
-        "tags": [
-          "Preview"
-        ],
-        "summary": "Fetch sample crypto news headlines without payment",
-        "operationId": "getPreviewNews",
-        "parameters": [
-          {
-            "name": "ticker",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "default": "general"
-            },
-            "description": "Ticker symbol or general for broad feed."
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": true
-                }
-              }
-            }
-          },
-          "429": {
-            "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
-            "headers": {
-              "Retry-After": {
-                "description": "Seconds the client must wait before retrying.",
-                "schema": {
-                  "type": "integer",
-                  "minimum": 1
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "required": [
-                    "success",
-                    "message"
-                  ],
-                  "properties": {
-                    "success": {
-                      "type": "boolean",
-                      "const": false
-                    },
-                    "message": {
-                      "type": "string",
-                      "example": "Too many requests. Please slow down."
-                    }
-                  },
-                  "additionalProperties": false
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/preview/sentiment": {
-      "get": {
-        "tags": [
-          "Preview"
-        ],
-        "summary": "Fetch sample market sentiment without payment",
-        "operationId": "getPreviewSentiment",
-        "parameters": [
-          {
-            "name": "ticker",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "default": "general"
-            },
-            "description": "Ticker symbol or general for broad feed."
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": true
-                }
-              }
-            }
-          },
-          "429": {
-            "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
-            "headers": {
-              "Retry-After": {
-                "description": "Seconds the client must wait before retrying.",
-                "schema": {
-                  "type": "integer",
-                  "minimum": 1
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "required": [
-                    "success",
-                    "message"
-                  ],
-                  "properties": {
-                    "success": {
-                      "type": "boolean",
-                      "const": false
-                    },
-                    "message": {
-                      "type": "string",
-                      "example": "Too many requests. Please slow down."
-                    }
-                  },
-                  "additionalProperties": false
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/preview/signal": {
-      "get": {
-        "tags": [
-          "Preview"
-        ],
-        "summary": "Fetch sample trading signal without payment",
-        "operationId": "getPreviewSignal",
-        "parameters": [
-          {
-            "name": "token",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "default": "bitcoin"
-            },
-            "description": "Asset name for signal routing (e.g. bitcoin, solana)."
-          },
-          {
-            "name": "source",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Data source. Default: binance. CEX: binance, coinbase, coingecko, okx, bybit, kraken, bitget, kucoin, upbit, cryptocom (alias: crypto.com → cryptocom). n8n | webhook for legacy webhook."
-          },
-          {
-            "name": "instId",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Venue symbol override (e.g. BTCUSDT, BTC-USDT)."
-          },
-          {
-            "name": "bar",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Candle interval (e.g. 1m, 1h, 4h, 1d)."
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Candle count (default ~200)."
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": true
-                }
-              }
-            }
-          },
-          "429": {
-            "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
-            "headers": {
-              "Retry-After": {
-                "description": "Seconds the client must wait before retrying.",
-                "schema": {
-                  "type": "integer",
-                  "minimum": 1
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "required": [
-                    "success",
-                    "message"
-                  ],
-                  "properties": {
-                    "success": {
-                      "type": "boolean",
-                      "const": false
-                    },
-                    "message": {
-                      "type": "string",
-                      "example": "Too many requests. Please slow down."
-                    }
-                  },
-                  "additionalProperties": false
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/dashboard-summary": {
-      "get": {
-        "tags": [
-          "Dashboard"
-        ],
-        "summary": "Get dashboard KPI summary for Syra markets",
-        "operationId": "getDashboardSummary",
+        "security": [],
         "responses": {
           "200": {
             "description": "OK",
@@ -707,72 +551,7 @@
             }
           }
         },
-        "security": [
-          {
-            "SyraApiKey": []
-          }
-        ]
-      }
-    },
-    "/binance-ticker": {
-      "get": {
-        "tags": [
-          "Dashboard"
-        ],
-        "summary": "Get Binance spot ticker prices for symbols",
-        "operationId": "getBinanceTicker",
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": true
-                }
-              }
-            }
-          },
-          "429": {
-            "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
-            "headers": {
-              "Retry-After": {
-                "description": "Seconds the client must wait before retrying.",
-                "schema": {
-                  "type": "integer",
-                  "minimum": 1
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "required": [
-                    "success",
-                    "message"
-                  ],
-                  "properties": {
-                    "success": {
-                      "type": "boolean",
-                      "const": false
-                    },
-                    "message": {
-                      "type": "string",
-                      "example": "Too many requests. Please slow down."
-                    }
-                  },
-                  "additionalProperties": false
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "SyraApiKey": []
-          }
-        ]
+        "x-syra-pillar": "spend"
       }
     },
     "/prediction-game/health": {
@@ -782,6 +561,7 @@
         ],
         "summary": "Check prediction game API health and status",
         "operationId": "getPredictionGameHealth",
+        "security": [],
         "responses": {
           "200": {
             "description": "OK",
@@ -828,248 +608,8 @@
               }
             }
           }
-        }
-      }
-    },
-    "/signal": {
-      "get": {
-        "tags": [
-          "Market data (x402)"
-        ],
-        "summary": "Get paid trading signal with RSI and MACD context",
-        "description": "Paid trading signal endpoint gated by x402.",
-        "operationId": "getSignal",
-        "parameters": [
-          {
-            "name": "token",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "default": "bitcoin"
-            },
-            "description": "Asset name for signal routing (e.g. bitcoin, solana)."
-          },
-          {
-            "name": "source",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Data source. Default: binance. CEX: binance, coinbase, coingecko, okx, bybit, kraken, bitget, kucoin, upbit, cryptocom (alias: crypto.com → cryptocom). n8n | webhook for legacy webhook."
-          },
-          {
-            "name": "instId",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Venue symbol override (e.g. BTCUSDT, BTC-USDT)."
-          },
-          {
-            "name": "bar",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Candle interval (e.g. 1m, 1h, 4h, 1d)."
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Candle count (default ~200)."
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Signal result",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "required": [
-                    "success"
-                  ],
-                  "properties": {
-                    "success": {
-                      "type": "boolean"
-                    },
-                    "data": {
-                      "type": "object",
-                      "properties": {
-                        "signal": {
-                          "type": "object",
-                          "additionalProperties": true
-                        }
-                      }
-                    },
-                    "meta": {
-                      "type": "object",
-                      "additionalProperties": true
-                    },
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": true
-                }
-              }
-            }
-          },
-          "402": {
-            "$ref": "#/components/responses/X402PaymentRequired"
-          },
-          "429": {
-            "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
-            "headers": {
-              "Retry-After": {
-                "description": "Seconds the client must wait before retrying.",
-                "schema": {
-                  "type": "integer",
-                  "minimum": 1
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "required": [
-                    "success",
-                    "message"
-                  ],
-                  "properties": {
-                    "success": {
-                      "type": "boolean",
-                      "const": false
-                    },
-                    "message": {
-                      "type": "string",
-                      "example": "Too many requests. Please slow down."
-                    }
-                  },
-                  "additionalProperties": false
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "tags": [
-          "Market data (x402)"
-        ],
-        "summary": "Get paid trading signal via JSON request body",
-        "operationId": "postSignal",
-        "requestBody": {
-          "required": false,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "token": {
-                    "type": "string"
-                  },
-                  "source": {
-                    "type": "string"
-                  },
-                  "instId": {
-                    "type": "string"
-                  },
-                  "bar": {
-                    "type": "string"
-                  },
-                  "limit": {
-                    "type": "number"
-                  }
-                },
-                "additionalProperties": false
-              }
-            }
-          }
         },
-        "responses": {
-          "200": {
-            "description": "Signal result",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "required": [
-                    "success"
-                  ],
-                  "properties": {
-                    "success": {
-                      "type": "boolean"
-                    },
-                    "data": {
-                      "type": "object",
-                      "properties": {
-                        "signal": {
-                          "type": "object",
-                          "additionalProperties": true
-                        }
-                      }
-                    },
-                    "meta": {
-                      "type": "object",
-                      "additionalProperties": true
-                    },
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": true
-                }
-              }
-            }
-          },
-          "402": {
-            "$ref": "#/components/responses/X402PaymentRequired"
-          },
-          "429": {
-            "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
-            "headers": {
-              "Retry-After": {
-                "description": "Seconds the client must wait before retrying.",
-                "schema": {
-                  "type": "integer",
-                  "minimum": 1
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "required": [
-                    "success",
-                    "message"
-                  ],
-                  "properties": {
-                    "success": {
-                      "type": "boolean",
-                      "const": false
-                    },
-                    "message": {
-                      "type": "string",
-                      "example": "Too many requests. Please slow down."
-                    }
-                  },
-                  "additionalProperties": false
-                }
-              }
-            }
-          }
-        }
+        "x-syra-pillar": "spend"
       }
     },
     "/news": {
@@ -1078,7 +618,32 @@
           "Market data (x402)"
         ],
         "summary": "Fetch curated crypto news headlines by ticker",
+        "description": "Curated crypto news articles with titles, sources, and URLs. Use when an agent needs recent headlines for a token, sector, or the whole market before trading or posting. Input: optional ticker (BTC, ETH, SOL, or general). Returns news[] with title, url, date, source.",
         "operationId": "getNews",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "protocols": [
+            {
+              "x402": {}
+            },
+            {
+              "mpp": {
+                "method": "",
+                "intent": "",
+                "currency": ""
+              }
+            }
+          ],
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.005"
+          }
+        },
         "parameters": [
           {
             "name": "ticker",
@@ -1104,7 +669,15 @@
             }
           },
           "402": {
-            "$ref": "#/components/responses/X402PaymentRequired"
+            "description": "Payment required — x402 v2 (Payment-Required header + JSON body with accepts). Retry with PAYMENT-SIGNATURE or X-PAYMENT.",
+            "headers": {
+              "Payment-Required": {
+                "description": "x402 v2 encoded payment requirements",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           },
           "429": {
             "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
@@ -1140,14 +713,40 @@
               }
             }
           }
-        }
+        },
+        "x-syra-pillar": "spend"
       },
       "post": {
         "tags": [
           "Market data (x402)"
         ],
-        "summary": "Fetch curated crypto news via JSON request body",
+        "summary": "Fetch curated crypto news via JSON body",
+        "description": "Curated crypto news articles with titles, sources, and URLs. Use when an agent needs recent headlines for a token, sector, or the whole market before trading or posting. Input: optional ticker (BTC, ETH, SOL, or general). Returns news[] with title, url, date, source.",
         "operationId": "postNews",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "protocols": [
+            {
+              "x402": {}
+            },
+            {
+              "mpp": {
+                "method": "",
+                "intent": "",
+                "currency": ""
+              }
+            }
+          ],
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.005"
+          }
+        },
         "requestBody": {
           "required": false,
           "content": {
@@ -1173,7 +772,15 @@
             }
           },
           "402": {
-            "$ref": "#/components/responses/X402PaymentRequired"
+            "description": "Payment required — x402 v2 (Payment-Required header + JSON body with accepts). Retry with PAYMENT-SIGNATURE or X-PAYMENT.",
+            "headers": {
+              "Payment-Required": {
+                "description": "x402 v2 encoded payment requirements",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           },
           "429": {
             "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
@@ -1209,7 +816,8 @@
               }
             }
           }
-        }
+        },
+        "x-syra-pillar": "spend"
       }
     },
     "/sentiment": {
@@ -1218,7 +826,32 @@
           "Market data (x402)"
         ],
         "summary": "Fetch 30-day crypto market sentiment by ticker",
+        "description": "Daily sentiment breakdown (positive/negative/neutral/score) over ~30 days from news-derived analysis. Use when an agent gauges crowd mood on BTC, ETH, or a ticker before narrative trades. Input: optional ticker. Returns sentimentAnalysis[] with per-day scores.",
         "operationId": "getSentiment",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "protocols": [
+            {
+              "x402": {}
+            },
+            {
+              "mpp": {
+                "method": "",
+                "intent": "",
+                "currency": ""
+              }
+            }
+          ],
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.005"
+          }
+        },
         "parameters": [
           {
             "name": "ticker",
@@ -1244,7 +877,15 @@
             }
           },
           "402": {
-            "$ref": "#/components/responses/X402PaymentRequired"
+            "description": "Payment required — x402 v2 (Payment-Required header + JSON body with accepts). Retry with PAYMENT-SIGNATURE or X-PAYMENT.",
+            "headers": {
+              "Payment-Required": {
+                "description": "x402 v2 encoded payment requirements",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           },
           "429": {
             "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
@@ -1280,14 +921,40 @@
               }
             }
           }
-        }
+        },
+        "x-syra-pillar": "spend"
       },
       "post": {
         "tags": [
           "Market data (x402)"
         ],
         "summary": "Fetch market sentiment via JSON request body",
+        "description": "Daily sentiment breakdown (positive/negative/neutral/score) over ~30 days from news-derived analysis. Use when an agent gauges crowd mood on BTC, ETH, or a ticker before narrative trades. Input: optional ticker. Returns sentimentAnalysis[] with per-day scores.",
         "operationId": "postSentiment",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "protocols": [
+            {
+              "x402": {}
+            },
+            {
+              "mpp": {
+                "method": "",
+                "intent": "",
+                "currency": ""
+              }
+            }
+          ],
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.005"
+          }
+        },
         "requestBody": {
           "required": false,
           "content": {
@@ -1313,7 +980,15 @@
             }
           },
           "402": {
-            "$ref": "#/components/responses/X402PaymentRequired"
+            "description": "Payment required — x402 v2 (Payment-Required header + JSON body with accepts). Retry with PAYMENT-SIGNATURE or X-PAYMENT.",
+            "headers": {
+              "Payment-Required": {
+                "description": "x402 v2 encoded payment requirements",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           },
           "429": {
             "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
@@ -1349,7 +1024,8 @@
               }
             }
           }
-        }
+        },
+        "x-syra-pillar": "spend"
       }
     },
     "/event": {
@@ -1358,7 +1034,32 @@
           "Market data (x402)"
         ],
         "summary": "Fetch upcoming and recent crypto event calendar",
+        "description": "Lists conferences, launches, listings, and macro events affecting crypto. Use when an agent schedules research around catalysts or filters noise by ticker. Input: optional ticker. Returns event[] with titles, dates, and metadata.",
         "operationId": "getEvent",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "protocols": [
+            {
+              "x402": {}
+            },
+            {
+              "mpp": {
+                "method": "",
+                "intent": "",
+                "currency": ""
+              }
+            }
+          ],
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.005"
+          }
+        },
         "parameters": [
           {
             "name": "ticker",
@@ -1384,7 +1085,15 @@
             }
           },
           "402": {
-            "$ref": "#/components/responses/X402PaymentRequired"
+            "description": "Payment required — x402 v2 (Payment-Required header + JSON body with accepts). Retry with PAYMENT-SIGNATURE or X-PAYMENT.",
+            "headers": {
+              "Payment-Required": {
+                "description": "x402 v2 encoded payment requirements",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           },
           "429": {
             "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
@@ -1420,14 +1129,40 @@
               }
             }
           }
-        }
+        },
+        "x-syra-pillar": "spend"
       },
       "post": {
         "tags": [
           "Market data (x402)"
         ],
         "summary": "Fetch crypto events via JSON request body",
+        "description": "Lists conferences, launches, listings, and macro events affecting crypto. Use when an agent schedules research around catalysts or filters noise by ticker. Input: optional ticker. Returns event[] with titles, dates, and metadata.",
         "operationId": "postEvent",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "protocols": [
+            {
+              "x402": {}
+            },
+            {
+              "mpp": {
+                "method": "",
+                "intent": "",
+                "currency": ""
+              }
+            }
+          ],
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.005"
+          }
+        },
         "requestBody": {
           "required": false,
           "content": {
@@ -1453,7 +1188,15 @@
             }
           },
           "402": {
-            "$ref": "#/components/responses/X402PaymentRequired"
+            "description": "Payment required — x402 v2 (Payment-Required header + JSON body with accepts). Retry with PAYMENT-SIGNATURE or X-PAYMENT.",
+            "headers": {
+              "Payment-Required": {
+                "description": "x402 v2 encoded payment requirements",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           },
           "429": {
             "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
@@ -1489,7 +1232,8 @@
               }
             }
           }
-        }
+        },
+        "x-syra-pillar": "spend"
       }
     },
     "/health": {
@@ -1498,7 +1242,32 @@
           "Gateway (x402)"
         ],
         "summary": "Check Syra API health and x402 liveness probe",
+        "description": "Minimal paid health check confirming Syra API is up and x402 settlement works. Use when an agent or monitor verifies connectivity before batch calls. No inputs. Returns ok, status, service, message, timestamp.",
         "operationId": "getHealth",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "protocols": [
+            {
+              "x402": {}
+            },
+            {
+              "mpp": {
+                "method": "",
+                "intent": "",
+                "currency": ""
+              }
+            }
+          ],
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001"
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -1512,7 +1281,15 @@
             }
           },
           "402": {
-            "$ref": "#/components/responses/X402PaymentRequired"
+            "description": "Payment required — x402 v2 (Payment-Required header + JSON body with accepts). Retry with PAYMENT-SIGNATURE or X-PAYMENT.",
+            "headers": {
+              "Payment-Required": {
+                "description": "x402 v2 encoded payment requirements",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           },
           "429": {
             "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
@@ -1548,14 +1325,40 @@
               }
             }
           }
-        }
+        },
+        "x-syra-pillar": "spend"
       },
       "post": {
         "tags": [
           "Gateway (x402)"
         ],
         "summary": "Check API health via JSON POST liveness probe",
+        "description": "Minimal paid health check confirming Syra API is up and x402 settlement works. Use when an agent or monitor verifies connectivity before batch calls. No inputs. Returns ok, status, service, message, timestamp.",
         "operationId": "postHealth",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "protocols": [
+            {
+              "x402": {}
+            },
+            {
+              "mpp": {
+                "method": "",
+                "intent": "",
+                "currency": ""
+              }
+            }
+          ],
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001"
+          }
+        },
         "requestBody": {
           "required": false,
           "content": {
@@ -1581,7 +1384,15 @@
             }
           },
           "402": {
-            "$ref": "#/components/responses/X402PaymentRequired"
+            "description": "Payment required — x402 v2 (Payment-Required header + JSON body with accepts). Retry with PAYMENT-SIGNATURE or X-PAYMENT.",
+            "headers": {
+              "Payment-Required": {
+                "description": "x402 v2 encoded payment requirements",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           },
           "429": {
             "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
@@ -1617,7 +1428,8 @@
               }
             }
           }
-        }
+        },
+        "x-syra-pillar": "spend"
       }
     },
     "/brain": {
@@ -1626,7 +1438,32 @@
           "AI (x402)"
         ],
         "summary": "Generate crypto answers with Syra Brain tools",
+        "description": "Answers one natural-language crypto question by selecting and running Syra tools (news, signals, on-chain reads) server-side. Use when an agent needs a grounded synthesis instead of calling many APIs manually. Input: question (required). Returns success, markdown/plain response, and toolUsages[] showing which tools ran. Treasury-paid tool calls included; not trade execution.",
         "operationId": "getBrain",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "protocols": [
+            {
+              "x402": {}
+            },
+            {
+              "mpp": {
+                "method": "",
+                "intent": "",
+                "currency": ""
+              }
+            }
+          ],
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.08"
+          }
+        },
         "parameters": [
           {
             "name": "question",
@@ -1651,7 +1488,15 @@
             }
           },
           "402": {
-            "$ref": "#/components/responses/X402PaymentRequired"
+            "description": "Payment required — x402 v2 (Payment-Required header + JSON body with accepts). Retry with PAYMENT-SIGNATURE or X-PAYMENT.",
+            "headers": {
+              "Payment-Required": {
+                "description": "x402 v2 encoded payment requirements",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           },
           "429": {
             "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
@@ -1687,14 +1532,40 @@
               }
             }
           }
-        }
+        },
+        "x-syra-pillar": "spend"
       },
       "post": {
         "tags": [
           "AI (x402)"
         ],
-        "summary": "Generate crypto answers via Syra Brain POST body",
+        "summary": "Generate crypto answers via Syra Brain body",
+        "description": "Answers one natural-language crypto question by selecting and running Syra tools (news, signals, on-chain reads) server-side. Use when an agent needs a grounded synthesis instead of calling many APIs manually. Input: question (required). Returns success, markdown/plain response, and toolUsages[] showing which tools ran. Treasury-paid tool calls included; not trade execution.",
         "operationId": "postBrain",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "protocols": [
+            {
+              "x402": {}
+            },
+            {
+              "mpp": {
+                "method": "",
+                "intent": "",
+                "currency": ""
+              }
+            }
+          ],
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.08"
+          }
+        },
         "requestBody": {
           "required": false,
           "content": {
@@ -1720,7 +1591,15 @@
             }
           },
           "402": {
-            "$ref": "#/components/responses/X402PaymentRequired"
+            "description": "Payment required — x402 v2 (Payment-Required header + JSON body with accepts). Retry with PAYMENT-SIGNATURE or X-PAYMENT.",
+            "headers": {
+              "Payment-Required": {
+                "description": "x402 v2 encoded payment requirements",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           },
           "429": {
             "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
@@ -1756,7 +1635,8 @@
               }
             }
           }
-        }
+        },
+        "x-syra-pillar": "spend"
       }
     },
     "/arbitrage": {
@@ -1764,8 +1644,33 @@
         "tags": [
           "Market data (x402)"
         ],
-        "summary": "Get cross-CEX arbitrage snapshots and ranked routes",
+        "summary": "Fetch ranked cross-CEX arbitrage spreads",
+        "description": "Bundles CoinMarketCap-style top tradable assets (stablecoins skipped) with live cross-venue USDT spot snapshots and ranked buy/sell routes by gross spread. Use when an agent scouts arbitrage ideas before fees/slippage. Input: limit (default 10, max 25). Returns cmcTop, snapshots[], ranked[], best, runnerUp — not financial advice.",
         "operationId": "getArbitrage",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "protocols": [
+            {
+              "x402": {}
+            },
+            {
+              "mpp": {
+                "method": "",
+                "intent": "",
+                "currency": ""
+              }
+            }
+          ],
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.04"
+          }
+        },
         "parameters": [
           {
             "name": "limit",
@@ -1793,7 +1698,15 @@
             }
           },
           "402": {
-            "$ref": "#/components/responses/X402PaymentRequired"
+            "description": "Payment required — x402 v2 (Payment-Required header + JSON body with accepts). Retry with PAYMENT-SIGNATURE or X-PAYMENT.",
+            "headers": {
+              "Payment-Required": {
+                "description": "x402 v2 encoded payment requirements",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           },
           "429": {
             "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
@@ -1829,14 +1742,40 @@
               }
             }
           }
-        }
+        },
+        "x-syra-pillar": "spend"
       },
       "post": {
         "tags": [
           "Market data (x402)"
         ],
-        "summary": "Get arbitrage routes with optional limit in body",
+        "summary": "Fetch arbitrage spreads via JSON request body",
+        "description": "Bundles CoinMarketCap-style top tradable assets (stablecoins skipped) with live cross-venue USDT spot snapshots and ranked buy/sell routes by gross spread. Use when an agent scouts arbitrage ideas before fees/slippage. Input: limit (default 10, max 25). Returns cmcTop, snapshots[], ranked[], best, runnerUp — not financial advice.",
         "operationId": "postArbitrage",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "protocols": [
+            {
+              "x402": {}
+            },
+            {
+              "mpp": {
+                "method": "",
+                "intent": "",
+                "currency": ""
+              }
+            }
+          ],
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.04"
+          }
+        },
         "requestBody": {
           "required": false,
           "content": {
@@ -1862,7 +1801,15 @@
             }
           },
           "402": {
-            "$ref": "#/components/responses/X402PaymentRequired"
+            "description": "Payment required — x402 v2 (Payment-Required header + JSON body with accepts). Retry with PAYMENT-SIGNATURE or X-PAYMENT.",
+            "headers": {
+              "Payment-Required": {
+                "description": "x402 v2 encoded payment requirements",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           },
           "429": {
             "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
@@ -1898,7 +1845,8 @@
               }
             }
           }
-        }
+        },
+        "x-syra-pillar": "spend"
       }
     },
     "/x-analyzer": {
@@ -1906,9 +1854,33 @@
         "tags": [
           "Social (x402)"
         ],
-        "summary": "Analyze X project profile, tweets, and score",
+        "summary": "Analyze X project profile tweets and score",
         "description": "Micropayment via x402. Returns deterministic 0–100 score, category breakdown, signals, red flags; optional `includeAiSummary` adds grounded LLM bullets. Example `200` body is maintained at `api/docs/examples/x-analyzer-response.example.json`.",
         "operationId": "getXAnalyzer",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "protocols": [
+            {
+              "x402": {}
+            },
+            {
+              "mpp": {
+                "method": "",
+                "intent": "",
+                "currency": ""
+              }
+            }
+          ],
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.024"
+          }
+        },
         "parameters": [
           {
             "name": "username",
@@ -1974,7 +1946,7 @@
                       "id": "1983380098406592515",
                       "username": "syra_agent",
                       "name": "Syra",
-                      "description": "Smart Intelligence Agent for Traders on Solana. https://t.co/9hRxUXzQFD",
+                      "description": "Machine money for agents on Solana. https://t.co/9hRxUXzQFD",
                       "url": "https://t.co/3Z1z9rVl2p",
                       "created_at": "2025-10-29T03:47:33.000Z",
                       "verified": true,
@@ -2061,7 +2033,15 @@
             }
           },
           "402": {
-            "$ref": "#/components/responses/X402PaymentRequired"
+            "description": "Payment required — x402 v2 (Payment-Required header + JSON body with accepts). Retry with PAYMENT-SIGNATURE or X-PAYMENT.",
+            "headers": {
+              "Payment-Required": {
+                "description": "x402 v2 encoded payment requirements",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           },
           "404": {
             "description": "X user not found"
@@ -2072,15 +2052,40 @@
           "503": {
             "description": "Server missing X_BEARER_TOKEN"
           }
-        }
+        },
+        "x-syra-pillar": "spend"
       },
       "post": {
         "tags": [
           "Social (x402)"
         ],
-        "summary": "Analyze X project profile via JSON request body",
+        "summary": "Analyze X project profile via JSON body",
         "description": "Same as GET; body may include `username`, `max_results`, `includeAiSummary`. Example response identical to GET.",
         "operationId": "postXAnalyzer",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "protocols": [
+            {
+              "x402": {}
+            },
+            {
+              "mpp": {
+                "method": "",
+                "intent": "",
+                "currency": ""
+              }
+            }
+          ],
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.024"
+          }
+        },
         "requestBody": {
           "required": false,
           "content": {
@@ -2141,7 +2146,7 @@
                       "id": "1983380098406592515",
                       "username": "syra_agent",
                       "name": "Syra",
-                      "description": "Smart Intelligence Agent for Traders on Solana. https://t.co/9hRxUXzQFD",
+                      "description": "Machine money for agents on Solana. https://t.co/9hRxUXzQFD",
                       "url": "https://t.co/3Z1z9rVl2p",
                       "created_at": "2025-10-29T03:47:33.000Z",
                       "verified": true,
@@ -2228,7 +2233,15 @@
             }
           },
           "402": {
-            "$ref": "#/components/responses/X402PaymentRequired"
+            "description": "Payment required — x402 v2 (Payment-Required header + JSON body with accepts). Retry with PAYMENT-SIGNATURE or X-PAYMENT.",
+            "headers": {
+              "Payment-Required": {
+                "description": "x402 v2 encoded payment requirements",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           },
           "404": {
             "description": "X user not found"
@@ -2239,17 +2252,53 @@
           "503": {
             "description": "Server missing X_BEARER_TOKEN"
           }
-        }
+        },
+        "x-syra-pillar": "spend"
       }
     },
-    "/x-projects-analyze/types": {
+    "/spcx": {
       "get": {
         "tags": [
-          "Social (batch)"
+          "Equity (x402)"
         ],
-        "summary": "List batch analyzer types",
-        "description": "Returns configured `type` ids (labels, provider). X accounts per type are fixed server-side. No X API calls. API key when server sets API_KEY.",
-        "operationId": "getXProjectsAnalyzeTypes",
+        "summary": "Fetch SPCXx Nasdaq vs on-chain price spread",
+        "description": "Tokenized equity intelligence for SpaceX IPO exposure (SPCXx). Use when an agent compares Nasdaq reference price vs on-chain SPCX venues for premium/discount and agent bias. Input: symbol (default SPCXx). Returns nasdaqPriceUsd, venues[], agentBias, agentTake, riskNotes[], opportunities[], disclaimer.",
+        "operationId": "getSpcxIntelligence",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "protocols": [
+            {
+              "x402": {}
+            },
+            {
+              "mpp": {
+                "method": "",
+                "intent": "",
+                "currency": ""
+              }
+            }
+          ],
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.02"
+          }
+        },
+        "parameters": [
+          {
+            "name": "symbol",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "default": "SPCXx"
+            },
+            "description": "Market symbol or ticker (for example BTCUSDT or TSLAx)."
+          }
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -2261,83 +2310,848 @@
                 }
               }
             }
+          },
+          "402": {
+            "description": "Payment required — x402 v2 (Payment-Required header + JSON body with accepts). Retry with PAYMENT-SIGNATURE or X-PAYMENT.",
+            "headers": {
+              "Payment-Required": {
+                "description": "x402 v2 encoded payment requirements",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds the client must wait before retrying.",
+                "schema": {
+                  "type": "integer",
+                  "minimum": 1
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "message"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Too many requests. Please slow down."
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            }
           }
         },
-        "security": [
-          {
-            "SyraApiKey": []
-          }
-        ]
+        "x-syra-pillar": "spend"
       }
     },
-    "/x-projects-analyze/account": {
+    "/equity": {
       "get": {
         "tags": [
-          "Social (batch)"
+          "Equity (x402)"
         ],
-        "summary": "Analyze single allowlisted X account Alpha signals",
-        "description": "`username` must belong to the configured `type` handle list. Returns full score payload, optional AI summary (default on), and `recentTweets` sample. API key when API_KEY is set.",
-        "operationId": "getXProjectsAnalyzeAccount",
+        "summary": "Fetch xStocks Nasdaq vs on-chain equity spread",
+        "description": "Parametric tokenized equity intelligence for xStocks symbols. Use when an agent needs Nasdaq vs on-chain premium/discount, venue prices, and narrative bias for stocks like TSLAx or NVDAx. Input: symbol (required, e.g. TSLAx). Returns same report shape as /spcx: venues, agentBias, agentTake, riskNotes, opportunities.",
+        "operationId": "getEquityIntelligence",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "protocols": [
+            {
+              "x402": {}
+            },
+            {
+              "mpp": {
+                "method": "",
+                "intent": "",
+                "currency": ""
+              }
+            }
+          ],
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.02"
+          }
+        },
         "parameters": [
           {
-            "name": "username",
+            "name": "symbol",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Market symbol or ticker (for example BTCUSDT or TSLAx)."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required — x402 v2 (Payment-Required header + JSON body with accepts). Retry with PAYMENT-SIGNATURE or X-PAYMENT.",
+            "headers": {
+              "Payment-Required": {
+                "description": "x402 v2 encoded payment requirements",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds the client must wait before retrying.",
+                "schema": {
+                  "type": "integer",
+                  "minimum": 1
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "message"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Too many requests. Please slow down."
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        },
+        "x-syra-pillar": "spend"
+      }
+    },
+    "/jupiter/quote": {
+      "get": {
+        "tags": [
+          "Jupiter quote (x402)"
+        ],
+        "summary": "Fetch Jupiter ExactIn swap quote with referral",
+        "description": "Fetches a Jupiter Swap V1 quoteResponse for ExactIn swaps with Syra referral platform fee when configured on-chain. Use when an agent prices a Solana swap before building a transaction. Inputs: inputMint, outputMint, amount (raw units), optional slippageBps. Returns quote object and referral metadata.",
+        "operationId": "getJupiterQuote",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "protocols": [
+            {
+              "x402": {}
+            },
+            {
+              "mpp": {
+                "method": "",
+                "intent": "",
+                "currency": ""
+              }
+            }
+          ],
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001"
+          }
+        },
+        "parameters": [
+          {
+            "name": "inputMint",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Input token mint (base58)"
+          },
+          {
+            "name": "outputMint",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Output token mint (referral fee taken on output)"
+          },
+          {
+            "name": "amount",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Input amount in raw token units"
+          },
+          {
+            "name": "slippageBps",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 50
+            },
+            "description": "Max slippage in basis points for the quote."
+          },
+          {
+            "name": "swapMode",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Jupiter swap mode (ExactIn or ExactOut)."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success — `{ success: true, data: { ... } }`",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "data"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "const": true
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "quote": {
+                          "type": "object",
+                          "additionalProperties": true,
+                          "description": "Jupiter quoteResponse payload"
+                        },
+                        "referral": {
+                          "type": "object",
+                          "additionalProperties": true,
+                          "description": "Syra referral fee metadata"
+                        },
+                        "computedAt": {
+                          "type": "string"
+                        }
+                      },
+                      "additionalProperties": true
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required — x402 v2 (Payment-Required header + JSON body with accepts). Retry with PAYMENT-SIGNATURE or X-PAYMENT.",
+            "headers": {
+              "Payment-Required": {
+                "description": "x402 v2 encoded payment requirements",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds the client must wait before retrying.",
+                "schema": {
+                  "type": "integer",
+                  "minimum": 1
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "message"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Too many requests. Please slow down."
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        },
+        "x-syra-pillar": "invest"
+      },
+      "post": {
+        "tags": [
+          "Jupiter quote (x402)"
+        ],
+        "summary": "Fetch Jupiter swap quote via JSON body",
+        "description": "Fetches a Jupiter Swap V1 quoteResponse for ExactIn swaps with Syra referral platform fee when configured on-chain. Use when an agent prices a Solana swap before building a transaction. Inputs: inputMint, outputMint, amount (raw units), optional slippageBps. Returns quote object and referral metadata.",
+        "operationId": "postJupiterQuote",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "protocols": [
+            {
+              "x402": {}
+            },
+            {
+              "mpp": {
+                "method": "",
+                "intent": "",
+                "currency": ""
+              }
+            }
+          ],
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "inputMint",
+                  "outputMint",
+                  "amount"
+                ],
+                "properties": {
+                  "inputMint": {
+                    "type": "string",
+                    "description": "Input token mint (base58)"
+                  },
+                  "outputMint": {
+                    "type": "string",
+                    "description": "Output token mint (base58)"
+                  },
+                  "amount": {
+                    "type": "string",
+                    "description": "Input amount in raw token units"
+                  },
+                  "slippageBps": {
+                    "type": "integer",
+                    "description": "Slippage in basis points (default 50)"
+                  },
+                  "swapMode": {
+                    "type": "string",
+                    "description": "Jupiter swapMode e.g. ExactIn"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — `{ success: true, data: { ... } }`",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "data"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "const": true
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "quote": {
+                          "type": "object",
+                          "additionalProperties": true,
+                          "description": "Jupiter quoteResponse payload"
+                        },
+                        "referral": {
+                          "type": "object",
+                          "additionalProperties": true,
+                          "description": "Syra referral fee metadata"
+                        },
+                        "computedAt": {
+                          "type": "string"
+                        }
+                      },
+                      "additionalProperties": true
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required — x402 v2 (Payment-Required header + JSON body with accepts). Retry with PAYMENT-SIGNATURE or X-PAYMENT.",
+            "headers": {
+              "Payment-Required": {
+                "description": "x402 v2 encoded payment requirements",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds the client must wait before retrying.",
+                "schema": {
+                  "type": "integer",
+                  "minimum": 1
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "message"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Too many requests. Please slow down."
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        },
+        "x-syra-pillar": "invest"
+      }
+    },
+    "/pumpfun/trending": {
+      "get": {
+        "tags": [
+          "pump.fun trending (x402)"
+        ],
+        "summary": "List trending pump.fun coins by volume",
+        "description": "Returns trending pump.fun coins from frontend-api-v3 (falls back to top-runners when primary feed is empty). Use when an agent scans hot memecoin launches or social momentum on pump.fun. Inputs: limit (default 20, max 50), offset, includeNsfw. Returns normalized coins[], count, upstream metadata.",
+        "operationId": "getPumpfunTrending",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "protocols": [
+            {
+              "x402": {}
+            },
+            {
+              "mpp": {
+                "method": "",
+                "intent": "",
+                "currency": ""
+              }
+            }
+          ],
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001"
+          }
+        },
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 20
+            },
+            "description": "Maximum number of results to return."
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 0
+            },
+            "description": "Number of results to skip before returning."
+          },
+          {
+            "name": "includeNsfw",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            },
+            "description": "When true, include NSFW-tagged coins."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required — x402 v2 (Payment-Required header + JSON body with accepts). Retry with PAYMENT-SIGNATURE or X-PAYMENT.",
+            "headers": {
+              "Payment-Required": {
+                "description": "x402 v2 encoded payment requirements",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds the client must wait before retrying.",
+                "schema": {
+                  "type": "integer",
+                  "minimum": 1
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "message"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Too many requests. Please slow down."
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        },
+        "x-syra-pillar": "spend"
+      }
+    },
+    "/pumpfun/movers": {
+      "get": {
+        "tags": [
+          "pump.fun movers (x402)"
+        ],
+        "summary": "List pump.fun market movers by timeframe",
+        "description": "Returns pump.fun market movers from frontend-api-v3 (falls back to currently-live when primary is empty). Use when an agent finds coins with unusual short-term price/volume action. Inputs: limit, offset, includeNsfw. Returns coins[], count, upstream metadata.",
+        "operationId": "getPumpfunMovers",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "protocols": [
+            {
+              "x402": {}
+            },
+            {
+              "mpp": {
+                "method": "",
+                "intent": "",
+                "currency": ""
+              }
+            }
+          ],
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001"
+          }
+        },
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 20
+            },
+            "description": "Maximum number of results to return."
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 0
+            },
+            "description": "Number of results to skip before returning."
+          },
+          {
+            "name": "includeNsfw",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            },
+            "description": "When true, include NSFW-tagged coins."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required — x402 v2 (Payment-Required header + JSON body with accepts). Retry with PAYMENT-SIGNATURE or X-PAYMENT.",
+            "headers": {
+              "Payment-Required": {
+                "description": "x402 v2 encoded payment requirements",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds the client must wait before retrying.",
+                "schema": {
+                  "type": "integer",
+                  "minimum": 1
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "message"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Too many requests. Please slow down."
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        },
+        "x-syra-pillar": "spend"
+      }
+    },
+    "/pumpfun/analyzer": {
+      "get": {
+        "tags": [
+          "pump.fun analyzer (x402)"
+        ],
+        "summary": "Analyze Solana memecoin mint due diligence",
+        "description": "Deep memecoin analysis for pump.fun or graduated tokens. Use when an agent must score risk/reward before trading. Input: mint (base58). Returns syraAlpha score/verdict, market stats, dossier risk, holders, distribution, onChainSecurity, kolShills — probabilistic, not financial advice.",
+        "operationId": "getPumpfunAnalyzer",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "protocols": [
+            {
+              "x402": {}
+            },
+            {
+              "mpp": {
+                "method": "",
+                "intent": "",
+                "currency": ""
+              }
+            }
+          ],
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.02"
+          }
+        },
+        "parameters": [
+          {
+            "name": "mint",
             "in": "query",
             "required": true,
             "schema": {
               "type": "string"
             },
-            "description": "X handle without @."
-          },
-          {
-            "name": "type",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "default": "x402"
-            },
-            "description": "Feed type key."
-          },
-          {
-            "name": "max_results",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "minimum": 10,
-              "maximum": 50,
-              "default": 35
-            },
-            "description": "Tweet sample size."
-          },
-          {
-            "name": "includeAiSummary",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "default": true
-            },
-            "description": "Grounded LLM bullets (OpenRouter)."
+            "description": "Solana token mint (base58)"
           }
         ],
         "responses": {
           "200": {
-            "description": "OK",
+            "description": "Success — `{ success: true, data: { ... } }`",
             "content": {
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "additionalProperties": true
+                  "required": [
+                    "success",
+                    "data"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "const": true
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "mint": {
+                          "type": "string"
+                        },
+                        "syraAlpha": {
+                          "type": "object",
+                          "additionalProperties": true
+                        },
+                        "market": {
+                          "type": "object",
+                          "additionalProperties": true
+                        },
+                        "dossier": {
+                          "type": "object",
+                          "additionalProperties": true
+                        },
+                        "pumpfun": {
+                          "type": "object",
+                          "additionalProperties": true
+                        },
+                        "holders": {
+                          "type": "object",
+                          "additionalProperties": true
+                        },
+                        "distribution": {
+                          "type": "object",
+                          "additionalProperties": true
+                        },
+                        "onChainSecurity": {
+                          "type": "object",
+                          "additionalProperties": true
+                        },
+                        "kolShills": {
+                          "type": "object",
+                          "additionalProperties": true
+                        },
+                        "fetchedAt": {
+                          "type": "string"
+                        }
+                      },
+                      "additionalProperties": true
+                    }
+                  },
+                  "additionalProperties": false
                 }
               }
             }
           },
-          "403": {
-            "description": "Username not in feed type allowlist"
-          },
-          "404": {
-            "description": "X user not found"
+          "402": {
+            "description": "Payment required — x402 v2 (Payment-Required header + JSON body with accepts). Retry with PAYMENT-SIGNATURE or X-PAYMENT.",
+            "headers": {
+              "Payment-Required": {
+                "description": "x402 v2 encoded payment requirements",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           },
           "429": {
             "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
@@ -2372,77 +3186,136 @@
                 }
               }
             }
-          },
-          "502": {
-            "description": "X API upstream error"
-          },
-          "503": {
-            "description": "Server missing X_BEARER_TOKEN"
           }
         },
-        "security": [
-          {
-            "SyraApiKey": []
-          }
-        ]
+        "x-syra-pillar": "spend"
       },
       "post": {
         "tags": [
-          "Social (batch)"
+          "pump.fun analyzer (x402)"
         ],
-        "summary": "Analyze allowlisted X account via JSON body",
-        "operationId": "postXProjectsAnalyzeAccount",
+        "summary": "Analyze memecoin mint via JSON request body",
+        "description": "Deep memecoin analysis for pump.fun or graduated tokens. Use when an agent must score risk/reward before trading. Input: mint (base58). Returns syraAlpha score/verdict, market stats, dossier risk, holders, distribution, onChainSecurity, kolShills — probabilistic, not financial advice.",
+        "operationId": "postPumpfunAnalyzer",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "protocols": [
+            {
+              "x402": {}
+            },
+            {
+              "mpp": {
+                "method": "",
+                "intent": "",
+                "currency": ""
+              }
+            }
+          ],
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.02"
+          }
+        },
         "requestBody": {
-          "required": false,
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
-                "properties": {
-                  "username": {
-                    "type": "string",
-                    "description": "X handle without @; must be on the allowlist for the selected type."
-                  },
-                  "type": {
-                    "type": "string",
-                    "default": "x402",
-                    "description": "Feed type key that owns the allowlisted handle list."
-                  },
-                  "max_results": {
-                    "type": "integer",
-                    "minimum": 10,
-                    "maximum": 50,
-                    "description": "Tweet sample size for scoring."
-                  },
-                  "includeAiSummary": {
-                    "type": "boolean",
-                    "description": "When true, include grounded LLM summary bullets."
-                  }
-                },
                 "required": [
-                  "username"
-                ]
+                  "mint"
+                ],
+                "properties": {
+                  "mint": {
+                    "type": "string",
+                    "description": "Solana token mint (base58)"
+                  }
+                }
               }
             }
           }
         },
         "responses": {
           "200": {
-            "description": "OK",
+            "description": "Success — `{ success: true, data: { ... } }`",
             "content": {
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "additionalProperties": true
+                  "required": [
+                    "success",
+                    "data"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "const": true
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "mint": {
+                          "type": "string"
+                        },
+                        "syraAlpha": {
+                          "type": "object",
+                          "additionalProperties": true
+                        },
+                        "market": {
+                          "type": "object",
+                          "additionalProperties": true
+                        },
+                        "dossier": {
+                          "type": "object",
+                          "additionalProperties": true
+                        },
+                        "pumpfun": {
+                          "type": "object",
+                          "additionalProperties": true
+                        },
+                        "holders": {
+                          "type": "object",
+                          "additionalProperties": true
+                        },
+                        "distribution": {
+                          "type": "object",
+                          "additionalProperties": true
+                        },
+                        "onChainSecurity": {
+                          "type": "object",
+                          "additionalProperties": true
+                        },
+                        "kolShills": {
+                          "type": "object",
+                          "additionalProperties": true
+                        },
+                        "fetchedAt": {
+                          "type": "string"
+                        }
+                      },
+                      "additionalProperties": true
+                    }
+                  },
+                  "additionalProperties": false
                 }
               }
             }
           },
-          "403": {
-            "description": "Username not in feed type allowlist"
-          },
-          "404": {
-            "description": "X user not found"
+          "402": {
+            "description": "Payment required — x402 v2 (Payment-Required header + JSON body with accepts). Retry with PAYMENT-SIGNATURE or X-PAYMENT.",
+            "headers": {
+              "Payment-Required": {
+                "description": "x402 v2 encoded payment requirements",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           },
           "429": {
             "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
@@ -2477,61 +3350,88 @@
                 }
               }
             }
-          },
-          "502": {
-            "description": "X API upstream error"
-          },
-          "503": {
-            "description": "Server missing X_BEARER_TOKEN"
           }
         },
-        "security": [
-          {
-            "SyraApiKey": []
-          }
-        ]
+        "x-syra-pillar": "spend"
       }
     },
-    "/x-projects-analyze": {
+    "/pumpfun/scout": {
       "get": {
         "tags": [
-          "Social (batch)"
+          "pump.fun scout (x402)"
         ],
-        "summary": "Run batch X project analyzer without payment",
-        "description": "Runs the same deterministic analysis as /x-analyzer for all X handles configured for `type` (default `x402`). Handles are not client-supplied. See GET /x-projects-analyze/types.",
-        "operationId": "getXProjectsAnalyze",
+        "summary": "Fetch pump.fun alpha beta predicted utility",
+        "description": "Live pump.fun intelligence with selector param segment=alpha|beta|predicted|utility. Optional period, limit, minPumpScore, llm. Returns scored tokens, analysis, and meta — deterministic by default.",
+        "operationId": "getPumpfunScout",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "protocols": [
+            {
+              "x402": {}
+            },
+            {
+              "mpp": {
+                "method": "",
+                "intent": "",
+                "currency": ""
+              }
+            }
+          ],
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.005"
+          }
+        },
         "parameters": [
           {
-            "name": "type",
+            "name": "segment",
             "in": "query",
-            "required": false,
             "schema": {
               "type": "string",
-              "default": "x402"
+              "default": "alpha"
             },
-            "description": "Analyzer type key (e.g. x402)."
+            "description": "Scout segment key (alpha, beta, predicted, utility)."
           },
           {
-            "name": "max_results",
+            "name": "period",
             "in": "query",
-            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "today"
+            },
+            "description": "Lookback period for scout ranking."
+          },
+          {
+            "name": "limit",
+            "in": "query",
             "schema": {
               "type": "integer",
-              "minimum": 5,
-              "maximum": 50,
-              "default": 20
+              "default": 10
             },
-            "description": "Tweet sample per account."
+            "description": "Maximum number of results to return."
           },
           {
-            "name": "includeAiSummary",
+            "name": "minPumpScore",
             "in": "query",
-            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 48
+            },
+            "description": "Minimum pump score threshold to include."
+          },
+          {
+            "name": "llm",
+            "in": "query",
             "schema": {
               "type": "boolean",
               "default": false
             },
-            "description": "Optional grounded LLM summary per account (OpenRouter)."
+            "description": "When true, include an LLM-assisted summary."
           }
         ],
         "responses": {
@@ -2542,6 +3442,17 @@
                 "schema": {
                   "type": "object",
                   "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required — x402 v2 (Payment-Required header + JSON body with accepts). Retry with PAYMENT-SIGNATURE or X-PAYMENT.",
+            "headers": {
+              "Payment-Required": {
+                "description": "x402 v2 encoded payment requirements",
+                "schema": {
+                  "type": "string"
                 }
               }
             }
@@ -2581,36 +3492,2295 @@
             }
           }
         },
+        "x-syra-pillar": "spend"
+      }
+    },
+    "/rise": {
+      "get": {
+        "tags": [
+          "RISE scout (x402)"
+        ],
+        "summary": "Fetch live RISE market intel and agent targets",
+        "description": "Live RISE intelligence with view=intel|markets|targets. Optional mint, limit, tier=ready|watch. Returns UPONLY token snapshot, fund lens, ranked markets, and agent-ready mint targets.",
+        "operationId": "getRiseScout",
         "security": [
           {
-            "SyraApiKey": []
+            "x402": []
           }
-        ]
+        ],
+        "x-payment-info": {
+          "protocols": [
+            {
+              "x402": {}
+            },
+            {
+              "mpp": {
+                "method": "",
+                "intent": "",
+                "currency": ""
+              }
+            }
+          ],
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.005"
+          }
+        },
+        "parameters": [
+          {
+            "name": "view",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "default": "intel"
+            },
+            "description": "Response view or segment key for this endpoint."
+          },
+          {
+            "name": "mint",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Solana mint address for the token or market."
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 25
+            },
+            "description": "Maximum number of results to return."
+          },
+          {
+            "name": "tier",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "RISE tier filter for agent targets."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required — x402 v2 (Payment-Required header + JSON body with accepts). Retry with PAYMENT-SIGNATURE or X-PAYMENT.",
+            "headers": {
+              "Payment-Required": {
+                "description": "x402 v2 encoded payment requirements",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds the client must wait before retrying.",
+                "schema": {
+                  "type": "integer",
+                  "minimum": 1
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "message"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Too many requests. Please slow down."
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        },
+        "x-syra-pillar": "spend"
+      }
+    },
+    "/coingecko": {
+      "get": {
+        "tags": [
+          "CoinGecko scout (x402)"
+        ],
+        "summary": "Fetch CoinGecko top gainers market brief",
+        "description": "Live CoinGecko scout with view=brief|gainers|predictions. Optional topN, minMarketCap, includeNews, llm. Returns top gainers, digests, predictions, and narrative meta — deterministic by default.",
+        "operationId": "getCoingeckoScout",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "protocols": [
+            {
+              "x402": {}
+            },
+            {
+              "mpp": {
+                "method": "",
+                "intent": "",
+                "currency": ""
+              }
+            }
+          ],
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001"
+          }
+        },
+        "parameters": [
+          {
+            "name": "view",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "default": "brief"
+            },
+            "description": "Response view or segment key for this endpoint."
+          },
+          {
+            "name": "topN",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 8
+            },
+            "description": "Number of top items to include in the brief."
+          },
+          {
+            "name": "minMarketCap",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 1000000
+            },
+            "description": "Minimum market-cap filter in USD."
+          },
+          {
+            "name": "includeNews",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": true
+            },
+            "description": "When true, include related news headlines."
+          },
+          {
+            "name": "llm",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            },
+            "description": "When true, include an LLM-assisted summary."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required — x402 v2 (Payment-Required header + JSON body with accepts). Retry with PAYMENT-SIGNATURE or X-PAYMENT.",
+            "headers": {
+              "Payment-Required": {
+                "description": "x402 v2 encoded payment requirements",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds the client must wait before retrying.",
+                "schema": {
+                  "type": "integer",
+                  "minimum": 1
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "message"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Too many requests. Please slow down."
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        },
+        "x-syra-pillar": "spend"
+      }
+    },
+    "/dexscreener/pairs": {
+      "get": {
+        "tags": [
+          "Onchain data (x402)"
+        ],
+        "summary": "Search DEX pairs by chain token or query",
+        "description": "Onchain DEX pair data from DexScreener across 80+ chains. Use when an agent needs live price, liquidity, volume, and txn counts for a token before trading or scouting. Inputs: chainId + tokenAddress OR q (search). Returns normalized pairs[] with priceUsd, liquidityUsd, volume24h, txns24h, fdv, pairAddress, dexId.",
+        "operationId": "getDexscreenerPairs",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "protocols": [
+            {
+              "x402": {}
+            },
+            {
+              "mpp": {
+                "method": "",
+                "intent": "",
+                "currency": ""
+              }
+            }
+          ],
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001"
+          }
+        },
+        "parameters": [
+          {
+            "name": "chainId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "DexScreener chain id (for example solana)."
+          },
+          {
+            "name": "tokenAddress",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Token mint or contract address to resolve pairs for."
+          },
+          {
+            "name": "q",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Free-text search query for pairs or pools."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required — x402 v2 (Payment-Required header + JSON body with accepts). Retry with PAYMENT-SIGNATURE or X-PAYMENT.",
+            "headers": {
+              "Payment-Required": {
+                "description": "x402 v2 encoded payment requirements",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds the client must wait before retrying.",
+                "schema": {
+                  "type": "integer",
+                  "minimum": 1
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "message"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Too many requests. Please slow down."
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        },
+        "x-syra-pillar": "spend"
+      }
+    },
+    "/geckoterminal/pools": {
+      "get": {
+        "tags": [
+          "Onchain data (x402)"
+        ],
+        "summary": "List trending or new DEX pools on a network",
+        "description": "Trending or newly listed DEX pools from GeckoTerminal across 100+ networks. Use when an agent scouts fresh liquidity or momentum pools on Solana, Base, Ethereum, etc. Inputs: network (default solana), kind=trending|new, limit (max 50). Returns pools[] with priceUsd, priceChange24h, volume24h, reserveUsd, poolAddress, dex.",
+        "operationId": "getGeckoterminalPools",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "protocols": [
+            {
+              "x402": {}
+            },
+            {
+              "mpp": {
+                "method": "",
+                "intent": "",
+                "currency": ""
+              }
+            }
+          ],
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001"
+          }
+        },
+        "parameters": [
+          {
+            "name": "network",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "default": "solana"
+            },
+            "description": "GeckoTerminal network slug (for example solana)."
+          },
+          {
+            "name": "kind",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "default": "trending",
+              "enum": [
+                "trending",
+                "new"
+              ]
+            },
+            "description": "One of: trending, new."
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 20
+            },
+            "description": "Maximum number of results to return."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required — x402 v2 (Payment-Required header + JSON body with accepts). Retry with PAYMENT-SIGNATURE or X-PAYMENT.",
+            "headers": {
+              "Payment-Required": {
+                "description": "x402 v2 encoded payment requirements",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds the client must wait before retrying.",
+                "schema": {
+                  "type": "integer",
+                  "minimum": 1
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "message"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Too many requests. Please slow down."
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        },
+        "x-syra-pillar": "spend"
+      }
+    },
+    "/defillama/tvl": {
+      "get": {
+        "tags": [
+          "Onchain data (x402)"
+        ],
+        "summary": "Fetch protocol or chain TVL from DefiLlama",
+        "description": "Total value locked for a DeFi protocol or blockchain from DefiLlama. Use when an agent assesses protocol scale, chain dominance, or macro DeFi health. Inputs: protocol (slug e.g. aave) OR chain (e.g. Solana, Ethereum). Returns currentTvlUsd, tvlHistory summary, name, category, chains[] when protocol.",
+        "operationId": "getDefillamaTvl",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "protocols": [
+            {
+              "x402": {}
+            },
+            {
+              "mpp": {
+                "method": "",
+                "intent": "",
+                "currency": ""
+              }
+            }
+          ],
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001"
+          }
+        },
+        "parameters": [
+          {
+            "name": "protocol",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "DefiLlama protocol slug to look up."
+          },
+          {
+            "name": "chain",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Chain name or slug for TVL lookup."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required — x402 v2 (Payment-Required header + JSON body with accepts). Retry with PAYMENT-SIGNATURE or X-PAYMENT.",
+            "headers": {
+              "Payment-Required": {
+                "description": "x402 v2 encoded payment requirements",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds the client must wait before retrying.",
+                "schema": {
+                  "type": "integer",
+                  "minimum": 1
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "message"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Too many requests. Please slow down."
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        },
+        "x-syra-pillar": "spend"
+      }
+    },
+    "/rugcheck/report": {
+      "get": {
+        "tags": [
+          "Onchain data (x402)"
+        ],
+        "summary": "Fetch Solana token risk report from RugCheck",
+        "description": "Solana token risk report from RugCheck: mint/freeze authority, holder concentration, LP status, and risk score. Use when an agent screens memecoins or new mints before trading. Input: mint (required, Solana base58). Returns riskScore, risks[], topHolders[], mintAuthority, freezeAuthority, lpLocked, marketCap, computedAt.",
+        "operationId": "getRugcheckReport",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "protocols": [
+            {
+              "x402": {}
+            },
+            {
+              "mpp": {
+                "method": "",
+                "intent": "",
+                "currency": ""
+              }
+            }
+          ],
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.005"
+          }
+        },
+        "parameters": [
+          {
+            "name": "mint",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Solana mint address for the token or market."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required — x402 v2 (Payment-Required header + JSON body with accepts). Retry with PAYMENT-SIGNATURE or X-PAYMENT.",
+            "headers": {
+              "Payment-Required": {
+                "description": "x402 v2 encoded payment requirements",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds the client must wait before retrying.",
+                "schema": {
+                  "type": "integer",
+                  "minimum": 1
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "message"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Too many requests. Please slow down."
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        },
+        "x-syra-pillar": "spend"
+      }
+    },
+    "/pyth/price": {
+      "get": {
+        "tags": [
+          "Onchain data (x402)"
+        ],
+        "summary": "Fetch real-time Pyth oracle prices via Hermes",
+        "description": "Latest Pyth oracle prices from Hermes for major crypto feeds. Use when an agent needs authoritative onchain-derived spot prices (BTC, ETH, SOL, etc.) with confidence intervals. Input: symbols (comma-separated, e.g. BTC/USD,SOL/USD). Returns prices[] with symbol, priceUsd, confidenceUsd, publishTime, feedId.",
+        "operationId": "getPythPrice",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "protocols": [
+            {
+              "x402": {}
+            },
+            {
+              "mpp": {
+                "method": "",
+                "intent": "",
+                "currency": ""
+              }
+            }
+          ],
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001"
+          }
+        },
+        "parameters": [
+          {
+            "name": "symbols",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Comma-separated Pyth price feed symbols."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required — x402 v2 (Payment-Required header + JSON body with accepts). Retry with PAYMENT-SIGNATURE or X-PAYMENT.",
+            "headers": {
+              "Payment-Required": {
+                "description": "x402 v2 encoded payment requirements",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds the client must wait before retrying.",
+                "schema": {
+                  "type": "integer",
+                  "minimum": 1
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "message"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Too many requests. Please slow down."
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        },
+        "x-syra-pillar": "spend"
+      }
+    },
+    "/insights/network-health": {
+      "get": {
+        "tags": [
+          "Insights (x402)"
+        ],
+        "summary": "Fetch Solana slot epoch TPS fee snapshot",
+        "description": "Real-time Solana mainnet health metrics: current slot, epoch progress, average TPS from recent performance samples, and median priority fee. Use when an agent needs chain liveness and congestion signals before submitting transactions.",
+        "operationId": "getInsightsNetworkHealth",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "protocols": [
+            {
+              "x402": {}
+            },
+            {
+              "mpp": {
+                "method": "",
+                "intent": "",
+                "currency": ""
+              }
+            }
+          ],
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.01"
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required — x402 v2 (Payment-Required header + JSON body with accepts). Retry with PAYMENT-SIGNATURE or X-PAYMENT.",
+            "headers": {
+              "Payment-Required": {
+                "description": "x402 v2 encoded payment requirements",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds the client must wait before retrying.",
+                "schema": {
+                  "type": "integer",
+                  "minimum": 1
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "message"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Too many requests. Please slow down."
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        },
+        "x-syra-pillar": "spend"
+      }
+    },
+    "/insights/gas-oracle": {
+      "get": {
+        "tags": [
+          "Insights (x402)"
+        ],
+        "summary": "Fetch Solana priority fee percentile oracle",
+        "description": "Priority fee oracle derived from recent Solana mainnet samples. Returns min, p25, p50, p75, p95, and max priority fees in lamports. Use when an agent needs data-driven fee estimation for reliable transaction landing.",
+        "operationId": "getInsightsGasOracle",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "protocols": [
+            {
+              "x402": {}
+            },
+            {
+              "mpp": {
+                "method": "",
+                "intent": "",
+                "currency": ""
+              }
+            }
+          ],
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.01"
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required — x402 v2 (Payment-Required header + JSON body with accepts). Retry with PAYMENT-SIGNATURE or X-PAYMENT.",
+            "headers": {
+              "Payment-Required": {
+                "description": "x402 v2 encoded payment requirements",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds the client must wait before retrying.",
+                "schema": {
+                  "type": "integer",
+                  "minimum": 1
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "message"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Too many requests. Please slow down."
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        },
+        "x-syra-pillar": "spend"
+      }
+    },
+    "/insights/market-pulse": {
+      "get": {
+        "tags": [
+          "Insights (x402)"
+        ],
+        "summary": "Fetch SOL BTC ETH spot prices via Pyth",
+        "description": "Cross-asset market pulse with latest Pyth oracle prices for SOL/USD, BTC/USD, and ETH/USD including confidence intervals and publish times. Use when an agent needs a quick multi-asset price snapshot from authoritative feeds.",
+        "operationId": "getInsightsMarketPulse",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "protocols": [
+            {
+              "x402": {}
+            },
+            {
+              "mpp": {
+                "method": "",
+                "intent": "",
+                "currency": ""
+              }
+            }
+          ],
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.02"
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required — x402 v2 (Payment-Required header + JSON body with accepts). Retry with PAYMENT-SIGNATURE or X-PAYMENT.",
+            "headers": {
+              "Payment-Required": {
+                "description": "x402 v2 encoded payment requirements",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds the client must wait before retrying.",
+                "schema": {
+                  "type": "integer",
+                  "minimum": 1
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "message"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Too many requests. Please slow down."
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        },
+        "x-syra-pillar": "spend"
+      }
+    },
+    "/insights/token-metrics": {
+      "get": {
+        "tags": [
+          "Insights (x402)"
+        ],
+        "summary": "Fetch SOL DEX pair metrics via DexScreener",
+        "description": "Token liquidity and trading metrics for SOL across major DEX pairs from DexScreener. Returns top pairs with price, 24h volume, price change, and liquidity. Use when an agent screens on-chain liquidity before execution.",
+        "operationId": "getInsightsTokenMetrics",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "protocols": [
+            {
+              "x402": {}
+            },
+            {
+              "mpp": {
+                "method": "",
+                "intent": "",
+                "currency": ""
+              }
+            }
+          ],
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.03"
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required — x402 v2 (Payment-Required header + JSON body with accepts). Retry with PAYMENT-SIGNATURE or X-PAYMENT.",
+            "headers": {
+              "Payment-Required": {
+                "description": "x402 v2 encoded payment requirements",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds the client must wait before retrying.",
+                "schema": {
+                  "type": "integer",
+                  "minimum": 1
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "message"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Too many requests. Please slow down."
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        },
+        "x-syra-pillar": "spend"
+      }
+    },
+    "/insights/defi-tvl": {
+      "get": {
+        "tags": [
+          "Insights (x402)"
+        ],
+        "summary": "Fetch Solana chain TVL overview from DefiLlama",
+        "description": "Solana DeFi total value locked overview from DefiLlama. Use when an agent assesses macro DeFi health and capital allocation on the Solana ecosystem.",
+        "operationId": "getInsightsDefiTvl",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "protocols": [
+            {
+              "x402": {}
+            },
+            {
+              "mpp": {
+                "method": "",
+                "intent": "",
+                "currency": ""
+              }
+            }
+          ],
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.05"
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required — x402 v2 (Payment-Required header + JSON body with accepts). Retry with PAYMENT-SIGNATURE or X-PAYMENT.",
+            "headers": {
+              "Payment-Required": {
+                "description": "x402 v2 encoded payment requirements",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds the client must wait before retrying.",
+                "schema": {
+                  "type": "integer",
+                  "minimum": 1
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "message"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Too many requests. Please slow down."
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        },
+        "x-syra-pillar": "spend"
+      }
+    },
+    "/insights/volatility-index": {
+      "get": {
+        "tags": [
+          "Insights (x402)"
+        ],
+        "summary": "Generate volatility index from Pyth price feeds",
+        "description": "Volatility index computed from Pyth price feed confidence intervals across SOL, BTC, and ETH. Returns index score and per-asset uncertainty metrics. Use when an agent gauges market uncertainty for risk-adjusted decisions.",
+        "operationId": "getInsightsVolatilityIndex",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "protocols": [
+            {
+              "x402": {}
+            },
+            {
+              "mpp": {
+                "method": "",
+                "intent": "",
+                "currency": ""
+              }
+            }
+          ],
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.1"
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required — x402 v2 (Payment-Required header + JSON body with accepts). Retry with PAYMENT-SIGNATURE or X-PAYMENT.",
+            "headers": {
+              "Payment-Required": {
+                "description": "x402 v2 encoded payment requirements",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds the client must wait before retrying.",
+                "schema": {
+                  "type": "integer",
+                  "minimum": 1
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "message"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Too many requests. Please slow down."
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        },
+        "x-syra-pillar": "spend"
+      }
+    },
+    "/assets": {
+      "get": {
+        "tags": [
+          "Assets board (x402)"
+        ],
+        "summary": "List curated Tokens.xyz assets with filters",
+        "description": "Paginated curated assets board (crypto + tokenized stocks) from Tokens.xyz — same data as the Syra Assets page. Use when an agent needs a ranked market universe, not a single asset. Inputs: list (all|majors|stocks|…), assetClass, q, sort, order, limit, offset. Returns items[] with price, marketCap, volume, assetClass.",
+        "operationId": "getAssetsBoard",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "protocols": [
+            {
+              "x402": {}
+            },
+            {
+              "mpp": {
+                "method": "",
+                "intent": "",
+                "currency": ""
+              }
+            }
+          ],
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001"
+          }
+        },
+        "parameters": [
+          {
+            "name": "list",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "default": "all",
+              "enum": [
+                "all",
+                "majors",
+                "lsts",
+                "currencies",
+                "rwas",
+                "etfs",
+                "metals",
+                "stocks"
+              ]
+            },
+            "description": "One of: all, majors, lsts, currencies, rwas, etfs, metals, stocks."
+          },
+          {
+            "name": "groupBy",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "default": "asset",
+              "enum": [
+                "asset",
+                "mint"
+              ]
+            },
+            "description": "One of: asset, mint."
+          },
+          {
+            "name": "assetClass",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "default": "all",
+              "enum": [
+                "all",
+                "crypto",
+                "equity"
+              ]
+            },
+            "description": "One of: all, crypto, equity."
+          },
+          {
+            "name": "q",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Search name, symbol, ref, or assetId"
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "default": "marketCap",
+              "enum": [
+                "marketCap",
+                "name",
+                "symbol",
+                "price",
+                "change24h",
+                "volume24h",
+                "assetClass"
+              ]
+            },
+            "description": "One of: marketCap, name, symbol, price, change24h, volume24h, assetClass."
+          },
+          {
+            "name": "order",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "asc",
+                "desc"
+              ]
+            },
+            "description": "One of: asc, desc."
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 20,
+              "maximum": 100
+            },
+            "description": "Maximum number of results to return."
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 0
+            },
+            "description": "Number of results to skip before returning."
+          },
+          {
+            "name": "maxPages",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 20,
+              "maximum": 20
+            },
+            "description": "Maximum upstream pages to scan when aggregating."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required — x402 v2 (Payment-Required header + JSON body with accepts). Retry with PAYMENT-SIGNATURE or X-PAYMENT.",
+            "headers": {
+              "Payment-Required": {
+                "description": "x402 v2 encoded payment requirements",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds the client must wait before retrying.",
+                "schema": {
+                  "type": "integer",
+                  "minimum": 1
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "message"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Too many requests. Please slow down."
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        },
+        "x-syra-pillar": "spend"
+      }
+    },
+    "/assets/detail": {
+      "get": {
+        "tags": [
+          "Asset detail (x402)"
+        ],
+        "summary": "Fetch Tokens.xyz mint dossier for one asset",
+        "description": "Full asset dossier: profile, risk, markets, and 1H OHLCV for a canonical asset. Use when an agent researches BTC, SOL, a stock token, or any Tokens.xyz asset by ref/mint/assetId. Inputs: ref, mint, assetId, or q. Returns asset, includes (profile/risk/markets), ohlcv candles, mintRisk.",
+        "operationId": "getAssetsDetail",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "protocols": [
+            {
+              "x402": {}
+            },
+            {
+              "mpp": {
+                "method": "",
+                "intent": "",
+                "currency": ""
+              }
+            }
+          ],
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.005"
+          }
+        },
+        "parameters": [
+          {
+            "name": "ref",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Canonical ref e.g. btc, solana, apple (alternatives: mint, assetId, q)"
+          },
+          {
+            "name": "mint",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Solana mint (base58)"
+          },
+          {
+            "name": "assetId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "assetId e.g. bitcoin"
+          },
+          {
+            "name": "q",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Freeform lookup (ref, mint, or assetId)"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success — `{ success: true, data: { ... } }`",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "data"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "const": true
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "query": {
+                          "type": "object",
+                          "additionalProperties": true
+                        },
+                        "assetId": {
+                          "type": "string"
+                        },
+                        "chartMint": {
+                          "type": "string"
+                        },
+                        "asset": {
+                          "type": "object",
+                          "additionalProperties": true
+                        },
+                        "includes": {
+                          "type": "object",
+                          "additionalProperties": true
+                        },
+                        "ohlcv": {
+                          "type": "object",
+                          "additionalProperties": true
+                        },
+                        "mintRisk": {
+                          "type": "object",
+                          "additionalProperties": true
+                        },
+                        "fetchedAt": {
+                          "type": "string"
+                        }
+                      },
+                      "additionalProperties": true
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required — x402 v2 (Payment-Required header + JSON body with accepts). Retry with PAYMENT-SIGNATURE or X-PAYMENT.",
+            "headers": {
+              "Payment-Required": {
+                "description": "x402 v2 encoded payment requirements",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds the client must wait before retrying.",
+                "schema": {
+                  "type": "integer",
+                  "minimum": 1
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "message"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Too many requests. Please slow down."
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        },
+        "x-syra-pillar": "spend"
       },
       "post": {
         "tags": [
-          "Social (batch)"
+          "Asset detail (x402)"
         ],
-        "summary": "Run batch X project analyzer via JSON body",
-        "operationId": "postXProjectsAnalyze",
+        "summary": "Fetch mint dossier via JSON request body",
+        "description": "Full asset dossier: profile, risk, markets, and 1H OHLCV for a canonical asset. Use when an agent researches BTC, SOL, a stock token, or any Tokens.xyz asset by ref/mint/assetId. Inputs: ref, mint, assetId, or q. Returns asset, includes (profile/risk/markets), ohlcv candles, mintRisk.",
+        "operationId": "postAssetsDetail",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "protocols": [
+            {
+              "x402": {}
+            },
+            {
+              "mpp": {
+                "method": "",
+                "intent": "",
+                "currency": ""
+              }
+            }
+          ],
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.005"
+          }
+        },
         "requestBody": {
-          "required": false,
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "ref"
+                ],
+                "properties": {
+                  "ref": {
+                    "type": "string",
+                    "description": "Canonical ref e.g. btc, solana, apple"
+                  },
+                  "mint": {
+                    "type": "string",
+                    "description": "Solana mint (base58)"
+                  },
+                  "assetId": {
+                    "type": "string",
+                    "description": "Tokens.xyz assetId e.g. bitcoin"
+                  },
+                  "q": {
+                    "type": "string",
+                    "description": "Freeform lookup (ref, mint, or assetId)"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — `{ success: true, data: { ... } }`",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "data"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "const": true
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "query": {
+                          "type": "object",
+                          "additionalProperties": true
+                        },
+                        "assetId": {
+                          "type": "string"
+                        },
+                        "chartMint": {
+                          "type": "string"
+                        },
+                        "asset": {
+                          "type": "object",
+                          "additionalProperties": true
+                        },
+                        "includes": {
+                          "type": "object",
+                          "additionalProperties": true
+                        },
+                        "ohlcv": {
+                          "type": "object",
+                          "additionalProperties": true
+                        },
+                        "mintRisk": {
+                          "type": "object",
+                          "additionalProperties": true
+                        },
+                        "fetchedAt": {
+                          "type": "string"
+                        }
+                      },
+                      "additionalProperties": true
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required — x402 v2 (Payment-Required header + JSON body with accepts). Retry with PAYMENT-SIGNATURE or X-PAYMENT.",
+            "headers": {
+              "Payment-Required": {
+                "description": "x402 v2 encoded payment requirements",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds the client must wait before retrying.",
+                "schema": {
+                  "type": "integer",
+                  "minimum": 1
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "message"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Too many requests. Please slow down."
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        },
+        "x-syra-pillar": "spend"
+      }
+    },
+    "/bitcoin": {
+      "get": {
+        "tags": [
+          "Bitcoin Intelligence Hub (x402)"
+        ],
+        "summary": "Fetch Bitcoin dashboard and taker-flow map",
+        "description": "Complete Bitcoin intelligence bundle from the Syra BTC page. Use when an agent needs macro BTC context: price, derivatives, technicals, sentiment, news, signal, and taker buy/sell bubblemap in one call. Inputs: exchange (binance|coinbase), interval, limit for bubblemap. Returns dashboard (overview + sections) and bubblemap points[].",
+        "operationId": "getBitcoinHub",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "protocols": [
+            {
+              "x402": {}
+            },
+            {
+              "mpp": {
+                "method": "",
+                "intent": "",
+                "currency": ""
+              }
+            }
+          ],
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.005"
+          }
+        },
+        "parameters": [
+          {
+            "name": "exchange",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "default": "binance",
+              "enum": [
+                "binance",
+                "coinbase"
+              ]
+            },
+            "description": "One of: binance, coinbase."
+          },
+          {
+            "name": "interval",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "default": "1h",
+              "enum": [
+                "1m",
+                "5m",
+                "15m",
+                "1h",
+                "4h",
+                "1d"
+              ]
+            },
+            "description": "One of: 1m, 5m, 15m, 1h, 4h, 1d."
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 200,
+              "minimum": 20,
+              "maximum": 500
+            },
+            "description": "Maximum number of results to return."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required — x402 v2 (Payment-Required header + JSON body with accepts). Retry with PAYMENT-SIGNATURE or X-PAYMENT.",
+            "headers": {
+              "Payment-Required": {
+                "description": "x402 v2 encoded payment requirements",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds the client must wait before retrying.",
+                "schema": {
+                  "type": "integer",
+                  "minimum": 1
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "message"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Too many requests. Please slow down."
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        },
+        "x-syra-pillar": "spend"
+      }
+    },
+    "/indicator": {
+      "get": {
+        "tags": [
+          "Technical indicators (x402)"
+        ],
+        "summary": "Generate RSI MACD EMA Bollinger indicator set",
+        "description": "Computes multiple technical indicators from OHLCV candles in one agent-readable response. Use when an agent needs RSI/MACD/EMA/Bollinger (or custom combos) without building indicator math. Inputs: symbol, source (binance/coinbase/coingecko), interval, limit, indicators (comma-separated), optional series=true. Returns indicators{} map, lastClose, candleCount, asOf.",
+        "operationId": "getIndicator",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "protocols": [
+            {
+              "x402": {}
+            },
+            {
+              "mpp": {
+                "method": "",
+                "intent": "",
+                "currency": ""
+              }
+            }
+          ],
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.005"
+          }
+        },
+        "parameters": [
+          {
+            "name": "symbol",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "default": "BTCUSDT"
+            },
+            "description": "Market symbol or ticker (for example BTCUSDT or TSLAx)."
+          },
+          {
+            "name": "source",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "default": "binance"
+            },
+            "description": "OHLCV data source key for indicator computation."
+          },
+          {
+            "name": "interval",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "default": "1h"
+            },
+            "description": "Candle interval (for example 1h, 4h, 1d)."
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 200
+            },
+            "description": "Maximum number of results to return."
+          },
+          {
+            "name": "series",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            },
+            "description": "Comma-separated indicator keys to compute."
+          },
+          {
+            "name": "indicators",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "default": "rsi"
+            },
+            "description": "Comma-separated ids e.g. rsi,macd. Per-indicator params: rsi.period=21"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required — x402 v2 (Payment-Required header + JSON body with accepts). Retry with PAYMENT-SIGNATURE or X-PAYMENT.",
+            "headers": {
+              "Payment-Required": {
+                "description": "x402 v2 encoded payment requirements",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds the client must wait before retrying.",
+                "schema": {
+                  "type": "integer",
+                  "minimum": 1
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "message"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Too many requests. Please slow down."
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        },
+        "x-syra-pillar": "spend"
+      },
+      "post": {
+        "tags": [
+          "Technical indicators (x402)"
+        ],
+        "summary": "Generate technical indicators via JSON body",
+        "description": "Same as GET /indicator with JSON body for complex multi-indicator requests.",
+        "operationId": "postIndicator",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "protocols": [
+            {
+              "x402": {}
+            },
+            {
+              "mpp": {
+                "method": "",
+                "intent": "",
+                "currency": ""
+              }
+            }
+          ],
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.005"
+          }
+        },
+        "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
                 "properties": {
-                  "type": {
-                    "type": "string",
-                    "default": "x402"
+                  "symbol": {
+                    "type": "string"
                   },
-                  "max_results": {
-                    "type": "integer",
-                    "minimum": 5,
-                    "maximum": 50
+                  "source": {
+                    "type": "string"
                   },
-                  "includeAiSummary": {
+                  "interval": {
+                    "type": "string"
+                  },
+                  "limit": {
+                    "type": "integer"
+                  },
+                  "series": {
                     "type": "boolean"
+                  },
+                  "indicators": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        }
+                      }
+                    }
                   }
                 }
               }
@@ -2629,6 +5799,17 @@
               }
             }
           },
+          "402": {
+            "description": "Payment required — x402 v2 (Payment-Required header + JSON body with accepts). Retry with PAYMENT-SIGNATURE or X-PAYMENT.",
+            "headers": {
+              "Payment-Required": {
+                "description": "x402 v2 encoded payment requirements",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
           "429": {
             "description": "Too Many Requests — burst (25 req / 10s per IP) or sustained (100 req / 60s per IP) limit exceeded. Wait for the duration in `Retry-After` (seconds) before retrying.",
             "headers": {
@@ -2664,30 +5845,14 @@
             }
           }
         },
-        "security": [
-          {
-            "SyraApiKey": []
-          }
-        ]
+        "x-syra-pillar": "spend"
       }
     }
   },
   "tags": [
     {
-      "name": "Signal",
-      "description": "GET/POST /api/signal — no x402"
-    },
-    {
       "name": "Info",
       "description": "Public info"
-    },
-    {
-      "name": "Preview",
-      "description": "No x402 mirrors of news/sentiment/signal"
-    },
-    {
-      "name": "Dashboard",
-      "description": "Dashboard helpers"
     },
     {
       "name": "Prediction game",
@@ -2695,7 +5860,7 @@
     },
     {
       "name": "Market data (x402)",
-      "description": "Cryptonews-backed; payment via x402"
+      "description": "Cryptonews-backed and signal engine; payment via x402"
     },
     {
       "name": "Gateway (x402)",
@@ -2710,104 +5875,39 @@
       "description": "X (Twitter) analysis — pay-per-call via x402"
     },
     {
-      "name": "Social (batch)",
-      "description": "Batch X project analysis — API key when configured; no x402"
+      "name": "Equity (x402)",
+      "description": "Tokenized equity intelligence — SPCX SpaceX IPO + xStocks catalog"
+    },
+    {
+      "name": "Insights (x402)",
+      "description": "On-chain intelligence — Solana network health, gas oracle, market pulse, TVL, volatility"
     }
   ],
   "components": {
     "securitySchemes": {
+      "x402": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "PAYMENT-SIGNATURE",
+        "description": "x402 v2 payment proof (also accepts X-PAYMENT header). Obtain by paying an offer from the HTTP 402 response."
+      },
       "SyraApiKey": {
         "type": "apiKey",
         "in": "header",
         "name": "X-API-Key",
-        "description": "When API_KEY is set: also `api-key` or `Authorization: Bearer`. x402 routes do not use this."
-      }
-    },
-    "schemas": {
-      "X402AcceptOffer": {
-        "type": "object",
-        "required": [
-          "scheme",
-          "network",
-          "asset",
-          "maxAmountRequired",
-          "payTo",
-          "resource"
-        ],
-        "properties": {
-          "scheme": {
-            "type": "string",
-            "example": "exact"
-          },
-          "network": {
-            "type": "string",
-            "example": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
-          },
-          "asset": {
-            "type": "string",
-            "example": "USDC"
-          },
-          "maxAmountRequired": {
-            "type": "string",
-            "description": "Price in micro-USDC units.",
-            "example": "10000"
-          },
-          "payTo": {
-            "type": "string",
-            "example": "7YfD...TreasuryAddress"
-          },
-          "resource": {
-            "type": "string",
-            "example": "https://api.syraa.fun/signal"
-          },
-          "maxTimeoutSeconds": {
-            "type": "integer",
-            "minimum": 1,
-            "example": 300
-          },
-          "outputSchema": {
-            "type": "object",
-            "additionalProperties": true
-          }
-        },
-        "additionalProperties": true
-      },
-      "X402PaymentRequiredResponse": {
-        "type": "object",
-        "required": [
-          "accepts"
-        ],
-        "properties": {
-          "accepts": {
-            "type": "array",
-            "minItems": 1,
-            "items": {
-              "$ref": "#/components/schemas/X402AcceptOffer"
-            }
-          },
-          "error": {
-            "type": "string",
-            "example": "payment_required"
-          },
-          "message": {
-            "type": "string",
-            "example": "Payment required to access this resource."
-          }
-        },
-        "additionalProperties": true
-      }
-    },
-    "responses": {
-      "X402PaymentRequired": {
-        "description": "Payment required - x402 (Solana/Base USDC). Retry with payment proof per response body.",
-        "content": {
-          "application/json": {
-            "schema": {
-              "$ref": "#/components/schemas/X402PaymentRequiredResponse"
-            }
-          }
-        }
+        "description": "Legacy internal routes only — openapi-listed free and x402 routes do not use this."
       }
     }
+  },
+  "x-syra-pillars": {
+    "narrative": "Machine Money for Agents",
+    "pillars": [
+      "earn",
+      "treasury",
+      "invest",
+      "spend",
+      "grow"
+    ],
+    "discovery": "/pillars"
   }
 }


### PR DESCRIPTION
## Summary
- Add `providers/syra/intelligence/PAY.md` to register Syra as a finance API provider in pay-skills.
- Commit Syra OpenAPI sidecar (`providers/syra/intelligence/openapi.json`) and reference it via `openapi.path` for deterministic catalog builds.
- Include spend-aware usage guidance for signal/news/sentiment/arbitrage/X-analyzer routing.

## Test plan
- [x] `npx -y @solana/pay catalog check providers/syra/intelligence/PAY.md`
- [x] `npx -y @solana/pay catalog check . --no-probe`