### PR TITLE
feat: add clawd provider (agents, x402 facilitator, dark private payments)

### DIFF
--- a/providers/clawd/agents/PAY.md
+++ b/providers/clawd/agents/PAY.md
@@ -1,0 +1,68 @@
+---
+name: agents
+title: "SolanaClawdAgents"
+description: "Pay-per-request AI inference and Solana DeFi intelligence via x402. 80+ specialized agents, 130+ MCP tools, and OpenAI-compatible chat completions — all gated by USDC micropayments on Solana mainnet with no API key required."
+use_case: "Use for AI chat completions, on-chain token and wallet analysis, alpha signal detection, pump.fun graduation scoring, smart money flow tracking, deep research reports, DFlow/Kalshi market intel, Vulcan perp trading signals, and agent-to-agent MCP tool calls payable in Solana USDC."
+category: ai_ml
+service_url: https://x402.wtf
+openapi:
+  path: openapi.json
+---
+
+SolanaClawdAgents is the sovereign agent runtime at [solanaclawd.com](https://solanaclawd.com)
+and [x402.wtf](https://x402.wtf). It exposes 80+ Solana DeFi agents and 130+ MCP tools
+behind HTTP 402 paywalls — no API key, no account, no registration. Agents pay USDC on
+Solana mainnet; the payment is verified on-chain by the Clawd facilitator at
+`https://clawdrouter.fly.dev` before the response is returned.
+
+Payment flow follows the [x402 protocol](https://www.x402.org):
+
+1. Call any endpoint without `X-Payment` → receive `402` with `X-Payment-Required` header
+2. Parse the `accepts[]` array — choose the `solana-mainnet` / `exact` option
+3. Sign a USDC SPL transfer using `@pump-fun/x402` or any x402 Solana client
+4. Retry with `X-Payment: <base64-encoded-payload>` → receive the response + `X-Payment-Settlement` tx signature
+
+The facilitator at `clawdrouter.fly.dev` handles verification and on-chain settlement so
+API routes are stateless and need no RPC access of their own.
+
+## Pricing tiers
+
+| Endpoint | Cost (USDC) |
+|---|---|
+| `/api/v1/chat/completions` (small) | ~$0.001–$0.01 per request |
+| `/api/v1/analyze` quick | $0.001 |
+| `/api/v1/analyze` full | $0.02 |
+| `/api/v1/research` quick | $0.02 |
+| `/api/v1/research` standard | $0.10 |
+| `/api/v1/research` deep | $0.50 |
+| `/api/v1/alpha` scan | $0.10 |
+| `/api/v1/agents/{id}/run` | Varies by agent — check 402 `description` |
+| `/api/v1/mcp` tool call | Varies by tool — check 402 `description` |
+
+All amounts are disclosed in the 402 challenge's `maxAmountRequired` field before the
+client signs. Never pay more than the disclosed amount.
+
+## Agent catalog
+
+`GET /api/v1/agents` returns the free catalog (no payment). Key agent categories:
+
+- **Trading** — Vulcan perps, DFlow spot, Kalshi/Polymarket prediction markets, pump.fun launcher
+- **Analytics** — Birdeye OHLCV, Nansen smart money, on-chain holder graphs, meme signals
+- **Research** — OODA-loop multi-agent research, Karpathy self-improving loop, social intel
+- **Infrastructure** — QuickNode RPC routing, wallet generation, MCP tool brokering
+- **Social** — X/Twitter alpha scanning, Discord community analytics, Telegram monitoring
+
+## MCP integration
+
+The `/api/v1/mcp` endpoint bridges the MCP protocol over x402. Send `{"tool": "...", "arguments": {...}}`
+and the payment gate is applied per-tool. Useful for agents that want to call Clawd's skill library
+without running a local MCP server. The MCP server itself is also available at `npx @pump-fun/mcp-server`.
+
+## Spend-aware usage
+
+- Call `GET /api/v1/agents` (free) first to discover agents and their per-call costs before committing spend.
+- Use `/api/v1/chat/completions` with a small model (llama-3.1-8b) for simple lookups; escalate to Claude or Grok only for tasks that need it.
+- Use `depth: "quick"` on `/api/v1/analyze` ($0.001) when only price + holder count is needed; reserve `full` for due-diligence flows.
+- Check the 402 challenge `description` field — it discloses the exact cost and what will be returned. Abort if the cost exceeds your session budget.
+- Reuse the `nonce` window — the challenge is valid for 5 minutes (`expiresAt`). If two calls to the same endpoint happen within that window, you only pay once per settlement.
+- Set `maxPaymentAmount` on the x402 client to cap per-request spend before the client even signs.

--- a/providers/clawd/agents/openapi.json
+++ b/providers/clawd/agents/openapi.json
@@ -1,0 +1,427 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "SolanaClawdAgents",
+    "version": "2.0.0",
+    "description": "x402-gated AI agent inference and Solana DeFi intelligence. 80+ specialized agents, 130+ skills, MCP tool access — all payable in USDC on Solana mainnet with no API key."
+  },
+  "servers": [
+    { "url": "https://x402.wtf", "description": "Production (Solana mainnet, x402 USDC)" }
+  ],
+  "paths": {
+    "/api/v1/chat/completions": {
+      "post": {
+        "operationId": "chatCompletions",
+        "summary": "LLM inference (OpenAI-compatible)",
+        "description": "Chat completion endpoint backed by Claude, Grok, or open-source models. x402-gated; first call without X-Payment returns 402 with Solana USDC payment requirement. Retry with X-Payment header to receive the completion.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["model", "messages"],
+                "properties": {
+                  "model": {
+                    "type": "string",
+                    "description": "Model ID (e.g. claude-sonnet-4-6, grok-4, llama-3.1-70b)",
+                    "examples": ["claude-sonnet-4-6"]
+                  },
+                  "messages": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "required": ["role", "content"],
+                      "properties": {
+                        "role": { "type": "string", "enum": ["system", "user", "assistant"] },
+                        "content": { "type": "string" }
+                      }
+                    }
+                  },
+                  "stream": { "type": "boolean", "default": false },
+                  "max_tokens": { "type": "integer" },
+                  "temperature": { "type": "number", "minimum": 0, "maximum": 2 }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Completion response (OpenAI-compatible)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": { "type": "string" },
+                    "object": { "type": "string", "enum": ["chat.completion"] },
+                    "choices": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "message": {
+                            "type": "object",
+                            "properties": {
+                              "role": { "type": "string" },
+                              "content": { "type": "string" }
+                            }
+                          },
+                          "finish_reason": { "type": "string" }
+                        }
+                      }
+                    },
+                    "usage": {
+                      "type": "object",
+                      "properties": {
+                        "prompt_tokens": { "type": "integer" },
+                        "completion_tokens": { "type": "integer" },
+                        "total_tokens": { "type": "integer" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required — USDC on Solana mainnet",
+            "headers": {
+              "X-Payment-Required": {
+                "schema": { "type": "string" },
+                "description": "Base64-encoded x402 PaymentRequiredResponse with Solana USDC accept options"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/PaymentRequired" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/research": {
+      "post": {
+        "operationId": "agentResearch",
+        "summary": "Deep agent research report",
+        "description": "Runs a multi-agent OODA-loop research pipeline. Synthesizes on-chain data, social signals, and market context into a structured report. Higher cost than a single chat completion; estimated $0.10 USDC.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["query"],
+                "properties": {
+                  "query": {
+                    "type": "string",
+                    "description": "Research question or token/wallet to investigate"
+                  },
+                  "depth": {
+                    "type": "string",
+                    "enum": ["quick", "standard", "deep"],
+                    "default": "standard",
+                    "description": "quick=$0.02, standard=$0.10, deep=$0.50 USDC"
+                  },
+                  "context": {
+                    "type": "object",
+                    "description": "Optional: token_mint, wallet_address, or timeframe hints"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Research report",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "report": { "type": "string", "description": "Markdown-formatted research report" },
+                    "signals": { "type": "array", "items": { "type": "object" } },
+                    "sources": { "type": "array", "items": { "type": "string" } },
+                    "confidence": { "type": "number", "minimum": 0, "maximum": 1 }
+                  }
+                }
+              }
+            }
+          },
+          "402": { "description": "Payment required", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/PaymentRequired" } } } }
+        }
+      }
+    },
+    "/api/v1/analyze": {
+      "post": {
+        "operationId": "chainAnalysis",
+        "summary": "On-chain token or wallet analysis",
+        "description": "Deep analysis of a Solana token mint or wallet address. Returns holder distribution, top traders, volume profile, graduation probability (pump.fun tokens), and smart money flows.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "token_mint": { "type": "string", "description": "Solana token mint address (Base58)" },
+                  "wallet": { "type": "string", "description": "Solana wallet address (Base58)" },
+                  "depth": {
+                    "type": "string",
+                    "enum": ["quick", "full"],
+                    "default": "full",
+                    "description": "quick=$0.001, full=$0.02 USDC"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Analysis result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "token": { "type": "string" },
+                    "holders": { "type": "integer" },
+                    "top_wallets": { "type": "array", "items": { "type": "string" } },
+                    "volume_24h": { "type": "string" },
+                    "smart_money_net": { "type": "number" },
+                    "graduation_probability": { "type": "number" },
+                    "security_flags": { "type": "array", "items": { "type": "string" } }
+                  }
+                }
+              }
+            }
+          },
+          "402": { "description": "Payment required", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/PaymentRequired" } } } }
+        }
+      }
+    },
+    "/api/v1/alpha": {
+      "post": {
+        "operationId": "alphaSignals",
+        "summary": "AI alpha signal detection",
+        "description": "Real-time alpha detection across Solana DEXes and social layers. Returns ranked opportunities filtered by smart money accumulation, bonding curve momentum, and on-chain velocity.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "timeframe": { "type": "string", "enum": ["1h", "6h", "24h"], "default": "6h" },
+                  "filters": {
+                    "type": "object",
+                    "properties": {
+                      "min_liquidity_usd": { "type": "number" },
+                      "min_holders": { "type": "integer" },
+                      "exclude_graduated": { "type": "boolean" }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Alpha signals",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "signals": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "token_mint": { "type": "string" },
+                          "symbol": { "type": "string" },
+                          "score": { "type": "number" },
+                          "reason": { "type": "string" },
+                          "price_usd": { "type": "number" },
+                          "volume_1h": { "type": "number" }
+                        }
+                      }
+                    },
+                    "generated_at": { "type": "string", "format": "date-time" }
+                  }
+                }
+              }
+            }
+          },
+          "402": { "description": "Payment required ($0.10 USDC)", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/PaymentRequired" } } } }
+        }
+      }
+    },
+    "/api/v1/agents": {
+      "get": {
+        "operationId": "listAgents",
+        "summary": "List available Clawd agents",
+        "description": "Returns the catalog of 80+ available Solana DeFi agents with their capabilities, pricing tiers, and skill tags. Free endpoint — no payment required.",
+        "parameters": [
+          { "name": "category", "in": "query", "schema": { "type": "string" }, "description": "Filter by category (trading, research, analytics, social, infrastructure)" },
+          { "name": "skill", "in": "query", "schema": { "type": "string" }, "description": "Filter by skill tag (e.g. pump.fun, jupiter, vulcan, dflow)" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Agent catalog",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "agents": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": { "type": "string" },
+                          "name": { "type": "string" },
+                          "description": { "type": "string" },
+                          "category": { "type": "string" },
+                          "skills": { "type": "array", "items": { "type": "string" } },
+                          "price_per_call_usdc": { "type": "string" }
+                        }
+                      }
+                    },
+                    "total": { "type": "integer" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/agents/{agentId}/run": {
+      "post": {
+        "operationId": "runAgent",
+        "summary": "Run a named Clawd agent",
+        "description": "Invoke a specific agent by ID. Pricing varies by agent — the 402 challenge discloses the exact USDC amount. Supports streaming (SSE) when `stream: true`.",
+        "parameters": [
+          { "name": "agentId", "in": "path", "required": true, "schema": { "type": "string" }, "description": "Agent ID from /api/v1/agents catalog" }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["input"],
+                "properties": {
+                  "input": { "type": "string", "description": "Free-text instruction for the agent" },
+                  "context": { "type": "object", "description": "Optional structured context (token_mint, wallet, etc.)" },
+                  "stream": { "type": "boolean", "default": false }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Agent output",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "agent_id": { "type": "string" },
+                    "output": { "type": "string" },
+                    "artifacts": { "type": "array", "items": { "type": "object" } },
+                    "tokens_used": { "type": "integer" }
+                  }
+                }
+              }
+            }
+          },
+          "402": { "description": "Payment required", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/PaymentRequired" } } } }
+        }
+      }
+    },
+    "/api/v1/mcp": {
+      "post": {
+        "operationId": "mcpToolCall",
+        "summary": "MCP tool call (paid)",
+        "description": "Invoke any of 130+ MCP tools exposed by the Clawd runtime. Tools span Solana RPC, pump.fun, DFlow, Kalshi, Vulcan perps, Birdeye, and social APIs. Each tool declares its own price in the 402 challenge.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["tool", "arguments"],
+                "properties": {
+                  "tool": { "type": "string", "description": "MCP tool name (e.g. pump_token_overview, dflow_spot_quote)" },
+                  "arguments": { "type": "object" }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Tool result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "content": {
+                      "type": "array",
+                      "items": { "type": "object", "properties": { "type": { "type": "string" }, "text": { "type": "string" } } }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "402": { "description": "Payment required", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/PaymentRequired" } } } }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "PaymentRequired": {
+        "type": "object",
+        "properties": {
+          "x402Version": { "type": "integer", "example": 1 },
+          "accepts": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "scheme": { "type": "string", "enum": ["exact"] },
+                "network": { "type": "string", "enum": ["solana-mainnet"] },
+                "maxAmountRequired": { "type": "string", "description": "USDC base units (6 decimals). e.g. 1000 = $0.001" },
+                "payTo": { "type": "string", "description": "Solana recipient address (Base58)" },
+                "token": { "type": "string", "description": "USDC mint: EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v" },
+                "resource": { "type": "string" },
+                "description": { "type": "string" }
+              }
+            }
+          },
+          "nonce": { "type": "string" },
+          "expiresAt": { "type": "string", "format": "date-time" }
+        }
+      }
+    },
+    "securitySchemes": {
+      "x402Payment": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-Payment",
+        "description": "Base64-encoded x402 PaymentPayload containing a signed Solana USDC transfer. Sign with @pump-fun/x402 or any x402 Solana client."
+      }
+    }
+  }
+}

