### PR TITLE
Add aaronjmars/miroshark provider

### DIFF
--- a/providers/aaronjmars/miroshark/PAY.md
+++ b/providers/aaronjmars/miroshark/PAY.md
@@ -23,12 +23,13 @@ Payment is x402, $1.00 USDC, settled through the Coinbase CDP facilitator. The
 whichever chain its wallet holds.
 
 `POST /run` returns `202` immediately with a `run_id` plus `wait_url` (HTML)
-and `status_url` (JSON, pollable, no auth). Poll until `status == completed` —
-the status payload then carries `share_url`, and
-`GET /report/{run_id}?format=json|md` serves the report itself. Optional
-knobs: `deep_research: true` (live-web context sweep, adds cost),
-`prediction_market` (pin the central market), and `affiliate` (an EVM `0x` or
-Solana base58 wallet, 50/50 net-profit share).
+and `status_url` (JSON, pollable, no auth). Poll until `status` is terminal:
+`completed`, `failed`, `budget_exceeded`, or `cancelled` — don't keep polling
+a non-`completed` terminal run; surface its `error` instead. On `completed`
+the status payload carries `share_url`, and `GET /report/{run_id}?format=json|md`
+serves the report itself. Optional knobs: `deep_research: true` (live-web
+context sweep, adds cost), `prediction_market` (pin the central market), and
+`affiliate` (an EVM `0x` or Solana base58 wallet, 50/50 net-profit share).
 
 ## Spend-aware usage
 

--- a/providers/aaronjmars/miroshark/PAY.md
+++ b/providers/aaronjmars/miroshark/PAY.md
@@ -23,11 +23,12 @@ Payment is x402, $1.00 USDC, settled through the Coinbase CDP facilitator. The
 whichever chain its wallet holds.
 
 `POST /run` returns `202` immediately with a `run_id` plus `wait_url` (HTML)
-and `status_url` (JSON, pollable, no auth). Poll until `status == completed`,
-then `GET /report/{run_id}?format=json` returns the report plus its
-`share_url`. Optional knobs: `deep_research: true` (live-web context sweep,
-adds cost), `prediction_market` (pin the central market), and `affiliate` (an
-EVM `0x` wallet, 50/50 net-profit share).
+and `status_url` (JSON, pollable, no auth). Poll until `status == completed` —
+the status payload then carries `share_url`, and
+`GET /report/{run_id}?format=json|md` serves the report itself. Optional
+knobs: `deep_research: true` (live-web context sweep, adds cost),
+`prediction_market` (pin the central market), and `affiliate` (an EVM `0x` or
+Solana base58 wallet, 50/50 net-profit share).
 
 ## Spend-aware usage
 

--- a/providers/aaronjmars/miroshark/PAY.md
+++ b/providers/aaronjmars/miroshark/PAY.md
@@ -23,10 +23,11 @@ Payment is x402, $1.00 USDC, settled through the Coinbase CDP facilitator. The
 whichever chain its wallet holds.
 
 `POST /run` returns `202` immediately with a `run_id` plus `wait_url` (HTML)
-and `status_url` (JSON, pollable, no auth). When `status == completed`,
-`share_url` points at the report. Optional knobs: `deep_research: true`
-(live-web context sweep, adds cost), `prediction_market` (pin the central
-market), and `affiliate` (an EVM or Solana wallet, 50/50 net-profit share).
+and `status_url` (JSON, pollable, no auth). Poll until `status == completed`,
+then `GET /report/{run_id}?format=json` returns the report plus its
+`share_url`. Optional knobs: `deep_research: true` (live-web context sweep,
+adds cost), `prediction_market` (pin the central market), and `affiliate` (an
+EVM `0x` wallet, 50/50 net-profit share).
 
 ## Spend-aware usage
 

