### PR TITLE
Add IDLE Protocol — Distributed Residential Compute Network

### DIFF
--- a/providers/idle-protocol/compute/PAY.md
+++ b/providers/idle-protocol/compute/PAY.md
@@ -1,0 +1,30 @@
+---
+name: compute
+title: "IDLE Protocol"
+description: "Distributed residential compute network on Solana. Access residential IPs for web scraping, DNS/SSL checks, latency measurement, price extraction, content verification, change detection, data queries, and AI agent task routing via x402 micropayments."
+use_case: "Use for web scraping from residential IPs, API health monitoring, DNS resolution, SSL verification, response time measurement, price extraction, stock checks, content verification, change detection, data queries, and AI agent task routing."
+category: compute
+service_url: https://gateway.earnidle.com
+openapi:
+  path: openapi.json
+---
+
+Distributed residential compute network on Solana. 14 paid endpoints across
+three tiers ($0.001–$0.005 per request) route tasks to distributed nodes
+running on residential IPs. All endpoints use x402 payment in USDC on Solana
+mainnet. The free `/health` endpoint checks gateway status without payment.
+
+## Spend-aware usage
+
+- Prefer `v1/compute/fetch` ($0.002) over `v1/compute/scrape` ($0.005) when
+  you only need status codes or headers.
+- Use `v1/compute/extract` with a CSS selector instead of scraping full HTML
+  when you need one element from a page.
+- Use `v1/compute/changes` to detect changes before pulling fresh data with
+  `v1/compute/price` — avoids paying for unchanged pages.
+- `v1/data/query` accepts natural language — use it for structured data lookups
+  instead of scraping and parsing HTML.
+- Use `v1/compute/dns` ($0.001) and `v1/compute/ssl` ($0.001) for lightweight
+  domain checks before committing to a full fetch or scrape.
+- Use `v1/compute/verify` ($0.003) to confirm content exists before paying for
+  a full scrape — avoids wasted calls on pages behind auth walls.

--- a/providers/idle-protocol/compute/PAY.md
+++ b/providers/idle-protocol/compute/PAY.md
@@ -1,23 +1,34 @@
 ---
 name: compute
 title: "IDLE Protocol"
-description: "Distributed residential compute network on Solana. Access residential IPs for web scraping, DNS/SSL checks, latency measurement, price extraction, content verification, change detection, data queries, and AI agent task routing via x402 micropayments."
-use_case: "Use for web scraping from residential IPs, API health monitoring, DNS resolution, SSL verification, response time measurement, price extraction, stock checks, content verification, change detection, data queries, and AI agent task routing."
+description: "Distributed compute & AI inference network on Solana. Access residential IPs for web scraping, DNS/SSL checks, latency measurement, price extraction, content verification, change detection, data queries, AI agent task routing, and multi-model AI inference (Claude, Gemini, Llama, Mistral) via x402 micropayments."
+use_case: "Use for AI inference (OpenAI-compatible chat completions with 21 models at $0.001/req), web scraping from residential IPs, API health monitoring, DNS resolution, SSL verification, response time measurement, price extraction, stock checks, content verification, change detection, data queries, and AI agent task routing."
 category: compute
-service_url: https://gateway.earnidle.com
+service_url: https://api.earnidle.com
 openapi:
   path: openapi.json
 ---
 
-Distributed residential compute network on Solana. 14 paid endpoints across
-three tiers ($0.001–$0.005 per request) route tasks to distributed nodes
-running on residential IPs. All endpoints use x402 payment in USDC on Solana
-mainnet. The free `GET /health` endpoint checks gateway status without
-payment — do not confuse it with the paid `POST /v1/compute/health` ($0.002),
-which checks external API endpoints from residential IPs.
+Distributed compute and AI inference network on Solana. 15 paid endpoints
+across four tiers ($0.001–$0.005 per request) route tasks to distributed
+nodes. All endpoints use x402 payment in USDC on Solana mainnet.
+
+The `v1/chat/completions` endpoint is OpenAI-compatible — change the base URL
+and existing SDKs work. 21 models including Claude Sonnet, Claude Haiku,
+Gemini 3.5 Flash, Llama 3.2, Mistral, and NVIDIA NIM models at $0.001/request.
+Use `GET /v1/models` (free) to list available models.
+
+The free `GET /health` endpoint checks gateway status without payment — do not
+confuse it with the paid `POST /v1/compute/health` ($0.002), which checks
+external API endpoints from residential IPs.
 
 ## Spend-aware usage
 
+- Use `v1/chat/completions` ($0.001) for any LLM task — cheapest endpoint and
+  OpenAI-compatible. Prefer `claude-haiku` for fast/cheap, `claude-sonnet` for
+  quality.
+- Use `GET /v1/models` (free) to discover available models before calling
+  chat/completions.
 - Use `GET /health` (free) to check if the IDLE gateway is up. Use
   `v1/compute/health` ($0.002) only when you need to test an external URL
   from a residential IP.

--- a/providers/idle-protocol/compute/PAY.md
+++ b/providers/idle-protocol/compute/PAY.md
@@ -12,10 +12,15 @@ openapi:
 Distributed residential compute network on Solana. 14 paid endpoints across
 three tiers ($0.001–$0.005 per request) route tasks to distributed nodes
 running on residential IPs. All endpoints use x402 payment in USDC on Solana
-mainnet. The free `/health` endpoint checks gateway status without payment.
+mainnet. The free `GET /health` endpoint checks gateway status without
+payment — do not confuse it with the paid `POST /v1/compute/health` ($0.002),
+which checks external API endpoints from residential IPs.
 
 ## Spend-aware usage
 
+- Use `GET /health` (free) to check if the IDLE gateway is up. Use
+  `v1/compute/health` ($0.002) only when you need to test an external URL
+  from a residential IP.
 - Prefer `v1/compute/fetch` ($0.002) over `v1/compute/scrape` ($0.005) when
   you only need status codes or headers.
 - Use `v1/compute/extract` with a CSS selector instead of scraping full HTML