--- a/providers/clawd/dark/PAY.md
+++ b/providers/clawd/dark/PAY.md
@@ -1,0 +1,115 @@
+---
+name: dark
+title: "ClawdDarkPrivateX402"
+description: "Privacy-first x402 payments on Solana via Dark-DeFi shielded infrastructure. Extends the standard x402 scheme with a 'dark-shielded' variant: USDC routed through Zcash Sapling shielded notes, AI inference executed inside SGX/SEV TEE enclaves attested on-chain via SAS — no payment graph, no prompt leakage."
+use_case: "Use for private AI inference where prompts must not appear on-chain, confidential agent-to-agent payments that break the sender-receiver payment graph, shielded USDC transfers using Zcash Sapling diversified addresses, TEE-attested completions with client-side encrypted messages, and compliance workflows requiring selective disclosure via viewing keys."
+category: security
+service_url: https://x402.wtf/dark
+openapi:
+  path: openapi.json
+---
+
+ClawdDarkPrivateX402 extends the standard [x402 protocol](https://www.x402.org) with a
+`dark-shielded` payment scheme built on the [Dark DeFi](https://github.com/x402agent/dark-defi)
+protocol. While standard x402 pays via a transparent Solana SPL transfer (visible on-chain),
+dark-shielded routes payments through Zcash Sapling-derived shielded notes — breaking the
+payment graph between the caller's wallet and the API operator.
+
+AI inference is further hardened by running inside SGX/SEV trusted execution environments
+attested on-chain via the **Solana Attestation Service (SAS)**. Messages are encrypted
+client-side using the enclave's X25519 public key; they never appear in plaintext on any
+network hop or in the operator's logs.
+
+**On-chain program:** Dark Protocol Anchor program at
+`4753b1cCrPzwr7taWWD8yrcM8dc98fTR7wCFdv1TsAbg` (Solana mainnet)
+
+**NPM SDK:** `@openclawdsol/dark-protocol-sdk`
+
+## Privacy model
+
+| Layer | Standard x402 | Dark-Shielded x402 |
+|---|---|---|
+| Payment | Transparent SPL transfer — payer + payTo visible on-chain | Shielded note — only commitment on-chain; payer/payTo unlinkable |
+| Recipient address | Operator's real wallet address | One-time diversified Sapling address (fresh per request) |
+| Inference prompt | Sent in plaintext HTTP body | ChaCha20-Poly1305 encrypted to TEE pubkey |
+| Inference response | Returned in plaintext | Encrypted to caller's ephemeral key inside TEE |
+| Operator visibility | Sees payer address + request | Sees nothing — note detected via scanning key only |
+| Auditability | Full ledger trail | Selective: share viewing key with auditor only |
+
+## Payment flow
+
+```
+1. GET /tee/pubkey
+   → X25519 enclave key + SAS attestation
+
+2. POST /shielded/challenge  { resource: "/tee/inference" }
+   → 402 + dark-shielded PaymentRequired
+     payTo = one-time diversified Sapling address
+     ephemeral_key = ECDH ephemeral for note encryption
+
+3. Client deposits shielded USDC note to payTo address
+   (using @openclawdsol/dark-protocol-sdk ShieldedWallet)
+   → note commitment added to on-chain Merkle tree
+
+4. POST /shielded/settle  { nullifier, commitment, merkle_path, proof, ... }
+   → ZK ownership proof verified on Dark Protocol program
+   → nullifier marked spent (prevents double-spend)
+   → access_token returned (scoped to resource + nonce)
+
+5. POST /tee/inference  X-Dark-Access: <access_token>
+   { model: "...", encrypted_messages: [...] }
+   → enclave decrypts, infers, re-encrypts completion
+   → caller decrypts with their ephemeral key
+```
+
+## SDK quickstart
+
+```ts
+import { ShieldedWallet, SaplingUtils } from "@openclawdsol/dark-protocol-sdk";
+
+// Generate shielded payer identity
+const { wallet } = await SaplingUtils.generateWallet();
+const sw = await ShieldedWallet.create({ network: "mainnet" });
+
+// Deposit USDC into shielded pool
+await sw.deposit({ amount: 1_000_000n, memo: "x402 dark payment" });
+
+// Pay a dark-shielded x402 challenge
+const proof = await sw.buildSpendingProof({
+  amount: 10_000n,            // $0.01 USDC in base units
+  challenge: darkChallenge,   // from POST /shielded/challenge
+});
+
+// Settle → get access token
+const { access_token } = await fetch("https://x402.wtf/dark/shielded/settle", {
+  method: "POST",
+  body: JSON.stringify(proof),
+}).then(r => r.json());
+
+// Encrypted inference — prompt never leaves plaintext
+const teeKey = await fetch("https://x402.wtf/dark/tee/pubkey").then(r => r.json());
+const encryptedMessages = await encryptMessages(messages, teeKey.pubkey);
+
+const { encrypted_content } = await fetch("https://x402.wtf/dark/tee/inference", {
+  method: "POST",
+  headers: { "X-Dark-Access": access_token },
+  body: JSON.stringify({ model: "claude-sonnet-4-6", encrypted_messages }),
+}).then(r => r.json());
+
+const completion = await decryptCompletion(encrypted_content, myEphemeralKey);
+```
+
+## Spend-aware usage
+
+- Fetch `GET /tee/pubkey` once per session — the enclave key rotates daily. Cache it
+  for the session duration (`valid_until`) rather than fetching per request.
+- Use `POST /shielded/verify` before `POST /shielded/settle` when testing proof
+  construction — verify is free and does not mark the nullifier spent.
+- Batch multiple inference calls under a single shielded note by depositing enough
+  USDC to cover the session; the note is split via partial spending proofs.
+- Set `diversifier_index` on your Sapling wallet to generate unlinkable change addresses
+  for each session — even the operator's viewing key cannot link sessions.
+- For selective auditability (e.g. compliance, tax), share only the incoming viewing key
+  for the relevant account index — it reveals received amounts but not the payer identity.
+- The `attestation` field on `/tee/pubkey` and `/tee/inference` responses can be verified
+  against the SAS program on-chain — do this before trusting the enclave key in sensitive flows.

--- a/providers/clawd/dark/openapi.json
+++ b/providers/clawd/dark/openapi.json
@@ -1,0 +1,285 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "ClawdDarkPrivateX402",
+    "version": "1.0.0",
+    "description": "Privacy-first x402 payments on Solana using Dark-DeFi shielded infrastructure. Extends the standard x402 scheme with a 'dark-shielded' variant: USDC transfers routed through Zcash Sapling-derived shielded notes, breaking the payment graph between caller and API operator. AI inference runs inside TEE (SGX/SEV) enclaves attested on-chain via SAS — prompts and completions never appear in plaintext on the Solana ledger."
+  },
+  "servers": [
+    { "url": "https://x402.wtf/dark", "description": "Dark-shielded x402 gateway (Solana mainnet)" }
+  ],
+  "paths": {
+    "/shielded/challenge": {
+      "post": {
+        "operationId": "shieldedChallenge",
+        "summary": "Get a dark-shielded payment challenge",
+        "description": "Returns a 402-style payment challenge using the 'dark-shielded' x402 scheme. The payTo address is a one-time diversified Sapling address generated fresh per request — unlinkable to the operator's on-chain identity. The caller funds a shielded note; the operator's scanning key detects it without exposing the graph.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["resource"],
+                "properties": {
+                  "resource": { "type": "string", "description": "API endpoint being requested" },
+                  "amount_hint": { "type": "string", "description": "Suggested USDC amount in base units — server may override" }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "402": {
+            "description": "Dark-shielded payment challenge",
+            "headers": {
+              "X-Payment-Required": {
+                "schema": { "type": "string" },
+                "description": "Base64-encoded dark-shielded PaymentRequiredResponse"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "x402Version": { "type": "integer", "example": 1 },
+                    "scheme": { "type": "string", "enum": ["dark-shielded"] },
+                    "accepts": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "scheme": { "type": "string", "enum": ["dark-shielded"] },
+                          "network": { "type": "string", "enum": ["solana-mainnet"] },
+                          "maxAmountRequired": { "type": "string" },
+                          "payTo": { "type": "string", "description": "Diversified Sapling address (one-time, unlinkable to operator)" },
+                          "token": { "type": "string", "description": "USDC mint" },
+                          "ephemeral_key": { "type": "string", "description": "ECDH ephemeral key for note encryption" },
+                          "commitment_tree_root": { "type": "string", "description": "Current Merkle root for proof verification" }
+                        }
+                      }
+                    },
+                    "nonce": { "type": "string" },
+                    "expiresAt": { "type": "string", "format": "date-time" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/shielded/verify": {
+      "post": {
+        "operationId": "shieldedVerify",
+        "summary": "Verify a shielded payment without settling",
+        "description": "Verifies a dark-shielded payment proof. Checks: note commitment exists in the Merkle tree, nullifier has not been spent, ZK ownership proof is valid, amount meets the requirement. Does not submit on-chain.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/ShieldedPaymentProof" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Verification result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "valid": { "type": "boolean" },
+                    "error": { "type": "string" },
+                    "amount_verified": { "type": "string" },
+                    "nullifier_fresh": { "type": "boolean" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/shielded/settle": {
+      "post": {
+        "operationId": "shieldedSettle",
+        "summary": "Settle a shielded payment and grant access",
+        "description": "Verifies the shielded proof, marks the nullifier as spent on the Dark Protocol Anchor program (program ID: 4753b1cCrPzwr7taWWD8yrcM8dc98fTR7wCFdv1TsAbg), and returns a signed access token scoped to the requested resource and nonce.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/ShieldedPaymentProof" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Settlement result with access token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": { "type": "boolean" },
+                    "access_token": { "type": "string", "description": "Short-lived signed token — present as X-Dark-Access header on the resource request" },
+                    "nullifier_tx": { "type": "string", "description": "On-chain tx signature registering the spent nullifier" },
+                    "expires_at": { "type": "string", "format": "date-time" }
+                  }
+                }
+              }
+            }
+          },
+          "402": { "description": "Proof invalid or nullifier already spent" }
+        }
+      }
+    },
+    "/tee/inference": {
+      "post": {
+        "operationId": "teeInference",
+        "summary": "Privacy-preserving AI inference in a TEE enclave",
+        "description": "Chat completion inside an SGX/SEV trusted execution environment attested via the Solana Attestation Service (SAS). Prompts are encrypted client-side before entering the enclave; completions are encrypted before leaving. Neither the operator nor the network sees plaintext. Requires a dark-shielded payment settled via /shielded/settle.",
+        "security": [{ "darkAccess": [] }],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["encrypted_messages", "model"],
+                "properties": {
+                  "model": { "type": "string", "description": "Model ID (e.g. claude-sonnet-4-6, grok-4)" },
+                  "encrypted_messages": {
+                    "type": "array",
+                    "description": "ChaCha20-Poly1305 encrypted message objects. Encrypt with the enclave's public key from /tee/pubkey.",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "ciphertext": { "type": "string", "description": "Base64 ciphertext" },
+                        "nonce": { "type": "string", "description": "12-byte nonce (Base64)" },
+                        "role": { "type": "string", "enum": ["user", "assistant", "system"] }
+                      }
+                    }
+                  },
+                  "max_tokens": { "type": "integer" }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Encrypted completion from TEE",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "encrypted_content": { "type": "string", "description": "Base64 ChaCha20-Poly1305 ciphertext of the completion, encrypted with caller's ephemeral key" },
+                    "nonce": { "type": "string" },
+                    "attestation": { "type": "string", "description": "Base64 SAS attestation quote proving the enclave produced this response" },
+                    "tokens_used": { "type": "integer" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/tee/pubkey": {
+      "get": {
+        "operationId": "teePublicKey",
+        "summary": "Get TEE enclave encryption public key",
+        "description": "Returns the current ChaCha20-Poly1305 / X25519 public key for the active TEE enclave, along with its SAS attestation. Use to encrypt messages before sending to /tee/inference.",
+        "responses": {
+          "200": {
+            "description": "Enclave public key and attestation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "pubkey": { "type": "string", "description": "X25519 public key (Base64)" },
+                    "attestation": { "type": "string", "description": "SAS on-chain attestation signature" },
+                    "enclave_type": { "type": "string", "enum": ["sgx", "sev", "dstack"] },
+                    "valid_until": { "type": "string", "format": "date-time" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/wallet/generate": {
+      "post": {
+        "operationId": "generateShieldedWallet",
+        "summary": "Generate a Sapling shielded wallet address",
+        "description": "Derives a Zcash Sapling-compatible shielded address from a ZIP-32 HD seed for use as a private payer identity. Call client-side via @openclawdsol/dark-protocol-sdk; this endpoint is for demo/test flows only.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "account_index": { "type": "integer", "default": 0 },
+                  "diversifier_index": { "type": "integer", "default": 0 }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Generated shielded address",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "shielded_address": { "type": "string", "description": "43-byte Sapling address (zs1... format)" },
+                    "viewing_key": { "type": "string", "description": "Incoming viewing key for scanning notes" },
+                    "diversifier": { "type": "string" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ShieldedPaymentProof": {
+        "type": "object",
+        "required": ["scheme", "network", "nullifier", "commitment", "proof", "amount", "resource", "nonce"],
+        "properties": {
+          "scheme": { "type": "string", "enum": ["dark-shielded"] },
+          "network": { "type": "string", "enum": ["solana-mainnet"] },
+          "nullifier": { "type": "string", "description": "32-byte nullifier (Base64) — derived from the spent note" },
+          "commitment": { "type": "string", "description": "32-byte note commitment (Base64) — proves the note exists in the Merkle tree" },
+          "merkle_path": { "type": "array", "items": { "type": "string" }, "description": "Merkle authentication path from leaf to root" },
+          "proof": { "type": "string", "description": "ZK-SNARK spending proof (Base64)" },
+          "amount": { "type": "string", "description": "USDC base units — must meet the challenge maxAmountRequired" },
+          "resource": { "type": "string" },
+          "nonce": { "type": "string" },
+          "payer_ephemeral_pk": { "type": "string", "description": "Payer's X25519 ephemeral public key for response encryption" }
+        }
+      }
+    },
+    "securitySchemes": {
+      "darkAccess": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-Dark-Access",
+        "description": "Short-lived access token returned by POST /shielded/settle after successful ZK proof verification."
+      }
+    }
+  }
+}

--- a/providers/clawd/x402/PAY.md
+++ b/providers/clawd/x402/PAY.md
@@ -1,0 +1,88 @@
+---
+name: x402
+title: "ClawdX402Facilitator"
+description: "Solana x402 payment facilitator — verifies, settles, and slug-routes USDC micropayments for HTTP 402 paywalled APIs. Handles full x402 lifecycle: decode payload, check SPL transfer, submit to Solana RPC, return settlement signature. Multi-tenant; any API operator can register slugs."
+use_case: "Use for verifying or settling x402 Solana USDC payments, resolving payment slugs to amounts and recipients, checking on-chain settlement confirmation, and building or integrating x402-gated APIs without running your own Solana RPC infrastructure."
+category: finance
+service_url: https://clawdrouter.fly.dev
+openapi:
+  path: openapi.json
+---
+
+The Clawd x402 facilitator is the shared payment verification and settlement backend for all
+services in the SolanaClawdAgents ecosystem. It implements the
+[x402 protocol](https://www.x402.org) server-side: any API operator can point their
+`x402Paywall` middleware at `https://clawdrouter.fly.dev` and immediately accept USDC
+micropayments on Solana mainnet without managing an RPC node.
+
+The facilitator also manages **payment slugs** — named pricing rules (e.g. `deep-chain-analysis`,
+`alpha-signals`) that map to a specific USDC amount, token mint, and Solana recipient. This lets
+operator APIs return 402 challenges by slug rather than hardcoding amounts, and enables clients to
+pre-fund or approve specific priced actions before making the request.
+
+## Integration patterns
+
+**API operator (server-side):**
+
+```ts
+import { x402Paywall } from "@pump-fun/x402/server";
+
+app.get("/premium",
+  x402Paywall({
+    payTo: "YourSolanaAddress",
+    amount: "10000",                       // $0.01 USDC
+    facilitatorUrl: "https://clawdrouter.fly.dev",
+  }),
+  handler
+);
+```
+
+**Agent client (pay automatically):**
+
+```ts
+import { X402Client } from "@pump-fun/x402/client";
+import { Keypair } from "@solana/web3.js";
+
+const client = new X402Client({
+  signer: Keypair.fromSecretKey(agentKey),
+  network: "solana-mainnet",
+  maxPaymentAmount: "100000",              // $0.10 USDC hard cap
+});
+
+const response = await client.fetch("https://api.example.com/premium");
+```
+
+**Verify without settlement (dry-run):**
+
+```ts
+const result = await fetch("https://clawdrouter.fly.dev/verify", {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify(paymentPayload),
+}).then(r => r.json());
+
+if (!result.valid) throw new Error(result.error);
+```
+
+## Slug catalog
+
+Well-known slugs for `x402.wtf` endpoints:
+
+| Slug | Price | Description |
+|---|---|---|
+| `quick-lookup` | $0.001 | Single-token price or holder count |
+| `chain-analysis` | $0.02 | Full on-chain token analysis |
+| `alpha-signals` | $0.10 | AI alpha detection scan |
+| `agent-research-standard` | $0.10 | Multi-agent research report |
+| `agent-research-deep` | $0.50 | Deep OODA-loop research |
+| `mcp-tool-call` | $0.001–$0.10 | MCP tool (price varies by tool) |
+
+Fetch `GET /slugs/{slug}` to resolve the current amount and payTo address before signing.
+
+## Spend-aware usage
+
+- Call `GET /health` before a high-value session to confirm the facilitator can reach the Solana RPC.
+- Use `POST /verify` before `POST /settle` when you want to validate the payment client-side without committing on-chain.
+- Use `GET /status/{txSignature}` to confirm finality on time-sensitive flows; the facilitator waits for `confirmed` commitment by default.
+- Slug amounts can change; always call `GET /slugs/{slug}` at session start rather than hardcoding amounts.
+- The nonce in the 402 challenge expires in 5 minutes — don't cache payment payloads across sessions.

--- a/providers/clawd/x402/openapi.json
+++ b/providers/clawd/x402/openapi.json
@@ -1,0 +1,204 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "ClawdX402Facilitator",
+    "version": "1.0.0",
+    "description": "Solana x402 payment facilitator — verifies, settles, and routes USDC micropayments for API paywalls. Handles the full x402 lifecycle: decode payment payload, verify the on-chain SPL transfer, submit to Solana RPC, and return a settlement signature."
+  },
+  "servers": [
+    { "url": "https://clawdrouter.fly.dev", "description": "Production facilitator (Solana mainnet)" },
+    { "url": "https://x402.wtf/facilitator", "description": "Gateway-proxied facilitator" }
+  ],
+  "paths": {
+    "/verify": {
+      "post": {
+        "operationId": "verifyPayment",
+        "summary": "Verify an x402 payment payload",
+        "description": "Decodes and validates an x402 PaymentPayload without submitting to chain. Checks signature, amount, recipient, nonce, and expiry. Use this before settle when you want a dry-run or when the API server manages its own settlement.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/PaymentPayload" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Verification result",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/VerificationResult" }
+              }
+            }
+          },
+          "400": { "description": "Malformed payment payload" }
+        }
+      }
+    },
+    "/settle": {
+      "post": {
+        "operationId": "settlePayment",
+        "summary": "Verify and settle an x402 payment on-chain",
+        "description": "Verifies the PaymentPayload then submits the Solana SPL-token transfer transaction to the network. Returns the transaction signature on success. Idempotent for the same nonce within the expiry window.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/PaymentPayload" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Settlement result",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/SettlementResult" }
+              }
+            }
+          },
+          "400": { "description": "Malformed or already-settled payment" },
+          "402": { "description": "Payment verification failed" }
+        }
+      }
+    },
+    "/status/{txSignature}": {
+      "get": {
+        "operationId": "settlementStatus",
+        "summary": "Check settlement confirmation status",
+        "description": "Polls the Solana cluster for the confirmation status of a previously submitted settlement transaction.",
+        "parameters": [
+          {
+            "name": "txSignature",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" },
+            "description": "Base58 Solana transaction signature returned by /settle"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Settlement status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "confirmed": { "type": "boolean" },
+                    "slot": { "type": "integer" },
+                    "err": { "type": "string", "nullable": true }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/slugs/{slug}": {
+      "get": {
+        "operationId": "resolveSlug",
+        "summary": "Resolve a payment slug to its price and recipient",
+        "description": "Slugs are short named pricing rules registered by API operators. Resolving a slug returns the USDC amount, Solana recipient, and network for building a payment payload without a live 402 challenge.",
+        "parameters": [
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" },
+            "description": "Slug name (e.g. premium-data-feed, deep-chain-analysis)"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Slug definition",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "slug": { "type": "string" },
+                    "label": { "type": "string" },
+                    "description": { "type": "string" },
+                    "amount": { "type": "string", "description": "USDC base units (6 decimals)" },
+                    "token": { "type": "string", "description": "USDC mint address" },
+                    "network": { "type": "string", "enum": ["solana-mainnet"] },
+                    "payTo": { "type": "string" }
+                  }
+                }
+              }
+            }
+          },
+          "404": { "description": "Slug not found" }
+        }
+      }
+    },
+    "/health": {
+      "get": {
+        "operationId": "health",
+        "summary": "Facilitator health check",
+        "description": "Returns facilitator uptime, Solana RPC connectivity, and current slot.",
+        "responses": {
+          "200": {
+            "description": "Health status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": { "type": "string", "enum": ["ok", "degraded"] },
+                    "network": { "type": "string" },
+                    "slot": { "type": "integer" },
+                    "rpc_latency_ms": { "type": "integer" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "PaymentPayload": {
+        "type": "object",
+        "required": ["x402Version", "scheme", "network", "transaction", "amount", "token", "payer", "payTo", "resource"],
+        "properties": {
+          "x402Version": { "type": "integer", "example": 1 },
+          "scheme": { "type": "string", "enum": ["exact"] },
+          "network": { "type": "string", "enum": ["solana-mainnet", "solana-devnet"] },
+          "transaction": { "type": "string", "description": "Base64 partially-signed Solana transaction" },
+          "amount": { "type": "string", "description": "USDC base units paid" },
+          "token": { "type": "string", "description": "USDC mint address" },
+          "payer": { "type": "string", "description": "Payer Solana address (Base58)" },
+          "payTo": { "type": "string", "description": "Recipient Solana address (Base58)" },
+          "resource": { "type": "string", "description": "URL of the resource being accessed" },
+          "nonce": { "type": "string" }
+        }
+      },
+      "VerificationResult": {
+        "type": "object",
+        "properties": {
+          "valid": { "type": "boolean" },
+          "error": { "type": "string" },
+          "amount": { "type": "string" },
+          "payer": { "type": "string" },
+          "payTo": { "type": "string" }
+        }
+      },
+      "SettlementResult": {
+        "type": "object",
+        "properties": {
+          "success": { "type": "boolean" },
+          "txSignature": { "type": "string" },
+          "error": { "type": "string" },
+          "network": { "type": "string" },
+          "payer": { "type": "string" },
+          "amount": { "type": "string" }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds **three new providers** under `providers/clawd/` for the SolanaClawdAgents ecosystem — a sovereign Solana AI agent runtime combining x402 micropayments, 80+ DeFi agents, and privacy-preserving inference.

- **`clawd/agents`** — [x402.wtf](https://x402.wtf): pay-per-request AI inference (OpenAI-compatible chat completions, on-chain analysis, alpha signals, deep research) backed by 80+ Solana DeFi agents and 130+ MCP tools. Gated by Solana USDC x402 with no API key required. Pricing: \$0.001–\$0.50 USDC per call.

- **`clawd/x402`** — [clawdrouter.fly.dev](https://clawdrouter.fly.dev): multi-tenant x402 payment facilitator for Solana mainnet. Handles verify, settle, slug resolution, and settlement status. Drop-in `facilitatorUrl` for any `@pump-fun/x402` server middleware deployment.

- **`clawd/dark`** — [x402.wtf/dark](https://x402.wtf/dark): privacy-first x402 extension via [Dark-DeFi](https://github.com/x402agent/dark-defi). Introduces a `dark-shielded` x402 payment scheme routing USDC through Zcash Sapling shielded notes (unlinkable payer/payTo). AI inference runs inside SGX/SEV TEE enclaves attested on-chain via SAS — prompts and completions are ChaCha20-Poly1305 encrypted end-to-end.

## Sources

- [solanaclawd.com](https://solanaclawd.com)
- [x402.wtf](https://x402.wtf)
- [cheshireterminal.ai](https://cheshireterminal.ai)
- [github.com/x402agent/solana-clawd](https://github.com/x402agent/solana-clawd)
- [github.com/Solizardking/solana-clawd](https://github.com/Solizardking/solana-clawd)
- [github.com/x402agent/dark-defi](https://github.com/x402agent/dark-defi)
- npm: `@openclawdsolana/leviathan`, `@pump-fun/x402`, `@openclawdsol/dark-protocol-sdk`

## Payment compliance

| Provider | Endpoint | Payment | Network |
|---|---|---|---|
| `clawd/agents` | `POST /api/v1/chat/completions` etc. | Solana USDC (exact scheme) | solana-mainnet |
| `clawd/x402` | Facilitator (no direct payment gate) | n/a — infrastructure | solana-mainnet |
| `clawd/dark` | `POST /shielded/settle` | Solana USDC (dark-shielded scheme) | solana-mainnet |

All paid endpoints return HTTP 402 with valid x402 challenges. The `dark-shielded` scheme is a superset of the standard `exact` scheme using ZK proofs for privacy.

## Test plan

- [ ] `pay catalog check providers/clawd/agents/PAY.md` — frontmatter valid, description/use_case within char limits
- [ ] `pay catalog check providers/clawd/x402/PAY.md`
- [ ] `pay catalog check providers/clawd/dark/PAY.md`
- [ ] OpenAPI 3.1.0 schemas parse without errors
- [ ] Live 402 probe: `GET https://x402.wtf/api/v1/agents` returns free catalog
- [ ] Live 402 probe: `POST https://x402.wtf/api/v1/chat/completions` returns 402 with valid Solana accept options
- [ ] Live 402 probe: `GET https://clawdrouter.fly.dev/health` returns `{"status":"ok"}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)