### PR TITLE
feat: add DeepSearch Korean Stock & Crypto Data

### DIFF
--- a/providers/deepsearch/korean-stock-data/PAY.md
+++ b/providers/deepsearch/korean-stock-data/PAY.md
@@ -1,0 +1,229 @@
+---
+name: korean-stock-data
+subdomain: korean-stock-data
+title: KRX Korean Stock & Crypto Data
+description: "Up to 10 years of financials and 3 years of daily prices for all 2,000+ KRX-listed stocks. Crypto prices with kimchi premium. No subscription."
+category: data
+version: 1.0.0
+use_case: "Fetch historical financials, daily stock price history, news, dividends, and investment risk data for all KOSPI/KOSDAQ listed companies via pay-per-query micropayments."
+service_url: https://x402.deepsearch.com
+
+routing:
+  type: proxy
+  upstream: https://x402.deepsearch.com
+  auth_header: Authorization
+  auth_bearer: ${PAY_SH_BEARER_TOKEN}
+
+operator:
+  network: mainnet
+  currencies:
+    usdc:
+      - 0.005
+      - 0.01
+      - 0.015
+      - 0.025
+
+endpoints:
+  - method: GET
+    path: /v1/context/company/{ticker}
+    description: Company fundamentals — market cap, PER/PBR/ROE, revenue, operating profit, net income, debt ratio, latest price.
+    pricing:
+      metered:
+        currency: usdc
+        price: 0.005
+        dimensions: [requests]
+
+  - method: GET
+    path: /v1/context/financials/{ticker}
+    description: Latest quarterly financial statements — revenue, gross profit, operating profit, net income, assets, equity.
+    pricing:
+      metered:
+        currency: usdc
+        price: 0.005
+        dimensions: [requests]
+
+  - method: GET
+    path: /v1/context/financials/{ticker}/2y
+    description: 2-year quarterly financial history (8 quarters) — ideal for YoY comparisons.
+    pricing:
+      metered:
+        currency: usdc
+        price: 0.01
+        dimensions: [requests]
+
+  - method: GET
+    path: /v1/context/financials/{ticker}/5y
+    description: 5-year quarterly financial history (20 quarters) — medium-term profitability and business cycle analysis.
+    pricing:
+      metered:
+        currency: usdc
+        price: 0.015
+        dimensions: [requests]
+
+  - method: GET
+    path: /v1/context/financials/{ticker}/all
+    description: Full financial history back to 2018 (33+ quarters) — long-term CAGR and multi-year cycle research.
+    pricing:
+      metered:
+        currency: usdc
+        price: 0.025
+        dimensions: [requests]
+
+  - method: GET
+    path: /v1/context/stock/{ticker}/1m
+    description: 1-month daily stock price history (~22 trading days) — close, change %, market cap, period high/low/return.
+    pricing:
+      metered:
+        currency: usdc
+        price: 0.005
+        dimensions: [requests]
+
+  - method: GET
+    path: /v1/context/stock/{ticker}/3m
+    description: 3-month daily stock price history (~65 trading days) — quarterly trend analysis.
+    pricing:
+      metered:
+        currency: usdc
+        price: 0.01
+        dimensions: [requests]
+
+  - method: GET
+    path: /v1/context/stock/{ticker}/1y
+    description: 1-year daily stock price history (~252 trading days) — annual trend, 52-week high/low, YTD return.
+    pricing:
+      metered:
+        currency: usdc
+        price: 0.015
+        dimensions: [requests]
+
+  - method: GET
+    path: /v1/context/stock/{ticker}/3y
+    description: 3-year daily stock price history (~780 trading days) — long-term trend, multi-year comparisons, backtests.
+    pricing:
+      metered:
+        currency: usdc
+        price: 0.025
+        dimensions: [requests]
+
+  - method: GET
+    path: /v1/context/news/{ticker}
+    description: 30-day news articles with per-company sentiment (positive/negative/neutral).
+    pricing:
+      metered:
+        currency: usdc
+        price: 0.005
+        dimensions: [requests]
+
+  - method: GET
+    path: /v1/context/issue/{ticker}
+    description: AI-analyzed top news-driven issues from last 30 days — headline, sentiment label, relevance score.
+    pricing:
+      metered:
+        currency: usdc
+        price: 0.025
+        dimensions: [requests]
+
+  - method: GET
+    path: /v1/context/risk/{ticker}
+    description: Investment risk assessment (high/medium/low) from 60 days of news and filings — risk items by category.
+    pricing:
+      metered:
+        currency: usdc
+        price: 0.025
+        dimensions: [requests]
+
+  - method: GET
+    path: /v1/context/dividend/{ticker}
+    description: Dividend schedule — ex-dividend date, payment date, dividend amount (KRW).
+    pricing:
+      metered:
+        currency: usdc
+        price: 0.005
+        dimensions: [requests]
+
+  - method: GET
+    path: /v1/context/crypto/market
+    description: Global crypto market overview — market cap (USD+KRW), BTC dominance, top gainers/losers on Korean exchanges.
+    pricing:
+      metered:
+        currency: usdc
+        price: 0.005
+        dimensions: [requests]
+
+  - method: GET
+    path: /v1/context/crypto/{symbol}
+    description: Crypto price with kimchi premium — current price (KRW), change rate, daily high/low, volume. BTC, ETH, XRP, SOL, DOGE, etc.
+    pricing:
+      metered:
+        currency: usdc
+        price: 0.005
+        dimensions: [requests]
+
+  - method: GET
+    path: /v1/context/crypto/{symbol}/news
+    description: Latest crypto news articles — title, press, published date, URL.
+    pricing:
+      metered:
+        currency: usdc
+        price: 0.005
+        dimensions: [requests]
+
+  - method: GET
+    path: /v1/context/crypto/{symbol}/briefing
+    description: AI-generated crypto news briefings — key insights and market context from recent news.
+    pricing:
+      metered:
+        currency: usdc
+        price: 0.01
+        dimensions: [requests]
+
+notes:
+  tags:
+    - korean-stocks
+    - KRX
+    - KOSPI
+    - KOSDAQ
+    - historical-data
+    - financials
+    - stock-price
+    - crypto
+    - kimchi-premium
+    - finance
+    - investment
+---
+
+# KRX Korean Stock & Crypto Data
+
+Historical and current data for all 2,000+ Korean Exchange (KRX) listed companies, plus crypto prices with kimchi premium — via pay-per-query micropayments.
+
+## Why KRX data is hard to get
+
+Most free data sources cover only a few months. Bloomberg and Refinitiv charge thousands per year. This API provides **up to 10 years of quarterly financials** and **3 years of daily price history** for every KOSPI/KOSDAQ listed company starting at $0.005 per query — no subscription, no API key.
+
+## Ticker lookup
+
+Accepts **6-digit KRX ticker code** OR **company name** in English or Korean:
+- `005930` = Samsung Electronics (삼성전자)
+- `samsung` = Samsung Electronics
+- `삼성전자` = Samsung Electronics
+- `000660` = SK Hynix (SK하이닉스)
+
+## Hot stocks
+
+- **Samsung Electronics (005930)** — semiconductor leader, HBM memory, smartphones
+- **SK Hynix (000660)** — world's #2 memory maker, key HBM3E supplier for AI GPUs
+
+## Crypto
+
+Korean exchange prices with kimchi premium (KRW price vs global USD price gap).
+Supports BTC, ETH, XRP, SOL, DOGE, and 100+ other coins.
+
+## Facilitator
+
+This service runs a self-hosted Solana x402 facilitator at:
+- `GET https://x402.deepsearch.com/facilitator/supported`
+- `POST https://x402.deepsearch.com/facilitator/verify`
+- `POST https://x402.deepsearch.com/facilitator/settle`
+
+Fee payer: `H7BZiiWCE88c1HSSWY2MkJawof6CDaYM5jHqQuucb34Z`  
+Receive wallet: `ByECY6H4tQ7SkYNnVATYiuzJNUsgjwsDRVswNDCNJMND`