--- a/providers/idle-protocol/compute/openapi.json
+++ b/providers/idle-protocol/compute/openapi.json
@@ -1132,7 +1132,7 @@
         "properties": {
           "task_id": {
             "type": "string",
-            "description": "Unique task identifier for reference."
+            "description": "Correlation ID for logging. This is not a polling handle — results are returned synchronously in the same response."
           },
           "status": {
             "type": "string",

--- a/providers/idle-protocol/compute/openapi.json
+++ b/providers/idle-protocol/compute/openapi.json
@@ -1,0 +1,1109 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "IDLE Protocol \u2014 Distributed Residential Compute API",
+    "version": "3.0.0",
+    "description": "Distributed residential compute network on Solana. AI agents pay per-request in USDC via x402 to access residential IPs for web scraping, monitoring, DNS/SSL checks, price extraction, content verification, change detection, natural language data queries, and AI agent task routing. 14 paid endpoints across 3 tiers ($0.001\u2013$0.005 per request).\n\n**Tier 1 \u2014 Basic Monitoring** ($0.001\u2013$0.002): fetch, health, dns, ssl, latency\n**Tier 2 \u2014 Web Intelligence** ($0.003\u2013$0.005): scrape, extract, links, price, availability, verify, changes\n**Tier 3 \u2014 Data & Agents** ($0.005): data/query, agent/task\n\nPrefer fetch ($0.002) over scrape ($0.005) when you only need status codes or headers. Use extract with a CSS selector instead of scraping full HTML. Use changes to detect updates before pulling fresh data with price."
+  },
+  "servers": [
+    {
+      "url": "https://gateway.earnidle.com"
+    }
+  ],
+  "paths": {
+    "/v1/compute/fetch": {
+      "post": {
+        "operationId": "httpFetch",
+        "summary": "Fetch any URL from a residential IP",
+        "description": "Fetch any URL from a residential IP. Returns status code, headers, and response body. Use this instead of scrape when you only need status codes or headers.",
+        "tags": [
+          "Basic Monitoring"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UrlRequest"
+              },
+              "example": {
+                "url": "https://example.com"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Fetch result with status code, headers, and body.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FetchResponse"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required. Returns x402 challenge with USDC amount.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentChallenge"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/compute/health": {
+      "post": {
+        "operationId": "apiHealth",
+        "summary": "API endpoint health check from a residential IP",
+        "description": "Check any API endpoint health from a residential IP. Verifies status code, response body, and latency.",
+        "tags": [
+          "Basic Monitoring"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UrlRequest"
+              },
+              "example": {
+                "url": "https://api.example.com/health"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Health check result with status, latency, and body preview.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HealthResponse"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentChallenge"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/compute/dns": {
+      "post": {
+        "operationId": "dnsLookup",
+        "summary": "Resolve domain DNS records from a residential IP",
+        "description": "Resolve domain DNS records (A, AAAA, MX, TXT, NS) from a residential IP.",
+        "tags": [
+          "Basic Monitoring"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DomainRequest"
+              },
+              "example": {
+                "domain": "example.com"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "DNS records for the domain.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DnsResponse"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentChallenge"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/compute/ssl": {
+      "post": {
+        "operationId": "sslCheck",
+        "summary": "Verify SSL certificate validity and expiry for any domain",
+        "description": "Verify SSL certificate validity, expiry date, and issuer for any domain.",
+        "tags": [
+          "Basic Monitoring"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DomainRequest"
+              },
+              "example": {
+                "domain": "example.com"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "SSL certificate details.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SslResponse"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentChallenge"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/compute/latency": {
+      "post": {
+        "operationId": "responseTime",
+        "summary": "Measure endpoint response time from residential IPs",
+        "description": "Measure endpoint response time with p50/p95/avg from residential IPs.",
+        "tags": [
+          "Basic Monitoring"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UrlRequest"
+              },
+              "example": {
+                "url": "https://api.example.com"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Latency measurements.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LatencyResponse"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentChallenge"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/compute/scrape": {
+      "post": {
+        "operationId": "htmlScrape",
+        "summary": "Scrape full HTML from any URL via residential IP",
+        "description": "Scrape full HTML from any URL via residential IP. Returns page title, extracted text, and raw HTML.",
+        "tags": [
+          "Web Intelligence"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UrlRequest"
+              },
+              "example": {
+                "url": "https://example.com"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Scraped page content.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ScrapeResponse"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentChallenge"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/compute/extract": {
+      "post": {
+        "operationId": "elementExtract",
+        "summary": "Extract specific elements from any page using CSS selectors",
+        "description": "Extract specific elements from any page using CSS selectors. Returns structured data for each matched element.",
+        "tags": [
+          "Web Intelligence"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ExtractRequest"
+              },
+              "example": {
+                "url": "https://example.com",
+                "selector": "h1"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Extracted elements.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExtractResponse"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentChallenge"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/compute/links": {
+      "post": {
+        "operationId": "linkExtract",
+        "summary": "Extract all links from a page with anchor text and type",
+        "description": "Extract all links from a page with href, anchor text, and type classification (internal, external, mailto, etc.).",
+        "tags": [
+          "Web Intelligence"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UrlRequest"
+              },
+              "example": {
+                "url": "https://example.com"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Extracted links.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LinksResponse"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentChallenge"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/compute/price": {
+      "post": {
+        "operationId": "priceExtract",
+        "summary": "Extract current price and currency from any product page",
+        "description": "Extract current price and currency from any product page. Returns the detected price, currency, and confidence score.",
+        "tags": [
+          "Web Intelligence"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UrlRequest"
+              },
+              "example": {
+                "url": "https://www.amazon.com/dp/B0EXAMPLE"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Extracted price data.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PriceResponse"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentChallenge"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/compute/availability": {
+      "post": {
+        "operationId": "availabilityCheck",
+        "summary": "Check if a product is in stock on any e-commerce page",
+        "description": "Check if a product is in stock on any e-commerce page. Returns stock status and any detected quantity or variant info.",
+        "tags": [
+          "Web Intelligence"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UrlRequest"
+              },
+              "example": {
+                "url": "https://www.amazon.com/dp/B0EXAMPLE"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Availability result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AvailabilityResponse"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentChallenge"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/compute/verify": {
+      "post": {
+        "operationId": "contentVerify",
+        "summary": "Verify that a page contains specific text or matches a pattern",
+        "description": "Verify that a page contains specific text, matches a regex, or has a specific CSS selector present.",
+        "tags": [
+          "Web Intelligence"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VerifyRequest"
+              },
+              "example": {
+                "url": "https://example.com",
+                "text": "Example Domain"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Verification result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VerifyResponse"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentChallenge"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/compute/changes": {
+      "post": {
+        "operationId": "changeDetect",
+        "summary": "Detect if page content has changed since last check",
+        "description": "Detect if page content has changed since last check. Returns SHA-256 hash of current content and a diff preview if changed.",
+        "tags": [
+          "Web Intelligence"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ChangesRequest"
+              },
+              "example": {
+                "url": "https://example.com"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Change detection result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChangesResponse"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentChallenge"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/data/query": {
+      "post": {
+        "operationId": "dataQuery",
+        "summary": "Natural language query against any IDLE-connected data source",
+        "description": "Query any IDLE-connected data source using natural language and receive structured results.",
+        "tags": [
+          "Data & Agents"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/QueryRequest"
+              },
+              "example": {
+                "query": "What is the current price of SOL?"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Query result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QueryResponse"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentChallenge"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/agent/task": {
+      "post": {
+        "operationId": "agentTask",
+        "summary": "Route a task to any registered IDLE agent by capability",
+        "description": "Route a task to any registered IDLE agent by capability. Describe what you need done and the network matches it to an available agent.",
+        "tags": [
+          "Data & Agents"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TaskRequest"
+              },
+              "example": {
+                "task": "Check if solana.com SSL certificate expires within 30 days"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Task result from the matched agent.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TaskResponse"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentChallenge"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/health": {
+      "get": {
+        "operationId": "gatewayHealth",
+        "summary": "Gateway health check (free, no payment required)",
+        "description": "Check if the IDLE Protocol gateway is operational. Free endpoint, no x402 payment required.",
+        "tags": [
+          "Free"
+        ],
+        "responses": {
+          "200": {
+            "description": "Gateway status.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "service": {
+                      "type": "string"
+                    },
+                    "version": {
+                      "type": "string"
+                    },
+                    "x402": {
+                      "type": "boolean"
+                    },
+                    "ts": {
+                      "type": "integer"
+                    }
+                  }
+                },
+                "example": {
+                  "ok": true,
+                  "service": "idle-gateway-upstream",
+                  "version": "v3",
+                  "x402": true,
+                  "ts": 1717459200000
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "UrlRequest": {
+        "type": "object",
+        "required": [
+          "url"
+        ],
+        "properties": {
+          "url": {
+            "type": "string",
+            "format": "uri",
+            "description": "The URL to fetch, scrape, or check."
+          }
+        }
+      },
+      "DomainRequest": {
+        "type": "object",
+        "required": [
+          "domain"
+        ],
+        "properties": {
+          "domain": {
+            "type": "string",
+            "description": "The domain name to look up (e.g. example.com)."
+          }
+        }
+      },
+      "ExtractRequest": {
+        "type": "object",
+        "required": [
+          "url",
+          "selector"
+        ],
+        "properties": {
+          "url": {
+            "type": "string",
+            "format": "uri",
+            "description": "The URL to extract elements from."
+          },
+          "selector": {
+            "type": "string",
+            "description": "CSS selector to match elements."
+          }
+        }
+      },
+      "VerifyRequest": {
+        "type": "object",
+        "required": [
+          "url"
+        ],
+        "properties": {
+          "url": {
+            "type": "string",
+            "format": "uri",
+            "description": "The URL to verify content on."
+          },
+          "text": {
+            "type": "string",
+            "description": "Text string to search for on the page."
+          },
+          "regex": {
+            "type": "string",
+            "description": "Regex pattern to match against page content."
+          },
+          "selector": {
+            "type": "string",
+            "description": "CSS selector that must be present on the page."
+          }
+        }
+      },
+      "ChangesRequest": {
+        "type": "object",
+        "required": [
+          "url"
+        ],
+        "properties": {
+          "url": {
+            "type": "string",
+            "format": "uri",
+            "description": "The URL to check for content changes."
+          },
+          "previous_hash": {
+            "type": "string",
+            "description": "SHA-256 hash from a previous check to compare against."
+          }
+        }
+      },
+      "QueryRequest": {
+        "type": "object",
+        "required": [
+          "query"
+        ],
+        "properties": {
+          "query": {
+            "type": "string",
+            "description": "Natural language question to answer from connected data sources."
+          }
+        }
+      },
+      "TaskRequest": {
+        "type": "object",
+        "required": [
+          "task"
+        ],
+        "properties": {
+          "task": {
+            "type": "string",
+            "description": "Description of the task to route to an available IDLE agent."
+          }
+        }
+      },
+      "PaymentChallenge": {
+        "type": "object",
+        "properties": {
+          "x402Version": {
+            "type": "integer"
+          },
+          "error": {
+            "type": "string"
+          },
+          "accepts": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "scheme": {
+                  "type": "string"
+                },
+                "network": {
+                  "type": "string"
+                },
+                "maxAmountRequired": {
+                  "type": "string"
+                },
+                "asset": {
+                  "type": "string"
+                },
+                "payTo": {
+                  "type": "string"
+                },
+                "resource": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "mimeType": {
+                  "type": "string"
+                },
+                "maxTimeoutSeconds": {
+                  "type": "integer"
+                }
+              }
+            }
+          }
+        }
+      },
+      "FetchResponse": {
+        "type": "object",
+        "properties": {
+          "status_code": {
+            "type": "integer"
+          },
+          "headers": {
+            "type": "object"
+          },
+          "body": {
+            "type": "string"
+          }
+        }
+      },
+      "HealthResponse": {
+        "type": "object",
+        "properties": {
+          "status_code": {
+            "type": "integer"
+          },
+          "latency_ms": {
+            "type": "number"
+          },
+          "body_preview": {
+            "type": "string"
+          },
+          "healthy": {
+            "type": "boolean"
+          }
+        }
+      },
+      "DnsResponse": {
+        "type": "object",
+        "properties": {
+          "records": {
+            "type": "object",
+            "properties": {
+              "A": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "AAAA": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "MX": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "TXT": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "NS": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "SslResponse": {
+        "type": "object",
+        "properties": {
+          "valid": {
+            "type": "boolean"
+          },
+          "issuer": {
+            "type": "string"
+          },
+          "expires": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "days_remaining": {
+            "type": "integer"
+          }
+        }
+      },
+      "LatencyResponse": {
+        "type": "object",
+        "properties": {
+          "p50_ms": {
+            "type": "number"
+          },
+          "p95_ms": {
+            "type": "number"
+          },
+          "avg_ms": {
+            "type": "number"
+          },
+          "samples": {
+            "type": "integer"
+          }
+        }
+      },
+      "ScrapeResponse": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "text": {
+            "type": "string"
+          },
+          "html": {
+            "type": "string"
+          }
+        }
+      },
+      "ExtractResponse": {
+        "type": "object",
+        "properties": {
+          "elements": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "tag": {
+                  "type": "string"
+                },
+                "text": {
+                  "type": "string"
+                },
+                "html": {
+                  "type": "string"
+                },
+                "attributes": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      },
+      "LinksResponse": {
+        "type": "object",
+        "properties": {
+          "links": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "href": {
+                  "type": "string"
+                },
+                "text": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "PriceResponse": {
+        "type": "object",
+        "properties": {
+          "price": {
+            "type": "number"
+          },
+          "currency": {
+            "type": "string"
+          },
+          "confidence": {
+            "type": "number"
+          }
+        }
+      },
+      "AvailabilityResponse": {
+        "type": "object",
+        "properties": {
+          "in_stock": {
+            "type": "boolean"
+          },
+          "quantity": {
+            "type": "integer"
+          },
+          "variants": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "VerifyResponse": {
+        "type": "object",
+        "properties": {
+          "verified": {
+            "type": "boolean"
+          },
+          "matches": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "ChangesResponse": {
+        "type": "object",
+        "properties": {
+          "changed": {
+            "type": "boolean"
+          },
+          "hash": {
+            "type": "string"
+          },
+          "diff_preview": {
+            "type": "string"
+          }
+        }
+      },
+      "QueryResponse": {
+        "type": "object",
+        "properties": {
+          "result": {
+            "type": "string"
+          },
+          "sources": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "TaskResponse": {
+        "type": "object",
+        "properties": {
+          "task_id": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "result": {
+            "type": "string"
+          },
+          "agent_id": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/providers/idle-protocol/compute/openapi.json
+++ b/providers/idle-protocol/compute/openapi.json
@@ -758,7 +758,24 @@
             "type": "string",
             "description": "CSS selector that must be present on the page."
           }
-        }
+        },
+        "anyOf": [
+          {
+            "required": [
+              "text"
+            ]
+          },
+          {
+            "required": [
+              "regex"
+            ]
+          },
+          {
+            "required": [
+              "selector"
+            ]
+          }
+        ]
       },
       "ChangesRequest": {
         "type": "object",
@@ -1089,18 +1106,30 @@
       },
       "TaskResponse": {
         "type": "object",
+        "required": [
+          "result",
+          "status"
+        ],
         "properties": {
           "task_id": {
-            "type": "string"
+            "type": "string",
+            "description": "Unique task identifier for reference."
           },
           "status": {
-            "type": "string"
+            "type": "string",
+            "enum": [
+              "completed",
+              "failed"
+            ],
+            "description": "Task status. Results are returned synchronously."
           },
           "result": {
-            "type": "string"
+            "type": "string",
+            "description": "The task result."
           },
           "agent_id": {
-            "type": "string"
+            "type": "string",
+            "description": "ID of the agent that processed the task."
           }
         }
       }

--- a/providers/idle-protocol/compute/openapi.json
+++ b/providers/idle-protocol/compute/openapi.json
@@ -754,30 +754,19 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": ["ok", "service", "version", "x402", "ts"],
+                  "required": ["ok", "ts"],
                   "properties": {
                     "ok": {
                       "type": "boolean"
                     },
-                    "service": {
-                      "type": "string"
-                    },
-                    "version": {
-                      "type": "string"
-                    },
-                    "x402": {
-                      "type": "boolean"
-                    },
                     "ts": {
-                      "type": "integer"
+                      "type": "integer",
+                      "description": "Unix timestamp in milliseconds"
                     }
                   }
                 },
                 "example": {
                   "ok": true,
-                  "service": "idle-gateway-upstream",
-                  "version": "v3",
-                  "x402": true,
                   "ts": 1717459200000
                 }
               }
@@ -1033,7 +1022,10 @@
                 "id": { "type": "string" },
                 "object": { "type": "string" },
                 "created": { "type": "integer" },
-                "owned_by": { "type": "string" }
+                "owned_by": { "type": "string" },
+                "permission": { "type": "array", "items": {} },
+                "root": { "type": "string" },
+                "parent": { "type": ["string", "null"] }
               }
             }
           }
@@ -1094,298 +1086,268 @@
       },
       "FetchResponse": {
         "type": "object",
-        "required": ["status_code", "body"],
+        "required": ["status", "result"],
         "properties": {
-          "status_code": {
-            "type": "integer"
-          },
-          "headers": {
-            "type": "object"
-          },
-          "body": {
-            "type": "string"
+          "status": { "type": "string", "enum": ["completed", "failed"] },
+          "result": {
+            "type": "object",
+            "required": ["success"],
+            "properties": {
+              "success": { "type": "boolean" },
+              "status": { "type": "integer", "description": "HTTP status code of the fetched URL" },
+              "body": { "type": "string", "description": "Response body text" },
+              "latency_ms": { "type": "number" }
+            }
           }
         }
       },
       "HealthResponse": {
         "type": "object",
-        "required": ["status_code", "healthy", "latency_ms"],
+        "required": ["status", "result"],
         "properties": {
-          "status_code": {
-            "type": "integer"
-          },
-          "latency_ms": {
-            "type": "number"
-          },
-          "body_preview": {
-            "type": "string"
-          },
-          "healthy": {
-            "type": "boolean"
+          "status": { "type": "string", "enum": ["completed", "failed"] },
+          "result": {
+            "type": "object",
+            "required": ["success", "healthy"],
+            "properties": {
+              "success": { "type": "boolean" },
+              "healthy": { "type": "boolean" },
+              "status": { "type": "integer", "description": "HTTP status code" },
+              "status_ok": { "type": "boolean" },
+              "body_ok": { "type": "boolean" },
+              "latency_ms": { "type": "number" },
+              "body_preview": { "type": "string" },
+              "error": { "type": "string", "description": "Error message if health check failed" }
+            }
           }
         }
       },
       "DnsResponse": {
         "type": "object",
-        "required": ["records"],
+        "required": ["status", "result"],
         "properties": {
-          "records": {
+          "status": { "type": "string", "enum": ["completed", "failed"] },
+          "result": {
             "type": "object",
+            "required": ["success", "records"],
             "properties": {
-              "A": {
+              "success": { "type": "boolean" },
+              "hostname": { "type": "string" },
+              "type": { "type": "string", "description": "Record type queried (e.g. A)" },
+              "records": {
                 "type": "array",
-                "items": {
-                  "type": "string"
-                }
+                "items": { "type": "string" },
+                "description": "Resolved DNS records"
               },
-              "AAAA": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
-              "MX": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
-              "TXT": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
-              "NS": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              }
+              "latency_ms": { "type": "number" }
             }
           }
         }
       },
       "SslResponse": {
         "type": "object",
-        "required": ["valid", "issuer", "expires", "days_remaining"],
+        "required": ["status", "result"],
         "properties": {
-          "valid": {
-            "type": "boolean"
-          },
-          "issuer": {
-            "type": "string"
-          },
-          "expires": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "days_remaining": {
-            "type": "integer"
+          "status": { "type": "string", "enum": ["completed", "failed"] },
+          "result": {
+            "type": "object",
+            "required": ["success", "valid"],
+            "properties": {
+              "success": { "type": "boolean" },
+              "hostname": { "type": "string" },
+              "valid": { "type": "boolean" },
+              "issuer": { "type": "string" },
+              "subject": { "type": "string" },
+              "expires_at": { "type": "string", "description": "Certificate expiry date" },
+              "days_until_expiry": { "type": "integer" },
+              "expired": { "type": "boolean" },
+              "latency_ms": { "type": "number" }
+            }
           }
         }
       },
       "LatencyResponse": {
         "type": "object",
-        "required": ["avg_ms", "samples", "p50_ms", "p95_ms"],
+        "required": ["status", "result"],
         "properties": {
-          "p50_ms": {
-            "type": "number"
-          },
-          "p95_ms": {
-            "type": "number"
-          },
-          "avg_ms": {
-            "type": "number"
-          },
-          "samples": {
-            "type": "integer"
+          "status": { "type": "string", "enum": ["completed", "failed"] },
+          "result": {
+            "type": "object",
+            "required": ["success", "avg_ms", "iterations"],
+            "properties": {
+              "success": { "type": "boolean" },
+              "url": { "type": "string" },
+              "status": { "type": "integer", "description": "HTTP status code" },
+              "p50_ms": { "type": "number" },
+              "min_ms": { "type": "number" },
+              "max_ms": { "type": "number" },
+              "avg_ms": { "type": "number" },
+              "iterations": { "type": "integer", "description": "Number of measurement iterations" }
+            }
           }
         }
       },
       "ScrapeResponse": {
         "type": "object",
-        "required": ["title", "text"],
+        "required": ["status", "result"],
         "properties": {
-          "title": {
-            "type": "string"
-          },
-          "text": {
-            "type": "string"
-          },
-          "html": {
-            "type": "string"
+          "status": { "type": "string", "enum": ["completed", "failed"] },
+          "result": {
+            "type": "object",
+            "required": ["success"],
+            "properties": {
+              "success": { "type": "boolean" },
+              "status": { "type": "integer", "description": "HTTP status code" },
+              "title": { "type": "string" },
+              "text": { "type": "string", "description": "Extracted text content" },
+              "html": { "type": "string", "description": "Raw HTML" },
+              "latency_ms": { "type": "number" }
+            }
           }
         }
       },
       "ExtractResponse": {
         "type": "object",
-        "required": ["elements"],
+        "required": ["status", "result"],
         "properties": {
-          "elements": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "tag": {
-                  "type": "string"
-                },
-                "text": {
-                  "type": "string"
-                },
-                "html": {
-                  "type": "string"
-                },
-                "attributes": {
-                  "type": "object"
-                }
-              }
+          "status": { "type": "string", "enum": ["completed", "failed"] },
+          "result": {
+            "type": "object",
+            "required": ["success"],
+            "properties": {
+              "success": { "type": "boolean" },
+              "extracted": { "type": "object", "description": "Extracted elements keyed by selector match" },
+              "latency_ms": { "type": "number" }
             }
           }
         }
       },
       "LinksResponse": {
         "type": "object",
-        "required": ["links"],
+        "required": ["status", "result"],
         "properties": {
-          "links": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "href": {
-                  "type": "string"
-                },
-                "text": {
-                  "type": "string"
-                },
-                "type": {
-                  "type": "string"
+          "status": { "type": "string", "enum": ["completed", "failed"] },
+          "result": {
+            "type": "object",
+            "required": ["success", "links"],
+            "properties": {
+              "success": { "type": "boolean" },
+              "links": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "href": { "type": "string" },
+                    "text": { "type": "string" },
+                    "type": { "type": "string", "description": "Link type: internal, external, mailto, etc." }
+                  }
                 }
-              }
+              },
+              "total": { "type": "integer", "description": "Total number of links found" },
+              "latency_ms": { "type": "number" }
             }
           }
         }
       },
       "PriceResponse": {
         "type": "object",
-        "required": ["price", "currency"],
+        "required": ["status", "result"],
         "properties": {
-          "price": {
-            "type": "number"
-          },
-          "currency": {
-            "type": "string"
-          },
-          "confidence": {
-            "type": "number"
+          "status": { "type": "string", "enum": ["completed", "failed"] },
+          "result": {
+            "type": "object",
+            "required": ["success"],
+            "properties": {
+              "success": { "type": "boolean" },
+              "price": { "type": ["number", "null"], "description": "Detected price, null if not found" },
+              "currency": { "type": ["string", "null"], "description": "Currency code, null if not detected" },
+              "raw": { "type": ["string", "null"], "description": "Raw price text from the page" },
+              "latency_ms": { "type": "number" }
+            }
           }
         }
       },
       "AvailabilityResponse": {
         "type": "object",
-        "required": ["in_stock"],
+        "required": ["status", "result"],
         "properties": {
-          "in_stock": {
-            "type": "boolean"
-          },
-          "quantity": {
-            "type": "integer"
-          },
-          "variants": {
-            "type": "array",
-            "items": {
-              "type": "string"
+          "status": { "type": "string", "enum": ["completed", "failed"] },
+          "result": {
+            "type": "object",
+            "required": ["success"],
+            "properties": {
+              "success": { "type": "boolean" },
+              "in_stock": { "type": ["boolean", "null"], "description": "Whether product is in stock, null if indeterminate" },
+              "latency_ms": { "type": "number" }
             }
           }
         }
       },
       "VerifyResponse": {
         "type": "object",
-        "required": ["verified"],
+        "required": ["status", "result"],
         "properties": {
-          "verified": {
-            "type": "boolean"
-          },
-          "matches": {
-            "type": "array",
-            "items": {
-              "type": "string"
+          "status": { "type": "string", "enum": ["completed", "failed"] },
+          "result": {
+            "type": "object",
+            "required": ["success", "found"],
+            "properties": {
+              "success": { "type": "boolean" },
+              "found": { "type": "boolean", "description": "Whether the content was found on the page" },
+              "matched_text": { "type": "string", "description": "The matched text on the page" },
+              "status": { "type": "integer", "description": "HTTP status code" },
+              "latency_ms": { "type": "number" }
             }
           }
         }
       },
       "ChangesResponse": {
         "type": "object",
-        "required": ["changed", "hash"],
+        "required": ["status", "result"],
         "properties": {
-          "changed": {
-            "type": "boolean"
-          },
-          "hash": {
-            "type": "string"
-          },
-          "diff_preview": {
-            "type": "string"
+          "status": { "type": "string", "enum": ["completed", "failed"] },
+          "result": {
+            "type": "object",
+            "required": ["success", "hash"],
+            "properties": {
+              "success": { "type": "boolean" },
+              "hash": { "type": "string", "description": "SHA-256 hash of current content" },
+              "changed": { "type": ["boolean", "null"], "description": "Whether content changed since previous_hash, null on first check" },
+              "content_length": { "type": "integer" },
+              "content_preview": { "type": "string", "description": "Preview of current content" },
+              "latency_ms": { "type": "number" }
+            }
           }
         }
       },
       "QueryResponse": {
         "type": "object",
-        "required": ["success", "answer", "source", "freshness"],
+        "required": ["status", "result"],
         "properties": {
-          "success": {
-            "type": "boolean"
-          },
-          "answer": {
-            "type": "string",
-            "description": "Human-readable answer to the query."
-          },
-          "data": {
+          "status": { "type": "string", "enum": ["completed", "failed"] },
+          "result": {
             "type": "object",
-            "description": "Structured data (e.g. { usd: 170.5, usd_24h_change: -2.1 })."
-          },
-          "source": {
-            "type": "string",
-            "description": "Data source (e.g. coingecko, idle-network)."
-          },
-          "freshness": {
-            "type": "string",
-            "enum": ["live", "cached"],
-            "description": "Whether the data was fetched live or from cache."
-          },
-          "latency_ms": {
-            "type": "number",
-            "description": "Time to resolve the query in milliseconds."
+            "required": ["success"],
+            "properties": {
+              "success": { "type": "boolean" },
+              "note": { "type": "string", "description": "Processing note or answer" },
+              "query": { "type": "string", "description": "The original query echoed back" }
+            }
           }
         }
       },
       "TaskResponse": {
         "type": "object",
-        "required": [
-          "result",
-          "status"
-        ],
+        "required": ["status", "result"],
         "properties": {
-          "task_id": {
-            "type": "string",
-            "description": "Correlation ID for logging. This is not a polling handle — results are returned synchronously in the same response."
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "completed",
-              "failed"
-            ],
-            "description": "Task status. Results are returned synchronously."
-          },
+          "status": { "type": "string", "enum": ["completed", "failed"] },
           "result": {
-            "type": "string",
-            "description": "The task result."
-          },
-          "agent_id": {
-            "type": "string",
-            "description": "ID of the agent that processed the task."
+            "type": "object",
+            "properties": {
+              "status": { "type": "integer", "description": "HTTP status code from the upstream task" },
+              "data": { "type": "string", "description": "Task result data" },
+              "error": { "type": "string", "description": "Error message if task failed" }
+            }
           }
         }
       }

--- a/providers/idle-protocol/compute/openapi.json
+++ b/providers/idle-protocol/compute/openapi.json
@@ -658,6 +658,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
+                  "required": ["ok", "service", "version", "x402", "ts"],
                   "properties": {
                     "ok": {
                       "type": "boolean"
@@ -866,6 +867,7 @@
       },
       "FetchResponse": {
         "type": "object",
+        "required": ["status_code", "body"],
         "properties": {
           "status_code": {
             "type": "integer"
@@ -880,6 +882,7 @@
       },
       "HealthResponse": {
         "type": "object",
+        "required": ["status_code", "healthy", "latency_ms"],
         "properties": {
           "status_code": {
             "type": "integer"
@@ -897,6 +900,7 @@
       },
       "DnsResponse": {
         "type": "object",
+        "required": ["records"],
         "properties": {
           "records": {
             "type": "object",
@@ -937,6 +941,7 @@
       },
       "SslResponse": {
         "type": "object",
+        "required": ["valid", "issuer", "expires", "days_remaining"],
         "properties": {
           "valid": {
             "type": "boolean"
@@ -955,6 +960,7 @@
       },
       "LatencyResponse": {
         "type": "object",
+        "required": ["avg_ms", "samples"],
         "properties": {
           "p50_ms": {
             "type": "number"
@@ -972,6 +978,7 @@
       },
       "ScrapeResponse": {
         "type": "object",
+        "required": ["title", "text"],
         "properties": {
           "title": {
             "type": "string"
@@ -986,6 +993,7 @@
       },
       "ExtractResponse": {
         "type": "object",
+        "required": ["elements"],
         "properties": {
           "elements": {
             "type": "array",
@@ -1011,6 +1019,7 @@
       },
       "LinksResponse": {
         "type": "object",
+        "required": ["links"],
         "properties": {
           "links": {
             "type": "array",
@@ -1033,6 +1042,7 @@
       },
       "PriceResponse": {
         "type": "object",
+        "required": ["price", "currency"],
         "properties": {
           "price": {
             "type": "number"
@@ -1047,6 +1057,7 @@
       },
       "AvailabilityResponse": {
         "type": "object",
+        "required": ["in_stock"],
         "properties": {
           "in_stock": {
             "type": "boolean"
@@ -1064,6 +1075,7 @@
       },
       "VerifyResponse": {
         "type": "object",
+        "required": ["verified"],
         "properties": {
           "verified": {
             "type": "boolean"
@@ -1078,6 +1090,7 @@
       },
       "ChangesResponse": {
         "type": "object",
+        "required": ["changed", "hash"],
         "properties": {
           "changed": {
             "type": "boolean"
@@ -1092,6 +1105,7 @@
       },
       "QueryResponse": {
         "type": "object",
+        "required": ["result"],
         "properties": {
           "result": {
             "type": "string"

--- a/providers/idle-protocol/compute/openapi.json
+++ b/providers/idle-protocol/compute/openapi.json
@@ -702,7 +702,8 @@
           "url": {
             "type": "string",
             "format": "uri",
-            "description": "The URL to fetch, scrape, or check."
+            "pattern": "^https?://",
+            "description": "The URL to fetch, scrape, or check. Only http/https schemes are accepted. Private, loopback, and link-local addresses (127.0.0.0/8, 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, 169.254.0.0/16) are rejected server-side to prevent SSRF."
           }
         }
       },
@@ -714,7 +715,8 @@
         "properties": {
           "domain": {
             "type": "string",
-            "description": "The domain name to look up (e.g. example.com)."
+            "pattern": "^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?(\\.[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?)*$",
+            "description": "The domain name to look up (e.g. example.com). Must be a public domain — localhost, private IPs, and link-local addresses are rejected."
           }
         }
       },
@@ -728,7 +730,8 @@
           "url": {
             "type": "string",
             "format": "uri",
-            "description": "The URL to extract elements from."
+            "pattern": "^https?://",
+            "description": "The URL to extract elements from. Only http/https; private/loopback addresses rejected."
           },
           "selector": {
             "type": "string",
@@ -745,7 +748,8 @@
           "url": {
             "type": "string",
             "format": "uri",
-            "description": "The URL to verify content on."
+            "pattern": "^https?://",
+            "description": "The URL to verify content on. Only http/https; private/loopback addresses rejected."
           },
           "text": {
             "type": "string",
@@ -787,7 +791,8 @@
           "url": {
             "type": "string",
             "format": "uri",
-            "description": "The URL to check for content changes."
+            "pattern": "^https?://",
+            "description": "The URL to check for content changes. Only http/https; private/loopback addresses rejected."
           },
           "previous_hash": {
             "type": "string",

--- a/providers/idle-protocol/compute/openapi.json
+++ b/providers/idle-protocol/compute/openapi.json
@@ -821,6 +821,7 @@
       },
       "PaymentChallenge": {
         "type": "object",
+        "required": ["x402Version", "accepts"],
         "properties": {
           "x402Version": {
             "type": "integer"
@@ -843,6 +844,7 @@
             "type": "array",
             "items": {
               "type": "object",
+              "required": ["scheme", "network", "amount", "asset", "payTo"],
               "properties": {
                 "scheme": {
                   "type": "string"
@@ -965,7 +967,7 @@
       },
       "LatencyResponse": {
         "type": "object",
-        "required": ["avg_ms", "samples"],
+        "required": ["avg_ms", "samples", "p50_ms", "p95_ms"],
         "properties": {
           "p50_ms": {
             "type": "number"
@@ -1110,16 +1112,31 @@
       },
       "QueryResponse": {
         "type": "object",
-        "required": ["result"],
+        "required": ["success", "answer", "source", "freshness"],
         "properties": {
-          "result": {
-            "type": "string"
+          "success": {
+            "type": "boolean"
           },
-          "sources": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
+          "answer": {
+            "type": "string",
+            "description": "Human-readable answer to the query."
+          },
+          "data": {
+            "type": "object",
+            "description": "Structured data (e.g. { usd: 170.5, usd_24h_change: -2.1 })."
+          },
+          "source": {
+            "type": "string",
+            "description": "Data source (e.g. coingecko, idle-network)."
+          },
+          "freshness": {
+            "type": "string",
+            "enum": ["live", "cached"],
+            "description": "Whether the data was fetched live or from cache."
+          },
+          "latency_ms": {
+            "type": "number",
+            "description": "Time to resolve the query in milliseconds."
           }
         }
       },

--- a/providers/idle-protocol/compute/openapi.json
+++ b/providers/idle-protocol/compute/openapi.json
@@ -60,7 +60,7 @@
       "post": {
         "operationId": "apiHealth",
         "summary": "API endpoint health check from a residential IP",
-        "description": "Check any API endpoint health from a residential IP. Verifies status code, response body, and latency.",
+        "description": "Check any API endpoint health from a residential IP. Verifies status code, response body, and latency. Note: this is a paid endpoint distinct from the free GET /health gateway check.",
         "tags": [
           "Basic Monitoring"
         ],
@@ -512,7 +512,7 @@
       "post": {
         "operationId": "changeDetect",
         "summary": "Detect if page content has changed since last check",
-        "description": "Detect if page content has changed since last check. Returns SHA-256 hash of current content and a diff preview if changed.",
+        "description": "Detect if page content has changed since last check. Returns SHA-256 hash of current content and a diff preview if changed. On first call without previous_hash, returns the current hash as a baseline (changed=false).",
         "tags": [
           "Web Intelligence"
         ],
@@ -557,7 +557,7 @@
       "post": {
         "operationId": "dataQuery",
         "summary": "Natural language query against any IDLE-connected data source",
-        "description": "Query any IDLE-connected data source using natural language and receive structured results.",
+        "description": "Natural language query against IDLE-connected data sources including Solana on-chain data (token prices, balances, transactions), DeFi protocol metrics, and web-scraped market data. Results include source attribution and freshness timestamps.",
         "tags": [
           "Data & Agents"
         ],
@@ -825,8 +825,19 @@
           "x402Version": {
             "type": "integer"
           },
-          "error": {
-            "type": "string"
+          "resource": {
+            "type": "object",
+            "properties": {
+              "url": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "mimeType": {
+                "type": "string"
+              }
+            }
           },
           "accepts": {
             "type": "array",
@@ -839,23 +850,17 @@
                 "network": {
                   "type": "string"
                 },
-                "maxAmountRequired": {
-                  "type": "string"
+                "amount": {
+                  "type": "string",
+                  "description": "Payment amount in atomic USDC units (6 decimals)."
                 },
                 "asset": {
-                  "type": "string"
+                  "type": "string",
+                  "description": "USDC mint address on Solana."
                 },
                 "payTo": {
-                  "type": "string"
-                },
-                "resource": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "mimeType": {
-                  "type": "string"
+                  "type": "string",
+                  "description": "Solana wallet to send payment to."
                 },
                 "maxTimeoutSeconds": {
                   "type": "integer"

--- a/providers/idle-protocol/compute/openapi.json
+++ b/providers/idle-protocol/compute/openapi.json
@@ -1,13 +1,14 @@
 {
   "openapi": "3.1.0",
   "info": {
-    "title": "IDLE Protocol \u2014 Distributed Residential Compute API",
-    "version": "3.0.0",
-    "description": "Distributed residential compute network on Solana. AI agents pay per-request in USDC via x402 to access residential IPs for web scraping, monitoring, DNS/SSL checks, price extraction, content verification, change detection, natural language data queries, and AI agent task routing. 14 paid endpoints across 3 tiers ($0.001\u2013$0.005 per request).\n\n**Tier 1 \u2014 Basic Monitoring** ($0.001\u2013$0.002): fetch, health, dns, ssl, latency\n**Tier 2 \u2014 Web Intelligence** ($0.003\u2013$0.005): scrape, extract, links, price, availability, verify, changes\n**Tier 3 \u2014 Data & Agents** ($0.005): data/query, agent/task\n\nPrefer fetch ($0.002) over scrape ($0.005) when you only need status codes or headers. Use extract with a CSS selector instead of scraping full HTML. Use changes to detect updates before pulling fresh data with price."
+    "title": "IDLE Protocol \u2014 Distributed Compute & AI Inference API",
+    "version": "4.0.0",
+    "description": "Distributed compute network on Solana. AI agents pay per-request in USDC via x402 to access residential IPs for web scraping, monitoring, DNS/SSL checks, price extraction, content verification, change detection, natural language data queries, AI agent task routing, and multi-model AI inference. 15 paid endpoints across 4 tiers ($0.001\u2013$0.005 per request).\n\n**Tier 1 \u2014 Basic Monitoring** ($0.001\u2013$0.002): fetch, health, dns, ssl, latency\n**Tier 2 \u2014 Web Intelligence** ($0.003\u2013$0.005): scrape, extract, links, price, availability, verify, changes\n**Tier 3 \u2014 Data & Agents** ($0.005): data/query, agent/task\n**Tier 4 \u2014 AI Inference** ($0.001): chat/completions (OpenAI-compatible, 21 models including Claude, Gemini, Llama, Mistral)\n\nPrefer chat/completions ($0.001) for any LLM task \u2014 it's OpenAI-compatible so existing SDKs work by changing the base URL. Prefer fetch ($0.002) over scrape ($0.005) when you only need status codes or headers. Use extract with a CSS selector instead of scraping full HTML. Use changes to detect updates before pulling fresh data with price."
   },
   "servers": [
     {
-      "url": "https://gateway.earnidle.com"
+      "url": "https://api.earnidle.com",
+      "description": "IDLE Protocol API — serves all endpoints (compute, inference, models)"
     }
   ],
   "paths": {
@@ -643,6 +644,101 @@
         }
       }
     },
+    "/v1/chat/completions": {
+      "post": {
+        "operationId": "chatCompletions",
+        "summary": "OpenAI-compatible chat completions — 21 AI models at $0.001/request",
+        "description": "OpenAI-compatible chat completions endpoint. Send messages in the standard OpenAI format and receive completions from 21 models including Claude Sonnet, Claude Haiku, Gemini 3.5 Flash, Llama 3.2, Mistral, and NVIDIA NIM models. Drop-in replacement for OpenAI — change the base URL and it works with existing SDKs.",
+        "tags": [
+          "AI Inference"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ChatRequest"
+              },
+              "example": {
+                "model": "claude-haiku",
+                "messages": [
+                  { "role": "user", "content": "Write a Python function to fetch the SOL/USD price from CoinGecko." }
+                ],
+                "max_tokens": 512,
+                "temperature": 0.7
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Chat completion result in OpenAI format.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChatResponse"
+                },
+                "example": {
+                  "id": "chatcmpl-abc123",
+                  "object": "chat.completion",
+                  "created": 1717459200,
+                  "model": "claude-haiku",
+                  "choices": [
+                    {
+                      "index": 0,
+                      "message": { "role": "assistant", "content": "```python\nimport requests\n\ndef get_sol_price():\n    r = requests.get('https://api.coingecko.com/api/v3/simple/price', params={'ids': 'solana', 'vs_currencies': 'usd'})\n    return r.json()['solana']['usd']\n```" },
+                      "finish_reason": "stop"
+                    }
+                  ],
+                  "usage": { "prompt_tokens": 25, "completion_tokens": 48, "total_tokens": 73 }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentChallenge"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/models": {
+      "get": {
+        "operationId": "listModels",
+        "summary": "List available AI models (free, no payment required)",
+        "description": "List all available AI models with their IDs and owners. Free endpoint, no x402 payment required. Use this to discover which models are available before calling chat/completions.",
+        "tags": [
+          "AI Inference"
+        ],
+        "responses": {
+          "200": {
+            "description": "List of available models in OpenAI format.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ModelsResponse"
+                },
+                "example": {
+                  "object": "list",
+                  "data": [
+                    { "id": "claude-haiku", "object": "model", "owned_by": "anthropic" },
+                    { "id": "claude-sonnet", "object": "model", "owned_by": "anthropic" },
+                    { "id": "llama-3.2-3b", "object": "model", "owned_by": "idle-protocol" },
+                    { "id": "gemini-3.5-flash", "object": "model", "owned_by": "google" }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/health": {
       "get": {
         "operationId": "gatewayHealth",
@@ -821,6 +917,125 @@
           "task": {
             "type": "string",
             "description": "Description of the task to route to an available IDLE agent."
+          }
+        }
+      },
+      "ChatRequest": {
+        "type": "object",
+        "required": ["model", "messages"],
+        "properties": {
+          "model": {
+            "type": "string",
+            "description": "Model ID. Use GET /v1/models to list available models. Examples: claude-haiku, claude-sonnet, llama-3.2-3b, gemini-3.5-flash, mistral-large-latest.",
+            "enum": [
+              "claude-haiku", "claude-sonnet",
+              "llama-3.2-3b", "llama-3.2-1b",
+              "gemini-3.5-flash",
+              "mistral-large-latest", "mistral-small-latest", "codestral-latest", "pixtral-large-latest",
+              "llama-3.1-70b", "llama-3.1-8b", "codellama-70b",
+              "mixtral-8x7b", "mistral-7b",
+              "hermes-3-8b", "hermes-3-70b",
+              "nemotron-ultra-253b", "nemotron-340b",
+              "kimi-k2", "mistral-large-3-675b", "qwen3-coder-480b"
+            ]
+          },
+          "messages": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "object",
+              "required": ["role", "content"],
+              "properties": {
+                "role": {
+                  "type": "string",
+                  "enum": ["system", "user", "assistant"]
+                },
+                "content": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Conversation messages in OpenAI format."
+          },
+          "max_tokens": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 16384,
+            "default": 256,
+            "description": "Maximum tokens to generate."
+          },
+          "temperature": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 2,
+            "default": 0.7,
+            "description": "Sampling temperature."
+          }
+        }
+      },
+      "ChatResponse": {
+        "type": "object",
+        "required": ["id", "object", "created", "model", "choices", "usage"],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "object": {
+            "type": "string",
+            "enum": ["chat.completion"]
+          },
+          "created": {
+            "type": "integer"
+          },
+          "model": {
+            "type": "string"
+          },
+          "choices": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "index": { "type": "integer" },
+                "message": {
+                  "type": "object",
+                  "properties": {
+                    "role": { "type": "string" },
+                    "content": { "type": "string" }
+                  }
+                },
+                "finish_reason": { "type": "string" }
+              }
+            }
+          },
+          "usage": {
+            "type": "object",
+            "properties": {
+              "prompt_tokens": { "type": "integer" },
+              "completion_tokens": { "type": "integer" },
+              "total_tokens": { "type": "integer" }
+            }
+          }
+        }
+      },
+      "ModelsResponse": {
+        "type": "object",
+        "required": ["object", "data"],
+        "properties": {
+          "object": {
+            "type": "string",
+            "enum": ["list"]
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": { "type": "string" },
+                "object": { "type": "string" },
+                "created": { "type": "integer" },
+                "owned_by": { "type": "string" }
+              }
+            }
           }
         }
       },


### PR DESCRIPTION
## Summary

- Adds IDLE Protocol as a new provider under `providers/idle-protocol/compute/`
- 14 x402-compatible endpoints across three pricing tiers ($0.001–$0.005/req)
- Distributed residential compute network on Solana mainnet (USDC payments)
- Gateway: `gateway.earnidle.com`
- Endpoints: web scraping, DNS/SSL checks, latency measurement, price extraction, content verification, change detection, data queries, AI agent task routing

## Endpoints

| Tier | Price | Endpoints |
|------|-------|-----------|
| $0.001 | Lightweight | `dns`, `ssl` |
| $0.002 | Standard | `fetch`, `monitor`, `latency` |
| $0.003 | Medium | `links`, `verify`, `changes` |
| $0.004 | Heavy | `extract`, `availability` |
| $0.005 | Premium | `scrape`, `price`, `query`, `agent` |

## Verification

- `pay catalog check` passes 14/14 gates
- All endpoints return proper x402 v2 `Payment-Required` challenges
- CAIP-2 network ID: `solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp`
- Free `/health` endpoint available

Re-submission of #107 (closed due to fork visibility change).