--- a/providers/aaronjmars/miroshark/PAY.md
+++ b/providers/aaronjmars/miroshark/PAY.md
@@ -1,0 +1,41 @@
+---
+name: miroshark
+title: "MiroShark"
+description: "Pay $1 USDC to run a 25-agent social-media simulation: seed a prompt, article URL, or raw text and get a knowledge-graph-driven Twitter/Reddit/Polymarket world over 10 rounds plus a synthesized markdown report. x402, settles on Base or Solana."
+use_case: "Use to forecast how a population reacts to a scenario, product launch, or news event: belief drift, narrative formation, top posts, and prediction-market trajectories. Good for social and market research, war-gaming reactions, and PR what-ifs."
+category: ai_ml
+service_url: https://x402.miroshark.xyz
+openapi:
+  path: openapi.json
+---
+
+MiroShark runs a multi-agent social-media simulation behind a single paid
+endpoint. Submit exactly one seed — a `prompt` (scenario/question), an article
+`url`, or raw `article` text — and it extracts entities, builds a knowledge
+graph, generates 25+ agent personas, runs 10 rounds of Twitter / Reddit /
+Polymarket activity, and synthesizes a markdown report (belief drift, top
+posts, market trajectories). Typical wall-clock: 15–25 minutes.
+
+Payment is x402, $1.00 USDC, settled through the Coinbase CDP facilitator. The
+402 challenge advertises two `accepts` entries — **Base mainnet**
+(`eip155:8453`) and **Solana mainnet**
+(`solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp`), both USDC — so a buyer pays on
+whichever chain its wallet holds.
+
+`POST /run` returns `202` immediately with a `run_id` plus `wait_url` (HTML)
+and `status_url` (JSON, pollable, no auth). When `status == completed`,
+`share_url` points at the report. Optional knobs: `deep_research: true`
+(live-web context sweep, adds cost), `prediction_market` (pin the central
+market), and `affiliate` (an EVM or Solana wallet, 50/50 net-profit share).
+
+## Spend-aware usage
+
+- Each `POST /run` costs $1 and takes 15–25 min — it's a heavyweight job, not a
+  lookup. Submit one well-formed scenario; don't loop or retry after a success.
+- Not sure what to run? `POST /suggest` (free) turns a vague topic into
+  launchable prompts — refine there before paying.
+- Track progress with `GET /status/{run_id}` (free) and read the result from
+  `GET /report/{run_id}` (free); never re-run to re-read a finished report.
+- Provide exactly one of `prompt`, `url`, or `article`. Only set
+  `deep_research: true` when you actually need current live-web context (it
+  adds web-search calls to the run's cost).

--- a/providers/aaronjmars/miroshark/openapi.json
+++ b/providers/aaronjmars/miroshark/openapi.json
@@ -1,0 +1,472 @@
+{
+    "info": {
+        "description": "Multi-agent social-media simulation. Seed it with a prompt, an article URL, or raw article text; get a 25-agent simulation across Twitter, Reddit, and Polymarket over 10 rounds plus a synthesized markdown report.",
+        "title": "MiroShark",
+        "version": "2",
+        "x-guidance": "POST /run and pay $1 USDC via x402 on EITHER Base (eip155:8453) or Solana (solana mainnet) \u2014 see x-payment-info.accepts for the exact networks, USDC asset, and payTo per chain. Provide exactly one seed: {\"prompt\": \"<scenario or question, 4-4000 chars>\"}, OR {\"url\": \"<article URL>\"}, OR {\"article\": \"<raw text>\"}. Optionally set \"deep_research\": true for a live-web context sweep first (adds web calls that count toward run cost), and pin the central market with \"prediction_market\" (string or object). You get back a run_id plus wait_url (HTML) and status_url (JSON, pollable, no auth); when status==completed, share_url points at the report. Not sure what to run? POST /suggest (free) with {\"prompt\": \"<vague topic>\"} to get launchable ideas first."
+    },
+    "openapi": "3.1.0",
+    "paths": {
+        "/": {
+            "get": {
+                "operationId": "root_index",
+                "responses": {
+                    "200": {
+                        "description": "JSON service index pointing at /openapi.json and the endpoints."
+                    }
+                },
+                "security": [],
+                "summary": "Get the service index and endpoint map",
+                "tags": [
+                    "Ops"
+                ]
+            }
+        },
+        "/health": {
+            "get": {
+                "operationId": "health",
+                "responses": {
+                    "200": {
+                        "description": "Service is up."
+                    }
+                },
+                "security": [],
+                "summary": "Check service liveness (no dependencies)",
+                "tags": [
+                    "Ops"
+                ]
+            }
+        },
+        "/metrics": {
+            "get": {
+                "operationId": "metrics",
+                "responses": {
+                    "200": {
+                        "description": "Metrics JSON."
+                    }
+                },
+                "security": [],
+                "summary": "Get run stats and cost rollup",
+                "tags": [
+                    "Ops"
+                ]
+            }
+        },
+        "/ready": {
+            "get": {
+                "operationId": "ready",
+                "responses": {
+                    "200": {
+                        "description": "Ready."
+                    },
+                    "503": {
+                        "description": "Not ready."
+                    }
+                },
+                "security": [],
+                "summary": "Check readiness: DB and Neo4j reachable",
+                "tags": [
+                    "Ops"
+                ]
+            }
+        },
+        "/report/{run_id}": {
+            "get": {
+                "operationId": "run_report",
+                "parameters": [
+                    {
+                        "description": "Run id returned by POST /run, e.g. run_abc123def456.",
+                        "in": "path",
+                        "name": "run_id",
+                        "required": true,
+                        "schema": {
+                            "example": "run_abc123def456",
+                            "pattern": "^run_[0-9a-f]{12}$",
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "json \u2192 JSON with report_markdown; md/text \u2192 raw text/markdown; omitted \u2192 302 redirect to the share page.",
+                        "in": "query",
+                        "name": "format",
+                        "required": false,
+                        "schema": {
+                            "enum": [
+                                "json",
+                                "md",
+                                "markdown",
+                                "text"
+                            ],
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Report content \u2014 JSON when format=json, text/markdown when format=md/text."
+                    },
+                    "302": {
+                        "description": "Redirect to /share/<sim_id> (done) or /wait/<run_id> (in progress) when no format is given."
+                    },
+                    "409": {
+                        "description": "Run not completed yet (when format=json|md)."
+                    }
+                },
+                "security": [],
+                "summary": "Read a run's report as JSON or markdown",
+                "tags": [
+                    "Simulation"
+                ]
+            }
+        },
+        "/run": {
+            "post": {
+                "operationId": "run",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "oneOf": [
+                                    {
+                                        "required": [
+                                            "prompt"
+                                        ]
+                                    },
+                                    {
+                                        "required": [
+                                            "url"
+                                        ]
+                                    },
+                                    {
+                                        "required": [
+                                            "article"
+                                        ]
+                                    }
+                                ],
+                                "properties": {
+                                    "affiliate": {
+                                        "description": "Optional affiliate referrer wallet (EVM 0x address). Earns 50% of the run's net profit ($1 price minus MiroShark's LLM cost for the run), settled off-chain to this address.",
+                                        "pattern": "^0x[0-9a-fA-F]{40}$",
+                                        "type": "string"
+                                    },
+                                    "article": {
+                                        "description": "Alternative to 'prompt'. Raw article/document text to build the simulation from. Provide exactly one of prompt, url, or article.",
+                                        "maxLength": 200000,
+                                        "minLength": 4,
+                                        "type": "string"
+                                    },
+                                    "deep_research": {
+                                        "default": false,
+                                        "description": "Optional. When true, MiroShark first runs a multi-query live-web research sweep to build a richer, current context document before the simulation. Adds several web-search LLM calls whose cost counts toward this run's spend (and the affiliate net-profit split). Default false.",
+                                        "type": "boolean"
+                                    },
+                                    "prediction_market": {
+                                        "description": "Optional. Pin the central Polymarket question instead of auto-designing it. A bare YES/NO question string, or an object with a required 'question' (4-300 chars) plus optional 'outcome_a', 'outcome_b', and 'initial_probability' (0-1, the opening YES price).",
+                                        "oneOf": [
+                                            {
+                                                "maxLength": 300,
+                                                "minLength": 4,
+                                                "type": "string"
+                                            },
+                                            {
+                                                "properties": {
+                                                    "initial_probability": {
+                                                        "exclusiveMaximum": 1,
+                                                        "exclusiveMinimum": 0,
+                                                        "type": "number"
+                                                    },
+                                                    "outcome_a": {
+                                                        "type": "string"
+                                                    },
+                                                    "outcome_b": {
+                                                        "type": "string"
+                                                    },
+                                                    "question": {
+                                                        "maxLength": 300,
+                                                        "minLength": 4,
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "question"
+                                                ],
+                                                "type": "object"
+                                            }
+                                        ]
+                                    },
+                                    "prompt": {
+                                        "description": "Scenario, question, or briefing to simulate. The pipeline extracts entities, builds a knowledge graph, generates 25+ agent personas, runs 10 rounds of Twitter / Reddit / Polymarket activity, and synthesizes a markdown report. Provide exactly one of prompt, url, or article.",
+                                        "maxLength": 4000,
+                                        "minLength": 4,
+                                        "type": "string"
+                                    },
+                                    "url": {
+                                        "description": "Alternative to 'prompt'. An article/news URL \u2014 MiroShark fetches the page and builds the simulation from its content. Provide exactly one of prompt, url, or article.",
+                                        "format": "uri",
+                                        "maxLength": 2048,
+                                        "type": "string"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "202": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "properties": {
+                                                "payer": {
+                                                    "type": "string"
+                                                },
+                                                "run_id": {
+                                                    "type": "string"
+                                                },
+                                                "stages": {
+                                                    "items": {
+                                                        "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                },
+                                                "status": {
+                                                    "type": "string"
+                                                },
+                                                "status_url": {
+                                                    "format": "uri",
+                                                    "type": "string"
+                                                },
+                                                "wait_url": {
+                                                    "format": "uri",
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "type": "object"
+                                        },
+                                        "success": {
+                                            "type": "boolean"
+                                        }
+                                    },
+                                    "required": [
+                                        "success",
+                                        "data"
+                                    ],
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Payment accepted; run queued."
+                    },
+                    "402": {
+                        "description": "Payment Required \u2014 retry with a signed X-PAYMENT header."
+                    }
+                },
+                "summary": "Run a multi-agent social-media simulation (x402-paid)",
+                "tags": [
+                    "Simulation",
+                    "Research"
+                ],
+                "x-payment-info": {
+                    "accepts": [
+                        {
+                            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                            "maxAmountRequired": "1000000",
+                            "network": "eip155:8453",
+                            "payTo": "0x67976cebb5266b50a08c0dcb676e03baf305e3a2",
+                            "scheme": "exact"
+                        },
+                        {
+                            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                            "maxAmountRequired": "1000000",
+                            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                            "payTo": "7SdBWQZZM46E1ZmsFhbNN1UD4UquyYsvNGNoas6UCHip",
+                            "scheme": "exact"
+                        }
+                    ],
+                    "price": {
+                        "amount": "1.000000",
+                        "currency": "USD",
+                        "mode": "fixed"
+                    },
+                    "protocols": [
+                        {
+                            "x402": {}
+                        }
+                    ]
+                }
+            }
+        },
+        "/status/{run_id}": {
+            "get": {
+                "operationId": "run_status",
+                "parameters": [
+                    {
+                        "description": "Run id returned by POST /run, e.g. run_abc123def456.",
+                        "in": "path",
+                        "name": "run_id",
+                        "required": true,
+                        "schema": {
+                            "example": "run_abc123def456",
+                            "pattern": "^run_[0-9a-f]{12}$",
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Run status JSON."
+                    }
+                },
+                "security": [],
+                "summary": "Get run status as JSON (run_id is the token)",
+                "tags": [
+                    "Simulation"
+                ]
+            }
+        },
+        "/suggest": {
+            "post": {
+                "operationId": "suggest_ideas",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "no_cache": {
+                                        "default": false,
+                                        "description": "Force a fresh LLM call instead of returning a cached result.",
+                                        "type": "boolean"
+                                    },
+                                    "prompt": {
+                                        "description": "A vague topic or seed idea to expand into launchable simulations.",
+                                        "maxLength": 400,
+                                        "minLength": 6,
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "prompt"
+                                ],
+                                "type": "object"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "properties": {
+                                                "cached": {
+                                                    "type": "boolean"
+                                                },
+                                                "ideas": {
+                                                    "items": {
+                                                        "properties": {
+                                                            "angle": {
+                                                                "type": "string"
+                                                            },
+                                                            "pitch": {
+                                                                "type": "string"
+                                                            },
+                                                            "prompt": {
+                                                                "description": "Submit this verbatim as the /run 'prompt'.",
+                                                                "type": "string"
+                                                            },
+                                                            "title": {
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "type": "object"
+                                                    },
+                                                    "type": "array"
+                                                },
+                                                "model": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "type": "object"
+                                        },
+                                        "success": {
+                                            "type": "boolean"
+                                        }
+                                    },
+                                    "required": [
+                                        "success",
+                                        "data"
+                                    ],
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Up to 5 ideas, each with a ready-to-run 'prompt'. Empty list (never an error) if the model is briefly unavailable."
+                    },
+                    "429": {
+                        "description": "Rate limited (per-IP). Retry shortly."
+                    }
+                },
+                "security": [],
+                "summary": "Generate launchable simulation ideas from a topic",
+                "tags": [
+                    "Simulation",
+                    "Research"
+                ]
+            }
+        },
+        "/wait/{run_id}": {
+            "get": {
+                "operationId": "run_wait",
+                "parameters": [
+                    {
+                        "description": "Run id returned by POST /run, e.g. run_abc123def456.",
+                        "in": "path",
+                        "name": "run_id",
+                        "required": true,
+                        "schema": {
+                            "example": "run_abc123def456",
+                            "pattern": "^run_[0-9a-f]{12}$",
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "HTML status page."
+                    }
+                },
+                "security": [],
+                "summary": "Fetch an auto-refreshing run-status page",
+                "tags": [
+                    "Simulation"
+                ]
+            }
+        }
+    },
+    "servers": [
+        {
+            "url": "https://x402.miroshark.xyz"
+        }
+    ],
+    "tags": [
+        {
+            "description": "Multi-agent social-media simulation: submit a prompt, run a 25-agent world across Twitter / Reddit / Polymarket, then read the report.",
+            "name": "Simulation"
+        },
+        {
+            "description": "Predictive social research \u2014 belief drift, narrative formation, and prediction-market trajectories over a simulated population.",
+            "name": "Research"
+        },
+        {
+            "description": "Operational probes (liveness, readiness, metrics) \u2014 free, unauthenticated.",
+            "name": "Ops"
+        }
+    ]
+}

--- a/providers/aaronjmars/miroshark/openapi.json
+++ b/providers/aaronjmars/miroshark/openapi.json
@@ -132,7 +132,8 @@
                                                     "type": "string"
                                                 },
                                                 "share_url": {
-                                                    "description": "Human-readable report page (/share/<sim_id>).",
+                                                    "description": "Absolute URL of the human-readable report page (<base>/share/<sim_id>), usable verbatim.",
+                                                    "format": "uri",
                                                     "type": [
                                                         "string",
                                                         "null"
@@ -532,7 +533,8 @@
                                                     "type": "string"
                                                 },
                                                 "share_url": {
-                                                    "description": "Human-readable report path (/share/<sim_id>). Null until status == completed.",
+                                                    "description": "Absolute URL of the human-readable report page (<base>/share/<sim_id>), usable verbatim. Null until status == completed.",
+                                                    "format": "uri",
                                                     "type": [
                                                         "string",
                                                         "null"

--- a/providers/aaronjmars/miroshark/openapi.json
+++ b/providers/aaronjmars/miroshark/openapi.json
@@ -37,6 +37,21 @@
                 ]
             }
         },
+        "/logo.png": {
+            "get": {
+                "operationId": "logo",
+                "responses": {
+                    "200": {
+                        "description": "PNG logo (same asset as /favicon.ico)."
+                    }
+                },
+                "security": [],
+                "summary": "Get the service logo as PNG",
+                "tags": [
+                    "Ops"
+                ]
+            }
+        },
         "/metrics": {
             "get": {
                 "operationId": "metrics",
@@ -300,6 +315,21 @@
                 }
             }
         },
+        "/skill.md": {
+            "get": {
+                "operationId": "skill_md",
+                "responses": {
+                    "200": {
+                        "description": "text/markdown manual covering the suggest \u2192 pay \u2192 poll \u2192 report loop."
+                    }
+                },
+                "security": [],
+                "summary": "Read the agent skill manual as markdown",
+                "tags": [
+                    "Ops"
+                ]
+            }
+        },
         "/status/{run_id}": {
             "get": {
                 "operationId": "run_status",
@@ -318,7 +348,66 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "Run status JSON."
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "properties": {
+                                                "budget": {
+                                                    "properties": {
+                                                        "cost_usd": {
+                                                            "description": "The run's LLM spend so far in USD; the affiliate net-profit split is computed from this.",
+                                                            "type": "number"
+                                                        }
+                                                    },
+                                                    "type": "object"
+                                                },
+                                                "progress": {
+                                                    "description": "Overall completion, 0-100.",
+                                                    "maximum": 100,
+                                                    "minimum": 0,
+                                                    "type": "number"
+                                                },
+                                                "run_id": {
+                                                    "type": "string"
+                                                },
+                                                "stages": {
+                                                    "description": "Per-stage progress breakdown.",
+                                                    "type": "array"
+                                                },
+                                                "status": {
+                                                    "description": "Poll until terminal: completed, failed, budget_exceeded, or cancelled. On completed, fetch GET /report/{run_id} (format=json includes share_url).",
+                                                    "enum": [
+                                                        "queued",
+                                                        "running",
+                                                        "completed",
+                                                        "failed",
+                                                        "budget_exceeded",
+                                                        "cancelled"
+                                                    ],
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "run_id",
+                                                "status"
+                                            ],
+                                            "type": "object"
+                                        },
+                                        "success": {
+                                            "type": "boolean"
+                                        }
+                                    },
+                                    "required": [
+                                        "success",
+                                        "data"
+                                    ],
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Run status JSON. Poll every 15-30 seconds until data.status is terminal."
                     }
                 },
                 "security": [],

--- a/providers/aaronjmars/miroshark/openapi.json
+++ b/providers/aaronjmars/miroshark/openapi.json
@@ -160,8 +160,8 @@
                                 ],
                                 "properties": {
                                     "affiliate": {
-                                        "description": "Optional affiliate referrer wallet (EVM 0x address). Earns 50% of the run's net profit ($1 price minus MiroShark's LLM cost for the run), settled off-chain to this address.",
-                                        "pattern": "^0x[0-9a-fA-F]{40}$",
+                                        "description": "Optional affiliate referrer wallet \u2014 an EVM 0x address or a base58 Solana address (the payout follows the address's chain family). Earns 50% of the run's net profit ($1 price minus MiroShark's LLM cost for the run), settled off-chain to this address.",
+                                        "pattern": "^(0x[0-9a-fA-F]{40}|[1-9A-HJ-NP-Za-km-z]{32,44})$",
                                         "type": "string"
                                     },
                                     "article": {
@@ -354,30 +354,128 @@
                                     "properties": {
                                         "data": {
                                             "properties": {
+                                                "affiliate": {
+                                                    "type": [
+                                                        "string",
+                                                        "null"
+                                                    ]
+                                                },
+                                                "affiliate_chain": {
+                                                    "description": "evm or solana \u2014 chain family of the affiliate wallet.",
+                                                    "type": [
+                                                        "string",
+                                                        "null"
+                                                    ]
+                                                },
                                                 "budget": {
+                                                    "description": "The run's LLM spend so far; the affiliate split is $1 \u2212 cost_usd.",
                                                     "properties": {
+                                                        "calls": {
+                                                            "type": [
+                                                                "integer",
+                                                                "null"
+                                                            ]
+                                                        },
                                                         "cost_usd": {
-                                                            "description": "The run's LLM spend so far in USD; the affiliate net-profit split is computed from this.",
-                                                            "type": "number"
+                                                            "type": [
+                                                                "number",
+                                                                "null"
+                                                            ]
+                                                        },
+                                                        "tokens_used": {
+                                                            "type": [
+                                                                "integer",
+                                                                "null"
+                                                            ]
                                                         }
                                                     },
                                                     "type": "object"
                                                 },
+                                                "completed_at": {
+                                                    "format": "date-time",
+                                                    "type": [
+                                                        "string",
+                                                        "null"
+                                                    ]
+                                                },
+                                                "created_at": {
+                                                    "format": "date-time",
+                                                    "type": [
+                                                        "string",
+                                                        "null"
+                                                    ]
+                                                },
+                                                "current_round": {
+                                                    "type": [
+                                                        "integer",
+                                                        "null"
+                                                    ]
+                                                },
+                                                "current_stage": {
+                                                    "type": [
+                                                        "string",
+                                                        "null"
+                                                    ]
+                                                },
+                                                "error": {
+                                                    "type": [
+                                                        "string",
+                                                        "null"
+                                                    ]
+                                                },
+                                                "message": {
+                                                    "type": [
+                                                        "string",
+                                                        "null"
+                                                    ]
+                                                },
+                                                "payment_chain": {
+                                                    "type": [
+                                                        "string",
+                                                        "null"
+                                                    ]
+                                                },
+                                                "payment_network": {
+                                                    "description": "CAIP-2 network the buyer settled on, e.g. eip155:8453.",
+                                                    "type": [
+                                                        "string",
+                                                        "null"
+                                                    ]
+                                                },
                                                 "progress": {
-                                                    "description": "Overall completion, 0-100.",
                                                     "maximum": 100,
                                                     "minimum": 0,
-                                                    "type": "number"
+                                                    "type": "integer"
                                                 },
                                                 "run_id": {
                                                     "type": "string"
                                                 },
+                                                "share_url": {
+                                                    "description": "Human-readable report path (/share/<sim_id>). Null until status == completed.",
+                                                    "type": [
+                                                        "string",
+                                                        "null"
+                                                    ]
+                                                },
+                                                "simulation_id": {
+                                                    "type": [
+                                                        "string",
+                                                        "null"
+                                                    ]
+                                                },
                                                 "stages": {
-                                                    "description": "Per-stage progress breakdown.",
-                                                    "type": "array"
+                                                    "description": "Per-stage progress breakdown, keyed by stage name.",
+                                                    "type": "object"
+                                                },
+                                                "started_at": {
+                                                    "format": "date-time",
+                                                    "type": [
+                                                        "string",
+                                                        "null"
+                                                    ]
                                                 },
                                                 "status": {
-                                                    "description": "Poll until terminal: completed, failed, budget_exceeded, or cancelled. On completed, fetch GET /report/{run_id} (format=json includes share_url).",
+                                                    "description": "Poll every 15-30s until terminal (completed, failed, budget_exceeded, or cancelled). On completed, share_url is set and GET /report/{run_id} serves the report.",
                                                     "enum": [
                                                         "queued",
                                                         "running",
@@ -408,6 +506,9 @@
                             }
                         },
                         "description": "Run status JSON. Poll every 15-30 seconds until data.status is terminal."
+                    },
+                    "404": {
+                        "description": "Unknown run_id (wrong id, or the instance was redeployed with a wiped DB)."
                     }
                 },
                 "security": [],

--- a/providers/aaronjmars/miroshark/openapi.json
+++ b/providers/aaronjmars/miroshark/openapi.json
@@ -239,6 +239,20 @@
                                                 "payer": {
                                                     "type": "string"
                                                 },
+                                                "payment_chain": {
+                                                    "description": "Short label of the chain the buyer settled on, e.g. base or solana.",
+                                                    "type": [
+                                                        "string",
+                                                        "null"
+                                                    ]
+                                                },
+                                                "payment_network": {
+                                                    "description": "CAIP-2 network the buyer settled on, e.g. eip155:8453.",
+                                                    "type": [
+                                                        "string",
+                                                        "null"
+                                                    ]
+                                                },
                                                 "run_id": {
                                                     "type": "string"
                                                 },
@@ -260,6 +274,13 @@
                                                     "type": "string"
                                                 }
                                             },
+                                            "required": [
+                                                "run_id",
+                                                "status",
+                                                "stages",
+                                                "wait_url",
+                                                "status_url"
+                                            ],
                                             "type": "object"
                                         },
                                         "success": {

--- a/providers/aaronjmars/miroshark/openapi.json
+++ b/providers/aaronjmars/miroshark/openapi.json
@@ -118,6 +118,66 @@
                 ],
                 "responses": {
                     "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "properties": {
+                                                "report_markdown": {
+                                                    "description": "The full synthesized report as markdown.",
+                                                    "type": "string"
+                                                },
+                                                "run_id": {
+                                                    "type": "string"
+                                                },
+                                                "share_url": {
+                                                    "description": "Human-readable report page (/share/<sim_id>).",
+                                                    "type": [
+                                                        "string",
+                                                        "null"
+                                                    ]
+                                                },
+                                                "simulation_id": {
+                                                    "type": [
+                                                        "string",
+                                                        "null"
+                                                    ]
+                                                },
+                                                "status": {
+                                                    "type": "string"
+                                                },
+                                                "title": {
+                                                    "type": [
+                                                        "string",
+                                                        "null"
+                                                    ]
+                                                }
+                                            },
+                                            "required": [
+                                                "run_id",
+                                                "status",
+                                                "report_markdown"
+                                            ],
+                                            "type": "object"
+                                        },
+                                        "success": {
+                                            "type": "boolean"
+                                        }
+                                    },
+                                    "required": [
+                                        "success",
+                                        "data"
+                                    ],
+                                    "type": "object"
+                                }
+                            },
+                            "text/markdown": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
                         "description": "Report content \u2014 JSON when format=json, text/markdown when format=md/text."
                     },
                     "302": {
@@ -583,27 +643,47 @@
                                                     "items": {
                                                         "properties": {
                                                             "angle": {
+                                                                "maxLength": 40,
                                                                 "type": "string"
                                                             },
                                                             "pitch": {
+                                                                "maxLength": 200,
                                                                 "type": "string"
                                                             },
                                                             "prompt": {
                                                                 "description": "Submit this verbatim as the /run 'prompt'.",
+                                                                "maxLength": 400,
+                                                                "minLength": 8,
                                                                 "type": "string"
                                                             },
                                                             "title": {
+                                                                "maxLength": 80,
+                                                                "minLength": 3,
                                                                 "type": "string"
                                                             }
                                                         },
+                                                        "required": [
+                                                            "title",
+                                                            "pitch",
+                                                            "prompt",
+                                                            "angle"
+                                                        ],
                                                         "type": "object"
                                                     },
                                                     "type": "array"
                                                 },
                                                 "model": {
                                                     "type": "string"
+                                                },
+                                                "reason": {
+                                                    "description": "Only present when ideas is empty: rate_limited, llm_unavailable, or llm_error.",
+                                                    "type": "string"
                                                 }
                                             },
+                                            "required": [
+                                                "ideas",
+                                                "cached"
+                                            ],
                                             "type": "object"
                                         },
                                         "success": {


### PR DESCRIPTION
Adds **MiroShark** — a multi-agent social-media simulation — to the catalog.

**What it does:** seed `POST /run` with a prompt, article URL, or raw text; it builds a knowledge graph, spins up 25+ agent personas, runs 10 rounds across Twitter / Reddit / Polymarket, and returns a synthesized markdown report. Returns `202` immediately with a pollable `status_url`; free `/suggest`, `/status`, `/report` siblings.

**Payment:** x402, $1.00 USDC, via the Coinbase CDP facilitator. The 402 advertises two `accepts` entries — **Base mainnet** (`eip155:8453`) and **Solana mainnet** (`solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp`), both USDC — so a buyer pays on whichever chain its wallet holds.

**Validation:**
- `pay catalog check providers/aaronjmars/miroshark/PAY.md` → `PAY.md check successful` (exit 0)
- Solana-compat verdict: **1/1** — the paid `POST /run` gate accepts USDC on Solana mainnet
- Co-located, pretty-printed `openapi.json` snapshot included

🤖 Generated with [Claude Code](https://claude.com/claude-code)