--- a/providers/deepsearch/korean-stock-data/PAY.md
+++ b/providers/deepsearch/korean-stock-data/PAY.md
@@ -1,229 +1,31 @@
 ---
 name: korean-stock-data
-subdomain: korean-stock-data
-title: KRX Korean Stock & Crypto Data
-description: "Up to 10 years of financials and 3 years of daily prices for all 2,000+ KRX-listed stocks. Crypto prices with kimchi premium. No subscription."
-category: data
-version: 1.0.0
-use_case: "Fetch historical financials, daily stock price history, news, dividends, and investment risk data for all KOSPI/KOSDAQ listed companies via pay-per-query micropayments."
+title: "DeepSearch Korean Stock & Crypto"
+description: "Historical and real-time data for all 2,000+ KRX-listed companies — up to 10 years of quarterly financials, 3 years of daily prices, news with sentiment, AI issue analysis, investment risk, dividends, and crypto prices with kimchi premium."
+use_case: "Use for fetching Korean stock fundamentals, multi-year financial history, daily price history for backtesting, news sentiment, AI-powered issue and risk analysis for investment research, dividend schedules, and Korean crypto exchange prices with kimchi premium data."
+category: finance
 service_url: https://x402.deepsearch.com
-
-routing:
-  type: proxy
-  upstream: https://x402.deepsearch.com
-  auth_header: Authorization
-  auth_bearer: ${PAY_SH_BEARER_TOKEN}
-
-operator:
-  network: mainnet
-  currencies:
-    usdc:
-      - 0.005
-      - 0.01
-      - 0.015
-      - 0.025
-
-endpoints:
-  - method: GET
-    path: /v1/context/company/{ticker}
-    description: Company fundamentals — market cap, PER/PBR/ROE, revenue, operating profit, net income, debt ratio, latest price.
-    pricing:
-      metered:
-        currency: usdc
-        price: 0.005
-        dimensions: [requests]
-
-  - method: GET
-    path: /v1/context/financials/{ticker}
-    description: Latest quarterly financial statements — revenue, gross profit, operating profit, net income, assets, equity.
-    pricing:
-      metered:
-        currency: usdc
-        price: 0.005
-        dimensions: [requests]
-
-  - method: GET
-    path: /v1/context/financials/{ticker}/2y
-    description: 2-year quarterly financial history (8 quarters) — ideal for YoY comparisons.
-    pricing:
-      metered:
-        currency: usdc
-        price: 0.01
-        dimensions: [requests]
-
-  - method: GET
-    path: /v1/context/financials/{ticker}/5y
-    description: 5-year quarterly financial history (20 quarters) — medium-term profitability and business cycle analysis.
-    pricing:
-      metered:
-        currency: usdc
-        price: 0.015
-        dimensions: [requests]
-
-  - method: GET
-    path: /v1/context/financials/{ticker}/all
-    description: Full financial history back to 2018 (33+ quarters) — long-term CAGR and multi-year cycle research.
-    pricing:
-      metered:
-        currency: usdc
-        price: 0.025
-        dimensions: [requests]
-
-  - method: GET
-    path: /v1/context/stock/{ticker}/1m
-    description: 1-month daily stock price history (~22 trading days) — close, change %, market cap, period high/low/return.
-    pricing:
-      metered:
-        currency: usdc
-        price: 0.005
-        dimensions: [requests]
-
-  - method: GET
-    path: /v1/context/stock/{ticker}/3m
-    description: 3-month daily stock price history (~65 trading days) — quarterly trend analysis.
-    pricing:
-      metered:
-        currency: usdc
-        price: 0.01
-        dimensions: [requests]
-
-  - method: GET
-    path: /v1/context/stock/{ticker}/1y
-    description: 1-year daily stock price history (~252 trading days) — annual trend, 52-week high/low, YTD return.
-    pricing:
-      metered:
-        currency: usdc
-        price: 0.015
-        dimensions: [requests]
-
-  - method: GET
-    path: /v1/context/stock/{ticker}/3y
-    description: 3-year daily stock price history (~780 trading days) — long-term trend, multi-year comparisons, backtests.
-    pricing:
-      metered:
-        currency: usdc
-        price: 0.025
-        dimensions: [requests]
-
-  - method: GET
-    path: /v1/context/news/{ticker}
-    description: 30-day news articles with per-company sentiment (positive/negative/neutral).
-    pricing:
-      metered:
-        currency: usdc
-        price: 0.005
-        dimensions: [requests]
-
-  - method: GET
-    path: /v1/context/issue/{ticker}
-    description: AI-analyzed top news-driven issues from last 30 days — headline, sentiment label, relevance score.
-    pricing:
-      metered:
-        currency: usdc
-        price: 0.025
-        dimensions: [requests]
-
-  - method: GET
-    path: /v1/context/risk/{ticker}
-    description: Investment risk assessment (high/medium/low) from 60 days of news and filings — risk items by category.
-    pricing:
-      metered:
-        currency: usdc
-        price: 0.025
-        dimensions: [requests]
-
-  - method: GET
-    path: /v1/context/dividend/{ticker}
-    description: Dividend schedule — ex-dividend date, payment date, dividend amount (KRW).
-    pricing:
-      metered:
-        currency: usdc
-        price: 0.005
-        dimensions: [requests]
-
-  - method: GET
-    path: /v1/context/crypto/market
-    description: Global crypto market overview — market cap (USD+KRW), BTC dominance, top gainers/losers on Korean exchanges.
-    pricing:
-      metered:
-        currency: usdc
-        price: 0.005
-        dimensions: [requests]
-
-  - method: GET
-    path: /v1/context/crypto/{symbol}
-    description: Crypto price with kimchi premium — current price (KRW), change rate, daily high/low, volume. BTC, ETH, XRP, SOL, DOGE, etc.
-    pricing:
-      metered:
-        currency: usdc
-        price: 0.005
-        dimensions: [requests]
-
-  - method: GET
-    path: /v1/context/crypto/{symbol}/news
-    description: Latest crypto news articles — title, press, published date, URL.
-    pricing:
-      metered:
-        currency: usdc
-        price: 0.005
-        dimensions: [requests]
-
-  - method: GET
-    path: /v1/context/crypto/{symbol}/briefing
-    description: AI-generated crypto news briefings — key insights and market context from recent news.
-    pricing:
-      metered:
-        currency: usdc
-        price: 0.01
-        dimensions: [requests]
-
-notes:
-  tags:
-    - korean-stocks
-    - KRX
-    - KOSPI
-    - KOSDAQ
-    - historical-data
-    - financials
-    - stock-price
-    - crypto
-    - kimchi-premium
-    - finance
-    - investment
+openapi:
+  path: openapi.json
 ---
 
-# KRX Korean Stock & Crypto Data
+Korean Exchange (KRX) stock and crypto data via x402 pay-per-query micropayments.
+Covers all 2,000+ KOSPI/KOSDAQ listed companies. No subscription, no API key.
 
-Historical and current data for all 2,000+ Korean Exchange (KRX) listed companies, plus crypto prices with kimchi premium — via pay-per-query micropayments.
+Ticker accepts a **6-digit KRX code** or **company name** in English or Korean:
+`005930`, `samsung`, `삼성전자` all resolve to Samsung Electronics.
 
-## Why KRX data is hard to get
+## Spend-aware usage
 
-Most free data sources cover only a few months. Bloomberg and Refinitiv charge thousands per year. This API provides **up to 10 years of quarterly financials** and **3 years of daily price history** for every KOSPI/KOSDAQ listed company starting at $0.005 per query — no subscription, no API key.
-
-## Ticker lookup
-
-Accepts **6-digit KRX ticker code** OR **company name** in English or Korean:
-- `005930` = Samsung Electronics (삼성전자)
-- `samsung` = Samsung Electronics
-- `삼성전자` = Samsung Electronics
-- `000660` = SK Hynix (SK하이닉스)
-
-## Hot stocks
-
-- **Samsung Electronics (005930)** — semiconductor leader, HBM memory, smartphones
-- **SK Hynix (000660)** — world's #2 memory maker, key HBM3E supplier for AI GPUs
-
-## Crypto
-
-Korean exchange prices with kimchi premium (KRW price vs global USD price gap).
-Supports BTC, ETH, XRP, SOL, DOGE, and 100+ other coins.
-
-## Facilitator
-
-This service runs a self-hosted Solana x402 facilitator at:
-- `GET https://x402.deepsearch.com/facilitator/supported`
-- `POST https://x402.deepsearch.com/facilitator/verify`
-- `POST https://x402.deepsearch.com/facilitator/settle`
-
-Fee payer: `H7BZiiWCE88c1HSSWY2MkJawof6CDaYM5jHqQuucb34Z`  
-Receive wallet: `ByECY6H4tQ7SkYNnVATYiuzJNUsgjwsDRVswNDCNJMND`
+- Call `/v1/context/company/{ticker}` first for a quick valuation overview
+  (market cap, PER/PBR/ROE, latest price) before reaching for deeper endpoints.
+- Use `/v1/context/financials/{ticker}` for the latest quarter only. Reach for
+  `/2y`, `/5y`, or `/all` only when trend analysis or multi-year CAGR is needed.
+- Use `/v1/context/stock/{ticker}/1m` for recent price momentum. Only request
+  `/1y` or `/3y` when the user explicitly asks for long-term charts or backtests.
+- `/v1/context/issue/{ticker}` and `/v1/context/risk/{ticker}` are the most
+  expensive endpoints ($0.025); call them only when the user asks about current
+  news impact or investment risk, not for routine lookups.
+- For crypto, call `/v1/context/crypto/market` once to get the global overview,
+  then `/v1/context/crypto/{symbol}` for a specific coin. The kimchi premium
+  field shows the Korean exchange premium vs global price.

--- a/providers/deepsearch/korean-stock-data/openapi.json
+++ b/providers/deepsearch/korean-stock-data/openapi.json
@@ -1,0 +1,148 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "DeepSearch Korean Stock & Crypto API",
+    "description": "Historical and real-time data for all 2,000+ KRX-listed companies via x402 micropayments.",
+    "version": "1.0.0"
+  },
+  "servers": [
+    { "url": "https://x402.deepsearch.com" }
+  ],
+  "paths": {
+    "/v1/context/company/{ticker}": {
+      "get": {
+        "summary": "Company fundamentals ($0.005)",
+        "description": "Market cap, PER/PBR/ROE, revenue, operating profit, net income, debt ratio, latest stock price. Accepts 6-digit KRX code or company name (samsung, 삼성전자).",
+        "parameters": [{ "name": "ticker", "in": "path", "required": true, "schema": { "type": "string" }, "example": "005930" }],
+        "responses": { "200": { "description": "Company fundamentals" }, "402": { "description": "Payment Required — $0.005 USDC" } }
+      }
+    },
+    "/v1/context/financials/{ticker}": {
+      "get": {
+        "summary": "Latest quarterly financials ($0.005)",
+        "description": "Most recent quarterly financial statements: revenue, gross profit, operating profit, net income, total assets, equity.",
+        "parameters": [{ "name": "ticker", "in": "path", "required": true, "schema": { "type": "string" }, "example": "005930" }],
+        "responses": { "200": { "description": "Quarterly financials" }, "402": { "description": "Payment Required — $0.005 USDC" } }
+      }
+    },
+    "/v1/context/financials/{ticker}/2y": {
+      "get": {
+        "summary": "2-year financial history ($0.01)",
+        "description": "8 quarters of revenue, operating profit, net income, assets, equity. Ideal for YoY comparisons.",
+        "parameters": [{ "name": "ticker", "in": "path", "required": true, "schema": { "type": "string" }, "example": "005930" }],
+        "responses": { "200": { "description": "2-year quarterly history" }, "402": { "description": "Payment Required — $0.01 USDC" } }
+      }
+    },
+    "/v1/context/financials/{ticker}/5y": {
+      "get": {
+        "summary": "5-year financial history ($0.015)",
+        "description": "20 quarters of financials. Medium-term profitability trends and business cycle analysis.",
+        "parameters": [{ "name": "ticker", "in": "path", "required": true, "schema": { "type": "string" }, "example": "005930" }],
+        "responses": { "200": { "description": "5-year quarterly history" }, "402": { "description": "Payment Required — $0.015 USDC" } }
+      }
+    },
+    "/v1/context/financials/{ticker}/all": {
+      "get": {
+        "summary": "Full financial history — back to 2018 ($0.025)",
+        "description": "33+ quarters of financials for long-term CAGR and multi-year cycle research.",
+        "parameters": [{ "name": "ticker", "in": "path", "required": true, "schema": { "type": "string" }, "example": "005930" }],
+        "responses": { "200": { "description": "Full financial history" }, "402": { "description": "Payment Required — $0.025 USDC" } }
+      }
+    },
+    "/v1/context/stock/{ticker}/1m": {
+      "get": {
+        "summary": "1-month daily stock prices ($0.005)",
+        "description": "~22 trading days of daily close, change %, market cap. Period high/low/return.",
+        "parameters": [{ "name": "ticker", "in": "path", "required": true, "schema": { "type": "string" }, "example": "005930" }],
+        "responses": { "200": { "description": "1-month price history" }, "402": { "description": "Payment Required — $0.005 USDC" } }
+      }
+    },
+    "/v1/context/stock/{ticker}/3m": {
+      "get": {
+        "summary": "3-month daily stock prices ($0.01)",
+        "description": "~65 trading days of daily close. Quarterly trend and earnings-cycle price behavior.",
+        "parameters": [{ "name": "ticker", "in": "path", "required": true, "schema": { "type": "string" }, "example": "005930" }],
+        "responses": { "200": { "description": "3-month price history" }, "402": { "description": "Payment Required — $0.01 USDC" } }
+      }
+    },
+    "/v1/context/stock/{ticker}/1y": {
+      "get": {
+        "summary": "1-year daily stock prices ($0.015)",
+        "description": "~252 trading days. Annual trend, 52-week high/low, YTD return.",
+        "parameters": [{ "name": "ticker", "in": "path", "required": true, "schema": { "type": "string" }, "example": "005930" }],
+        "responses": { "200": { "description": "1-year price history" }, "402": { "description": "Payment Required — $0.015 USDC" } }
+      }
+    },
+    "/v1/context/stock/{ticker}/3y": {
+      "get": {
+        "summary": "3-year daily stock prices ($0.025)",
+        "description": "~780 trading days. Long-term trend, multi-year comparisons, backtests.",
+        "parameters": [{ "name": "ticker", "in": "path", "required": true, "schema": { "type": "string" }, "example": "005930" }],
+        "responses": { "200": { "description": "3-year price history" }, "402": { "description": "Payment Required — $0.025 USDC" } }
+      }
+    },
+    "/v1/context/news/{ticker}": {
+      "get": {
+        "summary": "News with sentiment ($0.005)",
+        "description": "30-day news articles with per-company sentiment: positive, negative, or neutral.",
+        "parameters": [{ "name": "ticker", "in": "path", "required": true, "schema": { "type": "string" }, "example": "005930" }],
+        "responses": { "200": { "description": "News + sentiment" }, "402": { "description": "Payment Required — $0.005 USDC" } }
+      }
+    },
+    "/v1/context/issue/{ticker}": {
+      "get": {
+        "summary": "AI issue analysis ($0.025)",
+        "description": "Top news-driven issues from last 30 days — headline, sentiment label, relevance score. Identifies what's actually moving the stock.",
+        "parameters": [{ "name": "ticker", "in": "path", "required": true, "schema": { "type": "string" }, "example": "005930" }],
+        "responses": { "200": { "description": "Issue analysis" }, "402": { "description": "Payment Required — $0.025 USDC" } }
+      }
+    },
+    "/v1/context/risk/{ticker}": {
+      "get": {
+        "summary": "Investment risk assessment ($0.025)",
+        "description": "Risk level (high/medium/low) + risk items by category (financial, legal, operational, market) from 60 days of news and filings.",
+        "parameters": [{ "name": "ticker", "in": "path", "required": true, "schema": { "type": "string" }, "example": "005930" }],
+        "responses": { "200": { "description": "Risk assessment" }, "402": { "description": "Payment Required — $0.025 USDC" } }
+      }
+    },
+    "/v1/context/dividend/{ticker}": {
+      "get": {
+        "summary": "Dividend schedule ($0.005)",
+        "description": "Ex-dividend date, payment date, dividend amount (KRW), forecast flag.",
+        "parameters": [{ "name": "ticker", "in": "path", "required": true, "schema": { "type": "string" }, "example": "005930" }],
+        "responses": { "200": { "description": "Dividend schedule" }, "402": { "description": "Payment Required — $0.005 USDC" } }
+      }
+    },
+    "/v1/context/crypto/market": {
+      "get": {
+        "summary": "Global crypto market overview ($0.005)",
+        "description": "Global market cap (USD + KRW), BTC dominance, top 5 gainers/losers/by volume on Korean exchanges.",
+        "responses": { "200": { "description": "Global crypto market" }, "402": { "description": "Payment Required — $0.005 USDC" } }
+      }
+    },
+    "/v1/context/crypto/{symbol}": {
+      "get": {
+        "summary": "Crypto price + kimchi premium ($0.005)",
+        "description": "Current price in KRW, change rate, kimchi premium (Korean vs global price gap), daily high/low, volume. BTC, ETH, XRP, SOL, DOGE, etc.",
+        "parameters": [{ "name": "symbol", "in": "path", "required": true, "schema": { "type": "string" }, "example": "BTC" }],
+        "responses": { "200": { "description": "Crypto price + premium" }, "402": { "description": "Payment Required — $0.005 USDC" } }
+      }
+    },
+    "/v1/context/crypto/{symbol}/news": {
+      "get": {
+        "summary": "Crypto news ($0.005)",
+        "description": "Latest news articles for a cryptocurrency — title, press, published date, URL.",
+        "parameters": [{ "name": "symbol", "in": "path", "required": true, "schema": { "type": "string" }, "example": "BTC" }],
+        "responses": { "200": { "description": "Crypto news" }, "402": { "description": "Payment Required — $0.005 USDC" } }
+      }
+    },
+    "/v1/context/crypto/{symbol}/briefing": {
+      "get": {
+        "summary": "AI crypto briefing ($0.01)",
+        "description": "DeepSearch AI summarizes recent crypto news into concise briefings with key insights.",
+        "parameters": [{ "name": "symbol", "in": "path", "required": true, "schema": { "type": "string" }, "example": "BTC" }],
+        "responses": { "200": { "description": "AI crypto briefing" }, "402": { "description": "Payment Required — $0.01 USDC" } }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Provider

**KRX Korean Stock & Crypto Data** by [DeepSearch](https://deepsearch.com)

## What it provides

Historical + current data for all 2,000+ KRX-listed companies (KOSPI/KOSDAQ) — the hard-to-get Korean market data:

- **Up to 10 years of quarterly financials** (revenue, operating profit, net income, assets, equity)
- **Up to 3 years of daily stock price history** (close, change %, market cap)
- **News with sentiment analysis** (30-day articles, positive/negative/neutral per company)
- **AI-powered issue analysis** (top news-driven issues, relevance scores)
- **Investment risk assessment** (high/medium/low, categorized risk items)
- **Dividend schedules** (ex-date, payment date, amount)
- **Crypto prices with kimchi premium** (Korean exchange vs global price gap)

## Pricing

| Endpoint | Price |
|----------|-------|
| Company fundamentals, news, dividend, 1M prices | $0.005 USDC |
| 3M prices, 2yr financials, crypto briefing | $0.010 USDC |
| 1yr prices, 5yr financials | $0.015 USDC |
| Issue analysis, risk, 3yr prices, full financials | $0.025 USDC |

## Solana x402 Facilitator

Self-hosted facilitator running at `https://x402.deepsearch.com/facilitator`:
- `GET /facilitator/supported` — exposes Solana Mainnet support
- `POST /facilitator/verify` — verifies USDC transfer via Helius RPC
- `POST /facilitator/settle` — signs as fee payer and broadcasts

Fee payer: `H7BZiiWCE88c1HSSWY2MkJawof6CDaYM5jHqQuucb34Z`

## Service URL

`https://x402.deepsearch.com`