### PR TITLE
  feat: add Vybe Solana Analytics API (x402)

### DIFF
--- a/providers/vybenetwork/solana-analytics/PAY.md
+++ b/providers/vybenetwork/solana-analytics/PAY.md
@@ -1,15 +1,15 @@
 ---
 name: solana-analytics
 title: "Vybe Solana Analytics API (x402)"
-description: "Solana on-chain analytics — token prices, top holders, wallet PnL, DEX trades, transfers, NFTs, Pyth oracles. Pay-per-call USDC on Solana or Base; no API key."
-use_case: "Use for Solana token metrics (price, market cap, holders), wallet PnL and profiling, DEX market and trade data, SPL transfer history, NFT balances, and Pyth oracle prices. Reach for this instead of running your own RPC indexer for targeted reads."
-category: data
+description: "Solana on-chain analytics — token prices, top holders, wallet PnL, DEX trades, transfers, Pyth oracles. Pay-per-call USDC on Solana or Base; no API key."
+use_case: "Use for Solana token metrics (price, market cap, holders), wallet PnL and profiling, DEX market and trade data, SPL transfer history and Pyth oracle prices. Reach for this instead of running your own RPC indexer for targeted reads."
+category: finance
 service_url: https://x402-api.vybenetwork.xyz
 openapi:
   path: openapi.json
 ---
 
-The full [Vybe Network](https://docs.vybenetwork.com/) Solana analytics REST API, exposed pay-per-call via x402. Every `/v4/*` endpoint in the [Vybe API Reference](https://docs.vybenetwork.com/reference) is callable here at the same path — token details, top holders, market candles, wallet PnL, top traders, transfers, trades, NFT balances, Pyth oracle prices, etc.
+The full [Vybe Network](https://docs.vybenetwork.com/) Solana analytics REST API, exposed pay-per-call via x402. Every `/v4/*` endpoint in the [Vybe API Reference](https://docs.vybenetwork.com/reference) is callable here at the same path — token details, top holders, market candles, wallet PnL, top traders, transfers, trades, Pyth oracle prices, etc.
 
 Two payment chains are advertised in every `402` challenge:
 
@@ -18,17 +18,17 @@ Two payment chains are advertised in every `402` challenge:
 
 Pick whichever your wallet can sign. Coinbase's CDP facilitator signs and submits both — no gas required from the payer.
 
-WebSocket streaming uses prepaid credits: one $0.01 x402 payment buys 1,000 credits, each inbound event debits 1 credit, auto-topup fires before exhaustion. See [`/api/sessions` flow in the Vybe x402 protocol docs](https://docs.vybenetwork.com/docs/x402-payment-protocol).
+WebSocket streaming uses prepaid credits: one $0.10 x402 payment buys 10,000 credits, each inbound event debits 20 credits, auto-topup fires before exhaustion. See [`/api/sessions` flow in the Vybe x402 protocol docs](https://docs.vybenetwork.com/docs/x402-payment-protocol).
 
 ## Pricing
 
-Per-call USDC, $0.003 default and tiered up to $0.030 for the heaviest endpoints. Live table at `GET https://x402-api.vybenetwork.xyz/`.
+Per-call USDC, $0.012 default and tiered up to $0.030 for the heaviest endpoints. Live table at `GET https://x402-api.vybenetwork.xyz/`.
 
 | Tier | Price | Example routes |
 |------|-------|----------------|
-| default | $0.003 | token details, wallet token balances, markets list |
-| 30 cr | $0.009 | OHLCV candles |
-| 50 cr | $0.015 | wallet PnL, top traders, time-series counters |
+| default | $0.012 | token details, wallet token balances, markets list |
+| 30 cr | $0.015 | OHLCV candles |
+| 50 cr | $0.018 | wallet PnL, top traders, time-series counters |
 | 80 cr | $0.024 | top holders, transfers, trades, active users, TVL |
 | 100 cr | $0.030 | batch wallet endpoints (POST) |
 
@@ -36,6 +36,6 @@ Per-call USDC, $0.003 default and tiered up to $0.030 for the heaviest endpoints
 
 - **Use `/v4/tokens/{mint}` for token overview before reaching for `/top-holders` or `/trades`** — the cheap default-tier read carries name, symbol, price, market cap, volume, supply. Saves an $0.024 top-holders call when the lighter snapshot already answers.
 - **Cap `limit=` on list endpoints** — `top-holders`, `trades`, `transfers`, `markets` all accept pagination. `limit=3` answers most "top wallet" or "recent activity" questions; default limits can be 100+ which pays for data you won't use.
-- **Prefer point lookups over wallet-wide endpoints** — for a single token-balance question use `/v4/wallets/{owner}/token-balance?mint=...` (default tier $0.003) instead of `/v4/wallets/batch/token-balances` ($0.030). The batch endpoint is for genuine multi-wallet sweeps.
-- **WebSocket streaming for live feeds, not polling** — calling `/v4/tokens/{mint}` in a loop for price updates burns money. A single $0.01 WS session gives 1,000 streamed events at 1 credit each.
+- **Prefer point lookups over wallet-wide endpoints** — for a single token-balance question use `/v4/wallets/{owner}/token-balance?mint=...` (default tier $0.012) instead of `/v4/wallets/batch/token-balances` ($0.030). The batch endpoint is for genuine multi-wallet sweeps.
+- **WebSocket streaming for live feeds, not polling** — calling `/v4/tokens/{mint}` in a loop for price updates burns money. A single $0.10 WS session gives ~500 streamed events at 20 credits each.
 - **Pyth oracles cover most "current price" needs cheaply** — `/v4/oracle/pyth/pricefeeds/{id}/price` (default tier) updates frequently and is cheaper than candle endpoints when you only need spot.

--- a/providers/vybenetwork/solana-analytics/PAY.md
+++ b/providers/vybenetwork/solana-analytics/PAY.md
@@ -24,13 +24,13 @@ WebSocket streaming uses prepaid credits: one $0.10 x402 payment buys 10,000 cre
 
 Per-call USDC, $0.012 default and tiered up to $0.030 for the heaviest endpoints. Live table at `GET https://x402-api.vybenetwork.xyz/`.
 
-| Tier | Price | Example routes |
-|------|-------|----------------|
-| default | $0.012 | token details, wallet token balances, markets list |
-| 30 cr | $0.015 | OHLCV candles |
-| 50 cr | $0.018 | wallet PnL, top traders, time-series counters |
-| 80 cr | $0.024 | top holders, transfers, trades, active users, TVL |
-| 100 cr | $0.030 | batch wallet endpoints (POST) |
+| Price | Example routes |
+|-------|----------------|
+| $0.012 | token details, wallet token balances, markets list |
+| $0.015 | OHLCV candles |
+| $0.018 | wallet PnL, top traders, time-series counters |
+| $0.024 | top holders, transfers, trades, active users, TVL |
+| $0.030 | batch wallet endpoints (POST) |
 
 ## Spend-aware usage
 

--- a/providers/vybenetwork/solana-analytics/PAY.md
+++ b/providers/vybenetwork/solana-analytics/PAY.md
@@ -1,0 +1,41 @@
+---
+name: solana-analytics
+title: "Vybe Solana Analytics API (x402)"
+description: "Solana on-chain analytics — token prices, top holders, wallet PnL, DEX trades, transfers, NFTs, Pyth oracles. Pay-per-call USDC on Solana or Base; no API key."
+use_case: "Use for Solana token metrics (price, market cap, holders), wallet PnL and profiling, DEX market and trade data, SPL transfer history, NFT balances, and Pyth oracle prices. Reach for this instead of running your own RPC indexer for targeted reads."
+category: data
+service_url: https://x402-api.vybenetwork.xyz
+openapi:
+  path: openapi.json
+---
+
+The full [Vybe Network](https://docs.vybenetwork.com/) Solana analytics REST API, exposed pay-per-call via x402. Every `/v4/*` endpoint in the [Vybe API Reference](https://docs.vybenetwork.com/reference) is callable here at the same path — token details, top holders, market candles, wallet PnL, top traders, transfers, trades, NFT balances, Pyth oracle prices, etc.
+
+Two payment chains are advertised in every `402` challenge:
+
+- **Solana mainnet** — USDC SPL transfer via `@x402/svm`. Native chain for the underlying data.
+- **Base mainnet** — USDC EIP-3009 `transferWithAuthorization` via `@x402/evm`. Same dollar amount per call as Solana.
+
+Pick whichever your wallet can sign. Coinbase's CDP facilitator signs and submits both — no gas required from the payer.
+
+WebSocket streaming uses prepaid credits: one $0.01 x402 payment buys 1,000 credits, each inbound event debits 1 credit, auto-topup fires before exhaustion. See [`/api/sessions` flow in the Vybe x402 protocol docs](https://docs.vybenetwork.com/docs/x402-payment-protocol).
+
+## Pricing
+
+Per-call USDC, $0.003 default and tiered up to $0.030 for the heaviest endpoints. Live table at `GET https://x402-api.vybenetwork.xyz/`.
+
+| Tier | Price | Example routes |
+|------|-------|----------------|
+| default | $0.003 | token details, wallet token balances, markets list |
+| 30 cr | $0.009 | OHLCV candles |
+| 50 cr | $0.015 | wallet PnL, top traders, time-series counters |
+| 80 cr | $0.024 | top holders, transfers, trades, active users, TVL |
+| 100 cr | $0.030 | batch wallet endpoints (POST) |
+
+## Spend-aware usage
+
+- **Use `/v4/tokens/{mint}` for token overview before reaching for `/top-holders` or `/trades`** — the cheap default-tier read carries name, symbol, price, market cap, volume, supply. Saves an $0.024 top-holders call when the lighter snapshot already answers.
+- **Cap `limit=` on list endpoints** — `top-holders`, `trades`, `transfers`, `markets` all accept pagination. `limit=3` answers most "top wallet" or "recent activity" questions; default limits can be 100+ which pays for data you won't use.
+- **Prefer point lookups over wallet-wide endpoints** — for a single token-balance question use `/v4/wallets/{owner}/token-balance?mint=...` (default tier $0.003) instead of `/v4/wallets/batch/token-balances` ($0.030). The batch endpoint is for genuine multi-wallet sweeps.
+- **WebSocket streaming for live feeds, not polling** — calling `/v4/tokens/{mint}` in a loop for price updates burns money. A single $0.01 WS session gives 1,000 streamed events at 1 credit each.
+- **Pyth oracles cover most "current price" needs cheaply** — `/v4/oracle/pyth/pricefeeds/{id}/price` (default tier) updates frequently and is cheaper than candle endpoints when you only need spot.

--- a/providers/vybenetwork/solana-analytics/openapi.json
+++ b/providers/vybenetwork/solana-analytics/openapi.json
@@ -10891,7 +10891,7 @@
             "description": "Unexpected server error. The response body includes an `id` field — provide this when contacting support."
           }
         },
-        "summary": "Token Markets Timeseries",
+        "summary": "Get DEX market history for a Solana token",
         "tags": [
           "Tokens"
         ],
@@ -11272,7 +11272,7 @@
             "description": "Unexpected server error. The response body includes an `id` field — provide this when contacting support."
           }
         },
-        "summary": "Top PnL Traders (By Token)",
+        "summary": "List the top PnL traders for a token",
         "tags": [
           "Tokens"
         ],
@@ -12214,7 +12214,7 @@
             "description": "Internal server error"
           }
         },
-        "summary": "Build a Solana token swap transaction",
+        "summary": "Get an unsigned Solana token swap transaction",
         "tags": [
           "Trading"
         ],
@@ -13324,7 +13324,7 @@
             "description": "Internal server error"
           }
         },
-        "summary": "Token Balance History (Batch)",
+        "summary": "Get token-balance history for multiple wallets",
         "tags": [
           "Wallets"
         ],
@@ -14000,7 +14000,7 @@
             "description": "Internal server error"
           }
         },
-        "summary": "Build a transaction to close token accounts",
+        "summary": "Get a transaction to close token accounts",
         "tags": [
           "Utilities"
         ],
@@ -14109,7 +14109,7 @@
             "description": "Internal server error"
           }
         },
-        "summary": "Build a transaction to withdraw MEV rewards",
+        "summary": "Get a transaction to withdraw MEV rewards",
         "tags": [
           "Utilities"
         ],

--- a/providers/vybenetwork/solana-analytics/openapi.json
+++ b/providers/vybenetwork/solana-analytics/openapi.json
@@ -1,0 +1,16130 @@
+{
+  "components": {
+    "responses": {
+      "AccountTopTraderReturn": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "description": "The top trader wallet identity and performance metrics.",
+              "properties": {
+                "accountAddress": {
+                  "description": "The public key (pubKey) associated with the Solana account.",
+                  "type": "string"
+                },
+                "accountLabels": {
+                  "description": "Custom account labels assigned internally by the Vybe system.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "accountLogoUrl": {
+                  "description": "The URL to the account's logo image (optional).",
+                  "nullable": true,
+                  "type": "string"
+                },
+                "accountName": {
+                  "description": "The display name of the account (optional).",
+                  "nullable": true,
+                  "type": "string"
+                },
+                "accountTwitterUrl": {
+                  "description": "The URL to the account's Twitter profile (optional).",
+                  "nullable": true,
+                  "type": "string"
+                },
+                "metrics": {
+                  "$ref": "#/components/schemas/AccountTopTraderMetrics"
+                }
+              },
+              "required": [
+                "accountAddress",
+                "accountLabels",
+                "metrics"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": "The top trader wallet identity and performance metrics."
+      },
+      "AccountTradesSummaryReturn": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "description": "The overall summary and per-token metrics.",
+              "properties": {
+                "summary": {
+                  "$ref": "#/components/schemas/Summary"
+                },
+                "tokenMetrics": {
+                  "description": "Metrics for a token's trading performance.",
+                  "items": {
+                    "$ref": "#/components/schemas/Metrics"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "summary",
+                "tokenMetrics"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": "The overall summary and per-token metrics."
+      },
+      "ApiError": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "code": {
+                  "description": "Code ID of the error, uniquely identifying the error type",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "id": {
+                  "description": "A unique identifier for the error, representing the error ID in Sentry.\nThis should be submitted as a reference when contacting support.",
+                  "type": "string"
+                },
+                "message": {
+                  "description": "A human readable message describing the error that occurred.",
+                  "type": "string"
+                },
+                "violations": {
+                  "description": "Optional collection of validation violations representations.",
+                  "items": {
+                    "$ref": "#/components/schemas/ConstraintViolation"
+                  },
+                  "nullable": true,
+                  "type": "array"
+                }
+              },
+              "required": [
+                "code",
+                "message",
+                "id"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": ""
+      },
+      "CandleRowWS": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "baseMint": {
+                  "type": "string"
+                },
+                "close": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "high": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "low": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "open": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "quoteMint": {
+                  "type": "string"
+                },
+                "slot": {
+                  "format": "int64",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "timestamp": {
+                  "format": "int64",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "updateTime": {
+                  "format": "int64",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "volume": {
+                  "format": "double",
+                  "type": "number"
+                }
+              },
+              "required": [
+                "baseMint",
+                "quoteMint",
+                "timestamp",
+                "open",
+                "high",
+                "low",
+                "close",
+                "volume",
+                "slot",
+                "updateTime"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": ""
+      },
+      "Code": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "enum": [
+                "RangeValidation",
+                "InvalidKeySize",
+                "InvalidInput",
+                "SqlxError",
+                "NotEnoughCred",
+                "RequestQuotaReached",
+                "NotWebSocketSubscription",
+                "ClickhouseError",
+                "RedisError",
+                "InvalidInit",
+                "NoResultFound",
+                "InvalidResolution",
+                "BigQueryError",
+                "NoAuthorizationHeader",
+                "DeserializationError",
+                "ServerError",
+                "SlowClient",
+                "SlowQuery",
+                "InsufficientPermissions",
+                "NotFound",
+                "WebSocketHandshakeGetMethodRequired",
+                "WebSocketHandshakeNoWebsocketUpgrade",
+                "WebSocketHandshakeNoConnectionUpgrade",
+                "WebSocketHandshakeNoVersionHeader",
+                "WebSocketHandshakeUnsupportedVersion",
+                "WebSocketHandshakeBadWebsocketKey",
+                "NoAuthContextForRequest"
+              ],
+              "type": "string"
+            }
+          }
+        },
+        "description": ""
+      },
+      "ConstraintViolation": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "description": "Main structure to represent any kind of validation violation.",
+              "properties": {
+                "invalidValue": {
+                  "description": "Provided value which leaded to the violation.",
+                  "nullable": true,
+                  "type": "string"
+                },
+                "message": {
+                  "description": "Message to the end user.",
+                  "type": "string"
+                },
+                "propertyPath": {
+                  "description": "Property path to the field where violation occurred.",
+                  "nullable": true,
+                  "type": "string"
+                }
+              },
+              "required": [
+                "message"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": "Main structure to represent any kind of validation violation."
+      },
+      "CounterpartyDataResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "data": {
+                  "items": {
+                    "$ref": "#/components/schemas/CounterpartyData"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "data"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": ""
+      },
+      "DustAccountsResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "dustAccounts": {
+                  "description": "A paginated list of dust accounts for the wallet, where dust accounts are defined as token accounts with very low value (e.g. below $1) or no price information available.",
+                  "items": {
+                    "$ref": "#/components/schemas/DustAccounts"
+                  },
+                  "type": "array"
+                },
+                "totalDustAccounts": {
+                  "description": "The total number of dust accounts for the wallet, including those not returned in this paginated response.",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "totalDustValueSol": {
+                  "description": "The total value of all dust accounts in SOL.",
+                  "type": "string"
+                },
+                "totalDustValueUsd": {
+                  "description": "The total value of all dust accounts in USD.",
+                  "type": "string"
+                },
+                "totalRentReclaimSol": {
+                  "description": "The approximate total rent reclaim value of all dust accounts in SOL, calculated as the number of dust accounts multiplied by the rent_sol per account.",
+                  "type": "string"
+                },
+                "totalRentReclaimUsd": {
+                  "description": "The approximate total rent reclaim value of all dust accounts in USD, calculated as the number of dust accounts multiplied by the rent_usd per account.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "dustAccounts",
+                "totalDustAccounts",
+                "totalDustValueSol",
+                "totalDustValueUsd",
+                "totalRentReclaimSol",
+                "totalRentReclaimUsd"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": ""
+      },
+      "FetcherReport": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "name": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": ""
+      },
+      "InstructionName": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "callingInstructions": {
+                  "format": "binary",
+                  "type": "string"
+                },
+                "callingProgramAddress": {
+                  "type": "string"
+                },
+                "ixName": {
+                  "type": "string"
+                },
+                "programName": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "callingInstructions",
+                "ixName",
+                "callingProgramAddress",
+                "programName"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": ""
+      },
+      "InstructionNameList": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "data": {
+                  "items": {
+                    "$ref": "#/components/schemas/InstructionName"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "data"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": ""
+      },
+      "JoinedNftResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "data": {
+                  "items": {
+                    "$ref": "#/components/schemas/JoinedNftData"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "data"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": ""
+      },
+      "KnownAccountReturn": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "accountAddress": {
+                  "description": "The public key (pubKey) associated with the Solana account",
+                  "type": "string"
+                },
+                "dateAdded": {
+                  "description": "Date added to the database",
+                  "format": "date-time",
+                  "type": "string"
+                },
+                "entity": {
+                  "description": "Account entity, if available",
+                  "nullable": true,
+                  "type": "string"
+                },
+                "entityId": {
+                  "description": "Account entity ID, if available",
+                  "format": "int32",
+                  "nullable": true,
+                  "type": "integer"
+                },
+                "labels": {
+                  "description": "Account labels, eg: DEFI,NFT",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "logoUrl": {
+                  "description": "Account logo URL, if available",
+                  "nullable": true,
+                  "type": "string"
+                },
+                "name": {
+                  "description": "Account name",
+                  "nullable": true,
+                  "type": "string"
+                },
+                "twitterUrl": {
+                  "description": "Twiiter url for the account",
+                  "nullable": true,
+                  "type": "string"
+                }
+              },
+              "required": [
+                "accountAddress",
+                "labels",
+                "dateAdded"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": ""
+      },
+      "KnownAccountVecReturn": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "accounts": {
+                  "description": "Found accounts",
+                  "items": {
+                    "$ref": "#/components/schemas/KnownAccountReturn"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "accounts"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": ""
+      },
+      "KnownProgramReturn": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "dateAdded": {
+                  "description": "Date added to the database",
+                  "format": "date-time",
+                  "type": "string"
+                },
+                "defiLlamaId": {
+                  "description": "Program DeFi Llama ID",
+                  "nullable": true,
+                  "type": "string"
+                },
+                "entityId": {
+                  "description": "Program entity ID",
+                  "format": "int32",
+                  "nullable": true,
+                  "type": "integer"
+                },
+                "entityName": {
+                  "description": "Name of the business or entity that controls this program",
+                  "nullable": true,
+                  "type": "string"
+                },
+                "idlUrl": {
+                  "description": "Program IDL URL",
+                  "nullable": true,
+                  "type": "string"
+                },
+                "labels": {
+                  "description": "Program labels, eg: DEFI,NFT",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "logoUrl": {
+                  "description": "Program logo URL",
+                  "nullable": true,
+                  "type": "string"
+                },
+                "name": {
+                  "description": "Program name",
+                  "nullable": true,
+                  "type": "string"
+                },
+                "programAddress": {
+                  "description": "Program ID",
+                  "type": "string"
+                },
+                "programDescription": {
+                  "description": "Program description",
+                  "nullable": true,
+                  "type": "string"
+                },
+                "programDetail": {
+                  "description": "Program detail",
+                  "nullable": true,
+                  "type": "string"
+                },
+                "siteUrl": {
+                  "description": "Program site URL",
+                  "nullable": true,
+                  "type": "string"
+                },
+                "twitterUrl": {
+                  "description": "Twiiter url for the program account",
+                  "nullable": true,
+                  "type": "string"
+                }
+              },
+              "required": [
+                "programAddress",
+                "labels",
+                "dateAdded"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": ""
+      },
+      "MarketOhlcvCandleReturn": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "close": {
+                  "type": "string"
+                },
+                "count": {
+                  "format": "int64",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "high": {
+                  "type": "string"
+                },
+                "low": {
+                  "type": "string"
+                },
+                "open": {
+                  "type": "string"
+                },
+                "time": {
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "volume": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "time",
+                "open",
+                "high",
+                "low",
+                "close",
+                "volume",
+                "count"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": ""
+      },
+      "MarketOhlcvCandleVecReturn": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "data": {
+                  "description": "Found OHLCV data",
+                  "items": {
+                    "$ref": "#/components/schemas/MarketOhlcvCandleReturn"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "data"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": ""
+      },
+      "MarketsReturn": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "data": {
+                  "items": {
+                    "$ref": "#/components/schemas/TradePriceMarketReturn"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "data"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": ""
+      },
+      "NewMarketWsResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "dexId": {
+                  "type": "string"
+                },
+                "initialLiquidityTokenA": {
+                  "nullable": true,
+                  "type": "string"
+                },
+                "initialLiquidityTokenB": {
+                  "nullable": true,
+                  "type": "string"
+                },
+                "poolId": {
+                  "type": "string"
+                },
+                "signature": {
+                  "type": "string"
+                },
+                "slot": {
+                  "format": "int64",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "timestamp": {
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "tokenAMint": {
+                  "type": "string"
+                },
+                "tokenBMint": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "dexId",
+                "poolId",
+                "tokenAMint",
+                "tokenBMint",
+                "signature",
+                "slot",
+                "timestamp"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": ""
+      },
+      "NewTokenWsResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "decimals": {
+                  "format": "int32",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "freezeAuthority": {
+                  "nullable": true,
+                  "type": "string"
+                },
+                "maxSupply": {
+                  "format": "int64",
+                  "minimum": 0,
+                  "nullable": true,
+                  "type": "integer"
+                },
+                "mintAuthority": {
+                  "type": "string"
+                },
+                "signature": {
+                  "type": "string"
+                },
+                "slot": {
+                  "format": "int64",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "sourceId": {
+                  "nullable": true,
+                  "type": "string"
+                },
+                "sourceName": {
+                  "nullable": true,
+                  "type": "string"
+                },
+                "timestamp": {
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "tokenMint": {
+                  "type": "string"
+                },
+                "tokenName": {
+                  "nullable": true,
+                  "type": "string"
+                },
+                "tokenSymbol": {
+                  "nullable": true,
+                  "type": "string"
+                },
+                "tokenUri": {
+                  "nullable": true,
+                  "type": "string"
+                }
+              },
+              "required": [
+                "tokenMint",
+                "mintAuthority",
+                "decimals",
+                "signature",
+                "slot",
+                "timestamp"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": ""
+      },
+      "PnlTimeseriesResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "data": {
+                  "items": {
+                    "$ref": "#/components/schemas/PnlTimeseriesData"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "data"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": ""
+      },
+      "ProgramDetails": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "dau": {
+                  "description": "Unique fee payers in the last day",
+                  "format": "int64",
+                  "nullable": true,
+                  "type": "integer"
+                },
+                "entityName": {
+                  "description": "Name of the business or entity that controls this program",
+                  "nullable": true,
+                  "type": "string"
+                },
+                "friendlyName": {
+                  "description": "Friendly name",
+                  "nullable": true,
+                  "type": "string"
+                },
+                "idlUrl": {
+                  "description": "Program IDL URL",
+                  "nullable": true,
+                  "type": "string"
+                },
+                "instructions1d": {
+                  "description": "Instruction count in 1 day",
+                  "format": "int64",
+                  "nullable": true,
+                  "type": "integer"
+                },
+                "labels": {
+                  "description": "Labels to filter over. Only programs matching all labels will be returned (eg. labels=DEFI,NFT)",
+                  "items": {
+                    "type": "string"
+                  },
+                  "nullable": true,
+                  "type": "array"
+                },
+                "logoUrl": {
+                  "description": "Program logo URL",
+                  "nullable": true,
+                  "type": "string"
+                },
+                "name": {
+                  "description": "Program name",
+                  "nullable": true,
+                  "type": "string"
+                },
+                "newUsersChange1d": {
+                  "description": "1 day change in DAU",
+                  "format": "int64",
+                  "nullable": true,
+                  "type": "integer"
+                },
+                "programDescription": {
+                  "description": "Program description",
+                  "nullable": true,
+                  "type": "string"
+                },
+                "programDetail": {
+                  "description": "Program detail",
+                  "nullable": true,
+                  "type": "string"
+                },
+                "programId": {
+                  "description": "Program ID",
+                  "type": "string"
+                },
+                "transactions1d": {
+                  "description": "Total transactions in 1 day",
+                  "format": "int64",
+                  "nullable": true,
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "programId"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": ""
+      },
+      "ProgramInstructionName": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "callingInstructions": {
+                  "format": "binary",
+                  "type": "string"
+                },
+                "callingProgram": {
+                  "type": "string"
+                },
+                "ixName": {
+                  "type": "string"
+                },
+                "programLogoUrl": {
+                  "type": "string"
+                },
+                "programName": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "callingInstructions",
+                "ixName",
+                "callingProgram",
+                "programName",
+                "programLogoUrl"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": ""
+      },
+      "ProgramRankHelper": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "programId": {
+                  "description": "Program address in base 58 format",
+                  "type": "string"
+                },
+                "programName": {
+                  "description": "Program Name - null if we dont have it in the dict",
+                  "nullable": true,
+                  "type": "string"
+                },
+                "programRank": {
+                  "description": "Program rank for the day",
+                  "format": "int32",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "score": {
+                  "description": "rank score after calculation",
+                  "format": "double",
+                  "type": "number"
+                }
+              },
+              "required": [
+                "programRank",
+                "programId",
+                "score"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": ""
+      },
+      "ProgramRanks": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "data": {
+                  "description": "The Ranked programs",
+                  "items": {
+                    "$ref": "#/components/schemas/ProgramRankHelper"
+                  },
+                  "type": "array"
+                },
+                "date": {
+                  "description": "The epoch used to get the ranks for",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "interval": {
+                  "description": "Interval between the ranks - Possible values: '1d', '7d' or '30d'",
+                  "type": "string"
+                },
+                "limit": {
+                  "description": "The number of ranks returned",
+                  "format": "int32",
+                  "minimum": 0,
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "date",
+                "interval",
+                "limit",
+                "data"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": ""
+      },
+      "ProgramsActiveUsersCountVecReturn": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "data": {
+                  "items": {
+                    "$ref": "#/components/schemas/ProgramActiveUsersCount"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "data"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": ""
+      },
+      "ProgramsActiveUsersVecReturn": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "data": {
+                  "description": "Found active users",
+                  "items": {
+                    "$ref": "#/components/schemas/ProgramActiveUsers"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "data"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": ""
+      },
+      "ProgramsInstructionsCountVecReturn": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "data": {
+                  "description": "Found instructions count",
+                  "items": {
+                    "$ref": "#/components/schemas/ProgramInstructionsCount"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "data"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": ""
+      },
+      "ProgramsListResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "data": {
+                  "items": {
+                    "$ref": "#/components/schemas/ProgramDetails"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "data"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": ""
+      },
+      "ProgramsTransactionsCountVecReturn": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "data": {
+                  "description": "Found transactions count",
+                  "items": {
+                    "$ref": "#/components/schemas/ProgramTransactionsCount"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "data"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": ""
+      },
+      "PythPriceFeed": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "description": "User-facing Pyth price feed update",
+              "properties": {
+                "confidence": {
+                  "description": "Confidence interval of how close we think the true price is to the average.\nIt's influenced by both how sure each person quoting the price is, and how much they agree with each other.",
+                  "type": "string"
+                },
+                "emac1H": {
+                  "description": "Exponentially-weighted moving average confidence interval is a time-weighted average of the confidence interval",
+                  "type": "string"
+                },
+                "emap1H": {
+                  "description": "Exponentially-weighted moving average price is a time-weighted average of the aggregate price",
+                  "type": "string"
+                },
+                "lastUpdated": {
+                  "description": "The last updated time",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "priceFeedAddress": {
+                  "$ref": "#/components/schemas/SolanaId"
+                },
+                "priceUsd": {
+                  "description": "Price of asset expressed in USD",
+                  "type": "string"
+                },
+                "validSlot": {
+                  "description": "The last valid slot",
+                  "format": "int64",
+                  "minimum": 0,
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "priceFeedAddress",
+                "lastUpdated",
+                "validSlot",
+                "priceUsd",
+                "confidence",
+                "emac1H",
+                "emap1H"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": "User-facing Pyth price feed update"
+      },
+      "PythPriceFeedWsReturn": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "description": "WSS-specific Pyth price feed response that preserves legacy field names (`priceFeedAccount`, `price`)\nto avoid breaking WebSocket consumers.",
+              "properties": {
+                "confidence": {
+                  "type": "string"
+                },
+                "emac1H": {
+                  "type": "string"
+                },
+                "emap1H": {
+                  "type": "string"
+                },
+                "lastUpdated": {
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "price": {
+                  "type": "string"
+                },
+                "priceFeedAccount": {
+                  "$ref": "#/components/schemas/SolanaId"
+                },
+                "validSlot": {
+                  "format": "int64",
+                  "minimum": 0,
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "priceFeedAccount",
+                "lastUpdated",
+                "validSlot",
+                "price",
+                "confidence",
+                "emac1H",
+                "emap1H"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": "WSS-specific Pyth price feed response that preserves legacy field names (`priceFeedAccount`, `price`)\nto avoid breaking WebSocket consumers."
+      },
+      "PythPriceFeedsTimeSeriesReturn": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "data": {
+                  "items": {
+                    "$ref": "#/components/schemas/PythPriceFeed"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "data"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": ""
+      },
+      "PythPriceOhlcReturn": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "data": {
+                  "items": {
+                    "$ref": "#/components/schemas/PythPriceOhlc"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "data"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": ""
+      },
+      "PythPriceProductPairsReturn": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "data": {
+                  "items": {
+                    "$ref": "#/components/schemas/PythPriceProductPair"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "data"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": ""
+      },
+      "PythProduct": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "allOf": [
+                {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/PythProductSchedule"
+                    }
+                  ],
+                  "nullable": true
+                },
+                {
+                  "$ref": "#/components/schemas/PythProductSymbols"
+                },
+                {
+                  "properties": {
+                    "assetType": {
+                      "description": "The asset class: Crypto, Equity, FX, Metal, Rates, Commodities",
+                      "type": "string"
+                    },
+                    "base": {
+                      "description": "Base asset. Can be present for everything except rates and commodities.",
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "country": {
+                      "description": "The country code. Can be present for equity only.",
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "description": {
+                      "description": "Pair name",
+                      "type": "string"
+                    },
+                    "productAddress": {
+                      "description": "The pubkey identifying the Pyth Product.",
+                      "type": "string"
+                    },
+                    "quote": {
+                      "description": "Quote currency. Can be present for everything except rates and commodities.",
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    "symbol": {
+                      "description": "Pyth asset symbol",
+                      "type": "string"
+                    },
+                    "tenor": {
+                      "description": "The tenor. Can be present for FX or equity only.",
+                      "nullable": true,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "productAddress",
+                    "description",
+                    "symbol",
+                    "assetType"
+                  ],
+                  "type": "object"
+                }
+              ],
+              "description": "Structure corresponding to what we will fetch in the API\nThis is saved to a json file"
+            }
+          }
+        },
+        "description": "Structure corresponding to what we will fetch in the API\nThis is saved to a json file"
+      },
+      "SolanaId": {
+        "content": {
+          "application/octet-stream": {
+            "schema": {
+              "format": "binary",
+              "type": "string"
+            }
+          }
+        },
+        "description": ""
+      },
+      "TokenBalance": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "amount": {
+                  "description": "Amount of the token",
+                  "type": "string"
+                },
+                "averagePriceUsd": {
+                  "description": "Average price of the token in this wallet's trades",
+                  "type": "string"
+                },
+                "category": {
+                  "description": "Category for the token",
+                  "nullable": true,
+                  "type": "string"
+                },
+                "decimals": {
+                  "description": "Decimals for the token",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "logoUrl": {
+                  "description": "Logo URL for the token",
+                  "nullable": true,
+                  "type": "string"
+                },
+                "mintAddress": {
+                  "description": "Address for the token",
+                  "type": "string"
+                },
+                "name": {
+                  "description": "Name for the token, can be null for unknown addresses",
+                  "nullable": true,
+                  "type": "string"
+                },
+                "priceUsd": {
+                  "description": "Average price of the token in USD",
+                  "type": "string"
+                },
+                "priceUsd1dChange": {
+                  "description": "Change in the price of the token in USD over the last 24 hours",
+                  "type": "string"
+                },
+                "priceUsd7dTrend": {
+                  "description": "7 day trend of the token price in USD",
+                  "type": "string"
+                },
+                "slot": {
+                  "description": "Slot for the most recent update to the token balance. May be 0 if no information is available",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "symbol": {
+                  "description": "Symbol for the token, can be null for unknown addresses",
+                  "nullable": true,
+                  "type": "string"
+                },
+                "valueUsd": {
+                  "description": "Value of the held tokens in USD",
+                  "type": "string"
+                },
+                "valueUsd1dChange": {
+                  "description": "Change in the value of the held tokens in USD over the last 24 hours",
+                  "type": "string"
+                },
+                "verified": {
+                  "description": "Whether the token is verified or not.",
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "mintAddress",
+                "amount",
+                "priceUsd",
+                "priceUsd1dChange",
+                "priceUsd7dTrend",
+                "valueUsd",
+                "valueUsd1dChange",
+                "averagePriceUsd",
+                "decimals",
+                "verified",
+                "slot"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": ""
+      },
+      "TokenBalanceNft": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "collectionAddress": {
+                  "description": "Public key of the NFT collection",
+                  "type": "string"
+                },
+                "logoUrl": {
+                  "description": "Logo URL for the NFT",
+                  "nullable": true,
+                  "type": "string"
+                },
+                "name": {
+                  "description": "Symbol for the NFT",
+                  "nullable": true,
+                  "type": "string"
+                },
+                "priceSol": {
+                  "description": "Price of the NFT in SOL",
+                  "type": "string"
+                },
+                "priceUsd": {
+                  "description": "Price of the NFT in USD",
+                  "type": "string"
+                },
+                "slot": {
+                  "description": "Slot for the most recent update to the NFT balance",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "totalItems": {
+                  "description": "Amount of the NFT",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "valueSol": {
+                  "description": "Value of the held NFT in SOL",
+                  "type": "string"
+                },
+                "valueUsd": {
+                  "description": "Value of the held NFT in USD",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "collectionAddress",
+                "totalItems",
+                "valueSol",
+                "priceSol",
+                "valueUsd",
+                "priceUsd",
+                "slot"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": ""
+      },
+      "TokenData": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "decimal": {
+                  "description": "Decimal of the token",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "insertTime": {
+                  "description": "The time the data was inserted into the database",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "mintAddress": {
+                  "description": "The public key of the token of interest",
+                  "type": "string"
+                },
+                "name": {
+                  "description": "The name of the token",
+                  "type": "string"
+                },
+                "price": {
+                  "description": "The price of the token",
+                  "type": "string"
+                },
+                "symbol": {
+                  "description": "The symbol of the token",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "symbol",
+                "name",
+                "mintAddress",
+                "price",
+                "decimal",
+                "insertTime"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": ""
+      },
+      "TokenHoldersTimeSeriesReturn": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "data": {
+                  "description": "Token holders time series data.",
+                  "items": {
+                    "$ref": "#/components/schemas/TokenHoldersTimeSeriesData"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "data"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": ""
+      },
+      "TokenInformationCH": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "category": {
+                  "description": "Category of the token",
+                  "nullable": true,
+                  "type": "string"
+                },
+                "currentSupply": {
+                  "description": "Current token supply",
+                  "format": "double",
+                  "type": "number"
+                },
+                "decimal": {
+                  "description": "Decimal places",
+                  "format": "int32",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "logoUrl": {
+                  "description": "Logo associated with the token",
+                  "nullable": true,
+                  "type": "string"
+                },
+                "marketCap": {
+                  "description": "Current token market cap",
+                  "format": "double",
+                  "type": "number"
+                },
+                "mintAddress": {
+                  "description": "The public key of the token of interest",
+                  "type": "string"
+                },
+                "name": {
+                  "description": "Token mint name",
+                  "nullable": true,
+                  "type": "string"
+                },
+                "price": {
+                  "description": "Current price in USD",
+                  "format": "double",
+                  "type": "number"
+                },
+                "price1d": {
+                  "description": "Price in USD of the token 1 day ago",
+                  "format": "double",
+                  "type": "number"
+                },
+                "price7d": {
+                  "description": "Price in USD of the token 7 days ago",
+                  "format": "double",
+                  "type": "number"
+                },
+                "subcategory": {
+                  "description": "Subcategory of the token",
+                  "nullable": true,
+                  "type": "string"
+                },
+                "symbol": {
+                  "description": "Token mint symbol",
+                  "type": "string"
+                },
+                "tokenAmountVolume24h": {
+                  "description": "Token volume transferred in past 24 hours",
+                  "format": "double",
+                  "nullable": true,
+                  "type": "number"
+                },
+                "updateTime": {
+                  "description": "Time of last update of price",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "usdValueVolume24h": {
+                  "description": "Token volume transferred in past 24 hours USD value",
+                  "format": "double",
+                  "nullable": true,
+                  "type": "number"
+                },
+                "verified": {
+                  "description": "Verified status of the token",
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "symbol",
+                "mintAddress",
+                "price",
+                "price1d",
+                "price7d",
+                "decimal",
+                "verified",
+                "updateTime",
+                "currentSupply",
+                "marketCap"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": ""
+      },
+      "TokenLiquidity": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "liquidity": {
+                  "description": "Total liquidity in USD across all markets for this token, if available.",
+                  "format": "double",
+                  "nullable": true,
+                  "type": "number"
+                }
+              },
+              "type": "object"
+            }
+          }
+        },
+        "description": ""
+      },
+      "TokenMarketTimeseriesResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "data": {
+                  "items": {
+                    "$ref": "#/components/schemas/TokenMarketTimeseriesRow"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "data"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": ""
+      },
+      "TokenOhlcData": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "close": {
+                  "description": "Close price",
+                  "type": "string"
+                },
+                "count": {
+                  "description": "Number of trades",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "high": {
+                  "description": "High price",
+                  "type": "string"
+                },
+                "low": {
+                  "description": "Low price",
+                  "type": "string"
+                },
+                "open": {
+                  "description": "Open price",
+                  "type": "string"
+                },
+                "timeBucketStart": {
+                  "description": "OHLC time bucket start",
+                  "format": "int64",
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "timeBucketStart",
+                "open",
+                "high",
+                "low",
+                "close",
+                "count"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": ""
+      },
+      "TokenTransfersReturn": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "transfers": {
+                  "description": "Found transfer data",
+                  "items": {
+                    "$ref": "#/components/schemas/TransferReturn"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "transfers"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": ""
+      },
+      "TokensReturn": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "data": {
+                  "items": {
+                    "$ref": "#/components/schemas/TokenInformationCH"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "data"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": ""
+      },
+      "TopHolders": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "balance": {
+                  "description": "Current Token Amount",
+                  "type": "string"
+                },
+                "mintAddress": {
+                  "description": "The public key of the token of interest",
+                  "type": "string"
+                },
+                "ownerAddress": {
+                  "description": "Holder address",
+                  "type": "string"
+                },
+                "ownerLogoUrl": {
+                  "description": "Holder logo url",
+                  "nullable": true,
+                  "type": "string"
+                },
+                "ownerName": {
+                  "description": "Holder name",
+                  "nullable": true,
+                  "type": "string"
+                },
+                "percentageOfSupplyHeld": {
+                  "description": "Percentage of supply held",
+                  "format": "double",
+                  "type": "number"
+                },
+                "rank": {
+                  "description": "Rank",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "tokenLogoUrl": {
+                  "description": "Logo Url of the token of interest",
+                  "nullable": true,
+                  "type": "string"
+                },
+                "tokenSymbol": {
+                  "description": "Symbol of the token of interest",
+                  "nullable": true,
+                  "type": "string"
+                },
+                "valueUsd": {
+                  "description": "Value Usd",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "rank",
+                "ownerAddress",
+                "mintAddress",
+                "balance",
+                "valueUsd",
+                "percentageOfSupplyHeld"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": ""
+      },
+      "TopHoldersReturn": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "data": {
+                  "items": {
+                    "$ref": "#/components/schemas/TopHolders"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "data"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": ""
+      },
+      "TopPnlTraderByTokenTraderResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "data": {
+                  "items": {
+                    "$ref": "#/components/schemas/TopPnlTraderByTokenTrader"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "data"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": ""
+      },
+      "TradeAggregatedTimeseriesResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "data": {
+                  "items": {
+                    "$ref": "#/components/schemas/TradeAggregatedTimeseriesRow"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "data"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": ""
+      },
+      "TradeDataProgramVecReturn": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "data": {
+                  "description": "Found trade data",
+                  "items": {
+                    "$ref": "#/components/schemas/TradeDataProgramReturn"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "data"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": ""
+      },
+      "TradeOhlcvCandleReturn": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "close": {
+                  "description": "Close price",
+                  "type": "string"
+                },
+                "count": {
+                  "description": "Number of trades",
+                  "format": "int64",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "high": {
+                  "description": "High price",
+                  "type": "string"
+                },
+                "low": {
+                  "description": "Low price",
+                  "type": "string"
+                },
+                "open": {
+                  "description": "Open price",
+                  "type": "string"
+                },
+                "time": {
+                  "description": "OHLC time bucket start",
+                  "type": "string"
+                },
+                "volume": {
+                  "description": "Volume",
+                  "type": "string"
+                },
+                "volumeUsd": {
+                  "description": "Volume in USD",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "time",
+                "open",
+                "high",
+                "low",
+                "close",
+                "volume",
+                "volumeUsd",
+                "count"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": ""
+      },
+      "TradeOhlcvCandleVecReturn": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "data": {
+                  "description": "Found OHLCV data",
+                  "items": {
+                    "$ref": "#/components/schemas/TradeOhlcvCandleReturn"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "data"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": ""
+      },
+      "TradePriceMarketReturn": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "baseMintAddress": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/SolanaId"
+                    }
+                  ],
+                  "nullable": true
+                },
+                "baseTokenAmount": {
+                  "description": "The amount of the base token in the market",
+                  "nullable": true,
+                  "type": "string"
+                },
+                "baseTokenName": {
+                  "description": "Name of the base token",
+                  "nullable": true,
+                  "type": "string"
+                },
+                "baseTokenSymbol": {
+                  "description": "Ticker for the base token",
+                  "nullable": true,
+                  "type": "string"
+                },
+                "baseTokenVaultAddress": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/SolanaId"
+                    }
+                  ],
+                  "nullable": true
+                },
+                "marketAddress": {
+                  "$ref": "#/components/schemas/SolanaId"
+                },
+                "marketName": {
+                  "description": "Name of the market",
+                  "nullable": true,
+                  "type": "string"
+                },
+                "programAddress": {
+                  "$ref": "#/components/schemas/SolanaId"
+                },
+                "programName": {
+                  "description": "Name of the program",
+                  "nullable": true,
+                  "type": "string"
+                },
+                "quoteMintAddress": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/SolanaId"
+                    }
+                  ],
+                  "nullable": true
+                },
+                "quoteTokenAmount": {
+                  "description": "The amount of the quote token in the market",
+                  "nullable": true,
+                  "type": "string"
+                },
+                "quoteTokenName": {
+                  "description": "Name of the quote token",
+                  "nullable": true,
+                  "type": "string"
+                },
+                "quoteTokenSymbol": {
+                  "description": "Ticker for the quote token",
+                  "nullable": true,
+                  "type": "string"
+                },
+                "quoteTokenVaultAddress": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/SolanaId"
+                    }
+                  ],
+                  "nullable": true
+                },
+                "updatedAt": {
+                  "description": "Latest update Time",
+                  "format": "int64",
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "marketAddress",
+                "programAddress",
+                "updatedAt"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": ""
+      },
+      "TradePriceProgramsReturn": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "data": {
+                  "items": {
+                    "$ref": "#/components/schemas/TradesPricesProgram"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "data"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": ""
+      },
+      "TradesPricesProgram": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "programAddress": {
+                  "$ref": "#/components/schemas/SolanaId"
+                },
+                "programName": {
+                  "nullable": true,
+                  "type": "string"
+                }
+              },
+              "required": [
+                "programAddress"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": ""
+      },
+      "TradesTokenActivitySummaryResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "data": {
+                  "items": {
+                    "$ref": "#/components/schemas/TradesTokenActivitySummary"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "data"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": ""
+      },
+      "TransferReturn": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "amount": {
+                  "description": "The total number of tokens involved in the transaction.",
+                  "format": "int64",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "blockTime": {
+                  "description": "The timestamp when the transaction was confirmed on the blockchain, in Unix time.",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "calculatedAmount": {
+                  "description": "The resulting amount after applying the `decimal` to the `amount` value.",
+                  "type": "string"
+                },
+                "callingMetadata": {
+                  "description": "The public key of the Solana program that initiated the transaction.",
+                  "items": {
+                    "$ref": "#/components/schemas/InstructionName"
+                  },
+                  "type": "array"
+                },
+                "decimal": {
+                  "description": "The number of decimal places used for the token's smallest unit.",
+                  "format": "int64",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "feePayerAddress": {
+                  "description": "The public key of the account responsible for paying the transaction fees.",
+                  "type": "string"
+                },
+                "mintAddress": {
+                  "description": "The public key of the token's mint, specifying the token type involved in the transaction.",
+                  "type": "string"
+                },
+                "price": {
+                  "description": "Price of the token involved in the transaction (e.g. `mint_address`) expressed in USD.",
+                  "type": "string"
+                },
+                "receiverAccountAddress": {
+                  "description": "The public key of the specific token account address of the receiver.",
+                  "nullable": true,
+                  "type": "string"
+                },
+                "receiverAddress": {
+                  "description": "The public key of the account receiving the tokens.",
+                  "nullable": true,
+                  "type": "string"
+                },
+                "senderAccountAddress": {
+                  "description": "The public key of the specific token account address of the sender.",
+                  "nullable": true,
+                  "type": "string"
+                },
+                "senderAddress": {
+                  "description": "The public key of the account sending the tokens.",
+                  "type": "string"
+                },
+                "signature": {
+                  "description": "The cryptographic signature that uniquely identifies the transaction on the blockchain.",
+                  "type": "string"
+                },
+                "slot": {
+                  "description": "The slot number in which the transaction was processed on the Solana blockchain, helping to pinpoint the exact sequence of events.",
+                  "format": "int64",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "valueUsd": {
+                  "description": "Calculated total USD value of the transfer based on the `amount`, `decimal`, and `price` values.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "signature",
+                "callingMetadata",
+                "senderAddress",
+                "mintAddress",
+                "feePayerAddress",
+                "decimal",
+                "amount",
+                "slot",
+                "blockTime",
+                "price",
+                "calculatedAmount",
+                "valueUsd"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": ""
+      },
+      "TransferReturnWs": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "amount": {
+                  "description": "The total number of tokens involved in the transaction.",
+                  "format": "int64",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "blockTime": {
+                  "description": "The timestamp when the transaction was confirmed on the blockchain, in Unix time.",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "callingPrograms": {
+                  "description": "An array of all the programs that were utilized during the transaction If a specific program is used as a filter in the query, it may appear in the CallingPrograms array alongside other programs that were also part of the transaction.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "decimal": {
+                  "description": "The number of decimal places used for the token's smallest unit.",
+                  "format": "int64",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "feePayer": {
+                  "description": "The public key of the account responsible for paying the transaction fees.",
+                  "type": "string"
+                },
+                "id": {
+                  "description": "Unique identifier for the transaction.",
+                  "format": "binary",
+                  "type": "string"
+                },
+                "mintAddress": {
+                  "description": "The public key of the token's mint, specifying the token type involved in the transaction.",
+                  "type": "string"
+                },
+                "receiverAddress": {
+                  "description": "The public key of the account receiving the tokens.",
+                  "nullable": true,
+                  "type": "string"
+                },
+                "receiverTokenAccount": {
+                  "description": "The public key of the specific token account of the receiver.",
+                  "nullable": true,
+                  "type": "string"
+                },
+                "senderAddress": {
+                  "description": "The public key of the account sending the tokens.",
+                  "type": "string"
+                },
+                "senderTokenAccount": {
+                  "description": "The public key of the specific token account of the sender.",
+                  "nullable": true,
+                  "type": "string"
+                },
+                "signature": {
+                  "description": "The cryptographic signature that uniquely identifies the transaction on the blockchain.",
+                  "type": "string"
+                },
+                "slot": {
+                  "description": "The slot number in which the transaction was processed on the Solana blockchain, helping to pinpoint the exact sequence of events.",
+                  "format": "int64",
+                  "minimum": 0,
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "signature",
+                "callingPrograms",
+                "senderAddress",
+                "mintAddress",
+                "feePayer",
+                "decimal",
+                "amount",
+                "slot",
+                "blockTime",
+                "id"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": ""
+      },
+      "WalletBalanceNftResults": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "data": {
+                  "description": "NFTs in the wallet (up to limit)",
+                  "items": {
+                    "$ref": "#/components/schemas/TokenBalanceNft"
+                  },
+                  "type": "array"
+                },
+                "date": {
+                  "description": "Datetime of the report as a Unix timestamp",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "ownerAddress": {
+                  "$ref": "#/components/schemas/SolanaId"
+                },
+                "totalNftCollectionCount": {
+                  "description": "Total number of nfts in the wallet",
+                  "format": "int64",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "totalSol": {
+                  "description": "Value of the wallet in SOL",
+                  "type": "string"
+                },
+                "totalUsd": {
+                  "description": "Value of the wallet in USD",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "date",
+                "ownerAddress",
+                "totalSol",
+                "totalUsd",
+                "totalNftCollectionCount",
+                "data"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": ""
+      },
+      "WalletBalanceNftResultsMany": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "data": {
+                  "description": "NFTs in the wallet (up to limit)",
+                  "items": {
+                    "$ref": "#/components/schemas/TokenBalanceNft"
+                  },
+                  "type": "array"
+                },
+                "date": {
+                  "description": "Datetime of the report as a Unix timestamp",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "ownerAddresses": {
+                  "description": "Owners of the wallets",
+                  "items": {
+                    "$ref": "#/components/schemas/SolanaId"
+                  },
+                  "type": "array"
+                },
+                "totalNftCollectionCount": {
+                  "description": "Total number of nft collections in the wallet",
+                  "format": "int64",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "totalSol": {
+                  "description": "Value of the wallet in SOL",
+                  "type": "string"
+                },
+                "totalUsd": {
+                  "description": "Value of the wallet in USD",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "date",
+                "ownerAddresses",
+                "totalSol",
+                "totalUsd",
+                "totalNftCollectionCount",
+                "data"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": ""
+      },
+      "WalletBalanceTokenResults": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "activeStakedSolBalance": {
+                  "description": "Value of active staked SOL",
+                  "type": "string"
+                },
+                "activeStakedSolBalanceUsd": {
+                  "description": "Value of active staked SOL in USD",
+                  "type": "string"
+                },
+                "data": {
+                  "description": "Tokens in the wallet (up to limit)",
+                  "items": {
+                    "$ref": "#/components/schemas/TokenBalance"
+                  },
+                  "type": "array"
+                },
+                "date": {
+                  "description": "Datetime of the report as a Unix timestamp",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "ownerAddress": {
+                  "$ref": "#/components/schemas/SolanaId"
+                },
+                "stakedSolBalance": {
+                  "description": "Value of the staked SOL",
+                  "type": "string"
+                },
+                "stakedSolBalanceUsd": {
+                  "description": "Value of the staked SOL in USD",
+                  "type": "string"
+                },
+                "totalTokenCount": {
+                  "description": "Total number of tokens in the wallet",
+                  "format": "int64",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "totalTokenValueUsd": {
+                  "description": "Value of the wallet in USD, including SOL",
+                  "type": "string"
+                },
+                "totalTokenValueUsd1dChange": {
+                  "description": "Change in the value of the wallet in USD over the last 24 hours",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "date",
+                "ownerAddress",
+                "stakedSolBalanceUsd",
+                "stakedSolBalance",
+                "activeStakedSolBalanceUsd",
+                "activeStakedSolBalance",
+                "totalTokenValueUsd",
+                "totalTokenValueUsd1dChange",
+                "totalTokenCount",
+                "data"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": ""
+      },
+      "WalletBalanceTokenResultsMany": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "activeStakedSolBalance": {
+                  "description": "Value of active staked SOL",
+                  "type": "string"
+                },
+                "activeStakedSolBalanceUsd": {
+                  "description": "Value of active staked SOL in USD",
+                  "type": "string"
+                },
+                "data": {
+                  "description": "Tokens in the wallet (up to limit)",
+                  "items": {
+                    "$ref": "#/components/schemas/TokenBalance"
+                  },
+                  "type": "array"
+                },
+                "date": {
+                  "description": "Datetime of the report as a Unix timestamp",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "ownerAddresses": {
+                  "description": "Owners of the wallets",
+                  "items": {
+                    "$ref": "#/components/schemas/SolanaId"
+                  },
+                  "type": "array"
+                },
+                "stakedSolBalance": {
+                  "description": "Value of the staked SOL",
+                  "type": "string"
+                },
+                "stakedSolBalanceUsd": {
+                  "description": "Value of the staked SOL in USD",
+                  "type": "string"
+                },
+                "totalTokenCount": {
+                  "description": "Total number of tokens in the wallet",
+                  "format": "int64",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "totalTokenValueUsd": {
+                  "description": "Value of the wallet in USD, including SOL",
+                  "type": "string"
+                },
+                "totalTokenValueUsd1dChange": {
+                  "description": "Change in the value of the tokens in the wallet in USD over the last 24 hours",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "date",
+                "ownerAddresses",
+                "stakedSolBalanceUsd",
+                "stakedSolBalance",
+                "activeStakedSolBalanceUsd",
+                "activeStakedSolBalance",
+                "totalTokenValueUsd",
+                "totalTokenValueUsd1dChange",
+                "totalTokenCount",
+                "data"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": ""
+      },
+      "WalletBalanceTokenResultsTimeSeries": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "data": {
+                  "items": {
+                    "$ref": "#/components/schemas/WalletBalanceTokenResultsTimeSeriesElement"
+                  },
+                  "type": "array"
+                },
+                "ownerAddress": {
+                  "$ref": "#/components/schemas/SolanaId"
+                }
+              },
+              "required": [
+                "ownerAddress",
+                "data"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": ""
+      },
+      "WalletBalanceTokenResultsTimeSeriesElement": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "blockTime": {
+                  "description": "The timestamp, rounded to the day, of which this account snapshot was taken",
+                  "format": "int32",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "stakeValue": {
+                  "description": "The value of staked SOL in USD",
+                  "type": "string"
+                },
+                "stakeValueSol": {
+                  "description": "The value of staked SOL in SOL",
+                  "type": "string"
+                },
+                "systemValue": {
+                  "description": "The value of held System SOL in USD",
+                  "type": "string"
+                },
+                "tokenValue": {
+                  "description": "Combined value of valid SPL tokens in USD.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "blockTime",
+                "tokenValue",
+                "stakeValue",
+                "systemValue",
+                "stakeValueSol"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": ""
+      },
+      "WalletBalanceTokenResultsTimeSeriesMany": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "data": {
+                  "items": {
+                    "$ref": "#/components/schemas/WalletBalanceTokenResultsTimeSeriesElement"
+                  },
+                  "type": "array"
+                },
+                "ownerAddresses": {
+                  "items": {
+                    "$ref": "#/components/schemas/SolanaId"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "ownerAddresses",
+                "data"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": ""
+      },
+      "WalletTimeSeriesRaw": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "amount": {
+                  "format": "int64",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "amountScaled": {
+                  "format": "double",
+                  "type": "number"
+                },
+                "decimals": {
+                  "format": "int32",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "mintAddress": {
+                  "type": "string"
+                },
+                "ownerAddress": {
+                  "type": "string"
+                },
+                "priceUsd": {
+                  "type": "string"
+                },
+                "snapshotBlockTime": {
+                  "format": "int64",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "valueUsd": {
+                  "format": "double",
+                  "type": "number"
+                }
+              },
+              "required": [
+                "snapshotBlockTime",
+                "amount",
+                "decimals",
+                "amountScaled",
+                "ownerAddress",
+                "mintAddress",
+                "priceUsd",
+                "valueUsd"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": ""
+      },
+      "WalletTimeSeriesRawManyReturn": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "data": {
+                  "additionalProperties": {
+                    "items": {
+                      "$ref": "#/components/schemas/WalletTimeSeriesRaw"
+                    },
+                    "type": "array"
+                  },
+                  "type": "object"
+                },
+                "ownerAddresses": {
+                  "items": {
+                    "$ref": "#/components/schemas/SolanaId"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "ownerAddresses",
+                "data"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": ""
+      },
+      "WalletTimeSeriesRawReturn": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "data": {
+                  "additionalProperties": {
+                    "items": {
+                      "$ref": "#/components/schemas/WalletTimeSeriesRaw"
+                    },
+                    "type": "array"
+                  },
+                  "type": "object"
+                }
+              },
+              "required": [
+                "data"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": ""
+      }
+    },
+    "schemas": {
+      "AccountParamsNftsMany": {
+        "properties": {
+          "includeNoPriceBalance": {
+            "description": "Whether or not we should include NFTs we do not track prices for.",
+            "nullable": true,
+            "type": "boolean"
+          },
+          "limit": {
+            "description": "The limit of entries to return (per wallet). If not passed, first 1000 entries are returned (the maximum).",
+            "format": "int32",
+            "minimum": 0,
+            "nullable": true,
+            "type": "integer"
+          },
+          "ownerAddresses": {
+            "description": "Wallets to include in the returned results (max 10).",
+            "items": {
+              "$ref": "#/components/schemas/SolanaId"
+            },
+            "type": "array"
+          },
+          "page": {
+            "description": "The requested page.",
+            "format": "int32",
+            "minimum": 0,
+            "nullable": true,
+            "type": "integer"
+          },
+          "sortByAsc": {
+            "description": "Sort ascending based on amount or value of positions. Only one of sort_by_asc or sort_by_desc can be used",
+            "nullable": true,
+            "type": "string"
+          },
+          "sortByDesc": {
+            "description": "Sort descending based on amount or value of positions. Only one of sort_by_asc or sort_by_desc can be used",
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "required": [
+          "ownerAddresses"
+        ],
+        "type": "object"
+      },
+      "AccountParamsTokens": {
+        "properties": {
+          "includeNoPriceBalance": {
+            "description": "Whether or not we should include tokens we do not track prices for. Filtering is applied after limiting.",
+            "nullable": true,
+            "type": "boolean"
+          },
+          "limit": {
+            "description": "The limit of entries to return. If not passed, first 1000 entries are returned (the maximum).",
+            "format": "int32",
+            "minimum": 0,
+            "nullable": true,
+            "type": "integer"
+          },
+          "maxAssetValue": {
+            "description": "The maximum amount of total value in USD for an asset to be considered in the results. Overrides `includeNoPriceBalance`. Defaults to no limit.",
+            "nullable": true,
+            "type": "string"
+          },
+          "minAssetValue": {
+            "description": "The minimum amount of total value in USD for an asset to be considered in the results. Overrides `includeNoPriceBalance`. Defaults to no limit.",
+            "nullable": true,
+            "type": "string"
+          },
+          "mintAddresses": {
+            "description": "The allowable mints, if any, to filter the results by.",
+            "items": {
+              "$ref": "#/components/schemas/SolanaId"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "onlyVerified": {
+            "description": "Whether tokens returned should be restricted to verified tokens only. Default is false.",
+            "nullable": true,
+            "type": "boolean"
+          },
+          "page": {
+            "description": "The requested page.",
+            "format": "int32",
+            "minimum": 0,
+            "nullable": true,
+            "type": "integer"
+          },
+          "sortByAsc": {
+            "description": "Sort ascending based on amount or value of positions. Only one of sort_by_asc or sort_by_desc can be used",
+            "nullable": true,
+            "type": "string"
+          },
+          "sortByDesc": {
+            "description": "Sort descending based on amount or value of positions. Only one of sort_by_asc or sort_by_desc can be used",
+            "nullable": true,
+            "type": "string"
+          },
+          "vybeTokenFilter": {
+            "description": "Whether Vybe's token filter should restrict the tokens that are returned. Default is true.",
+            "nullable": true,
+            "type": "boolean"
+          }
+        },
+        "type": "object"
+      },
+      "AccountParamsTokensMany": {
+        "properties": {
+          "includeNoPriceBalance": {
+            "description": "Whether or not we should include tokens we do not track prices for.",
+            "nullable": true,
+            "type": "boolean"
+          },
+          "limit": {
+            "description": "The limit of entries to return (per wallet). If not passed, first 1000 entries are returned (the maximum).",
+            "format": "int32",
+            "minimum": 0,
+            "nullable": true,
+            "type": "integer"
+          },
+          "maxAssetValue": {
+            "description": "The maximum amount of total value in USD for an asset to be considered in the results. Overrides `includeNoPriceBalance` Defaults to no limit.",
+            "nullable": true,
+            "type": "string"
+          },
+          "minAssetValue": {
+            "description": "The minimum amount of total value in USD for an asset to be considered in the results. Overrides `includeNoPriceBalance` Defaults to no limit.",
+            "nullable": true,
+            "type": "string"
+          },
+          "mintAddresses": {
+            "description": "The allowable mint addresses, if any, to filter the results by.",
+            "items": {
+              "$ref": "#/components/schemas/SolanaId"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "onlyVerified": {
+            "description": "Whether tokens returned should be restricted to verified tokens only. Default is false.",
+            "nullable": true,
+            "type": "boolean"
+          },
+          "ownerAddresses": {
+            "description": "Wallets to include in the returned results (max 10, with 10,000 maximum token accounts between them).",
+            "items": {
+              "$ref": "#/components/schemas/SolanaId"
+            },
+            "type": "array"
+          },
+          "page": {
+            "description": "The requested page.",
+            "format": "int32",
+            "minimum": 0,
+            "nullable": true,
+            "type": "integer"
+          },
+          "sortByAsc": {
+            "description": "Sort ascending based on amount or value of positions. Only one of sort_by_asc or sort_by_desc can be used",
+            "nullable": true,
+            "type": "string"
+          },
+          "sortByDesc": {
+            "description": "Sort descending based on amount or value of positions. Only one of sort_by_asc or sort_by_desc can be used",
+            "nullable": true,
+            "type": "string"
+          },
+          "vybeTokenFilter": {
+            "description": "Whether Vybe's token filter should restrict the tokens that are returned. Default is true.",
+            "nullable": true,
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "ownerAddresses"
+        ],
+        "type": "object"
+      },
+      "AccountPnLResolution": {
+        "description": "Represents the supported time-window resolutions for account/PnL queries.",
+        "enum": [
+          "1d",
+          "7d",
+          "30d",
+          "Full"
+        ],
+        "type": "string"
+      },
+      "AccountPnlRequestParams": {
+        "properties": {
+          "limit": {
+            "description": "The limit of entries to return. If not passed, first 1000 entries are returned (the maximum).",
+            "format": "int32",
+            "minimum": 0,
+            "nullable": true,
+            "type": "integer"
+          },
+          "mintAddress": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SolanaId"
+              }
+            ],
+            "nullable": true
+          },
+          "page": {
+            "description": "The requested page.",
+            "format": "int32",
+            "minimum": 0,
+            "nullable": true,
+            "type": "integer"
+          },
+          "resolution": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AccountPnLResolution"
+              }
+            ],
+            "nullable": true
+          },
+          "sortByAsc": {
+            "description": "Sort ascending by 'mintAddress', 'tokenSymbol', 'buysTransactionCount', 'buysTokenAmount', 'buysVolumeUsd', 'sellsTransactionCount', 'sellsTokenAmount', 'sellsVolumeUsd', 'realizedPnlUsd', 'unrealizedPnlUsd'. Only one of sort_by_asc or sort_by_desc can be used.",
+            "nullable": true,
+            "type": "string"
+          },
+          "sortByDesc": {
+            "description": "Sort descending by 'mintAddress', 'tokenSymbol', 'buysTransactionCount', 'buysTokenAmount', 'buysVolumeUsd', 'sellsTransactionCount', 'sellsTokenAmount', 'sellsVolumeUsd', 'realizedPnlUsd', 'unrealizedPnlUsd'. Only one of sort_by_asc or sort_by_desc can be used.",
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "AccountResolution": {
+        "description": "Represents the supported time-window resolutions for account/PnL queries.",
+        "enum": [
+          "1d",
+          "7d",
+          "30d"
+        ],
+        "type": "string"
+      },
+      "AccountTimeSeriesParamsMany": {
+        "properties": {
+          "days": {
+            "description": "Number of previous days to include in the data (from today's date).\nIf time provided does not include the start of the resolution time block (e.g: the 1st of the month for \"1mo\"), the time block is not included in the results.\nAllowed values depend on the resolution:\n- For \"1d\": 1 to 30 days (default is 14 days)\n- For \"1w\": 1 to 90 days (default is 30 days)\n- For \"1mo\": 1 to 365 days (default is 90 days)",
+            "format": "int32",
+            "minimum": 0,
+            "nullable": true,
+            "type": "integer"
+          },
+          "ownerAddresses": {
+            "description": "Wallets to include in the returned results (max 10).",
+            "items": {
+              "$ref": "#/components/schemas/SolanaId"
+            },
+            "type": "array"
+          },
+          "resolution": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AccountTimeSeriesResolution"
+              }
+            ],
+            "nullable": true
+          },
+          "vybeTokenFilter": {
+            "description": "Whether Vybe's token filter should restrict the tokens that are returned. If false, all priced tokens are included. Default is true.",
+            "nullable": true,
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "ownerAddresses"
+        ],
+        "type": "object"
+      },
+      "AccountTimeSeriesRawParams": {
+        "properties": {
+          "days": {
+            "description": "Number of previous days to include in the data (from today's date), up to 30 days (default 14).",
+            "format": "int32",
+            "minimum": 0,
+            "nullable": true,
+            "type": "integer"
+          },
+          "limit": {
+            "description": "Limit of entries to return (per day). If not passed, first 1000 entries are returned (the maximum).",
+            "format": "int32",
+            "minimum": 0,
+            "nullable": true,
+            "type": "integer"
+          },
+          "page": {
+            "description": "The requested page.",
+            "format": "int32",
+            "minimum": 0,
+            "nullable": true,
+            "type": "integer"
+          },
+          "sortByAsc": {
+            "description": "Sort ascending based on 'amount', 'amountScaled', 'ownerAddress', 'priceUsd', 'valueUsd', or 'mintAddress'. Only one of sort_by_asc or sort_by_desc can be used",
+            "nullable": true,
+            "type": "string"
+          },
+          "sortByDesc": {
+            "description": "Sort descending based on 'amount', 'amountScaled', 'ownerAddress', 'priceUsd', 'valueUsd', or 'mintAddress'. Only one of sort_by_asc or sort_by_desc can be used",
+            "nullable": true,
+            "type": "string"
+          },
+          "vybeTokenFilter": {
+            "description": "Whether Vybe's token filter should restrict the tokens that are returned. If false, all priced tokens are included. Default is true.",
+            "nullable": true,
+            "type": "boolean"
+          }
+        },
+        "type": "object"
+      },
+      "AccountTimeSeriesRawParamsMany": {
+        "properties": {
+          "days": {
+            "description": "Number of previous days to include in the data (from today's date), up to 30 days (default 14).",
+            "format": "int32",
+            "minimum": 0,
+            "nullable": true,
+            "type": "integer"
+          },
+          "limit": {
+            "description": "Limit of entries to return (per day). If not passed, first 1000 entries are returned (the maximum).",
+            "format": "int32",
+            "minimum": 0,
+            "nullable": true,
+            "type": "integer"
+          },
+          "ownerAddresses": {
+            "description": "Wallets to include in the returned results (max 10).",
+            "items": {
+              "$ref": "#/components/schemas/SolanaId"
+            },
+            "type": "array"
+          },
+          "page": {
+            "description": "The requested page.",
+            "format": "int32",
+            "minimum": 0,
+            "nullable": true,
+            "type": "integer"
+          },
+          "sortByAsc": {
+            "description": "Sort ascending based on 'amount', 'amountScaled', 'priceUsd', 'valueUsd', or 'mintAddress'. Only one of sort_by_asc or sort_by_desc can be used",
+            "nullable": true,
+            "type": "string"
+          },
+          "sortByDesc": {
+            "description": "Sort descending based on 'amount', 'amountScaled', 'priceUsd', 'valueUsd', or 'mintAddress'. Only one of sort_by_asc or sort_by_desc can be used",
+            "nullable": true,
+            "type": "string"
+          },
+          "vybeTokenFilter": {
+            "description": "Whether Vybe's token filter should restrict the tokens that are returned. If false, all priced tokens are included. Default is true.",
+            "nullable": true,
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "ownerAddresses"
+        ],
+        "type": "object"
+      },
+      "AccountTimeSeriesResolution": {
+        "enum": [
+          "1d",
+          "1w",
+          "1mo"
+        ],
+        "type": "string"
+      },
+      "AccountTopTraderMetrics": {
+        "description": "Trading metrics and performance statistics for an account.",
+        "properties": {
+          "bestPerformingToken": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/TokenPerformance"
+              }
+            ],
+            "nullable": true
+          },
+          "realizedPnlUsd": {
+            "description": "The total realized profit in USD.",
+            "format": "double",
+            "type": "number"
+          },
+          "sevenDayPnl": {
+            "description": "The profit and loss trend over the last seven days.",
+            "items": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "type": "array"
+          },
+          "tradesCount": {
+            "description": "The total number of trades executed.",
+            "format": "int64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "tradesVolumeUsd": {
+            "description": "The total trading volume in USD.",
+            "format": "double",
+            "type": "number"
+          },
+          "uniqueTokensTraded": {
+            "description": "The count of unique tokens traded by the account.",
+            "format": "int64",
+            "minimum": 0,
+            "nullable": true,
+            "type": "integer"
+          },
+          "unrealizedPnlUsd": {
+            "description": "The total unrealized profit in USD.",
+            "format": "double",
+            "type": "number"
+          },
+          "winRate": {
+            "description": "The percentage of winning trades (0.0 to 100.0).",
+            "format": "double",
+            "type": "number"
+          },
+          "worstPerformingToken": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/TokenPerformance"
+              }
+            ],
+            "nullable": true
+          }
+        },
+        "required": [
+          "realizedPnlUsd",
+          "unrealizedPnlUsd",
+          "winRate",
+          "tradesVolumeUsd",
+          "tradesCount",
+          "sevenDayPnl"
+        ],
+        "type": "object"
+      },
+      "AccountTopTraderReturn": {
+        "description": "The top trader wallet identity and performance metrics.",
+        "properties": {
+          "accountAddress": {
+            "description": "The public key (pubKey) associated with the Solana account.",
+            "type": "string"
+          },
+          "accountLabels": {
+            "description": "Custom account labels assigned internally by the Vybe system.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "accountLogoUrl": {
+            "description": "The URL to the account's logo image (optional).",
+            "nullable": true,
+            "type": "string"
+          },
+          "accountName": {
+            "description": "The display name of the account (optional).",
+            "nullable": true,
+            "type": "string"
+          },
+          "accountTwitterUrl": {
+            "description": "The URL to the account's Twitter profile (optional).",
+            "nullable": true,
+            "type": "string"
+          },
+          "metrics": {
+            "$ref": "#/components/schemas/AccountTopTraderMetrics"
+          }
+        },
+        "required": [
+          "accountAddress",
+          "accountLabels",
+          "metrics"
+        ],
+        "type": "object"
+      },
+      "AccountTopTradersRequestParams": {
+        "properties": {
+          "ilikeFilter": {
+            "description": "Optional ILIKE filter applied to both trader names and address fields for any match.",
+            "nullable": true,
+            "type": "string"
+          },
+          "label": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Label"
+              }
+            ],
+            "nullable": true
+          },
+          "limit": {
+            "description": "The limit of entries to return. If not passed, a maximum of 1000 entries are returned.",
+            "format": "int32",
+            "minimum": 0,
+            "nullable": true,
+            "type": "integer"
+          },
+          "mintAddress": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SolanaId"
+              }
+            ],
+            "nullable": true
+          },
+          "page": {
+            "description": "The requested page.",
+            "format": "int32",
+            "minimum": 0,
+            "nullable": true,
+            "type": "integer"
+          },
+          "resolution": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AccountResolution"
+              }
+            ],
+            "nullable": true
+          },
+          "sortByAsc": {
+            "description": "Sort ascending by 'realizedPnlUsd', 'unrealizedPnlUsd', 'winRate', 'tradesVolumeUsd', 'tradesCount', 'accountAddress'. Only one of sort_by_asc or sort_by_desc can be used.",
+            "nullable": true,
+            "type": "string"
+          },
+          "sortByDesc": {
+            "description": "Sort descending by 'realizedPnlUsd', 'unrealizedPnlUsd', 'winRate', 'tradesVolumeUsd', 'tradesCount', 'accountAddress'. Only one of sort_by_asc or sort_by_desc can be used.",
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "AccountTradesSummaryReturn": {
+        "description": "The overall summary and per-token metrics.",
+        "properties": {
+          "summary": {
+            "$ref": "#/components/schemas/Summary"
+          },
+          "tokenMetrics": {
+            "description": "Metrics for a token's trading performance.",
+            "items": {
+              "$ref": "#/components/schemas/Metrics"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "summary",
+          "tokenMetrics"
+        ],
+        "type": "object"
+      },
+      "ApiError": {
+        "properties": {
+          "code": {
+            "description": "Code ID of the error, uniquely identifying the error type",
+            "format": "int32",
+            "type": "integer"
+          },
+          "id": {
+            "description": "A unique identifier for the error, representing the error ID in Sentry.\nThis should be submitted as a reference when contacting support.",
+            "type": "string"
+          },
+          "message": {
+            "description": "A human readable message describing the error that occurred.",
+            "type": "string"
+          },
+          "violations": {
+            "description": "Optional collection of validation violations representations.",
+            "items": {
+              "$ref": "#/components/schemas/ConstraintViolation"
+            },
+            "nullable": true,
+            "type": "array"
+          }
+        },
+        "required": [
+          "code",
+          "message",
+          "id"
+        ],
+        "type": "object"
+      },
+      "CandleRowWS": {
+        "properties": {
+          "baseMint": {
+            "type": "string"
+          },
+          "close": {
+            "format": "double",
+            "type": "number"
+          },
+          "high": {
+            "format": "double",
+            "type": "number"
+          },
+          "low": {
+            "format": "double",
+            "type": "number"
+          },
+          "open": {
+            "format": "double",
+            "type": "number"
+          },
+          "quoteMint": {
+            "type": "string"
+          },
+          "slot": {
+            "format": "int64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "timestamp": {
+            "format": "int64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "updateTime": {
+            "format": "int64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "volume": {
+            "format": "double",
+            "type": "number"
+          }
+        },
+        "required": [
+          "baseMint",
+          "quoteMint",
+          "timestamp",
+          "open",
+          "high",
+          "low",
+          "close",
+          "volume",
+          "slot",
+          "updateTime"
+        ],
+        "type": "object"
+      },
+      "CloseTokenAccountsParam": {
+        "properties": {
+          "accountAddresses": {
+            "description": "Specific token account addresses to close (auto-fetches if not provided)",
+            "items": {
+              "$ref": "#/components/schemas/SolanaId"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "gasless": {
+            "description": "Use Vybe fee payer for gas",
+            "nullable": true,
+            "type": "boolean"
+          },
+          "ownerAddress": {
+            "$ref": "#/components/schemas/SolanaId"
+          },
+          "partner": {
+            "description": "Partner identifier",
+            "nullable": true,
+            "type": "string"
+          },
+          "rentFee": {
+            "description": "Fee percentage on recovered rent (0-1, e.g., 0.20 for 20%)",
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          }
+        },
+        "required": [
+          "ownerAddress"
+        ],
+        "type": "object"
+      },
+      "CloseTokenAccountsReturn": {
+        "description": "Wallet performance attribution response for API endpoints.\n\nAll fields default to 0.0 when no historical data is available.",
+        "properties": {
+          "errors": {
+            "description": "Array of error objects for failed accounts",
+            "items": {},
+            "type": "array"
+          },
+          "summary": {
+            "$ref": "#/components/schemas/CloseTokenAccountsSummary"
+          },
+          "transactions": {
+            "description": "Array of transaction objects",
+            "items": {
+              "$ref": "#/components/schemas/CloseTokenAccountsTx"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "transactions",
+          "errors",
+          "summary"
+        ],
+        "type": "object"
+      },
+      "CloseTokenAccountsSummary": {
+        "properties": {
+          "netRecovered": {
+            "description": "Net recovered",
+            "format": "double",
+            "type": "number"
+          },
+          "totalAccountsClosed": {
+            "description": "Total number of token accounts closed",
+            "type": "string"
+          },
+          "totalFeeCharged": {
+            "description": "Total fee deducted (in SOL units)",
+            "format": "double",
+            "type": "number"
+          },
+          "totalRentRecovered": {
+            "description": "Total SOL recovered from rent (in SOL units)",
+            "format": "double",
+            "type": "number"
+          }
+        },
+        "required": [
+          "totalAccountsClosed",
+          "totalRentRecovered",
+          "totalFeeCharged",
+          "netRecovered"
+        ],
+        "type": "object"
+      },
+      "CloseTokenAccountsTx": {
+        "properties": {
+          "accountsClosed": {
+            "description": "Number of accounts closed in this transaction",
+            "format": "int32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "feeCharged": {
+            "description": "Fee deducted (in SOL units)",
+            "format": "double",
+            "type": "number"
+          },
+          "rentRecovered": {
+            "description": "SOL recovered from rent (in SOL units)",
+            "format": "double",
+            "type": "number"
+          },
+          "transaction": {
+            "description": "Base64-encoded unsigned transaction",
+            "type": "string"
+          }
+        },
+        "required": [
+          "transaction",
+          "accountsClosed",
+          "rentRecovered",
+          "feeCharged"
+        ],
+        "type": "object"
+      },
+      "Code": {
+        "enum": [
+          "RangeValidation",
+          "InvalidKeySize",
+          "InvalidInput",
+          "SqlxError",
+          "NotEnoughCred",
+          "RequestQuotaReached",
+          "NotWebSocketSubscription",
+          "ClickhouseError",
+          "RedisError",
+          "InvalidInit",
+          "NoResultFound",
+          "InvalidResolution",
+          "BigQueryError",
+          "NoAuthorizationHeader",
+          "DeserializationError",
+          "ServerError",
+          "SlowClient",
+          "SlowQuery",
+          "InsufficientPermissions",
+          "NotFound",
+          "WebSocketHandshakeGetMethodRequired",
+          "WebSocketHandshakeNoWebsocketUpgrade",
+          "WebSocketHandshakeNoConnectionUpgrade",
+          "WebSocketHandshakeNoVersionHeader",
+          "WebSocketHandshakeUnsupportedVersion",
+          "WebSocketHandshakeBadWebsocketKey",
+          "NoAuthContextForRequest"
+        ],
+        "type": "string"
+      },
+      "ConstraintViolation": {
+        "description": "Main structure to represent any kind of validation violation.",
+        "properties": {
+          "invalidValue": {
+            "description": "Provided value which leaded to the violation.",
+            "nullable": true,
+            "type": "string"
+          },
+          "message": {
+            "description": "Message to the end user.",
+            "type": "string"
+          },
+          "propertyPath": {
+            "description": "Property path to the field where violation occurred.",
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "required": [
+          "message"
+        ],
+        "type": "object"
+      },
+      "CounterpartyData": {
+        "properties": {
+          "address": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SolanaId"
+              }
+            ],
+            "nullable": true
+          },
+          "buyTransfers": {
+            "description": "Number of buy transfers the wallet has made from the counterparty.",
+            "format": "int32",
+            "type": "integer"
+          },
+          "buyVolume": {
+            "description": "Total volume in USD of buy transfers the wallet has made from the counterparty.",
+            "format": "double",
+            "type": "number"
+          },
+          "friendlyName": {
+            "description": "The friendly name of the counterparty (program or wallet), if available.",
+            "nullable": true,
+            "type": "string"
+          },
+          "logoUrl": {
+            "description": "The logo URL of the counterparty, if available.",
+            "nullable": true,
+            "type": "string"
+          },
+          "netVolume": {
+            "description": "Net volume in USD (sell_volume - buy_volume). Positive means the queried wallet sent more value to this counterparty than it received.",
+            "format": "double",
+            "type": "number"
+          },
+          "sellTransfers": {
+            "description": "Number of sell transfers the wallet has made to the counterparty.",
+            "format": "int32",
+            "type": "integer"
+          },
+          "sellVolume": {
+            "description": "Total volume in USD of sell transfers the wallet has made to the counterparty.",
+            "format": "double",
+            "type": "number"
+          },
+          "topMints": {
+            "description": "Top tokens that the queried wallet has traded with this counterparty, sorted by number of trades.",
+            "items": {
+              "$ref": "#/components/schemas/CounterpartyTopMint"
+            },
+            "type": "array"
+          },
+          "totalTransfers": {
+            "description": "Total number of transfers (sell + buy) the wallet has made with the counterparty.",
+            "format": "int32",
+            "type": "integer"
+          },
+          "totalVolume": {
+            "description": "Total volume in USD of all transfers (sell + buy) the wallet has made with the counterparty.",
+            "format": "double",
+            "type": "number"
+          }
+        },
+        "required": [
+          "sellTransfers",
+          "buyTransfers",
+          "totalTransfers",
+          "sellVolume",
+          "buyVolume",
+          "totalVolume",
+          "netVolume",
+          "topMints"
+        ],
+        "type": "object"
+      },
+      "CounterpartyDataResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/CounterpartyData"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "CounterpartyGrouping": {
+        "enum": [
+          "wallet",
+          "program"
+        ],
+        "type": "string"
+      },
+      "CounterpartyTopMint": {
+        "properties": {
+          "logoUrl": {
+            "description": "The logo URL of the token, if available.",
+            "nullable": true,
+            "type": "string"
+          },
+          "mintAddress": {
+            "description": "The base58 representation of the mint address.",
+            "type": "string"
+          },
+          "mintAddressInteger": {
+            "$ref": "#/components/schemas/SolanaId"
+          },
+          "name": {
+            "description": "The name of the token, if available.",
+            "nullable": true,
+            "type": "string"
+          },
+          "symbol": {
+            "description": "The symbol of the token, if available.",
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "required": [
+          "mintAddressInteger",
+          "mintAddress"
+        ],
+        "type": "object"
+      },
+      "DustAccounts": {
+        "properties": {
+          "balance": {
+            "description": "The balance of the token account, in human-readable format (i.e. scaled by decimals).",
+            "type": "string"
+          },
+          "case": {
+            "$ref": "#/components/schemas/DustReason"
+          },
+          "decimals": {
+            "description": "The decimals of the token.",
+            "format": "int32",
+            "type": "integer"
+          },
+          "logoUrl": {
+            "description": "The logo URL of the token, if available.",
+            "nullable": true,
+            "type": "string"
+          },
+          "mintAddress": {
+            "description": "The mint address of the token of the account.",
+            "type": "string"
+          },
+          "name": {
+            "description": "The name of the token, if available.",
+            "nullable": true,
+            "type": "string"
+          },
+          "rentSol": {
+            "description": "Rent reserved for this token account in SOL. Assumes standard 165-byte account size. Token-2022 accounts with extensions may have higher actual rent.",
+            "type": "string"
+          },
+          "rentUsd": {
+            "description": "Rent reserved for this token account in USD (based on current SOL price), if available. Assumes standard 165-byte account size.",
+            "nullable": true,
+            "type": "string"
+          },
+          "symbol": {
+            "description": "The symbol of the token, if available.",
+            "nullable": true,
+            "type": "string"
+          },
+          "tokenAccountAddress": {
+            "description": "The public key of the token account.",
+            "type": "string"
+          },
+          "valueUsd": {
+            "description": "The value of the token account in USD, calculated as balance * price, if available.",
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "required": [
+          "tokenAccountAddress",
+          "mintAddress",
+          "balance",
+          "decimals",
+          "rentSol",
+          "case"
+        ],
+        "type": "object"
+      },
+      "DustAccountsManyParams": {
+        "properties": {
+          "limit": {
+            "description": "Maximum number of dust accounts to return across all wallets. Defaults to 1000.",
+            "format": "int32",
+            "minimum": 0,
+            "nullable": true,
+            "type": "integer"
+          },
+          "ownerAddresses": {
+            "description": "List of Solana wallet addresses to query (1-10 wallets).",
+            "items": {
+              "$ref": "#/components/schemas/SolanaId"
+            },
+            "type": "array"
+          },
+          "page": {
+            "description": "Page number to return (zero-indexed). Defaults to 0.",
+            "format": "int32",
+            "minimum": 0,
+            "nullable": true,
+            "type": "integer"
+          },
+          "sortByAsc": {
+            "description": "Sort ascending by 'tokenAccountAddress', 'mintAddress', 'name', 'symbol', 'balance', 'valueUsd', or 'rentUsd'. If omitted, no sorting is applied. Only one of `sortByAsc` or `sortByDesc` can be used.",
+            "nullable": true,
+            "type": "string"
+          },
+          "sortByDesc": {
+            "description": "Sort descending by 'tokenAccountAddress', 'mintAddress', 'name', 'symbol', 'balance', 'valueUsd', or 'rentUsd'. If omitted, no sorting is applied. Only one of `sortByAsc` or `sortByDesc` can be used.",
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "required": [
+          "ownerAddresses"
+        ],
+        "type": "object"
+      },
+      "DustAccountsResponse": {
+        "properties": {
+          "dustAccounts": {
+            "description": "A paginated list of dust accounts for the wallet, where dust accounts are defined as token accounts with very low value (e.g. below $1) or no price information available.",
+            "items": {
+              "$ref": "#/components/schemas/DustAccounts"
+            },
+            "type": "array"
+          },
+          "totalDustAccounts": {
+            "description": "The total number of dust accounts for the wallet, including those not returned in this paginated response.",
+            "format": "int64",
+            "type": "integer"
+          },
+          "totalDustValueSol": {
+            "description": "The total value of all dust accounts in SOL.",
+            "type": "string"
+          },
+          "totalDustValueUsd": {
+            "description": "The total value of all dust accounts in USD.",
+            "type": "string"
+          },
+          "totalRentReclaimSol": {
+            "description": "The approximate total rent reclaim value of all dust accounts in SOL, calculated as the number of dust accounts multiplied by the rent_sol per account.",
+            "type": "string"
+          },
+          "totalRentReclaimUsd": {
+            "description": "The approximate total rent reclaim value of all dust accounts in USD, calculated as the number of dust accounts multiplied by the rent_usd per account.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "dustAccounts",
+          "totalDustAccounts",
+          "totalDustValueSol",
+          "totalDustValueUsd",
+          "totalRentReclaimSol",
+          "totalRentReclaimUsd"
+        ],
+        "type": "object"
+      },
+      "DustReason": {
+        "enum": [
+          "lowValue",
+          "noPrice",
+          "unknown"
+        ],
+        "type": "string"
+      },
+      "EmptyAccounts": {
+        "properties": {
+          "decimals": {
+            "description": "The number of decimal places for this token.",
+            "format": "int32",
+            "type": "integer"
+          },
+          "logoUrl": {
+            "description": "The logo URL of the token, if available.",
+            "nullable": true,
+            "type": "string"
+          },
+          "mintAddress": {
+            "description": "The mint address of the empty account.",
+            "type": "string"
+          },
+          "name": {
+            "description": "The name of the token, if available.",
+            "nullable": true,
+            "type": "string"
+          },
+          "rentSol": {
+            "description": "Rent reserved for this token account in SOL. Assumes standard 165-byte account size. Token-2022 accounts with extensions may have higher actual rent.",
+            "type": "string"
+          },
+          "rentUsd": {
+            "description": "Rent reserved for this token account in USD (based on current SOL price). Assumes standard 165-byte account size.",
+            "type": "string"
+          },
+          "symbol": {
+            "description": "The symbol of the token, if available.",
+            "nullable": true,
+            "type": "string"
+          },
+          "tokenAccountAddress": {
+            "description": "The public key of the empty account.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "tokenAccountAddress",
+          "mintAddress",
+          "decimals",
+          "rentSol",
+          "rentUsd"
+        ],
+        "type": "object"
+      },
+      "EmptyAccountsManyParams": {
+        "properties": {
+          "limit": {
+            "description": "Maximum number of empty accounts to return across all wallets. Defaults to 1000.",
+            "format": "int32",
+            "minimum": 0,
+            "nullable": true,
+            "type": "integer"
+          },
+          "ownerAddresses": {
+            "description": "List of Solana wallet addresses to query (1-10 wallets).",
+            "items": {
+              "$ref": "#/components/schemas/SolanaId"
+            },
+            "type": "array"
+          },
+          "page": {
+            "description": "Page number to return (zero-indexed). Defaults to 0.",
+            "format": "int32",
+            "minimum": 0,
+            "nullable": true,
+            "type": "integer"
+          },
+          "sortByAsc": {
+            "description": "Sort ascending by 'tokenAccountAddress', 'mintAddress', 'name', 'symbol', 'decimals', or 'rentUsd'. If omitted, no sorting is applied. Only one of `sortByAsc` or `sortByDesc` can be used.",
+            "nullable": true,
+            "type": "string"
+          },
+          "sortByDesc": {
+            "description": "Sort descending by 'tokenAccountAddress', 'mintAddress', 'name', 'symbol', 'decimals', or 'rentUsd'. If omitted, no sorting is applied. Only one of `sortByAsc` or `sortByDesc` can be used.",
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "required": [
+          "ownerAddresses"
+        ],
+        "type": "object"
+      },
+      "EmptyAccountsResponse": {
+        "properties": {
+          "emptyAccounts": {
+            "description": "The list of empty accounts found.",
+            "items": {
+              "$ref": "#/components/schemas/EmptyAccounts"
+            },
+            "type": "array"
+          },
+          "totalEmptyAccounts": {
+            "description": "Total number of empty accounts found.",
+            "format": "int64",
+            "type": "integer"
+          },
+          "totalRentReclaimSol": {
+            "description": "Approximate total rent that could be reclaimed in SOL by closing these empty accounts.",
+            "type": "string"
+          },
+          "totalRentReclaimUsd": {
+            "description": "Approximate total rent that could be reclaimed in USD by closing these empty accounts.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "emptyAccounts",
+          "totalEmptyAccounts",
+          "totalRentReclaimSol",
+          "totalRentReclaimUsd"
+        ],
+        "type": "object"
+      },
+      "FetcherReport": {
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "Filters": {
+        "properties": {
+          "newMarket": {
+            "description": "Live new markets stream",
+            "items": {
+              "$ref": "#/components/schemas/NewMarketFilter"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "newToken": {
+            "description": "Live new token metadata stream",
+            "items": {
+              "$ref": "#/components/schemas/NewTokenFilter"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "oraclePrices": {
+            "description": "Live Pyth Oracle prices stream",
+            "items": {
+              "$ref": "#/components/schemas/PythUpdatesFilter"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "priceCandles": {
+            "description": "Live price candle stream.",
+            "items": {
+              "$ref": "#/components/schemas/PriceCandleFilter"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "tokenUpdates": {
+            "description": "Live token updates stream.",
+            "items": {
+              "$ref": "#/components/schemas/TokenUpdateFilter"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "tradePrices": {
+            "description": "Trades based per-block average prices stream",
+            "items": {
+              "$ref": "#/components/schemas/TradePriceUpdateFilter"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "trades": {
+            "description": "Live trades stream",
+            "items": {
+              "$ref": "#/components/schemas/TradesFilter"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "transfers": {
+            "description": "Live token transfers stream",
+            "items": {
+              "$ref": "#/components/schemas/TransfersFilter"
+            },
+            "nullable": true,
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "InstructionName": {
+        "properties": {
+          "callingInstructions": {
+            "format": "binary",
+            "type": "string"
+          },
+          "callingProgramAddress": {
+            "type": "string"
+          },
+          "ixName": {
+            "type": "string"
+          },
+          "programName": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "callingInstructions",
+          "ixName",
+          "callingProgramAddress",
+          "programName"
+        ],
+        "type": "object"
+      },
+      "InstructionNameList": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/InstructionName"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "JoinedNftData": {
+        "properties": {
+          "certainty": {
+            "description": "Level of confidence for NFT match, a value between 0 and 1",
+            "format": "double",
+            "type": "number"
+          },
+          "collectionAddress": {
+            "$ref": "#/components/schemas/SolanaId"
+          },
+          "collectionName": {
+            "description": "NFT collection name",
+            "type": "string"
+          },
+          "imageUrl": {
+            "description": "NFT image url",
+            "nullable": true,
+            "type": "string"
+          },
+          "mintAddress": {
+            "$ref": "#/components/schemas/SolanaId"
+          },
+          "ownerAddress": {
+            "$ref": "#/components/schemas/SolanaId"
+          },
+          "tokenName": {
+            "description": "NFT token name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "ownerAddress",
+          "mintAddress",
+          "collectionAddress",
+          "collectionName",
+          "tokenName",
+          "certainty"
+        ],
+        "type": "object"
+      },
+      "JoinedNftResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/JoinedNftData"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "KnownAccountReturn": {
+        "properties": {
+          "accountAddress": {
+            "description": "The public key (pubKey) associated with the Solana account",
+            "type": "string"
+          },
+          "dateAdded": {
+            "description": "Date added to the database",
+            "format": "date-time",
+            "type": "string"
+          },
+          "entity": {
+            "description": "Account entity, if available",
+            "nullable": true,
+            "type": "string"
+          },
+          "entityId": {
+            "description": "Account entity ID, if available",
+            "format": "int32",
+            "nullable": true,
+            "type": "integer"
+          },
+          "labels": {
+            "description": "Account labels, eg: DEFI,NFT",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "logoUrl": {
+            "description": "Account logo URL, if available",
+            "nullable": true,
+            "type": "string"
+          },
+          "name": {
+            "description": "Account name",
+            "nullable": true,
+            "type": "string"
+          },
+          "twitterUrl": {
+            "description": "Twiiter url for the account",
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "required": [
+          "accountAddress",
+          "labels",
+          "dateAdded"
+        ],
+        "type": "object"
+      },
+      "KnownAccountVecReturn": {
+        "properties": {
+          "accounts": {
+            "description": "Found accounts",
+            "items": {
+              "$ref": "#/components/schemas/KnownAccountReturn"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "accounts"
+        ],
+        "type": "object"
+      },
+      "KnownProgramReturn": {
+        "properties": {
+          "dateAdded": {
+            "description": "Date added to the database",
+            "format": "date-time",
+            "type": "string"
+          },
+          "defiLlamaId": {
+            "description": "Program DeFi Llama ID",
+            "nullable": true,
+            "type": "string"
+          },
+          "entityId": {
+            "description": "Program entity ID",
+            "format": "int32",
+            "nullable": true,
+            "type": "integer"
+          },
+          "entityName": {
+            "description": "Name of the business or entity that controls this program",
+            "nullable": true,
+            "type": "string"
+          },
+          "idlUrl": {
+            "description": "Program IDL URL",
+            "nullable": true,
+            "type": "string"
+          },
+          "labels": {
+            "description": "Program labels, eg: DEFI,NFT",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "logoUrl": {
+            "description": "Program logo URL",
+            "nullable": true,
+            "type": "string"
+          },
+          "name": {
+            "description": "Program name",
+            "nullable": true,
+            "type": "string"
+          },
+          "programAddress": {
+            "description": "Program ID",
+            "type": "string"
+          },
+          "programDescription": {
+            "description": "Program description",
+            "nullable": true,
+            "type": "string"
+          },
+          "programDetail": {
+            "description": "Program detail",
+            "nullable": true,
+            "type": "string"
+          },
+          "siteUrl": {
+            "description": "Program site URL",
+            "nullable": true,
+            "type": "string"
+          },
+          "twitterUrl": {
+            "description": "Twiiter url for the program account",
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "required": [
+          "programAddress",
+          "labels",
+          "dateAdded"
+        ],
+        "type": "object"
+      },
+      "KnownProgramVecReturn": {
+        "properties": {
+          "programs": {
+            "description": "List of found programs",
+            "items": {
+              "$ref": "#/components/schemas/KnownProgramReturn"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "programs"
+        ],
+        "type": "object"
+      },
+      "Label": {
+        "description": "Represents the label type for trader categorization.",
+        "enum": [
+          "All",
+          "Kol"
+        ],
+        "type": "string"
+      },
+      "MarketOhlcvCandleReturn": {
+        "properties": {
+          "close": {
+            "type": "string"
+          },
+          "count": {
+            "format": "int64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "high": {
+            "type": "string"
+          },
+          "low": {
+            "type": "string"
+          },
+          "open": {
+            "type": "string"
+          },
+          "time": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "volume": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "time",
+          "open",
+          "high",
+          "low",
+          "close",
+          "volume",
+          "count"
+        ],
+        "type": "object"
+      },
+      "MarketOhlcvCandleVecReturn": {
+        "properties": {
+          "data": {
+            "description": "Found OHLCV data",
+            "items": {
+              "$ref": "#/components/schemas/MarketOhlcvCandleReturn"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "MarketsReturn": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/TradePriceMarketReturn"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "Metrics": {
+        "description": "Metrics for a token's trading performance.",
+        "properties": {
+          "buys": {
+            "$ref": "#/components/schemas/TradeSideSummary"
+          },
+          "latestTradeBlocktime": {
+            "description": "The blocktime of the latest trade (buy or sell) in Unix seconds.",
+            "format": "int64",
+            "nullable": true,
+            "type": "integer"
+          },
+          "mintAddress": {
+            "description": "The address of the mint.",
+            "type": "string"
+          },
+          "realizedPnlUsd": {
+            "description": "The total realized profit in USD for this token (if any).",
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "sells": {
+            "$ref": "#/components/schemas/TradeSideSummary"
+          },
+          "status": {
+            "description": "The token specific trades status: \"open\" or \"closed\".",
+            "type": "string"
+          },
+          "tokenLabels": {
+            "description": "Custom wallet labels assigned internally by the Vybe system (if any).",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "tokenLogoUrl": {
+            "description": "The URL to the token's logo image (if any).",
+            "nullable": true,
+            "type": "string"
+          },
+          "tokenName": {
+            "description": "The name of the token (if any).",
+            "nullable": true,
+            "type": "string"
+          },
+          "tokenSymbol": {
+            "description": "The symbol of the token.",
+            "nullable": true,
+            "type": "string"
+          },
+          "unrealizedPnlUsd": {
+            "description": "The total unrealized profit in USD for this token (if any).",
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          }
+        },
+        "required": [
+          "mintAddress",
+          "tokenLabels",
+          "buys",
+          "sells",
+          "status"
+        ],
+        "type": "object"
+      },
+      "MintId": {
+        "$ref": "#/components/schemas/SolanaId"
+      },
+      "MostReliableAmmsQuoteReport": {
+        "properties": {
+          "info": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Quote information from reliable AMMs",
+            "type": "object"
+          }
+        },
+        "required": [
+          "info"
+        ],
+        "type": "object"
+      },
+      "NewMarketFilter": {
+        "properties": {
+          "source": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SolanaId"
+              }
+            ],
+            "nullable": true
+          },
+          "tokenAMint": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SolanaId"
+              }
+            ],
+            "nullable": true
+          },
+          "tokenBMint": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SolanaId"
+              }
+            ],
+            "nullable": true
+          }
+        },
+        "type": "object"
+      },
+      "NewMarketWsResponse": {
+        "properties": {
+          "dexId": {
+            "type": "string"
+          },
+          "initialLiquidityTokenA": {
+            "nullable": true,
+            "type": "string"
+          },
+          "initialLiquidityTokenB": {
+            "nullable": true,
+            "type": "string"
+          },
+          "poolId": {
+            "type": "string"
+          },
+          "signature": {
+            "type": "string"
+          },
+          "slot": {
+            "format": "int64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "timestamp": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "tokenAMint": {
+            "type": "string"
+          },
+          "tokenBMint": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "dexId",
+          "poolId",
+          "tokenAMint",
+          "tokenBMint",
+          "signature",
+          "slot",
+          "timestamp"
+        ],
+        "type": "object"
+      },
+      "NewTokenFilter": {
+        "properties": {
+          "source": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SolanaId"
+              }
+            ],
+            "nullable": true
+          },
+          "tokenNameContains": {
+            "description": "Filter by token symbol",
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "NewTokenWsResponse": {
+        "properties": {
+          "decimals": {
+            "format": "int32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "freezeAuthority": {
+            "nullable": true,
+            "type": "string"
+          },
+          "maxSupply": {
+            "format": "int64",
+            "minimum": 0,
+            "nullable": true,
+            "type": "integer"
+          },
+          "mintAuthority": {
+            "type": "string"
+          },
+          "signature": {
+            "type": "string"
+          },
+          "slot": {
+            "format": "int64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "sourceId": {
+            "nullable": true,
+            "type": "string"
+          },
+          "sourceName": {
+            "nullable": true,
+            "type": "string"
+          },
+          "timestamp": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "tokenMint": {
+            "type": "string"
+          },
+          "tokenName": {
+            "nullable": true,
+            "type": "string"
+          },
+          "tokenSymbol": {
+            "nullable": true,
+            "type": "string"
+          },
+          "tokenUri": {
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "required": [
+          "tokenMint",
+          "mintAuthority",
+          "decimals",
+          "signature",
+          "slot",
+          "timestamp"
+        ],
+        "type": "object"
+      },
+      "NftUrlSearchBody": {
+        "properties": {
+          "url": {
+            "description": "Url for requested nft",
+            "type": "string"
+          }
+        },
+        "required": [
+          "url"
+        ],
+        "type": "object"
+      },
+      "PnlTimeseriesData": {
+        "properties": {
+          "pnl": {
+            "description": "The realized PnL in USD for this time period.",
+            "format": "double",
+            "type": "number"
+          },
+          "timestamp": {
+            "description": "The start of the time period (unix timestamp).",
+            "format": "int64",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "timestamp",
+          "pnl"
+        ],
+        "type": "object"
+      },
+      "PnlTimeseriesResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/PnlTimeseriesData"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "PriceCandleFilter": {
+        "properties": {
+          "baseMintAddress": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SolanaId"
+              }
+            ],
+            "nullable": true
+          }
+        },
+        "type": "object"
+      },
+      "ProgramActiveUsers": {
+        "properties": {
+          "instructions": {
+            "description": "Amount of instructions triggered by the user",
+            "format": "int64",
+            "type": "integer"
+          },
+          "programId": {
+            "description": "Id of requested program",
+            "type": "string"
+          },
+          "transactions": {
+            "description": "Amount of transactions triggered by the user",
+            "format": "int64",
+            "type": "integer"
+          },
+          "wallet": {
+            "description": "User's wallet id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "programId",
+          "wallet",
+          "transactions",
+          "instructions"
+        ],
+        "type": "object"
+      },
+      "ProgramActiveUsersCount": {
+        "properties": {
+          "blockTime": {
+            "description": "Block time",
+            "format": "int64",
+            "type": "integer"
+          },
+          "dau": {
+            "description": "Count of unique fee payers in the selected resolution",
+            "format": "int64",
+            "type": "integer"
+          },
+          "programId": {
+            "description": "Unique public key for a Solana program",
+            "type": "string"
+          }
+        },
+        "required": [
+          "programId",
+          "dau",
+          "blockTime"
+        ],
+        "type": "object"
+      },
+      "ProgramDetails": {
+        "properties": {
+          "dau": {
+            "description": "Unique fee payers in the last day",
+            "format": "int64",
+            "nullable": true,
+            "type": "integer"
+          },
+          "entityName": {
+            "description": "Name of the business or entity that controls this program",
+            "nullable": true,
+            "type": "string"
+          },
+          "friendlyName": {
+            "description": "Friendly name",
+            "nullable": true,
+            "type": "string"
+          },
+          "idlUrl": {
+            "description": "Program IDL URL",
+            "nullable": true,
+            "type": "string"
+          },
+          "instructions1d": {
+            "description": "Instruction count in 1 day",
+            "format": "int64",
+            "nullable": true,
+            "type": "integer"
+          },
+          "labels": {
+            "description": "Labels to filter over. Only programs matching all labels will be returned (eg. labels=DEFI,NFT)",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "logoUrl": {
+            "description": "Program logo URL",
+            "nullable": true,
+            "type": "string"
+          },
+          "name": {
+            "description": "Program name",
+            "nullable": true,
+            "type": "string"
+          },
+          "newUsersChange1d": {
+            "description": "1 day change in DAU",
+            "format": "int64",
+            "nullable": true,
+            "type": "integer"
+          },
+          "programDescription": {
+            "description": "Program description",
+            "nullable": true,
+            "type": "string"
+          },
+          "programDetail": {
+            "description": "Program detail",
+            "nullable": true,
+            "type": "string"
+          },
+          "programId": {
+            "description": "Program ID",
+            "type": "string"
+          },
+          "transactions1d": {
+            "description": "Total transactions in 1 day",
+            "format": "int64",
+            "nullable": true,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "programId"
+        ],
+        "type": "object"
+      },
+      "ProgramInstructionName": {
+        "properties": {
+          "callingInstructions": {
+            "format": "binary",
+            "type": "string"
+          },
+          "callingProgram": {
+            "type": "string"
+          },
+          "ixName": {
+            "type": "string"
+          },
+          "programLogoUrl": {
+            "type": "string"
+          },
+          "programName": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "callingInstructions",
+          "ixName",
+          "callingProgram",
+          "programName",
+          "programLogoUrl"
+        ],
+        "type": "object"
+      },
+      "ProgramInstructionsCount": {
+        "properties": {
+          "blockTime": {
+            "description": "Block time",
+            "format": "int64",
+            "type": "integer"
+          },
+          "instructionsCount": {
+            "description": "Instructions count",
+            "format": "int64",
+            "type": "integer"
+          },
+          "programId": {
+            "description": "Unique public key for a Solana program",
+            "type": "string"
+          }
+        },
+        "required": [
+          "programId",
+          "instructionsCount",
+          "blockTime"
+        ],
+        "type": "object"
+      },
+      "ProgramRankHelper": {
+        "properties": {
+          "programId": {
+            "description": "Program address in base 58 format",
+            "type": "string"
+          },
+          "programName": {
+            "description": "Program Name - null if we dont have it in the dict",
+            "nullable": true,
+            "type": "string"
+          },
+          "programRank": {
+            "description": "Program rank for the day",
+            "format": "int32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "score": {
+            "description": "rank score after calculation",
+            "format": "double",
+            "type": "number"
+          }
+        },
+        "required": [
+          "programRank",
+          "programId",
+          "score"
+        ],
+        "type": "object"
+      },
+      "ProgramRanks": {
+        "properties": {
+          "data": {
+            "description": "The Ranked programs",
+            "items": {
+              "$ref": "#/components/schemas/ProgramRankHelper"
+            },
+            "type": "array"
+          },
+          "date": {
+            "description": "The epoch used to get the ranks for",
+            "format": "int64",
+            "type": "integer"
+          },
+          "interval": {
+            "description": "Interval between the ranks - Possible values: '1d', '7d' or '30d'",
+            "type": "string"
+          },
+          "limit": {
+            "description": "The number of ranks returned",
+            "format": "int32",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "date",
+          "interval",
+          "limit",
+          "data"
+        ],
+        "type": "object"
+      },
+      "ProgramTransactionsCount": {
+        "properties": {
+          "blockTime": {
+            "description": "Block time",
+            "format": "int64",
+            "type": "integer"
+          },
+          "programId": {
+            "description": "Unique public key for a Solana program",
+            "type": "string"
+          },
+          "transactionsCount": {
+            "description": "Transactions count",
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "programId",
+          "transactionsCount",
+          "blockTime"
+        ],
+        "type": "object"
+      },
+      "ProgramsActiveUsersCountVecReturn": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/ProgramActiveUsersCount"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "ProgramsActiveUsersVecReturn": {
+        "properties": {
+          "data": {
+            "description": "Found active users",
+            "items": {
+              "$ref": "#/components/schemas/ProgramActiveUsers"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "ProgramsInstructionsCountVecReturn": {
+        "properties": {
+          "data": {
+            "description": "Found instructions count",
+            "items": {
+              "$ref": "#/components/schemas/ProgramInstructionsCount"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "ProgramsListResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/ProgramDetails"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "ProgramsTransactionsCountVecReturn": {
+        "properties": {
+          "data": {
+            "description": "Found transactions count",
+            "items": {
+              "$ref": "#/components/schemas/ProgramTransactionsCount"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "ProxyUserDefiPlatformProxyReturn": {
+        "properties": {
+          "data": {
+            "items": {},
+            "type": "array"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "PythPriceFeed": {
+        "description": "User-facing Pyth price feed update",
+        "properties": {
+          "confidence": {
+            "description": "Confidence interval of how close we think the true price is to the average.\nIt's influenced by both how sure each person quoting the price is, and how much they agree with each other.",
+            "type": "string"
+          },
+          "emac1H": {
+            "description": "Exponentially-weighted moving average confidence interval is a time-weighted average of the confidence interval",
+            "type": "string"
+          },
+          "emap1H": {
+            "description": "Exponentially-weighted moving average price is a time-weighted average of the aggregate price",
+            "type": "string"
+          },
+          "lastUpdated": {
+            "description": "The last updated time",
+            "format": "int64",
+            "type": "integer"
+          },
+          "priceFeedAddress": {
+            "$ref": "#/components/schemas/SolanaId"
+          },
+          "priceUsd": {
+            "description": "Price of asset expressed in USD",
+            "type": "string"
+          },
+          "validSlot": {
+            "description": "The last valid slot",
+            "format": "int64",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "priceFeedAddress",
+          "lastUpdated",
+          "validSlot",
+          "priceUsd",
+          "confidence",
+          "emac1H",
+          "emap1H"
+        ],
+        "type": "object"
+      },
+      "PythPriceFeedWsReturn": {
+        "description": "WSS-specific Pyth price feed response that preserves legacy field names (`priceFeedAccount`, `price`)\nto avoid breaking WebSocket consumers.",
+        "properties": {
+          "confidence": {
+            "type": "string"
+          },
+          "emac1H": {
+            "type": "string"
+          },
+          "emap1H": {
+            "type": "string"
+          },
+          "lastUpdated": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "price": {
+            "type": "string"
+          },
+          "priceFeedAccount": {
+            "$ref": "#/components/schemas/SolanaId"
+          },
+          "validSlot": {
+            "format": "int64",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "priceFeedAccount",
+          "lastUpdated",
+          "validSlot",
+          "price",
+          "confidence",
+          "emac1H",
+          "emap1H"
+        ],
+        "type": "object"
+      },
+      "PythPriceFeedsTimeSeriesReturn": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/PythPriceFeed"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "PythPriceOhlc": {
+        "properties": {
+          "avgConf": {
+            "description": "Average confidence",
+            "type": "string"
+          },
+          "avgPrice": {
+            "description": "Average price",
+            "type": "string"
+          },
+          "close": {
+            "description": "Close price",
+            "type": "string"
+          },
+          "high": {
+            "description": "High price",
+            "type": "string"
+          },
+          "low": {
+            "description": "Low price",
+            "type": "string"
+          },
+          "open": {
+            "description": "Open price",
+            "type": "string"
+          },
+          "timeBucketStart": {
+            "description": "Time bucket start",
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "timeBucketStart",
+          "open",
+          "high",
+          "low",
+          "close",
+          "avgPrice",
+          "avgConf"
+        ],
+        "type": "object"
+      },
+      "PythPriceOhlcReturn": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/PythPriceOhlc"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "PythPriceProductPair": {
+        "properties": {
+          "priceFeedAddress": {
+            "description": "The pubkey identifying the Pyth Price feed account.",
+            "type": "string"
+          },
+          "productAddress": {
+            "description": "The pubkey identifying the Pyth Product account.",
+            "type": "string"
+          },
+          "symbol": {
+            "description": "The Pyth asset symbol",
+            "type": "string"
+          }
+        },
+        "required": [
+          "productAddress",
+          "priceFeedAddress",
+          "symbol"
+        ],
+        "type": "object"
+      },
+      "PythPriceProductPairsReturn": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/PythPriceProductPair"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "PythProduct": {
+        "allOf": [
+          {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PythProductSchedule"
+              }
+            ],
+            "nullable": true
+          },
+          {
+            "$ref": "#/components/schemas/PythProductSymbols"
+          },
+          {
+            "properties": {
+              "assetType": {
+                "description": "The asset class: Crypto, Equity, FX, Metal, Rates, Commodities",
+                "type": "string"
+              },
+              "base": {
+                "description": "Base asset. Can be present for everything except rates and commodities.",
+                "nullable": true,
+                "type": "string"
+              },
+              "country": {
+                "description": "The country code. Can be present for equity only.",
+                "nullable": true,
+                "type": "string"
+              },
+              "description": {
+                "description": "Pair name",
+                "type": "string"
+              },
+              "productAddress": {
+                "description": "The pubkey identifying the Pyth Product.",
+                "type": "string"
+              },
+              "quote": {
+                "description": "Quote currency. Can be present for everything except rates and commodities.",
+                "nullable": true,
+                "type": "string"
+              },
+              "symbol": {
+                "description": "Pyth asset symbol",
+                "type": "string"
+              },
+              "tenor": {
+                "description": "The tenor. Can be present for FX or equity only.",
+                "nullable": true,
+                "type": "string"
+              }
+            },
+            "required": [
+              "productAddress",
+              "description",
+              "symbol",
+              "assetType"
+            ],
+            "type": "object"
+          }
+        ],
+        "description": "Structure corresponding to what we will fetch in the API\nThis is saved to a json file"
+      },
+      "PythProductSchedule": {
+        "oneOf": [
+          {
+            "properties": {
+              "schedule": {
+                "description": "Weekly schedule",
+                "type": "string"
+              }
+            },
+            "required": [
+              "schedule"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "umtf": {
+                "description": "UMTF",
+                "type": "string"
+              }
+            },
+            "required": [
+              "umtf"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "PythProductSymbols": {
+        "oneOf": [
+          {
+            "properties": {
+              "genericSymbol": {
+                "description": "Ticker symbol",
+                "type": "string"
+              }
+            },
+            "required": [
+              "genericSymbol"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "cmsSymbol": {
+                "description": "CMS market symbol",
+                "type": "string"
+              },
+              "cqsSymbol": {
+                "description": "CQS market symbol",
+                "type": "string"
+              },
+              "nasdaqSymbol": {
+                "description": "Nasdaq market symbol",
+                "type": "string"
+              }
+            },
+            "required": [
+              "cmsSymbol",
+              "cqsSymbol",
+              "nasdaqSymbol"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "PythUpdatesFilter": {
+        "properties": {
+          "priceFeedAccount": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SolanaId"
+              }
+            ],
+            "nullable": true
+          },
+          "productAccount": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SolanaId"
+              }
+            ],
+            "nullable": true
+          }
+        },
+        "type": "object"
+      },
+      "RecentRange": {
+        "format": "recent_range",
+        "type": "string"
+      },
+      "Resolution": {
+        "enum": [
+          "1m",
+          "3m",
+          "5m",
+          "15m",
+          "30m",
+          "1h",
+          "2h",
+          "3h",
+          "4h",
+          "1d",
+          "1w",
+          "1mo",
+          "1y"
+        ],
+        "type": "string"
+      },
+      "ResolutionDeprecated": {
+        "format": "resolution",
+        "type": "string"
+      },
+      "RoutePlan": {
+        "properties": {
+          "bps": {
+            "description": "Basis points",
+            "format": "int32",
+            "nullable": true,
+            "type": "integer"
+          },
+          "percent": {
+            "description": "Percentage of the swap",
+            "format": "int32",
+            "type": "integer"
+          },
+          "swapInfo": {
+            "$ref": "#/components/schemas/SwapInfo"
+          }
+        },
+        "required": [
+          "swapInfo",
+          "percent"
+        ],
+        "type": "object"
+      },
+      "SolanaId": {
+        "format": "pubkey",
+        "type": "string"
+      },
+      "Summary": {
+        "description": "Summary of overall trading performance.",
+        "properties": {
+          "averageTradeUsd": {
+            "description": "The average size of trades in USD.",
+            "format": "double",
+            "type": "number"
+          },
+          "bestPerformingToken": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/TokenPerformance"
+              }
+            ],
+            "nullable": true
+          },
+          "losingTradesCount": {
+            "description": "The number of trades that resulted in a loss.",
+            "format": "int64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "pnlTrendSevenDays": {
+            "description": "The profit and loss trend over the last seven days.",
+            "items": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "type": "array"
+          },
+          "realizedPnlUsd": {
+            "description": "The total realized profit in USD (if any).",
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "tradesCount": {
+            "description": "The total number of trades executed.",
+            "format": "int64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "tradesVolumeUsd": {
+            "description": "The total trading volume in USD.",
+            "format": "double",
+            "type": "number"
+          },
+          "uniqueTokensTraded": {
+            "description": "The count of unique tokens traded by the account.",
+            "format": "int64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "unrealizedPnlUsd": {
+            "description": "The total unrealized profit in USD (if any).",
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "winRate": {
+            "description": "The percentage of winning trades (0.0 to 100.0).",
+            "format": "double",
+            "type": "number"
+          },
+          "winningTradesCount": {
+            "description": "The number of trades that resulted in a profit.",
+            "format": "int64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "worstPerformingToken": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/TokenPerformance"
+              }
+            ],
+            "nullable": true
+          }
+        },
+        "required": [
+          "winRate",
+          "uniqueTokensTraded",
+          "averageTradeUsd",
+          "tradesCount",
+          "winningTradesCount",
+          "losingTradesCount",
+          "tradesVolumeUsd",
+          "pnlTrendSevenDays"
+        ],
+        "type": "object"
+      },
+      "Swap": {
+        "properties": {
+          "details": {
+            "$ref": "#/components/schemas/SwapDetails"
+          },
+          "provider": {
+            "description": "Provider name",
+            "type": "string"
+          },
+          "slippage": {
+            "description": "Slippage percentage",
+            "format": "double",
+            "type": "number"
+          },
+          "slippageSource": {
+            "description": "Source of slippage (e.g., \"manual\", \"auto\")",
+            "type": "string"
+          },
+          "transaction": {
+            "description": "Base64-encoded unsigned transaction",
+            "type": "string"
+          }
+        },
+        "required": [
+          "transaction",
+          "provider",
+          "details",
+          "slippage",
+          "slippageSource"
+        ],
+        "type": "object"
+      },
+      "SwapDetails": {
+        "properties": {
+          "closeAccountIx": {
+            "description": "Whether close account instruction is included",
+            "type": "boolean"
+          },
+          "inputAmount": {
+            "description": "Input amount in decimal units",
+            "format": "double",
+            "type": "number"
+          },
+          "inputDecimals": {
+            "description": "Input token decimals",
+            "format": "int32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "inputMintAddress": {
+            "description": "Input token label/mint",
+            "type": "string"
+          },
+          "outputDecimals": {
+            "description": "Output token decimals",
+            "format": "int32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "outputMintAddress": {
+            "description": "Output token label/mint",
+            "type": "string"
+          },
+          "quote": {
+            "$ref": "#/components/schemas/SwapQuoteDetails"
+          },
+          "swapFee": {
+            "description": "Swap fee amount",
+            "format": "int64",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "inputAmount",
+          "inputMintAddress",
+          "outputMintAddress",
+          "inputDecimals",
+          "outputDecimals",
+          "swapFee",
+          "quote",
+          "closeAccountIx"
+        ],
+        "type": "object"
+      },
+      "SwapInfo": {
+        "properties": {
+          "ammKey": {
+            "description": "AMM key identifier",
+            "type": "string"
+          },
+          "feeAmount": {
+            "description": "Fee amount in base units",
+            "type": "string"
+          },
+          "feeMintAddress": {
+            "description": "Fee token mint address",
+            "type": "string"
+          },
+          "inAmount": {
+            "description": "Input amount in base units",
+            "type": "string"
+          },
+          "inputMintAddress": {
+            "description": "Input token mint address",
+            "type": "string"
+          },
+          "label": {
+            "description": "Label/name of the DEX",
+            "type": "string"
+          },
+          "outAmount": {
+            "description": "Output amount in base units",
+            "type": "string"
+          },
+          "outputMintAddress": {
+            "description": "Output token mint address",
+            "type": "string"
+          }
+        },
+        "required": [
+          "ammKey",
+          "label",
+          "inputMintAddress",
+          "outputMintAddress",
+          "inAmount",
+          "outAmount",
+          "feeAmount",
+          "feeMintAddress"
+        ],
+        "type": "object"
+      },
+      "SwapProxyParams": {
+        "properties": {
+          "accountAddress": {
+            "$ref": "#/components/schemas/SolanaId"
+          },
+          "amount": {
+            "description": "Amount to swap (in UI units)",
+            "format": "double",
+            "type": "number"
+          },
+          "autoCalculateSlippage": {
+            "description": "Auto-calculate optimal slippage",
+            "nullable": true,
+            "type": "boolean"
+          },
+          "gasless": {
+            "description": "Use Vybe fee payer for gas",
+            "nullable": true,
+            "type": "boolean"
+          },
+          "inputMintAddress": {
+            "$ref": "#/components/schemas/SolanaId"
+          },
+          "outputMintAddress": {
+            "$ref": "#/components/schemas/SolanaId"
+          },
+          "partner": {
+            "description": "Partner identifier for fee routing",
+            "nullable": true,
+            "type": "string"
+          },
+          "poolAddress": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SolanaId"
+              }
+            ],
+            "nullable": true
+          },
+          "protocol": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SwapProxyProtocol"
+              }
+            ],
+            "nullable": true
+          },
+          "router": {
+            "$ref": "#/components/schemas/SwapProxyRouter"
+          },
+          "simulate": {
+            "description": "Simulate transaction without building",
+            "nullable": true,
+            "type": "boolean"
+          },
+          "slippage": {
+            "description": "Slippage tolerance (percentage)",
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "swapFee": {
+            "description": "Service fee percentage (e.g., 1 for 1%)",
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          }
+        },
+        "required": [
+          "accountAddress",
+          "amount",
+          "inputMintAddress",
+          "outputMintAddress"
+        ],
+        "type": "object"
+      },
+      "SwapProxyProtocol": {
+        "enum": [
+          "PUMPFUN",
+          "PUMPSWAP",
+          "RAYDIUMAMMV4",
+          "RAYDIUMCPMM",
+          "RAYDIUMCLMM",
+          "RAYDIUMLAUNCHLAB",
+          "METEORADBC",
+          "METEORADAMM2",
+          "METEORADLMM",
+          "SANCTUM"
+        ],
+        "type": "string"
+      },
+      "SwapProxyRouter": {
+        "enum": [
+          "titan",
+          "jupiter",
+          "vybe"
+        ],
+        "type": "string"
+      },
+      "SwapQuote": {
+        "properties": {
+          "contextSlot": {
+            "description": "Context slot",
+            "format": "int64",
+            "minimum": 0,
+            "nullable": true,
+            "type": "integer"
+          },
+          "inAmount": {
+            "description": "Input amount in base units (lamports)",
+            "type": "string"
+          },
+          "inputMintAddress": {
+            "description": "Input mint address",
+            "type": "string"
+          },
+          "instructionVersion": {
+            "description": "Instruction version",
+            "nullable": true
+          },
+          "loadedLongtailToken": {
+            "description": "Whether longtail token was loaded",
+            "nullable": true,
+            "type": "boolean"
+          },
+          "mostReliableAmmsQuoteReport": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/MostReliableAmmsQuoteReport"
+              }
+            ],
+            "nullable": true
+          },
+          "otherAmountThreshold": {
+            "description": "Minimum output considering slippage (base units)",
+            "type": "string"
+          },
+          "otherAmountThresholdUi": {
+            "description": "Minimum output in UI units",
+            "format": "double",
+            "type": "number"
+          },
+          "otherRoutePlans": {
+            "description": "Other route plans",
+            "nullable": true
+          },
+          "outAmount": {
+            "description": "Expected output amount in base units",
+            "type": "string"
+          },
+          "outAmountUi": {
+            "description": "Output amount in UI units (human-readable)",
+            "format": "double",
+            "type": "number"
+          },
+          "outputMintAddress": {
+            "description": "Output mint address",
+            "type": "string"
+          },
+          "platformFee": {
+            "description": "Platform fee",
+            "nullable": true
+          },
+          "priceImpactPct": {
+            "description": "Price impact percentage",
+            "type": "string"
+          },
+          "routePlan": {
+            "description": "Route plan with swap information",
+            "items": {
+              "$ref": "#/components/schemas/RoutePlan"
+            },
+            "type": "array"
+          },
+          "simplerRouteUsed": {
+            "description": "Whether simpler route was used",
+            "nullable": true,
+            "type": "boolean"
+          },
+          "slippageBps": {
+            "description": "Slippage in basis points",
+            "format": "int32",
+            "nullable": true,
+            "type": "integer"
+          },
+          "swapMode": {
+            "description": "Swap mode (e.g., \"ExactIn\")",
+            "type": "string"
+          },
+          "swapRate": {
+            "description": "Exchange rate (output per 1 input token)",
+            "format": "double",
+            "type": "number"
+          },
+          "swapUsdValue": {
+            "description": "USD value of the swap",
+            "nullable": true,
+            "type": "string"
+          },
+          "timeTaken": {
+            "description": "Time taken to compute quote",
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "useIncurredSlippageForQuoting": {
+            "description": "Use incurred slippage for quoting",
+            "nullable": true
+          }
+        },
+        "required": [
+          "inputMintAddress",
+          "inAmount",
+          "outputMintAddress",
+          "outAmount",
+          "otherAmountThreshold",
+          "swapMode",
+          "priceImpactPct",
+          "routePlan",
+          "outAmountUi",
+          "otherAmountThresholdUi",
+          "swapRate"
+        ],
+        "type": "object"
+      },
+      "SwapQuoteDetails": {
+        "properties": {
+          "inAmount": {
+            "description": "Input amount in base units",
+            "type": "string"
+          },
+          "outAmount": {
+            "description": "Output amount in base units",
+            "type": "string"
+          },
+          "provider": {
+            "description": "Provider name for the quote",
+            "type": "string"
+          }
+        },
+        "required": [
+          "inAmount",
+          "outAmount",
+          "provider"
+        ],
+        "type": "object"
+      },
+      "TokenBalance": {
+        "properties": {
+          "amount": {
+            "description": "Amount of the token",
+            "type": "string"
+          },
+          "averagePriceUsd": {
+            "description": "Average price of the token in this wallet's trades",
+            "type": "string"
+          },
+          "category": {
+            "description": "Category for the token",
+            "nullable": true,
+            "type": "string"
+          },
+          "decimals": {
+            "description": "Decimals for the token",
+            "format": "int64",
+            "type": "integer"
+          },
+          "logoUrl": {
+            "description": "Logo URL for the token",
+            "nullable": true,
+            "type": "string"
+          },
+          "mintAddress": {
+            "description": "Address for the token",
+            "type": "string"
+          },
+          "name": {
+            "description": "Name for the token, can be null for unknown addresses",
+            "nullable": true,
+            "type": "string"
+          },
+          "priceUsd": {
+            "description": "Average price of the token in USD",
+            "type": "string"
+          },
+          "priceUsd1dChange": {
+            "description": "Change in the price of the token in USD over the last 24 hours",
+            "type": "string"
+          },
+          "priceUsd7dTrend": {
+            "description": "7 day trend of the token price in USD",
+            "type": "string"
+          },
+          "slot": {
+            "description": "Slot for the most recent update to the token balance. May be 0 if no information is available",
+            "format": "int64",
+            "type": "integer"
+          },
+          "symbol": {
+            "description": "Symbol for the token, can be null for unknown addresses",
+            "nullable": true,
+            "type": "string"
+          },
+          "valueUsd": {
+            "description": "Value of the held tokens in USD",
+            "type": "string"
+          },
+          "valueUsd1dChange": {
+            "description": "Change in the value of the held tokens in USD over the last 24 hours",
+            "type": "string"
+          },
+          "verified": {
+            "description": "Whether the token is verified or not.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "mintAddress",
+          "amount",
+          "priceUsd",
+          "priceUsd1dChange",
+          "priceUsd7dTrend",
+          "valueUsd",
+          "valueUsd1dChange",
+          "averagePriceUsd",
+          "decimals",
+          "verified",
+          "slot"
+        ],
+        "type": "object"
+      },
+      "TokenBalanceNft": {
+        "properties": {
+          "collectionAddress": {
+            "description": "Public key of the NFT collection",
+            "type": "string"
+          },
+          "logoUrl": {
+            "description": "Logo URL for the NFT",
+            "nullable": true,
+            "type": "string"
+          },
+          "name": {
+            "description": "Symbol for the NFT",
+            "nullable": true,
+            "type": "string"
+          },
+          "priceSol": {
+            "description": "Price of the NFT in SOL",
+            "type": "string"
+          },
+          "priceUsd": {
+            "description": "Price of the NFT in USD",
+            "type": "string"
+          },
+          "slot": {
+            "description": "Slot for the most recent update to the NFT balance",
+            "format": "int64",
+            "type": "integer"
+          },
+          "totalItems": {
+            "description": "Amount of the NFT",
+            "format": "int32",
+            "type": "integer"
+          },
+          "valueSol": {
+            "description": "Value of the held NFT in SOL",
+            "type": "string"
+          },
+          "valueUsd": {
+            "description": "Value of the held NFT in USD",
+            "type": "string"
+          }
+        },
+        "required": [
+          "collectionAddress",
+          "totalItems",
+          "valueSol",
+          "priceSol",
+          "valueUsd",
+          "priceUsd",
+          "slot"
+        ],
+        "type": "object"
+      },
+      "TokenData": {
+        "properties": {
+          "decimal": {
+            "description": "Decimal of the token",
+            "format": "int32",
+            "type": "integer"
+          },
+          "insertTime": {
+            "description": "The time the data was inserted into the database",
+            "format": "int64",
+            "type": "integer"
+          },
+          "mintAddress": {
+            "description": "The public key of the token of interest",
+            "type": "string"
+          },
+          "name": {
+            "description": "The name of the token",
+            "type": "string"
+          },
+          "price": {
+            "description": "The price of the token",
+            "type": "string"
+          },
+          "symbol": {
+            "description": "The symbol of the token",
+            "type": "string"
+          }
+        },
+        "required": [
+          "symbol",
+          "name",
+          "mintAddress",
+          "price",
+          "decimal",
+          "insertTime"
+        ],
+        "type": "object"
+      },
+      "TokenHoldersTimeSeriesData": {
+        "properties": {
+          "holdersTimestamp": {
+            "description": "Unix timestamp of the record.",
+            "format": "int32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "nDust": {
+            "description": "Number of dust accounts at the instant. (< 100 tokens)",
+            "format": "int64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "nHolders": {
+            "description": "Number of token holders at the instant.",
+            "format": "int64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "nLarge": {
+            "description": "Number of large accounts at the instant. (between 10000 and 100000 tokens)",
+            "format": "int64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "nMedium": {
+            "description": "Number of medium accounts at the instant. (between 1000 and 10000 tokens)",
+            "format": "int64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "nSmall": {
+            "description": "Number of small accounts at the instant. (between 100 and 1000 tokens)",
+            "format": "int64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "nWhale": {
+            "description": "Number of whale accounts at the instant. (> 100000 tokens)",
+            "format": "int64",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "holdersTimestamp",
+          "nHolders",
+          "nDust",
+          "nSmall",
+          "nMedium",
+          "nLarge",
+          "nWhale"
+        ],
+        "type": "object"
+      },
+      "TokenHoldersTimeSeriesInterval": {
+        "description": "Enumerates the supported time intervals for token holders.",
+        "enum": [
+          "hour",
+          "day"
+        ],
+        "type": "string"
+      },
+      "TokenHoldersTimeSeriesReturn": {
+        "properties": {
+          "data": {
+            "description": "Token holders time series data.",
+            "items": {
+              "$ref": "#/components/schemas/TokenHoldersTimeSeriesData"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "TokenInformationCH": {
+        "properties": {
+          "category": {
+            "description": "Category of the token",
+            "nullable": true,
+            "type": "string"
+          },
+          "currentSupply": {
+            "description": "Current token supply",
+            "format": "double",
+            "type": "number"
+          },
+          "decimal": {
+            "description": "Decimal places",
+            "format": "int32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "logoUrl": {
+            "description": "Logo associated with the token",
+            "nullable": true,
+            "type": "string"
+          },
+          "marketCap": {
+            "description": "Current token market cap",
+            "format": "double",
+            "type": "number"
+          },
+          "mintAddress": {
+            "description": "The public key of the token of interest",
+            "type": "string"
+          },
+          "name": {
+            "description": "Token mint name",
+            "nullable": true,
+            "type": "string"
+          },
+          "price": {
+            "description": "Current price in USD",
+            "format": "double",
+            "type": "number"
+          },
+          "price1d": {
+            "description": "Price in USD of the token 1 day ago",
+            "format": "double",
+            "type": "number"
+          },
+          "price7d": {
+            "description": "Price in USD of the token 7 days ago",
+            "format": "double",
+            "type": "number"
+          },
+          "subcategory": {
+            "description": "Subcategory of the token",
+            "nullable": true,
+            "type": "string"
+          },
+          "symbol": {
+            "description": "Token mint symbol",
+            "type": "string"
+          },
+          "tokenAmountVolume24h": {
+            "description": "Token volume transferred in past 24 hours",
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "updateTime": {
+            "description": "Time of last update of price",
+            "format": "int64",
+            "type": "integer"
+          },
+          "usdValueVolume24h": {
+            "description": "Token volume transferred in past 24 hours USD value",
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "verified": {
+            "description": "Verified status of the token",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "symbol",
+          "mintAddress",
+          "price",
+          "price1d",
+          "price7d",
+          "decimal",
+          "verified",
+          "updateTime",
+          "currentSupply",
+          "marketCap"
+        ],
+        "type": "object"
+      },
+      "TokenLiquidity": {
+        "properties": {
+          "liquidity": {
+            "description": "Total liquidity in USD across all markets for this token, if available.",
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          }
+        },
+        "type": "object"
+      },
+      "TokenMarketTimeseriesResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/TokenMarketTimeseriesRow"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "TokenMarketTimeseriesRow": {
+        "properties": {
+          "mintAddress": {
+            "$ref": "#/components/schemas/SolanaId"
+          },
+          "rate": {
+            "description": "The aggregated trade activity for this market and time bucket.",
+            "format": "double",
+            "type": "number"
+          },
+          "timestamp": {
+            "description": "The start of the time bucket, as milliseconds since Unix epoch.",
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "mintAddress",
+          "timestamp",
+          "rate"
+        ],
+        "type": "object"
+      },
+      "TokenOhlcData": {
+        "properties": {
+          "close": {
+            "description": "Close price",
+            "type": "string"
+          },
+          "count": {
+            "description": "Number of trades",
+            "format": "int64",
+            "type": "integer"
+          },
+          "high": {
+            "description": "High price",
+            "type": "string"
+          },
+          "low": {
+            "description": "Low price",
+            "type": "string"
+          },
+          "open": {
+            "description": "Open price",
+            "type": "string"
+          },
+          "timeBucketStart": {
+            "description": "OHLC time bucket start",
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "timeBucketStart",
+          "open",
+          "high",
+          "low",
+          "close",
+          "count"
+        ],
+        "type": "object"
+      },
+      "TokenPerformance": {
+        "description": "Summary of a token's performance.",
+        "properties": {
+          "mintAddress": {
+            "description": "The address of mint.",
+            "type": "string"
+          },
+          "pnlUsd": {
+            "description": "The profit or loss for the token in USD.",
+            "format": "double",
+            "type": "number"
+          },
+          "tokenLogoUrl": {
+            "description": "The logo URL of token (if any).",
+            "nullable": true,
+            "type": "string"
+          },
+          "tokenName": {
+            "description": "The name of token (if any).",
+            "nullable": true,
+            "type": "string"
+          },
+          "tokenSymbol": {
+            "description": "The symbol of token.",
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "required": [
+          "mintAddress",
+          "pnlUsd"
+        ],
+        "type": "object"
+      },
+      "TokenTransfersReturn": {
+        "properties": {
+          "transfers": {
+            "description": "Found transfer data",
+            "items": {
+              "$ref": "#/components/schemas/TransferReturn"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "transfers"
+        ],
+        "type": "object"
+      },
+      "TokenUpdateFilter": {
+        "properties": {
+          "baseMintAddress": {
+            "description": "Token mint address of token to watch updates for.",
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "TokensReturn": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/TokenInformationCH"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "TopHolders": {
+        "properties": {
+          "balance": {
+            "description": "Current Token Amount",
+            "type": "string"
+          },
+          "mintAddress": {
+            "description": "The public key of the token of interest",
+            "type": "string"
+          },
+          "ownerAddress": {
+            "description": "Holder address",
+            "type": "string"
+          },
+          "ownerLogoUrl": {
+            "description": "Holder logo url",
+            "nullable": true,
+            "type": "string"
+          },
+          "ownerName": {
+            "description": "Holder name",
+            "nullable": true,
+            "type": "string"
+          },
+          "percentageOfSupplyHeld": {
+            "description": "Percentage of supply held",
+            "format": "double",
+            "type": "number"
+          },
+          "rank": {
+            "description": "Rank",
+            "format": "int64",
+            "type": "integer"
+          },
+          "tokenLogoUrl": {
+            "description": "Logo Url of the token of interest",
+            "nullable": true,
+            "type": "string"
+          },
+          "tokenSymbol": {
+            "description": "Symbol of the token of interest",
+            "nullable": true,
+            "type": "string"
+          },
+          "valueUsd": {
+            "description": "Value Usd",
+            "type": "string"
+          }
+        },
+        "required": [
+          "rank",
+          "ownerAddress",
+          "mintAddress",
+          "balance",
+          "valueUsd",
+          "percentageOfSupplyHeld"
+        ],
+        "type": "object"
+      },
+      "TopHoldersReturn": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/TopHolders"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "TopPnlTraderByTokenTrader": {
+        "properties": {
+          "buyCount": {
+            "description": "Total number of buy trades of this token executed by the trader.",
+            "format": "int64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "buyVolumeUsd": {
+            "description": "Total buy volume in USD for the trader.",
+            "format": "double",
+            "type": "number"
+          },
+          "labels": {
+            "description": "Labels associated with the trader.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "logoUrl": {
+            "description": "Logo URL of the trader, if available.",
+            "nullable": true,
+            "type": "string"
+          },
+          "name": {
+            "description": "Name of the trader, if available.",
+            "nullable": true,
+            "type": "string"
+          },
+          "realizedPnlUsd": {
+            "description": "Realized profit and loss (PnL) in USD for the trader.",
+            "format": "double",
+            "type": "number"
+          },
+          "sellCount": {
+            "description": "Total number of sell trades of this token executed by the trader.",
+            "format": "int64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "sellVolumeUsd": {
+            "description": "Total sell volume in USD for the trader.",
+            "format": "double",
+            "type": "number"
+          },
+          "totalVolumeUsd": {
+            "description": "Total trading volume in USD for the trader.",
+            "format": "double",
+            "type": "number"
+          },
+          "traderAddress": {
+            "$ref": "#/components/schemas/SolanaId"
+          },
+          "tradesCount": {
+            "description": "Total number of trades of this token executed by the trader.",
+            "format": "int64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "unrealizedPnlUsd": {
+            "description": "Unrealized profit and loss (PnL) in USD for the trader.",
+            "format": "double",
+            "type": "number"
+          }
+        },
+        "required": [
+          "labels",
+          "traderAddress",
+          "realizedPnlUsd",
+          "unrealizedPnlUsd",
+          "buyVolumeUsd",
+          "sellVolumeUsd",
+          "totalVolumeUsd",
+          "buyCount",
+          "sellCount",
+          "tradesCount"
+        ],
+        "type": "object"
+      },
+      "TopPnlTraderByTokenTraderResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/TopPnlTraderByTokenTrader"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "TradeAggregatedTimeseriesResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/TradeAggregatedTimeseriesRow"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "TradeAggregatedTimeseriesRow": {
+        "properties": {
+          "rate": {
+            "description": "The aggregated value for this time bucket based on the selected projection (e.g. volume in USD or trade count).",
+            "format": "double",
+            "type": "number"
+          },
+          "timestamp": {
+            "description": "The start of the time bucket (unix timestamp in milliseconds).",
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "timestamp",
+          "rate"
+        ],
+        "type": "object"
+      },
+      "TradeDataProgramReturn": {
+        "properties": {
+          "authorityAddress": {
+            "description": "The public key of the signer who authorized the trade.",
+            "type": "string"
+          },
+          "baseMintAddress": {
+            "description": "The mint address of the base token involved in the trade.",
+            "type": "string"
+          },
+          "baseSize": {
+            "description": "The quantity of the base token involved in the trade.",
+            "type": "string"
+          },
+          "blockTime": {
+            "description": "The Unix timestamp at which the trade occurred on the blockchain.",
+            "format": "int64",
+            "type": "integer"
+          },
+          "fee": {
+            "description": "The amount of fees paid for the trade.",
+            "type": "string"
+          },
+          "feePayerAddress": {
+            "description": "The public key of the account responsible for paying the transaction fees.",
+            "type": "string"
+          },
+          "iixOrdinal": {
+            "description": "The location of the trade inner ix inside the transaction. 255 is returned if not applicable.",
+            "format": "int32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "interIxOrdinal": {
+            "description": "The location of the trade inside an ix (in 2 hop swaps). 255 is returned if not applicable.",
+            "format": "int32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "ixOrdinal": {
+            "description": "The location of the trade ix inside the transaction.",
+            "format": "int32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "marketAddress": {
+            "description": "The address of the market pair, e.g., SOL/USDC, where the trade took place.",
+            "type": "string"
+          },
+          "price": {
+            "description": "The price of one unit of the base token, expressed in terms of the quote token.",
+            "type": "string"
+          },
+          "programAddress": {
+            "description": "The public key of the AMM or DEX program that facilitated the trade.",
+            "type": "string"
+          },
+          "quoteMintAddress": {
+            "description": "The mint address of the quote token used in the trade.",
+            "type": "string"
+          },
+          "quoteSize": {
+            "description": "The amount of the quote token exchanged in the trade.",
+            "type": "string"
+          },
+          "signature": {
+            "description": "The unique identifier of the transaction signature on the blockchain.",
+            "type": "string"
+          },
+          "slot": {
+            "description": "Slot of the trade",
+            "format": "int64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "txIndex": {
+            "description": "The transaction index of the trade.",
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "authorityAddress",
+          "blockTime",
+          "iixOrdinal",
+          "baseMintAddress",
+          "interIxOrdinal",
+          "ixOrdinal",
+          "marketAddress",
+          "quoteMintAddress",
+          "price",
+          "programAddress",
+          "signature",
+          "slot",
+          "txIndex",
+          "fee",
+          "feePayerAddress",
+          "baseSize",
+          "quoteSize"
+        ],
+        "type": "object"
+      },
+      "TradeDataProgramVecReturn": {
+        "properties": {
+          "data": {
+            "description": "Found trade data",
+            "items": {
+              "$ref": "#/components/schemas/TradeDataProgramReturn"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "TradeDataProgramWsReturn": {
+        "description": "WSS-specific trade response that preserves legacy field names (`marketId`, `programId`, `feePayer`)\nto avoid breaking WebSocket consumers.",
+        "properties": {
+          "authorityAddress": {
+            "type": "string"
+          },
+          "baseMintAddress": {
+            "type": "string"
+          },
+          "baseSize": {
+            "type": "string"
+          },
+          "blockTime": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "fee": {
+            "type": "string"
+          },
+          "feePayer": {
+            "type": "string"
+          },
+          "iixOrdinal": {
+            "format": "int32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "interIxOrdinal": {
+            "format": "int32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "ixOrdinal": {
+            "format": "int32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "marketId": {
+            "type": "string"
+          },
+          "price": {
+            "type": "string"
+          },
+          "programId": {
+            "type": "string"
+          },
+          "quoteMintAddress": {
+            "type": "string"
+          },
+          "quoteSize": {
+            "type": "string"
+          },
+          "signature": {
+            "type": "string"
+          },
+          "slot": {
+            "format": "int64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "txIndex": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "authorityAddress",
+          "blockTime",
+          "iixOrdinal",
+          "baseMintAddress",
+          "interIxOrdinal",
+          "ixOrdinal",
+          "marketId",
+          "quoteMintAddress",
+          "price",
+          "programId",
+          "signature",
+          "slot",
+          "txIndex",
+          "fee",
+          "feePayer",
+          "baseSize",
+          "quoteSize"
+        ],
+        "type": "object"
+      },
+      "TradeOhlcvCandleReturn": {
+        "properties": {
+          "close": {
+            "description": "Close price",
+            "type": "string"
+          },
+          "count": {
+            "description": "Number of trades",
+            "format": "int64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "high": {
+            "description": "High price",
+            "type": "string"
+          },
+          "low": {
+            "description": "Low price",
+            "type": "string"
+          },
+          "open": {
+            "description": "Open price",
+            "type": "string"
+          },
+          "time": {
+            "description": "OHLC time bucket start",
+            "type": "string"
+          },
+          "volume": {
+            "description": "Volume",
+            "type": "string"
+          },
+          "volumeUsd": {
+            "description": "Volume in USD",
+            "type": "string"
+          }
+        },
+        "required": [
+          "time",
+          "open",
+          "high",
+          "low",
+          "close",
+          "volume",
+          "volumeUsd",
+          "count"
+        ],
+        "type": "object"
+      },
+      "TradeOhlcvCandleVecReturn": {
+        "properties": {
+          "data": {
+            "description": "Found OHLCV data",
+            "items": {
+              "$ref": "#/components/schemas/TradeOhlcvCandleReturn"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "TradePriceMarketReturn": {
+        "properties": {
+          "baseMintAddress": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SolanaId"
+              }
+            ],
+            "nullable": true
+          },
+          "baseTokenAmount": {
+            "description": "The amount of the base token in the market",
+            "nullable": true,
+            "type": "string"
+          },
+          "baseTokenName": {
+            "description": "Name of the base token",
+            "nullable": true,
+            "type": "string"
+          },
+          "baseTokenSymbol": {
+            "description": "Ticker for the base token",
+            "nullable": true,
+            "type": "string"
+          },
+          "baseTokenVaultAddress": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SolanaId"
+              }
+            ],
+            "nullable": true
+          },
+          "marketAddress": {
+            "$ref": "#/components/schemas/SolanaId"
+          },
+          "marketName": {
+            "description": "Name of the market",
+            "nullable": true,
+            "type": "string"
+          },
+          "programAddress": {
+            "$ref": "#/components/schemas/SolanaId"
+          },
+          "programName": {
+            "description": "Name of the program",
+            "nullable": true,
+            "type": "string"
+          },
+          "quoteMintAddress": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SolanaId"
+              }
+            ],
+            "nullable": true
+          },
+          "quoteTokenAmount": {
+            "description": "The amount of the quote token in the market",
+            "nullable": true,
+            "type": "string"
+          },
+          "quoteTokenName": {
+            "description": "Name of the quote token",
+            "nullable": true,
+            "type": "string"
+          },
+          "quoteTokenSymbol": {
+            "description": "Ticker for the quote token",
+            "nullable": true,
+            "type": "string"
+          },
+          "quoteTokenVaultAddress": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SolanaId"
+              }
+            ],
+            "nullable": true
+          },
+          "updatedAt": {
+            "description": "Latest update Time",
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "marketAddress",
+          "programAddress",
+          "updatedAt"
+        ],
+        "type": "object"
+      },
+      "TradePriceProgramsReturn": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/TradesPricesProgram"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "TradePriceUpdateFilter": {
+        "properties": {
+          "baseMintAddress": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SolanaId"
+              }
+            ],
+            "nullable": true
+          },
+          "quoteMintAddress": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SolanaId"
+              }
+            ],
+            "nullable": true
+          }
+        },
+        "type": "object"
+      },
+      "TradeSideSummary": {
+        "description": "Summary metrics for a trade side (buy or sell).",
+        "properties": {
+          "latestTradeBlocktime": {
+            "description": "Latest sell/buy trade blocktime.",
+            "format": "int64",
+            "nullable": true,
+            "type": "integer"
+          },
+          "latestTradeSignature": {
+            "description": "Latest sell/buy trade signature.",
+            "nullable": true,
+            "type": "string"
+          },
+          "tokenAmount": {
+            "description": "The total volume of tokens traded on this side.",
+            "format": "double",
+            "type": "number"
+          },
+          "transactionCount": {
+            "description": "The number of trades executed on this side.",
+            "format": "int64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "volumeUsd": {
+            "description": "The total traded volume expressed in USD on this side.",
+            "format": "double",
+            "type": "number"
+          }
+        },
+        "required": [
+          "volumeUsd",
+          "tokenAmount",
+          "transactionCount"
+        ],
+        "type": "object"
+      },
+      "TradesFilter": {
+        "properties": {
+          "authorityAddress": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SolanaId"
+              }
+            ],
+            "nullable": true
+          },
+          "baseMintAddress": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SolanaId"
+              }
+            ],
+            "nullable": true
+          },
+          "feePayer": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SolanaId"
+              }
+            ],
+            "nullable": true
+          },
+          "marketId": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SolanaId"
+              }
+            ],
+            "nullable": true
+          },
+          "programId": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SolanaId"
+              }
+            ],
+            "nullable": true
+          },
+          "quoteMintAddress": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SolanaId"
+              }
+            ],
+            "nullable": true
+          },
+          "tokenMintAddress": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SolanaId"
+              }
+            ],
+            "nullable": true
+          }
+        },
+        "type": "object"
+      },
+      "TradesPricesProgram": {
+        "properties": {
+          "programAddress": {
+            "$ref": "#/components/schemas/SolanaId"
+          },
+          "programName": {
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "required": [
+          "programAddress"
+        ],
+        "type": "object"
+      },
+      "TradesTokenActivitySummary": {
+        "properties": {
+          "averageBuyPrice": {
+            "description": "Average buy price of this token for the trader.",
+            "format": "double",
+            "type": "number"
+          },
+          "buyCount": {
+            "description": "Total number of buy trades of this token executed by the trader.",
+            "format": "int64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "buyValueUsd": {
+            "description": "Total buy value in USD of this token executed by the trader.",
+            "format": "double",
+            "type": "number"
+          },
+          "buyVolume": {
+            "description": "Total buy volume of this token executed by the trader.",
+            "format": "double",
+            "type": "number"
+          },
+          "createdAt": {
+            "description": "The timestamp when the summary was created, in seconds since the Unix epoch.",
+            "format": "int32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "labels": {
+            "description": "Labels associated with the trader (e.g. \"KOL\", \"CEX\", \"Market Maker\").",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "logoUrl": {
+            "description": "Logo URL of the trader, if they are a known/labeled account.",
+            "nullable": true,
+            "type": "string"
+          },
+          "losingTradesCount": {
+            "description": "Total number of losing trades of this token executed by the trader.",
+            "format": "int64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "mintAddress": {
+            "$ref": "#/components/schemas/SolanaId"
+          },
+          "name": {
+            "description": "Display name of the trader, if they are a known/labeled account.",
+            "nullable": true,
+            "type": "string"
+          },
+          "negativePnl": {
+            "description": "Sum of all losing trades in USD for this trader (negative value).",
+            "format": "double",
+            "type": "number"
+          },
+          "positivePnl": {
+            "description": "Sum of all profitable trades in USD for this trader.",
+            "format": "double",
+            "type": "number"
+          },
+          "realizedPnlUsd": {
+            "description": "Realized profit and loss (PnL) in USD for the trader.",
+            "format": "double",
+            "type": "number"
+          },
+          "sellCount": {
+            "description": "Total number of sell trades of this token executed by the trader.",
+            "format": "int64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "sellValueUsd": {
+            "description": "Total sell value in USD of this token executed by the trader.",
+            "format": "double",
+            "type": "number"
+          },
+          "sellVolume": {
+            "description": "Total sell volume of this token executed by the trader.",
+            "format": "double",
+            "type": "number"
+          },
+          "totalPnlUsd": {
+            "description": "Total profit and loss (PnL) in USD for the trader.",
+            "format": "double",
+            "type": "number"
+          },
+          "traderAddress": {
+            "$ref": "#/components/schemas/SolanaId"
+          },
+          "unrealizedPnlUsd": {
+            "description": "Unrealized profit and loss (PnL) in USD for the trader.",
+            "format": "double",
+            "type": "number"
+          },
+          "winningTradesCount": {
+            "description": "Total number of winning trades of this token executed by the trader.",
+            "format": "int64",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "createdAt",
+          "traderAddress",
+          "mintAddress",
+          "sellCount",
+          "sellVolume",
+          "sellValueUsd",
+          "buyCount",
+          "buyVolume",
+          "buyValueUsd",
+          "realizedPnlUsd",
+          "unrealizedPnlUsd",
+          "totalPnlUsd",
+          "winningTradesCount",
+          "losingTradesCount",
+          "averageBuyPrice",
+          "positivePnl",
+          "negativePnl",
+          "labels"
+        ],
+        "type": "object"
+      },
+      "TradesTokenActivitySummaryResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/TradesTokenActivitySummary"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "TransferReturn": {
+        "properties": {
+          "amount": {
+            "description": "The total number of tokens involved in the transaction.",
+            "format": "int64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "blockTime": {
+            "description": "The timestamp when the transaction was confirmed on the blockchain, in Unix time.",
+            "format": "int64",
+            "type": "integer"
+          },
+          "calculatedAmount": {
+            "description": "The resulting amount after applying the `decimal` to the `amount` value.",
+            "type": "string"
+          },
+          "callingMetadata": {
+            "description": "The public key of the Solana program that initiated the transaction.",
+            "items": {
+              "$ref": "#/components/schemas/InstructionName"
+            },
+            "type": "array"
+          },
+          "decimal": {
+            "description": "The number of decimal places used for the token's smallest unit.",
+            "format": "int64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "feePayerAddress": {
+            "description": "The public key of the account responsible for paying the transaction fees.",
+            "type": "string"
+          },
+          "mintAddress": {
+            "description": "The public key of the token's mint, specifying the token type involved in the transaction.",
+            "type": "string"
+          },
+          "price": {
+            "description": "Price of the token involved in the transaction (e.g. `mint_address`) expressed in USD.",
+            "type": "string"
+          },
+          "receiverAccountAddress": {
+            "description": "The public key of the specific token account address of the receiver.",
+            "nullable": true,
+            "type": "string"
+          },
+          "receiverAddress": {
+            "description": "The public key of the account receiving the tokens.",
+            "nullable": true,
+            "type": "string"
+          },
+          "senderAccountAddress": {
+            "description": "The public key of the specific token account address of the sender.",
+            "nullable": true,
+            "type": "string"
+          },
+          "senderAddress": {
+            "description": "The public key of the account sending the tokens.",
+            "type": "string"
+          },
+          "signature": {
+            "description": "The cryptographic signature that uniquely identifies the transaction on the blockchain.",
+            "type": "string"
+          },
+          "slot": {
+            "description": "The slot number in which the transaction was processed on the Solana blockchain, helping to pinpoint the exact sequence of events.",
+            "format": "int64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "valueUsd": {
+            "description": "Calculated total USD value of the transfer based on the `amount`, `decimal`, and `price` values.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "signature",
+          "callingMetadata",
+          "senderAddress",
+          "mintAddress",
+          "feePayerAddress",
+          "decimal",
+          "amount",
+          "slot",
+          "blockTime",
+          "price",
+          "calculatedAmount",
+          "valueUsd"
+        ],
+        "type": "object"
+      },
+      "TransferReturnWs": {
+        "properties": {
+          "amount": {
+            "description": "The total number of tokens involved in the transaction.",
+            "format": "int64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "blockTime": {
+            "description": "The timestamp when the transaction was confirmed on the blockchain, in Unix time.",
+            "format": "int64",
+            "type": "integer"
+          },
+          "callingPrograms": {
+            "description": "An array of all the programs that were utilized during the transaction If a specific program is used as a filter in the query, it may appear in the CallingPrograms array alongside other programs that were also part of the transaction.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "decimal": {
+            "description": "The number of decimal places used for the token's smallest unit.",
+            "format": "int64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "feePayer": {
+            "description": "The public key of the account responsible for paying the transaction fees.",
+            "type": "string"
+          },
+          "id": {
+            "description": "Unique identifier for the transaction.",
+            "format": "binary",
+            "type": "string"
+          },
+          "mintAddress": {
+            "description": "The public key of the token's mint, specifying the token type involved in the transaction.",
+            "type": "string"
+          },
+          "receiverAddress": {
+            "description": "The public key of the account receiving the tokens.",
+            "nullable": true,
+            "type": "string"
+          },
+          "receiverTokenAccount": {
+            "description": "The public key of the specific token account of the receiver.",
+            "nullable": true,
+            "type": "string"
+          },
+          "senderAddress": {
+            "description": "The public key of the account sending the tokens.",
+            "type": "string"
+          },
+          "senderTokenAccount": {
+            "description": "The public key of the specific token account of the sender.",
+            "nullable": true,
+            "type": "string"
+          },
+          "signature": {
+            "description": "The cryptographic signature that uniquely identifies the transaction on the blockchain.",
+            "type": "string"
+          },
+          "slot": {
+            "description": "The slot number in which the transaction was processed on the Solana blockchain, helping to pinpoint the exact sequence of events.",
+            "format": "int64",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "signature",
+          "callingPrograms",
+          "senderAddress",
+          "mintAddress",
+          "feePayer",
+          "decimal",
+          "amount",
+          "slot",
+          "blockTime",
+          "id"
+        ],
+        "type": "object"
+      },
+      "TransferVolumeUsd": {
+        "properties": {
+          "valueReceiver": {
+            "description": "Total transfer volume in USD received by this wallet.",
+            "format": "double",
+            "type": "number"
+          },
+          "valueSender": {
+            "description": "Total transfer volume in USD sent by this wallet.",
+            "format": "double",
+            "type": "number"
+          }
+        },
+        "required": [
+          "valueSender",
+          "valueReceiver"
+        ],
+        "type": "object"
+      },
+      "TransfersFilter": {
+        "properties": {
+          "feePayer": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SolanaId"
+              }
+            ],
+            "nullable": true
+          },
+          "maxAmount": {
+            "description": "Inclusive maximum of transfered amount\nCan be combined with [Self::min_amount]",
+            "format": "int64",
+            "minimum": 0,
+            "nullable": true,
+            "type": "integer"
+          },
+          "minAmount": {
+            "description": "Inclusive minimum of transfered amount\nCan be combined with [Self::max_amount]",
+            "format": "int64",
+            "minimum": 0,
+            "nullable": true,
+            "type": "integer"
+          },
+          "programId": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SolanaId"
+              }
+            ],
+            "nullable": true
+          },
+          "receiverAddress": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SolanaId"
+              }
+            ],
+            "nullable": true
+          },
+          "receiverTokenAccount": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SolanaId"
+              }
+            ],
+            "nullable": true
+          },
+          "senderAddress": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SolanaId"
+              }
+            ],
+            "nullable": true
+          },
+          "senderTokenAccount": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SolanaId"
+              }
+            ],
+            "nullable": true
+          },
+          "tokenMintAddress": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SolanaId"
+              }
+            ],
+            "nullable": true
+          }
+        },
+        "type": "object"
+      },
+      "WalletBalanceNftResults": {
+        "properties": {
+          "data": {
+            "description": "NFTs in the wallet (up to limit)",
+            "items": {
+              "$ref": "#/components/schemas/TokenBalanceNft"
+            },
+            "type": "array"
+          },
+          "date": {
+            "description": "Datetime of the report as a Unix timestamp",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "ownerAddress": {
+            "$ref": "#/components/schemas/SolanaId"
+          },
+          "totalNftCollectionCount": {
+            "description": "Total number of nfts in the wallet",
+            "format": "int64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "totalSol": {
+            "description": "Value of the wallet in SOL",
+            "type": "string"
+          },
+          "totalUsd": {
+            "description": "Value of the wallet in USD",
+            "type": "string"
+          }
+        },
+        "required": [
+          "date",
+          "ownerAddress",
+          "totalSol",
+          "totalUsd",
+          "totalNftCollectionCount",
+          "data"
+        ],
+        "type": "object"
+      },
+      "WalletBalanceNftResultsMany": {
+        "properties": {
+          "data": {
+            "description": "NFTs in the wallet (up to limit)",
+            "items": {
+              "$ref": "#/components/schemas/TokenBalanceNft"
+            },
+            "type": "array"
+          },
+          "date": {
+            "description": "Datetime of the report as a Unix timestamp",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "ownerAddresses": {
+            "description": "Owners of the wallets",
+            "items": {
+              "$ref": "#/components/schemas/SolanaId"
+            },
+            "type": "array"
+          },
+          "totalNftCollectionCount": {
+            "description": "Total number of nft collections in the wallet",
+            "format": "int64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "totalSol": {
+            "description": "Value of the wallet in SOL",
+            "type": "string"
+          },
+          "totalUsd": {
+            "description": "Value of the wallet in USD",
+            "type": "string"
+          }
+        },
+        "required": [
+          "date",
+          "ownerAddresses",
+          "totalSol",
+          "totalUsd",
+          "totalNftCollectionCount",
+          "data"
+        ],
+        "type": "object"
+      },
+      "WalletBalanceTokenResults": {
+        "properties": {
+          "activeStakedSolBalance": {
+            "description": "Value of active staked SOL",
+            "type": "string"
+          },
+          "activeStakedSolBalanceUsd": {
+            "description": "Value of active staked SOL in USD",
+            "type": "string"
+          },
+          "data": {
+            "description": "Tokens in the wallet (up to limit)",
+            "items": {
+              "$ref": "#/components/schemas/TokenBalance"
+            },
+            "type": "array"
+          },
+          "date": {
+            "description": "Datetime of the report as a Unix timestamp",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "ownerAddress": {
+            "$ref": "#/components/schemas/SolanaId"
+          },
+          "stakedSolBalance": {
+            "description": "Value of the staked SOL",
+            "type": "string"
+          },
+          "stakedSolBalanceUsd": {
+            "description": "Value of the staked SOL in USD",
+            "type": "string"
+          },
+          "totalTokenCount": {
+            "description": "Total number of tokens in the wallet",
+            "format": "int64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "totalTokenValueUsd": {
+            "description": "Value of the wallet in USD, including SOL",
+            "type": "string"
+          },
+          "totalTokenValueUsd1dChange": {
+            "description": "Change in the value of the wallet in USD over the last 24 hours",
+            "type": "string"
+          }
+        },
+        "required": [
+          "date",
+          "ownerAddress",
+          "stakedSolBalanceUsd",
+          "stakedSolBalance",
+          "activeStakedSolBalanceUsd",
+          "activeStakedSolBalance",
+          "totalTokenValueUsd",
+          "totalTokenValueUsd1dChange",
+          "totalTokenCount",
+          "data"
+        ],
+        "type": "object"
+      },
+      "WalletBalanceTokenResultsMany": {
+        "properties": {
+          "activeStakedSolBalance": {
+            "description": "Value of active staked SOL",
+            "type": "string"
+          },
+          "activeStakedSolBalanceUsd": {
+            "description": "Value of active staked SOL in USD",
+            "type": "string"
+          },
+          "data": {
+            "description": "Tokens in the wallet (up to limit)",
+            "items": {
+              "$ref": "#/components/schemas/TokenBalance"
+            },
+            "type": "array"
+          },
+          "date": {
+            "description": "Datetime of the report as a Unix timestamp",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "ownerAddresses": {
+            "description": "Owners of the wallets",
+            "items": {
+              "$ref": "#/components/schemas/SolanaId"
+            },
+            "type": "array"
+          },
+          "stakedSolBalance": {
+            "description": "Value of the staked SOL",
+            "type": "string"
+          },
+          "stakedSolBalanceUsd": {
+            "description": "Value of the staked SOL in USD",
+            "type": "string"
+          },
+          "totalTokenCount": {
+            "description": "Total number of tokens in the wallet",
+            "format": "int64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "totalTokenValueUsd": {
+            "description": "Value of the wallet in USD, including SOL",
+            "type": "string"
+          },
+          "totalTokenValueUsd1dChange": {
+            "description": "Change in the value of the tokens in the wallet in USD over the last 24 hours",
+            "type": "string"
+          }
+        },
+        "required": [
+          "date",
+          "ownerAddresses",
+          "stakedSolBalanceUsd",
+          "stakedSolBalance",
+          "activeStakedSolBalanceUsd",
+          "activeStakedSolBalance",
+          "totalTokenValueUsd",
+          "totalTokenValueUsd1dChange",
+          "totalTokenCount",
+          "data"
+        ],
+        "type": "object"
+      },
+      "WalletBalanceTokenResultsTimeSeries": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/WalletBalanceTokenResultsTimeSeriesElement"
+            },
+            "type": "array"
+          },
+          "ownerAddress": {
+            "$ref": "#/components/schemas/SolanaId"
+          }
+        },
+        "required": [
+          "ownerAddress",
+          "data"
+        ],
+        "type": "object"
+      },
+      "WalletBalanceTokenResultsTimeSeriesElement": {
+        "properties": {
+          "blockTime": {
+            "description": "The timestamp, rounded to the day, of which this account snapshot was taken",
+            "format": "int32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "stakeValue": {
+            "description": "The value of staked SOL in USD",
+            "type": "string"
+          },
+          "stakeValueSol": {
+            "description": "The value of staked SOL in SOL",
+            "type": "string"
+          },
+          "systemValue": {
+            "description": "The value of held System SOL in USD",
+            "type": "string"
+          },
+          "tokenValue": {
+            "description": "Combined value of valid SPL tokens in USD.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "blockTime",
+          "tokenValue",
+          "stakeValue",
+          "systemValue",
+          "stakeValueSol"
+        ],
+        "type": "object"
+      },
+      "WalletBalanceTokenResultsTimeSeriesMany": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/WalletBalanceTokenResultsTimeSeriesElement"
+            },
+            "type": "array"
+          },
+          "ownerAddresses": {
+            "items": {
+              "$ref": "#/components/schemas/SolanaId"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "ownerAddresses",
+          "data"
+        ],
+        "type": "object"
+      },
+      "WalletTimeSeriesRaw": {
+        "properties": {
+          "amount": {
+            "format": "int64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "amountScaled": {
+            "format": "double",
+            "type": "number"
+          },
+          "decimals": {
+            "format": "int32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "mintAddress": {
+            "type": "string"
+          },
+          "ownerAddress": {
+            "type": "string"
+          },
+          "priceUsd": {
+            "type": "string"
+          },
+          "snapshotBlockTime": {
+            "format": "int64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "valueUsd": {
+            "format": "double",
+            "type": "number"
+          }
+        },
+        "required": [
+          "snapshotBlockTime",
+          "amount",
+          "decimals",
+          "amountScaled",
+          "ownerAddress",
+          "mintAddress",
+          "priceUsd",
+          "valueUsd"
+        ],
+        "type": "object"
+      },
+      "WalletTimeSeriesRawManyReturn": {
+        "properties": {
+          "data": {
+            "additionalProperties": {
+              "items": {
+                "$ref": "#/components/schemas/WalletTimeSeriesRaw"
+              },
+              "type": "array"
+            },
+            "type": "object"
+          },
+          "ownerAddresses": {
+            "items": {
+              "$ref": "#/components/schemas/SolanaId"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "ownerAddresses",
+          "data"
+        ],
+        "type": "object"
+      },
+      "WalletTimeSeriesRawReturn": {
+        "properties": {
+          "data": {
+            "additionalProperties": {
+              "items": {
+                "$ref": "#/components/schemas/WalletTimeSeriesRaw"
+              },
+              "type": "array"
+            },
+            "type": "object"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "WithdrawMevAccountDetail": {
+        "properties": {
+          "address": {
+            "description": "Stake account address",
+            "type": "string"
+          },
+          "mev": {
+            "description": "MEV portion (in SOL)",
+            "format": "double",
+            "type": "number"
+          },
+          "status": {
+            "description": "Status",
+            "type": "string"
+          },
+          "withdrawable": {
+            "description": "Withdrawable amount (in SOL)",
+            "format": "double",
+            "type": "number"
+          }
+        },
+        "required": [
+          "address",
+          "withdrawable",
+          "mev",
+          "status"
+        ],
+        "type": "object"
+      },
+      "WithdrawMevChunk": {
+        "properties": {
+          "accounts": {
+            "description": "Details for each stake account",
+            "items": {
+              "$ref": "#/components/schemas/WithdrawMevAccountDetail"
+            },
+            "type": "array"
+          },
+          "transaction": {
+            "description": "Base64-encoded unsigned transaction",
+            "type": "string"
+          }
+        },
+        "required": [
+          "transaction",
+          "accounts"
+        ],
+        "type": "object"
+      },
+      "WithdrawMevParam": {
+        "properties": {
+          "gasless": {
+            "description": "Use Vybe fee payer for gas",
+            "nullable": true,
+            "type": "boolean"
+          },
+          "mevFee": {
+            "description": "Fee percentage on withdrawn MEV (0-1, e.g., 0.05 for 5%)",
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          },
+          "ownerAddress": {
+            "$ref": "#/components/schemas/SolanaId"
+          },
+          "partner": {
+            "description": "Partner identifier",
+            "nullable": true,
+            "type": "string"
+          },
+          "router": {
+            "description": "Router for vybesol conversion (if vybesol is true)",
+            "nullable": true,
+            "type": "string"
+          },
+          "simulate": {
+            "description": "Simulate transaction without building",
+            "nullable": true,
+            "type": "boolean"
+          },
+          "stakeAccountAddresses": {
+            "description": "Specific stake account addresses to close (auto-fetches if not provided)",
+            "items": {
+              "$ref": "#/components/schemas/SolanaId"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "vybeSOL": {
+            "description": "Convert withdrawn SOL to VybeSOL",
+            "nullable": true,
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "ownerAddress"
+        ],
+        "type": "object"
+      },
+      "WithdrawMevReturn": {
+        "description": "Wallet performance attribution response for API endpoints.\n\nAll fields default to 0.0 when no historical data is available.",
+        "oneOf": [
+          {
+            "properties": {
+              "accounts": {
+                "description": "Details for each stake account",
+                "items": {
+                  "$ref": "#/components/schemas/WithdrawMevAccountDetail"
+                },
+                "type": "array"
+              },
+              "chunked": {
+                "description": "Whether response contains multiple transactions (false)",
+                "type": "boolean"
+              },
+              "mev": {
+                "description": "MEV portion of withdrawable (in SOL)",
+                "format": "double",
+                "type": "number"
+              },
+              "net": {
+                "description": "Net amount after fee (in SOL)",
+                "format": "double",
+                "type": "number"
+              },
+              "protocol_fee": {
+                "description": "Fee charged (in SOL)",
+                "format": "double",
+                "type": "number"
+              },
+              "simulation": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/WithdrawMevSimulation"
+                  }
+                ],
+                "nullable": true
+              },
+              "total_withdrawable": {
+                "description": "Total withdrawable amount (in SOL)",
+                "format": "double",
+                "type": "number"
+              },
+              "transaction": {
+                "description": "Base64-encoded unsigned transaction",
+                "type": "string"
+              }
+            },
+            "required": [
+              "transaction",
+              "chunked",
+              "total_withdrawable",
+              "mev",
+              "protocol_fee",
+              "net",
+              "accounts"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "chunked": {
+                "description": "Whether response contains multiple transactions (true)",
+                "type": "boolean"
+              },
+              "simulation": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/WithdrawMevSimulation"
+                  }
+                ],
+                "nullable": true
+              },
+              "total_mev": {
+                "description": "MEV portion of withdrawable (in SOL)",
+                "format": "double",
+                "type": "number"
+              },
+              "total_withdrawable": {
+                "description": "Total withdrawable amount (in SOL)",
+                "format": "double",
+                "type": "number"
+              },
+              "transactions": {
+                "description": "Array of chunks",
+                "items": {
+                  "$ref": "#/components/schemas/WithdrawMevChunk"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "chunked",
+              "transactions",
+              "total_withdrawable",
+              "total_mev"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "WithdrawMevSimulation": {
+        "properties": {
+          "logs": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "success": {
+            "type": "boolean"
+          },
+          "unit_consumed": {
+            "format": "int64",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "success",
+          "unit_consumed",
+          "logs"
+        ],
+        "type": "object"
+      }
+    }
+  },
+  "info": {
+    "contact": {
+      "email": "info@vybenetwork.com",
+      "name": "Vybe Dev Team"
+    },
+    "description": "Read access to Solana on-chain data — tokens, wallets, markets, prices, trades, transfers, NFTs. No API key, no signup. Pay in USDC per request with the x402 protocol; the per-route price is declared in `x-payment-info`. WebSocket streaming uses prepaid credits.",
+    "license": {
+      "name": "Terms of Service",
+      "url": "https://alpha.vybenetwork.com/terms"
+    },
+    "title": "Vybe Solana Analytics API (x402)",
+    "version": "3.28.21",
+    "x-guidance": "Fastest path: install the official client `@vybenetwork/x402-client` (https://github.com/vybenetwork/x402-client) — it handles 402 challenges, USDC signing, and WebSocket session/credit management for you. Manual flow: call any /v4/* endpoint without auth to receive a 402 challenge describing the USDC amount, asset, network, and recipient; sign the transfer with any x402 client (e.g. x402-axios) and retry with the `payment-signature` header to receive the response. For WebSocket streaming, POST /api/sessions with an x402 payment to receive a JWT session token + 1000 credits, then connect to /ws?token=<jwt>; each inbound event debits 1 credit and the session auto-tops up when the balance gets low.",
+    "x-client-sdk": {
+      "npm": "@vybenetwork/x402-client",
+      "repository": "https://github.com/vybenetwork/x402-client"
+    }
+  },
+  "openapi": "3.0.3",
+  "paths": {
+    "/v4/markets": {
+      "get": {
+        "description": "Solana API endpoint for fetching Solana DEX markets by program address. Returns market IDs, token pairs, and program names for Pump.fun, Raydium and more.",
+        "operationId": "get_markets_v4",
+        "parameters": [
+          {
+            "description": "Unique public key for a Solana program. See the `/reference/dex` endpoint for more details of supported DEXes and their program addresses.",
+            "in": "query",
+            "name": "programAddress",
+            "required": false,
+            "schema": {
+              "allOf": [
+                {
+                  "format": "pubkey",
+                  "type": "string"
+                }
+              ],
+              "nullable": true
+            }
+          },
+          {
+            "description": "Base token mint address filter.",
+            "in": "query",
+            "name": "baseMintAddress",
+            "required": false,
+            "schema": {
+              "allOf": [
+                {
+                  "format": "pubkey",
+                  "type": "string"
+                }
+              ],
+              "nullable": true
+            }
+          },
+          {
+            "description": "Quote token mint address filter.",
+            "in": "query",
+            "name": "quoteMintAddress",
+            "required": false,
+            "schema": {
+              "allOf": [
+                {
+                  "format": "pubkey",
+                  "type": "string"
+                }
+              ],
+              "nullable": true
+            }
+          },
+          {
+            "description": "Token mint address field (for either base or quote) filter.",
+            "in": "query",
+            "name": "tokenMintAddress",
+            "required": false,
+            "schema": {
+              "allOf": [
+                {
+                  "format": "pubkey",
+                  "type": "string"
+                }
+              ],
+              "nullable": true
+            }
+          },
+          {
+            "description": "Page selection, 0-indexed.",
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "format": "int32",
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Specifies the maximum number of markets to retrieve.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "format": "int32",
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MarketsReturn"
+                }
+              }
+            },
+            "description": "Markets supported by our price endpoints."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "402": {
+            "description": "Payment Required"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Market not found"
+          }
+        },
+        "summary": "Market List",
+        "tags": [
+          "Markets"
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.003000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "x-extensions": {
+          "bazaar": {
+            "schema": {
+              "properties": {
+                "input": {
+                  "type": "object",
+                  "properties": {
+                    "programAddress": {
+                      "allOf": [
+                        {
+                          "format": "pubkey",
+                          "type": "string"
+                        }
+                      ],
+                      "nullable": true,
+                      "description": "Unique public key for a Solana program. See the `/reference/dex` endpoint for more details of supported DEXes and their program addresses."
+                    },
+                    "baseMintAddress": {
+                      "allOf": [
+                        {
+                          "format": "pubkey",
+                          "type": "string"
+                        }
+                      ],
+                      "nullable": true,
+                      "description": "Base token mint address filter."
+                    },
+                    "quoteMintAddress": {
+                      "allOf": [
+                        {
+                          "format": "pubkey",
+                          "type": "string"
+                        }
+                      ],
+                      "nullable": true,
+                      "description": "Quote token mint address filter."
+                    },
+                    "tokenMintAddress": {
+                      "allOf": [
+                        {
+                          "format": "pubkey",
+                          "type": "string"
+                        }
+                      ],
+                      "nullable": true,
+                      "description": "Token mint address field (for either base or quote) filter."
+                    },
+                    "page": {
+                      "format": "int32",
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer",
+                      "description": "Page selection, 0-indexed."
+                    },
+                    "limit": {
+                      "format": "int32",
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer",
+                      "description": "Specifies the maximum number of markets to retrieve."
+                    }
+                  }
+                },
+                "output": {
+                  "$ref": "#/components/schemas/MarketsReturn"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v4/markets/{marketAddress}": {
+      "get": {
+        "description": "Solana API endpoint for fetching details about a specific market on Solana. Details are filtered by market or pool address on Pump.fun, Raydium and more.",
+        "operationId": "get_market_v4",
+        "parameters": [
+          {
+            "description": "The unique identifier assigned to a specific trading pair or market.",
+            "in": "path",
+            "name": "marketAddress",
+            "required": true,
+            "schema": {
+              "format": "pubkey",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TradePriceMarketReturn"
+                }
+              }
+            },
+            "description": "Market details."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "402": {
+            "description": "Payment Required"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Market not found"
+          }
+        },
+        "summary": "Market Details",
+        "tags": [
+          "Markets"
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.003000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "x-extensions": {
+          "bazaar": {
+            "schema": {
+              "properties": {
+                "input": {
+                  "type": "object",
+                  "properties": {
+                    "marketAddress": {
+                      "format": "pubkey",
+                      "type": "string",
+                      "description": "The unique identifier assigned to a specific trading pair or market."
+                    }
+                  },
+                  "required": [
+                    "marketAddress"
+                  ]
+                },
+                "output": {
+                  "$ref": "#/components/schemas/TradePriceMarketReturn"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v4/markets/{marketAddress}/candles": {
+      "get": {
+        "description": "Solana API endpoint for fetching OHLCV candlestick data for a specific Solana market/pool. Returns clean price data from vetted DEX pools and markets.",
+        "operationId": "get_market_filtered_ohlcv_v4",
+        "parameters": [
+          {
+            "description": "The unique identifier assigned to a specific trading pair or market.",
+            "in": "path",
+            "name": "marketAddress",
+            "required": true,
+            "schema": {
+              "format": "pubkey",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Resolution of the data. Possible values: 1m, 3m, 5m, 15m, 30m, 1h, 2h, 3h, 4h, 1d, 1w, 1mo, 1y. Default is \"1m\".",
+            "in": "query",
+            "name": "resolution",
+            "required": false,
+            "schema": {
+              "allOf": [
+                {
+                  "enum": [
+                    "1m",
+                    "3m",
+                    "5m",
+                    "15m",
+                    "30m",
+                    "1h",
+                    "2h",
+                    "3h",
+                    "4h",
+                    "1d",
+                    "1w",
+                    "1mo",
+                    "1y"
+                  ],
+                  "type": "string"
+                }
+              ],
+              "nullable": true
+            }
+          },
+          {
+            "description": "Start time of the data to return (unix timestamp)",
+            "in": "query",
+            "name": "timeStart",
+            "required": false,
+            "schema": {
+              "format": "int64",
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "End time of the data to return (unix timestamp)",
+            "in": "query",
+            "name": "timeEnd",
+            "required": false,
+            "schema": {
+              "format": "int64",
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Page selection, 0-indexed.",
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "format": "int32",
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Specifies the maximum number of candles to retrieve within a given resolution. Default is 1000.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "format": "int32",
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Eliminate gaps between candles by using previous close as next open. Default is true.",
+            "in": "query",
+            "name": "eliminateCloseToOpenGaps",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MarketOhlcvCandleVecReturn"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "402": {
+            "description": "Payment Required"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Internal server error"
+          }
+        },
+        "summary": "Market Price Candles",
+        "tags": [
+          "Markets"
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.009000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "x-extensions": {
+          "bazaar": {
+            "schema": {
+              "properties": {
+                "input": {
+                  "type": "object",
+                  "properties": {
+                    "marketAddress": {
+                      "format": "pubkey",
+                      "type": "string",
+                      "description": "The unique identifier assigned to a specific trading pair or market."
+                    },
+                    "resolution": {
+                      "allOf": [
+                        {
+                          "enum": [
+                            "1m",
+                            "3m",
+                            "5m",
+                            "15m",
+                            "30m",
+                            "1h",
+                            "2h",
+                            "3h",
+                            "4h",
+                            "1d",
+                            "1w",
+                            "1mo",
+                            "1y"
+                          ],
+                          "type": "string"
+                        }
+                      ],
+                      "nullable": true,
+                      "description": "Resolution of the data. Possible values: 1m, 3m, 5m, 15m, 30m, 1h, 2h, 3h, 4h, 1d, 1w, 1mo, 1y. Default is \"1m\"."
+                    },
+                    "timeStart": {
+                      "format": "int64",
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer",
+                      "description": "Start time of the data to return (unix timestamp)"
+                    },
+                    "timeEnd": {
+                      "format": "int64",
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer",
+                      "description": "End time of the data to return (unix timestamp)"
+                    },
+                    "page": {
+                      "format": "int32",
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer",
+                      "description": "Page selection, 0-indexed."
+                    },
+                    "limit": {
+                      "format": "int32",
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer",
+                      "description": "Specifies the maximum number of candles to retrieve within a given resolution. Default is 1000."
+                    },
+                    "eliminateCloseToOpenGaps": {
+                      "type": "boolean",
+                      "description": "Eliminate gaps between candles by using previous close as next open. Default is true."
+                    }
+                  },
+                  "required": [
+                    "marketAddress"
+                  ]
+                },
+                "output": {
+                  "$ref": "#/components/schemas/MarketOhlcvCandleVecReturn"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v4/oracle/pyth/pricefeeds": {
+      "get": {
+        "description": "**Replaces**: `GET /price/pyth-accounts`\n\nLists all Pyth price feeds with their product accounts and symbols.",
+        "operationId": "get_pyth_price_product_pairs_v4",
+        "parameters": [
+          {
+            "description": "Pyth product address to filter over.",
+            "in": "query",
+            "name": "productAddress",
+            "required": false,
+            "schema": {
+              "allOf": [
+                {
+                  "format": "pubkey",
+                  "type": "string"
+                }
+              ],
+              "nullable": true
+            }
+          },
+          {
+            "description": "Pyth price feed address to filter over.",
+            "in": "query",
+            "name": "priceFeedAddress",
+            "required": false,
+            "schema": {
+              "allOf": [
+                {
+                  "format": "pubkey",
+                  "type": "string"
+                }
+              ],
+              "nullable": true
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PythPriceProductPairsReturn"
+                }
+              }
+            },
+            "description": "Pyth product"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "summary": "Pyth Price Feeds",
+        "tags": [
+          "Oracle (Pyth)"
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.003000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "x-extensions": {
+          "bazaar": {
+            "schema": {
+              "properties": {
+                "input": {
+                  "type": "object",
+                  "properties": {
+                    "productAddress": {
+                      "allOf": [
+                        {
+                          "format": "pubkey",
+                          "type": "string"
+                        }
+                      ],
+                      "nullable": true,
+                      "description": "Pyth product address to filter over."
+                    },
+                    "priceFeedAddress": {
+                      "allOf": [
+                        {
+                          "format": "pubkey",
+                          "type": "string"
+                        }
+                      ],
+                      "nullable": true,
+                      "description": "Pyth price feed address to filter over."
+                    }
+                  }
+                },
+                "output": {
+                  "$ref": "#/components/schemas/PythPriceProductPairsReturn"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v4/oracle/pyth/pricefeeds/{priceFeedAddress}/candles": {
+      "get": {
+        "operationId": "get_pyth_price_ohlc_v4",
+        "parameters": [
+          {
+            "description": "The public key identifying the Pyth price feed account",
+            "in": "path",
+            "name": "priceFeedAddress",
+            "required": true,
+            "schema": {
+              "format": "pubkey",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Resolution of the data. Possible values: 1h, 1d, 1w, 1m, 1y, or a string parseable to seconds",
+            "in": "query",
+            "name": "resolution",
+            "required": false,
+            "schema": {
+              "allOf": [
+                {
+                  "format": "resolution",
+                  "type": "string"
+                }
+              ],
+              "nullable": true
+            }
+          },
+          {
+            "description": "Start time of the data to return (unix timestamp)",
+            "in": "query",
+            "name": "timeStart",
+            "required": false,
+            "schema": {
+              "format": "int64",
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "End time of the data to return (unix timestamp)",
+            "in": "query",
+            "name": "timeEnd",
+            "required": false,
+            "schema": {
+              "format": "int64",
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Limit of the number of records to return",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "format": "int32",
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Pagination offset",
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "format": "int32",
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Eliminate gaps between candles by using previous close as next open. Default is true.",
+            "in": "query",
+            "name": "eliminateCloseToOpenGaps",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PythPriceOhlcReturn"
+                }
+              }
+            },
+            "description": "Pyth ohlc data"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "402": {
+            "description": "Payment Required"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Product not found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Internal server error"
+          }
+        },
+        "summary": "Pyth Price Candles",
+        "tags": [
+          "Oracle (Pyth)"
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.009000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "x-extensions": {
+          "bazaar": {
+            "schema": {
+              "properties": {
+                "input": {
+                  "type": "object",
+                  "properties": {
+                    "priceFeedAddress": {
+                      "format": "pubkey",
+                      "type": "string",
+                      "description": "The public key identifying the Pyth price feed account"
+                    },
+                    "resolution": {
+                      "allOf": [
+                        {
+                          "format": "resolution",
+                          "type": "string"
+                        }
+                      ],
+                      "nullable": true,
+                      "description": "Resolution of the data. Possible values: 1h, 1d, 1w, 1m, 1y, or a string parseable to seconds"
+                    },
+                    "timeStart": {
+                      "format": "int64",
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer",
+                      "description": "Start time of the data to return (unix timestamp)"
+                    },
+                    "timeEnd": {
+                      "format": "int64",
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer",
+                      "description": "End time of the data to return (unix timestamp)"
+                    },
+                    "limit": {
+                      "format": "int32",
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer",
+                      "description": "Limit of the number of records to return"
+                    },
+                    "page": {
+                      "format": "int32",
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer",
+                      "description": "Pagination offset"
+                    },
+                    "eliminateCloseToOpenGaps": {
+                      "type": "boolean",
+                      "description": "Eliminate gaps between candles by using previous close as next open. Default is true."
+                    }
+                  },
+                  "required": [
+                    "priceFeedAddress"
+                  ]
+                },
+                "output": {
+                  "$ref": "#/components/schemas/PythPriceOhlcReturn"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v4/oracle/pyth/pricefeeds/{priceFeedAddress}/price": {
+      "get": {
+        "description": "**Replaces**: `GET /price/{priceFeedId}/pyth-price`\n\nReturns current price from a Pyth oracle feed.",
+        "operationId": "get_pyth_price_v4",
+        "parameters": [
+          {
+            "description": "The public key identifying the Pyth price feed account",
+            "in": "path",
+            "name": "priceFeedAddress",
+            "required": true,
+            "schema": {
+              "format": "pubkey",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PythPriceFeed"
+                }
+              }
+            },
+            "description": "Pyth price account"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "402": {
+            "description": "Payment Required"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Product not found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Internal server error"
+          }
+        },
+        "summary": "Pyth Current Price",
+        "tags": [
+          "Oracle (Pyth)"
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.003000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "x-extensions": {
+          "bazaar": {
+            "schema": {
+              "properties": {
+                "input": {
+                  "type": "object",
+                  "properties": {
+                    "priceFeedAddress": {
+                      "format": "pubkey",
+                      "type": "string",
+                      "description": "The public key identifying the Pyth price feed account"
+                    }
+                  },
+                  "required": [
+                    "priceFeedAddress"
+                  ]
+                },
+                "output": {
+                  "$ref": "#/components/schemas/PythPriceFeed"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v4/oracle/pyth/pricefeeds/{priceFeedAddress}/price-ts": {
+      "get": {
+        "description": "**Replaces**: `GET /price/{priceFeedId}/pyth-price-ts`\n\nReturns historical price data from a Pyth oracle feed.",
+        "operationId": "get_pyth_price_ts_v4",
+        "parameters": [
+          {
+            "description": "The public key identifying the Pyth price feed account",
+            "in": "path",
+            "name": "priceFeedAddress",
+            "required": true,
+            "schema": {
+              "format": "pubkey",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Resolution of the data. Possible values: 1h, 1d, 1w, 1m, 1y, or a string parseable to seconds",
+            "in": "query",
+            "name": "resolution",
+            "required": false,
+            "schema": {
+              "allOf": [
+                {
+                  "format": "resolution",
+                  "type": "string"
+                }
+              ],
+              "nullable": true
+            }
+          },
+          {
+            "description": "Start time of the data to return (unix timestamp)",
+            "in": "query",
+            "name": "timeStart",
+            "required": false,
+            "schema": {
+              "format": "int64",
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "End time of the data to return (unix timestamp)",
+            "in": "query",
+            "name": "timeEnd",
+            "required": false,
+            "schema": {
+              "format": "int64",
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Limit of the number of records to return",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "format": "int32",
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Pagination offset",
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "format": "int32",
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PythPriceFeedsTimeSeriesReturn"
+                }
+              }
+            },
+            "description": "Pyth price account"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "402": {
+            "description": "Payment Required"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Product not found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Internal server error"
+          }
+        },
+        "summary": "Pyth Price History",
+        "tags": [
+          "Oracle (Pyth)"
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.003000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "x-extensions": {
+          "bazaar": {
+            "schema": {
+              "properties": {
+                "input": {
+                  "type": "object",
+                  "properties": {
+                    "priceFeedAddress": {
+                      "format": "pubkey",
+                      "type": "string",
+                      "description": "The public key identifying the Pyth price feed account"
+                    },
+                    "resolution": {
+                      "allOf": [
+                        {
+                          "format": "resolution",
+                          "type": "string"
+                        }
+                      ],
+                      "nullable": true,
+                      "description": "Resolution of the data. Possible values: 1h, 1d, 1w, 1m, 1y, or a string parseable to seconds"
+                    },
+                    "timeStart": {
+                      "format": "int64",
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer",
+                      "description": "Start time of the data to return (unix timestamp)"
+                    },
+                    "timeEnd": {
+                      "format": "int64",
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer",
+                      "description": "End time of the data to return (unix timestamp)"
+                    },
+                    "limit": {
+                      "format": "int32",
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer",
+                      "description": "Limit of the number of records to return"
+                    },
+                    "page": {
+                      "format": "int32",
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer",
+                      "description": "Pagination offset"
+                    }
+                  },
+                  "required": [
+                    "priceFeedAddress"
+                  ]
+                },
+                "output": {
+                  "$ref": "#/components/schemas/PythPriceFeedsTimeSeriesReturn"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v4/oracle/pyth/products/{productAddress}": {
+      "get": {
+        "description": "**Replaces**: `GET /price/{productId}/pyth-product`\n\nReturns metadata for a Pyth product by its ID.",
+        "operationId": "get_pyth_product_v4",
+        "parameters": [
+          {
+            "description": "The pubkey identifying the Pyth Product.",
+            "in": "path",
+            "name": "productAddress",
+            "required": true,
+            "schema": {
+              "format": "pubkey",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PythProduct"
+                }
+              }
+            },
+            "description": "Pyth product"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "402": {
+            "description": "Payment Required"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Product not found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Internal server error"
+          }
+        },
+        "summary": "Pyth Product",
+        "tags": [
+          "Oracle (Pyth)"
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.003000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "x-extensions": {
+          "bazaar": {
+            "schema": {
+              "properties": {
+                "input": {
+                  "type": "object",
+                  "properties": {
+                    "productAddress": {
+                      "format": "pubkey",
+                      "type": "string",
+                      "description": "The pubkey identifying the Pyth Product."
+                    }
+                  },
+                  "required": [
+                    "productAddress"
+                  ]
+                },
+                "output": {
+                  "$ref": "#/components/schemas/PythProduct"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v4/programs/labeled-program-accounts": {
+      "get": {
+        "description": "**Replaces**: `GET /program/known-program-accounts`\n\nReturns labeled programs categorized by sector (NFT, perps, DeFi, etc.) and entity.",
+        "operationId": "get_known_program_accounts_v4",
+        "parameters": [
+          {
+            "description": "Unique public key for a Solana program",
+            "in": "query",
+            "name": "programAddress",
+            "required": false,
+            "schema": {
+              "allOf": [
+                {
+                  "format": "pubkey",
+                  "type": "string"
+                }
+              ],
+              "nullable": true
+            }
+          },
+          {
+            "description": "Known program name",
+            "in": "query",
+            "name": "name",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          },
+          {
+            "description": "Labels to filter over. Only programs matching all labels will be returned (eg. labels=DEFI,NFT)",
+            "in": "query",
+            "name": "labels",
+            "required": false,
+            "schema": {
+              "items": {
+                "type": "string"
+              },
+              "nullable": true,
+              "type": "array"
+            }
+          },
+          {
+            "description": "Name of the business or entity that controls this program",
+            "in": "query",
+            "name": "entityName",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          },
+          {
+            "description": "Entity id to filter with (including as empty or null, such as \"entity_id=\" will filter programs without an entity_id)",
+            "in": "query",
+            "name": "entityId",
+            "required": false,
+            "schema": {
+              "format": "int32",
+              "nullable": true,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Sort by ascending. Only one of sort_by_asc or sort_by_desc can be used",
+            "in": "query",
+            "name": "sortByAsc",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          },
+          {
+            "description": "Sort by descending. Only one of sort_by_asc or sort_by_desc can be used",
+            "in": "query",
+            "name": "sortByDesc",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/KnownProgramVecReturn"
+                }
+              }
+            },
+            "description": "Tokens info collected"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "402": {
+            "description": "Payment Required"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "No data could be found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Internal server error"
+          }
+        },
+        "summary": "Labeled Programs",
+        "tags": [
+          "Programs"
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.003000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "x-extensions": {
+          "bazaar": {
+            "schema": {
+              "properties": {
+                "input": {
+                  "type": "object",
+                  "properties": {
+                    "programAddress": {
+                      "allOf": [
+                        {
+                          "format": "pubkey",
+                          "type": "string"
+                        }
+                      ],
+                      "nullable": true,
+                      "description": "Unique public key for a Solana program"
+                    },
+                    "name": {
+                      "nullable": true,
+                      "type": "string",
+                      "description": "Known program name"
+                    },
+                    "labels": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "nullable": true,
+                      "type": "array",
+                      "description": "Labels to filter over. Only programs matching all labels will be returned (eg. labels=DEFI,NFT)"
+                    },
+                    "entityName": {
+                      "nullable": true,
+                      "type": "string",
+                      "description": "Name of the business or entity that controls this program"
+                    },
+                    "entityId": {
+                      "format": "int32",
+                      "nullable": true,
+                      "type": "integer",
+                      "description": "Entity id to filter with (including as empty or null, such as \"entity_id=\" will filter programs without an entity_id)"
+                    },
+                    "sortByAsc": {
+                      "nullable": true,
+                      "type": "string",
+                      "description": "Sort by ascending. Only one of sort_by_asc or sort_by_desc can be used"
+                    },
+                    "sortByDesc": {
+                      "nullable": true,
+                      "type": "string",
+                      "description": "Sort by descending. Only one of sort_by_asc or sort_by_desc can be used"
+                    }
+                  }
+                },
+                "output": {
+                  "$ref": "#/components/schemas/KnownProgramVecReturn"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v4/reference/dexes": {
+      "get": {
+        "description": "**Replaces**: `GET /price/programs`\n\nLists supported DEX and AMM programs for trading data.",
+        "operationId": "get_programs_v4",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TradePriceProgramsReturn"
+                }
+              }
+            },
+            "description": "Programs supported by our price endpoints."
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "summary": "Supported DEXs",
+        "tags": [
+          "Reference (Metadata)"
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.003000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "x-extensions": {
+          "bazaar": {
+            "schema": {
+              "properties": {
+                "input": {
+                  "type": "object",
+                  "properties": {}
+                },
+                "output": {
+                  "$ref": "#/components/schemas/TradePriceProgramsReturn"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v4/reference/instruction-names": {
+      "get": {
+        "description": "**Replaces**: `GET /token/instruction-names`\n\nReturns instruction names derived from discriminants across Solana programs.",
+        "operationId": "get_token_instruction_names_v4",
+        "parameters": [
+          {
+            "description": "Fuzzy search for similar instructions based on your input.",
+            "in": "query",
+            "name": "ixName",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          },
+          {
+            "description": "Enter the discriminant for a direct instruction name match.",
+            "in": "query",
+            "name": "callingInstructions",
+            "required": false,
+            "schema": {
+              "format": "binary",
+              "nullable": true,
+              "type": "string"
+            }
+          },
+          {
+            "description": "Return all the instructions for this program address",
+            "in": "query",
+            "name": "callingProgramAddress",
+            "required": false,
+            "schema": {
+              "allOf": [
+                {
+                  "format": "pubkey",
+                  "type": "string"
+                }
+              ],
+              "nullable": true
+            }
+          },
+          {
+            "description": "Return all the instructions for this program name",
+            "in": "query",
+            "name": "programName",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InstructionNameList"
+                }
+              }
+            },
+            "description": "A list of Solana program instructions matching the query"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "402": {
+            "description": "Payment Required"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "No data matches provided query"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Internal server error"
+          }
+        },
+        "summary": "Instruction Names",
+        "tags": [
+          "Reference (Metadata)"
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.003000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "x-extensions": {
+          "bazaar": {
+            "schema": {
+              "properties": {
+                "input": {
+                  "type": "object",
+                  "properties": {
+                    "ixName": {
+                      "nullable": true,
+                      "type": "string",
+                      "description": "Fuzzy search for similar instructions based on your input."
+                    },
+                    "callingInstructions": {
+                      "format": "binary",
+                      "nullable": true,
+                      "type": "string",
+                      "description": "Enter the discriminant for a direct instruction name match."
+                    },
+                    "callingProgramAddress": {
+                      "allOf": [
+                        {
+                          "format": "pubkey",
+                          "type": "string"
+                        }
+                      ],
+                      "nullable": true,
+                      "description": "Return all the instructions for this program address"
+                    },
+                    "programName": {
+                      "nullable": true,
+                      "type": "string",
+                      "description": "Return all the instructions for this program name"
+                    }
+                  }
+                },
+                "output": {
+                  "$ref": "#/components/schemas/InstructionNameList"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v4/tokens": {
+      "get": {
+        "description": "**Replaces**: `GET /tokens`\n\nLists tracked tokens with price, market cap, volume, and 24h change.",
+        "operationId": "get_tokens_summary_v4",
+        "parameters": [
+          {
+            "description": "Optional ascending sort field specification. Only one of sort_by_asc or sort_by_desc can be used",
+            "in": "query",
+            "name": "sortByAsc",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          },
+          {
+            "description": "Optional descending sort field specification. Only one of sort_by_asc or sort_by_desc can be used",
+            "in": "query",
+            "name": "sortByDesc",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter by a case-insensitive substring of the token name.",
+            "in": "query",
+            "name": "name",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter by a case-insensitive substring of the token symbol.",
+            "in": "query",
+            "name": "symbol",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          },
+          {
+            "description": "Result page size specifier.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "format": "int32",
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Page selection, 0-indexed.",
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "format": "int32",
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TokensReturn"
+                }
+              }
+            },
+            "description": "Tokens summary collected"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "402": {
+            "description": "Payment Required"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "No data matches provided query"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Internal server error"
+          }
+        },
+        "summary": "Token List",
+        "tags": [
+          "Tokens"
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.003000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "x-extensions": {
+          "bazaar": {
+            "schema": {
+              "properties": {
+                "input": {
+                  "type": "object",
+                  "properties": {
+                    "sortByAsc": {
+                      "nullable": true,
+                      "type": "string",
+                      "description": "Optional ascending sort field specification. Only one of sort_by_asc or sort_by_desc can be used"
+                    },
+                    "sortByDesc": {
+                      "nullable": true,
+                      "type": "string",
+                      "description": "Optional descending sort field specification. Only one of sort_by_asc or sort_by_desc can be used"
+                    },
+                    "name": {
+                      "nullable": true,
+                      "type": "string",
+                      "description": "Filter by a case-insensitive substring of the token name."
+                    },
+                    "symbol": {
+                      "nullable": true,
+                      "type": "string",
+                      "description": "Filter by a case-insensitive substring of the token symbol."
+                    },
+                    "limit": {
+                      "format": "int32",
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer",
+                      "description": "Result page size specifier."
+                    },
+                    "page": {
+                      "format": "int32",
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer",
+                      "description": "Page selection, 0-indexed."
+                    }
+                  }
+                },
+                "output": {
+                  "$ref": "#/components/schemas/TokensReturn"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v4/tokens/{mintAddress}": {
+      "get": {
+        "description": "Solana API endpoint for fetching complete Token-2022 and SPL token details such as price, volume, market cap, holder count, supply and social links.",
+        "operationId": "get_token_details_v4",
+        "parameters": [
+          {
+            "description": "The public key of the token of interest",
+            "in": "path",
+            "name": "mintAddress",
+            "required": true,
+            "schema": {
+              "format": "pubkey",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TokenInformationCH"
+                }
+              }
+            },
+            "description": "Token details collected"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "402": {
+            "description": "Payment Required"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "No data matches provided query"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Internal server error"
+          }
+        },
+        "summary": "Token Details",
+        "tags": [
+          "Tokens"
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.003000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "x-extensions": {
+          "bazaar": {
+            "schema": {
+              "properties": {
+                "input": {
+                  "type": "object",
+                  "properties": {
+                    "mintAddress": {
+                      "format": "pubkey",
+                      "type": "string",
+                      "description": "The public key of the token of interest"
+                    }
+                  },
+                  "required": [
+                    "mintAddress"
+                  ]
+                },
+                "output": {
+                  "$ref": "#/components/schemas/TokenInformationCH"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v4/tokens/{mintAddress}/candles": {
+      "get": {
+        "description": "Solana API endpoint for fetching token candles OHLCV prices for any Token-2022 or SPL token on Solana. Multiple resolutions from 1-minute to 1-year.",
+        "operationId": "get_token_trade_ohlc_v4",
+        "parameters": [
+          {
+            "description": "The public key of the token of interest",
+            "in": "path",
+            "name": "mintAddress",
+            "required": true,
+            "schema": {
+              "format": "pubkey",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Resolution of the data. Possible values: 1m, 3m, 5m, 15m, 30m, 1h, 2h, 3h, 4h, 1d, 1w, 1mo, 1y. Default is \"1h\".",
+            "in": "query",
+            "name": "resolution",
+            "required": false,
+            "schema": {
+              "allOf": [
+                {
+                  "enum": [
+                    "1m",
+                    "3m",
+                    "5m",
+                    "15m",
+                    "30m",
+                    "1h",
+                    "2h",
+                    "3h",
+                    "4h",
+                    "1d",
+                    "1w",
+                    "1mo",
+                    "1y"
+                  ],
+                  "type": "string"
+                }
+              ],
+              "nullable": true
+            }
+          },
+          {
+            "description": "Start time of the data to return (unix timestamp)",
+            "in": "query",
+            "name": "timeStart",
+            "required": false,
+            "schema": {
+              "format": "int64",
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "End time of the data to return (unix timestamp)",
+            "in": "query",
+            "name": "timeEnd",
+            "required": false,
+            "schema": {
+              "format": "int64",
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Result page size specifier. Default is 1000.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "format": "int32",
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Page number for paginated results",
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "format": "int32",
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Eliminate gaps between candles by using previous close as next open. Default is true.",
+            "in": "query",
+            "name": "eliminateCloseToOpenGaps",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TradeOhlcvCandleVecReturn"
+                }
+              }
+            },
+            "description": "Tokens info collected"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "402": {
+            "description": "Payment Required"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Internal server error"
+          }
+        },
+        "summary": "Token Candles",
+        "tags": [
+          "Tokens"
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.009000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "x-extensions": {
+          "bazaar": {
+            "schema": {
+              "properties": {
+                "input": {
+                  "type": "object",
+                  "properties": {
+                    "mintAddress": {
+                      "format": "pubkey",
+                      "type": "string",
+                      "description": "The public key of the token of interest"
+                    },
+                    "resolution": {
+                      "allOf": [
+                        {
+                          "enum": [
+                            "1m",
+                            "3m",
+                            "5m",
+                            "15m",
+                            "30m",
+                            "1h",
+                            "2h",
+                            "3h",
+                            "4h",
+                            "1d",
+                            "1w",
+                            "1mo",
+                            "1y"
+                          ],
+                          "type": "string"
+                        }
+                      ],
+                      "nullable": true,
+                      "description": "Resolution of the data. Possible values: 1m, 3m, 5m, 15m, 30m, 1h, 2h, 3h, 4h, 1d, 1w, 1mo, 1y. Default is \"1h\"."
+                    },
+                    "timeStart": {
+                      "format": "int64",
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer",
+                      "description": "Start time of the data to return (unix timestamp)"
+                    },
+                    "timeEnd": {
+                      "format": "int64",
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer",
+                      "description": "End time of the data to return (unix timestamp)"
+                    },
+                    "limit": {
+                      "format": "int32",
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer",
+                      "description": "Result page size specifier. Default is 1000."
+                    },
+                    "page": {
+                      "format": "int32",
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer",
+                      "description": "Page number for paginated results"
+                    },
+                    "eliminateCloseToOpenGaps": {
+                      "type": "boolean",
+                      "description": "Eliminate gaps between candles by using previous close as next open. Default is true."
+                    }
+                  },
+                  "required": [
+                    "mintAddress"
+                  ]
+                },
+                "output": {
+                  "$ref": "#/components/schemas/TradeOhlcvCandleVecReturn"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v4/tokens/{mintAddress}/holders-count-ts": {
+      "get": {
+        "description": "**Replaces**: `GET /token/{mintAddress}/holders-ts`\n\nTrack historical holder count at daily or hourly intervals.",
+        "operationId": "get_token_holders_time_series_v4",
+        "parameters": [
+          {
+            "description": "The public key of the token of interest",
+            "in": "path",
+            "name": "mintAddress",
+            "required": true,
+            "schema": {
+              "format": "pubkey",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Start time of period of interest as a unix timestamp.",
+            "in": "query",
+            "name": "startTime",
+            "required": false,
+            "schema": {
+              "format": "int64",
+              "nullable": true,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "End time of period of interest as a unix timestamp.",
+            "in": "query",
+            "name": "endTime",
+            "required": false,
+            "schema": {
+              "format": "int64",
+              "nullable": true,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Time interval specifier (currently, only \"day\" or \"hour\" is supported).",
+            "in": "query",
+            "name": "interval",
+            "required": false,
+            "schema": {
+              "description": "Enumerates the supported time intervals for token holders.",
+              "enum": [
+                "hour",
+                "day"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Result page size specifier.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "format": "int32",
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Page selection, 0-indexed.",
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "format": "int32",
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TokenHoldersTimeSeriesReturn"
+                }
+              }
+            },
+            "description": "Token holder numbers collected"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "402": {
+            "description": "Payment Required"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "No data matches provided query"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Internal server error"
+          }
+        },
+        "summary": "Holder Count History",
+        "tags": [
+          "Tokens"
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.003000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "x-extensions": {
+          "bazaar": {
+            "schema": {
+              "properties": {
+                "input": {
+                  "type": "object",
+                  "properties": {
+                    "mintAddress": {
+                      "format": "pubkey",
+                      "type": "string",
+                      "description": "The public key of the token of interest"
+                    },
+                    "startTime": {
+                      "format": "int64",
+                      "nullable": true,
+                      "type": "integer",
+                      "description": "Start time of period of interest as a unix timestamp."
+                    },
+                    "endTime": {
+                      "format": "int64",
+                      "nullable": true,
+                      "type": "integer",
+                      "description": "End time of period of interest as a unix timestamp."
+                    },
+                    "interval": {
+                      "description": "Time interval specifier (currently, only \"day\" or \"hour\" is supported).",
+                      "enum": [
+                        "hour",
+                        "day"
+                      ],
+                      "type": "string"
+                    },
+                    "limit": {
+                      "format": "int32",
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer",
+                      "description": "Result page size specifier."
+                    },
+                    "page": {
+                      "format": "int32",
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer",
+                      "description": "Page selection, 0-indexed."
+                    }
+                  },
+                  "required": [
+                    "mintAddress"
+                  ]
+                },
+                "output": {
+                  "$ref": "#/components/schemas/TokenHoldersTimeSeriesReturn"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v4/tokens/{mintAddress}/liquidity": {
+      "get": {
+        "description": "Returns the total USD liquidity for a token, calculated by summing liquidity across all of its trading markets.\nThe value may be `null` if no liquidity data is available for this token.\n\nUse this to assess how liquid a token is before executing trades, or to display liquidity depth alongside price data.",
+        "operationId": "get_token_liquidity",
+        "parameters": [
+          {
+            "description": "The mint address of the token.",
+            "in": "path",
+            "name": "mintAddress",
+            "required": true,
+            "schema": {
+              "format": "pubkey",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TokenLiquidity"
+                }
+              }
+            },
+            "description": "Total USD liquidity across all markets for this token. The `liquidity` field is `null` if no data is available."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Invalid mint address format."
+          },
+          "402": {
+            "description": "Payment Required"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Unexpected server error. The response body includes an `id` field — provide this when contacting support."
+          }
+        },
+        "summary": "Token Liquidity",
+        "tags": [
+          "Tokens"
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.003000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "x-extensions": {
+          "bazaar": {
+            "schema": {
+              "properties": {
+                "input": {
+                  "type": "object",
+                  "properties": {
+                    "mintAddress": {
+                      "format": "pubkey",
+                      "type": "string",
+                      "description": "The mint address of the token."
+                    }
+                  },
+                  "required": [
+                    "mintAddress"
+                  ]
+                },
+                "output": {
+                  "$ref": "#/components/schemas/TokenLiquidity"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v4/tokens/{mintAddress}/markets-ts": {
+      "get": {
+        "description": "Returns trade activity for each market (trading pair) that involves a given token, bucketed over time.\nEach data point contains the market's mint address, a timestamp, and the aggregated trade activity for that period.\nSupports daily (1d), weekly (7d), and monthly (30d) resolutions, and optionally filters to a single market.\nDefaults to daily resolution ('1d') over the last 24 hours with up to 1000 data points.\n\nUse this to compare how a token performs across different markets over time — for example,\nto see whether volume shifted from one DEX pool to another.",
+        "operationId": "get_token_markets_timeseries_v4",
+        "parameters": [
+          {
+            "description": "The mint address of the token.",
+            "in": "path",
+            "name": "mintAddress",
+            "required": true,
+            "schema": {
+              "format": "pubkey",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Optional market address to restrict results to a single trading pair. If omitted, all markets for the token are returned.",
+            "in": "query",
+            "name": "marketId",
+            "required": false,
+            "schema": {
+              "allOf": [
+                {
+                  "format": "pubkey",
+                  "type": "string"
+                }
+              ],
+              "nullable": true
+            }
+          },
+          {
+            "description": "Time bucket size. Possible values: '1d' (daily), '7d' (weekly), '30d' (monthly). Defaults to '1d'.",
+            "in": "query",
+            "name": "resolution",
+            "required": false,
+            "schema": {
+              "allOf": [
+                {
+                  "description": "Represents the supported time-window resolutions for account/PnL queries.",
+                  "enum": [
+                    "1d",
+                    "7d",
+                    "30d"
+                  ],
+                  "type": "string"
+                }
+              ],
+              "nullable": true
+            }
+          },
+          {
+            "description": "Maximum number of data points to return. Defaults to 1000.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "format": "int32",
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Page number to return (zero-indexed). Defaults to 0.",
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "format": "int32",
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Start of the time range (unix timestamp, seconds). Defaults to 24 hours ago.",
+            "in": "query",
+            "name": "timeStart",
+            "required": false,
+            "schema": {
+              "format": "int64",
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "End of the time range (unix timestamp, seconds). Defaults to the current time.",
+            "in": "query",
+            "name": "timeEnd",
+            "required": false,
+            "schema": {
+              "format": "int64",
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TokenMarketTimeseriesResponse"
+                }
+              }
+            },
+            "description": "Array of per-market data points with mint address, timestamp, and aggregated trade activity."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Invalid parameters — check that `resolution` is one of '1d', '7d', '30d', and that `timeStart` < `timeEnd` if provided."
+          },
+          "402": {
+            "description": "Payment Required"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Unexpected server error. The response body includes an `id` field — provide this when contacting support."
+          }
+        },
+        "summary": "Token Markets Timeseries",
+        "tags": [
+          "Tokens"
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.003000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "x-extensions": {
+          "bazaar": {
+            "schema": {
+              "properties": {
+                "input": {
+                  "type": "object",
+                  "properties": {
+                    "mintAddress": {
+                      "format": "pubkey",
+                      "type": "string",
+                      "description": "The mint address of the token."
+                    },
+                    "marketId": {
+                      "allOf": [
+                        {
+                          "format": "pubkey",
+                          "type": "string"
+                        }
+                      ],
+                      "nullable": true,
+                      "description": "Optional market address to restrict results to a single trading pair. If omitted, all markets for the token are returned."
+                    },
+                    "resolution": {
+                      "allOf": [
+                        {
+                          "description": "Represents the supported time-window resolutions for account/PnL queries.",
+                          "enum": [
+                            "1d",
+                            "7d",
+                            "30d"
+                          ],
+                          "type": "string"
+                        }
+                      ],
+                      "nullable": true,
+                      "description": "Time bucket size. Possible values: '1d' (daily), '7d' (weekly), '30d' (monthly). Defaults to '1d'."
+                    },
+                    "limit": {
+                      "format": "int32",
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer",
+                      "description": "Maximum number of data points to return. Defaults to 1000."
+                    },
+                    "page": {
+                      "format": "int32",
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer",
+                      "description": "Page number to return (zero-indexed). Defaults to 0."
+                    },
+                    "timeStart": {
+                      "format": "int64",
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer",
+                      "description": "Start of the time range (unix timestamp, seconds). Defaults to 24 hours ago."
+                    },
+                    "timeEnd": {
+                      "format": "int64",
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer",
+                      "description": "End of the time range (unix timestamp, seconds). Defaults to the current time."
+                    }
+                  },
+                  "required": [
+                    "mintAddress"
+                  ]
+                },
+                "output": {
+                  "$ref": "#/components/schemas/TokenMarketTimeseriesResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v4/tokens/{mintAddress}/top-holders": {
+      "get": {
+        "description": "Solana API endpoint for fetching top token holders and whales. Get ownership %, USD value, and labels for top 1000 wallets, updated every 3 hours.",
+        "operationId": "get_top_holders_v4",
+        "parameters": [
+          {
+            "description": "The public key of the token of interest",
+            "in": "path",
+            "name": "mintAddress",
+            "required": true,
+            "schema": {
+              "format": "pubkey",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Page selection, 0-indexed.",
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "format": "int32",
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Limit of the number of transfers to return per page. Default/max is 1000.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "format": "int32",
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Sort ascending by 'rank', 'ownerName', 'ownerAddress', 'valueUsd', 'balance' or 'percentageOfSupplyHeld'. Only one of sort_by_asc or sort_by_desc can be used",
+            "in": "query",
+            "name": "sortByAsc",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          },
+          {
+            "description": "Sort descending by 'rank', 'ownerName', 'ownerAddress', 'valueUsd', 'balance' or 'percentageOfSupplyHeld'. Only one of sort_by_asc or sort_by_desc can be used",
+            "in": "query",
+            "name": "sortByDesc",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TopHoldersReturn"
+                }
+              }
+            },
+            "description": "Token details collected"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "402": {
+            "description": "Payment Required"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "No data matches provided query"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Internal server error"
+          }
+        },
+        "summary": "Top Holders",
+        "tags": [
+          "Tokens"
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.024000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "x-extensions": {
+          "bazaar": {
+            "schema": {
+              "properties": {
+                "input": {
+                  "type": "object",
+                  "properties": {
+                    "mintAddress": {
+                      "format": "pubkey",
+                      "type": "string",
+                      "description": "The public key of the token of interest"
+                    },
+                    "page": {
+                      "format": "int32",
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer",
+                      "description": "Page selection, 0-indexed."
+                    },
+                    "limit": {
+                      "format": "int32",
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer",
+                      "description": "Limit of the number of transfers to return per page. Default/max is 1000."
+                    },
+                    "sortByAsc": {
+                      "nullable": true,
+                      "type": "string",
+                      "description": "Sort ascending by 'rank', 'ownerName', 'ownerAddress', 'valueUsd', 'balance' or 'percentageOfSupplyHeld'. Only one of sort_by_asc or sort_by_desc can be used"
+                    },
+                    "sortByDesc": {
+                      "nullable": true,
+                      "type": "string",
+                      "description": "Sort descending by 'rank', 'ownerName', 'ownerAddress', 'valueUsd', 'balance' or 'percentageOfSupplyHeld'. Only one of sort_by_asc or sort_by_desc can be used"
+                    }
+                  },
+                  "required": [
+                    "mintAddress"
+                  ]
+                },
+                "output": {
+                  "$ref": "#/components/schemas/TopHoldersReturn"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v4/tokens/{mintAddress}/top-pnl-traders": {
+      "get": {
+        "description": "Solana API endpoint for fetching top token traders by realized and unrealized PnL, including trade volumes, counts, and wallet addresses.",
+        "operationId": "get_top_pnl_traders_by_token_v4",
+        "parameters": [
+          {
+            "description": "The mint address of the token.",
+            "in": "path",
+            "name": "mintAddress",
+            "required": true,
+            "schema": {
+              "format": "pubkey",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Time window for PnL calculation. Possible values: '1d' (last day), '7d' (last 7 days), '30d' (last 30 days). Defaults to '1d'.",
+            "in": "query",
+            "name": "resolution",
+            "required": false,
+            "schema": {
+              "allOf": [
+                {
+                  "description": "Represents the supported time-window resolutions for account/PnL queries.",
+                  "enum": [
+                    "1d",
+                    "7d",
+                    "30d"
+                  ],
+                  "type": "string"
+                }
+              ],
+              "nullable": true
+            }
+          },
+          {
+            "description": "Maximum number of traders to return. Defaults to 1000.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "format": "int32",
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Page number to return. Defaults to 0.",
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "format": "int32",
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Sort ascending by 'traderAddress', 'realizedPnlUsd', 'totalVolumeUsd', or 'tradesCount'. If omitted, no sorting is applied. Only one of `sortByAsc` or `sortByDesc` can be used.",
+            "in": "query",
+            "name": "sortByAsc",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          },
+          {
+            "description": "Sort descending by 'traderAddress', 'realizedPnlUsd', 'totalVolumeUsd', or 'tradesCount'. If omitted, no sorting is applied. Only one of `sortByAsc` or `sortByDesc` can be used.",
+            "in": "query",
+            "name": "sortByDesc",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TopPnlTraderByTokenTraderResponse"
+                }
+              }
+            },
+            "description": "Ranked list of traders with realized/unrealized PnL, buy/sell volumes, and trade counts."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Invalid parameters — check that `resolution` is one of '1d', '7d', '30d', limit does not exceed 1000, and only one of `sortByAsc`/`sortByDesc` is set."
+          },
+          "402": {
+            "description": "Payment Required"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Unexpected server error. The response body includes an `id` field — provide this when contacting support."
+          }
+        },
+        "summary": "Top PnL Traders (By Token)",
+        "tags": [
+          "Tokens"
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.003000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "x-extensions": {
+          "bazaar": {
+            "schema": {
+              "properties": {
+                "input": {
+                  "type": "object",
+                  "properties": {
+                    "mintAddress": {
+                      "format": "pubkey",
+                      "type": "string",
+                      "description": "The mint address of the token."
+                    },
+                    "resolution": {
+                      "allOf": [
+                        {
+                          "description": "Represents the supported time-window resolutions for account/PnL queries.",
+                          "enum": [
+                            "1d",
+                            "7d",
+                            "30d"
+                          ],
+                          "type": "string"
+                        }
+                      ],
+                      "nullable": true,
+                      "description": "Time window for PnL calculation. Possible values: '1d' (last day), '7d' (last 7 days), '30d' (last 30 days). Defaults to '1d'."
+                    },
+                    "limit": {
+                      "format": "int32",
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer",
+                      "description": "Maximum number of traders to return. Defaults to 1000."
+                    },
+                    "page": {
+                      "format": "int32",
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer",
+                      "description": "Page number to return. Defaults to 0."
+                    },
+                    "sortByAsc": {
+                      "nullable": true,
+                      "type": "string",
+                      "description": "Sort ascending by 'traderAddress', 'realizedPnlUsd', 'totalVolumeUsd', or 'tradesCount'. If omitted, no sorting is applied. Only one of `sortByAsc` or `sortByDesc` can be used."
+                    },
+                    "sortByDesc": {
+                      "nullable": true,
+                      "type": "string",
+                      "description": "Sort descending by 'traderAddress', 'realizedPnlUsd', 'totalVolumeUsd', or 'tradesCount'. If omitted, no sorting is applied. Only one of `sortByAsc` or `sortByDesc` can be used."
+                    }
+                  },
+                  "required": [
+                    "mintAddress"
+                  ]
+                },
+                "output": {
+                  "$ref": "#/components/schemas/TopPnlTraderByTokenTraderResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v4/tokens/{mintAddress}/trade-volume-ts": {
+      "get": {
+        "description": "Returns aggregated trade data for a token over time, bucketed by hour or day.\nYou choose which metric to project via the `projection` parameter: `sellVolumeUsd`, `buyVolumeUsd`, `sellCount`, or `buyCount`.\nEach data point contains a timestamp and the aggregated value for that bucket.\n\nUse this to chart trading activity trends — for example, plotting daily buy volume for a token over the past month.",
+        "operationId": "get_trade_aggregated_timeseries_v4",
+        "parameters": [
+          {
+            "description": "The mint address of the token.",
+            "in": "path",
+            "name": "mintAddress",
+            "required": true,
+            "schema": {
+              "format": "pubkey",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Time bucket size — either 'HOUR' or 'DAY'. Determines the granularity of returned data points.",
+            "in": "query",
+            "name": "unit",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Start of the time range (unix timestamp, seconds). Required.",
+            "in": "query",
+            "name": "timeStart",
+            "required": true,
+            "schema": {
+              "format": "int64",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "End of the time range (unix timestamp, seconds). Required.",
+            "in": "query",
+            "name": "timeEnd",
+            "required": true,
+            "schema": {
+              "format": "int64",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "The metric to aggregate per time bucket. One of: 'sellVolumeUsd', 'buyVolumeUsd', 'sellCount', 'buyCount'.",
+            "in": "query",
+            "name": "projection",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TradeAggregatedTimeseriesResponse"
+                }
+              }
+            },
+            "description": "Array of timestamp + value pairs, one per time bucket. The value represents the selected projection (volume in USD or trade count)."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Invalid parameters — check that `unit` is 'HOUR' or 'DAY', `projection` is one of 'sellVolumeUsd'/'buyVolumeUsd'/'sellCount'/'buyCount', and `timeStart` < `timeEnd`."
+          },
+          "402": {
+            "description": "Payment Required"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Unexpected server error. The response body includes an `id` field — provide this when contacting support."
+          }
+        },
+        "summary": "Trade Volume Timeseries",
+        "tags": [
+          "Trades & Transfers"
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.003000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "x-extensions": {
+          "bazaar": {
+            "schema": {
+              "properties": {
+                "input": {
+                  "type": "object",
+                  "properties": {
+                    "mintAddress": {
+                      "format": "pubkey",
+                      "type": "string",
+                      "description": "The mint address of the token."
+                    },
+                    "unit": {
+                      "type": "string",
+                      "description": "Time bucket size — either 'HOUR' or 'DAY'. Determines the granularity of returned data points."
+                    },
+                    "timeStart": {
+                      "format": "int64",
+                      "minimum": 0,
+                      "type": "integer",
+                      "description": "Start of the time range (unix timestamp, seconds). Required."
+                    },
+                    "timeEnd": {
+                      "format": "int64",
+                      "minimum": 0,
+                      "type": "integer",
+                      "description": "End of the time range (unix timestamp, seconds). Required."
+                    },
+                    "projection": {
+                      "type": "string",
+                      "description": "The metric to aggregate per time bucket. One of: 'sellVolumeUsd', 'buyVolumeUsd', 'sellCount', 'buyCount'."
+                    }
+                  },
+                  "required": [
+                    "mintAddress",
+                    "unit",
+                    "timeStart",
+                    "timeEnd",
+                    "projection"
+                  ]
+                },
+                "output": {
+                  "$ref": "#/components/schemas/TradeAggregatedTimeseriesResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v4/tokens/{mintAddress}/trader-activity": {
+      "get": {
+        "description": "Returns a list of individual traders and their buy/sell activity for a specific token.\nEach row includes the trader's address, buy and sell counts, volumes (token amount and USD),\nrealized and unrealized PnL, win/loss counts, and average buy price.\nResults can be filtered by minimum buy/sell count or volume thresholds.\nDefaults to the last day ('1d') of activity with up to 1000 traders returned.\n\nUse this to analyze the trading community around a token — for example, identifying active traders,\nor filtering for whales by setting a minimum buy volume.",
+        "operationId": "get_trades_tokens_activity_summary_v4",
+        "parameters": [
+          {
+            "description": "The mint address of the token.",
+            "in": "path",
+            "name": "mintAddress",
+            "required": true,
+            "schema": {
+              "format": "pubkey",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Only include traders with more than this many buy trades (exclusive). For example, `buyCountGt=5` returns traders with 6+ buys. If omitted, no minimum buy count filter is applied.",
+            "in": "query",
+            "name": "buyCountGt",
+            "required": false,
+            "schema": {
+              "format": "int32",
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Only include traders with more than this many sell trades (exclusive). If omitted, no minimum sell count filter is applied.",
+            "in": "query",
+            "name": "sellCountGt",
+            "required": false,
+            "schema": {
+              "format": "int32",
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Only include traders with buy volume greater than this value (exclusive, in token amount). If omitted, no minimum buy volume filter is applied.",
+            "in": "query",
+            "name": "buyVolumeGt",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          },
+          {
+            "description": "Only include traders with sell volume greater than this value (exclusive, in token amount). If omitted, no minimum sell volume filter is applied.",
+            "in": "query",
+            "name": "sellVolumeGt",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          },
+          {
+            "description": "Time window for the activity summary. Possible values: '1d' (last day), '7d' (last 7 days), '30d' (last 30 days). Defaults to '1d'.",
+            "in": "query",
+            "name": "resolution",
+            "required": false,
+            "schema": {
+              "allOf": [
+                {
+                  "description": "Represents the supported time-window resolutions for account/PnL queries.",
+                  "enum": [
+                    "1d",
+                    "7d",
+                    "30d"
+                  ],
+                  "type": "string"
+                }
+              ],
+              "nullable": true
+            }
+          },
+          {
+            "description": "Maximum number of traders to return. Defaults to 1000.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "format": "int32",
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Page number to return (zero-indexed). Defaults to 0.",
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "format": "int32",
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Sort ascending by 'buyVolumeUsd', 'sellVolumeUsd', 'buyCount', 'sellCount', or 'traderAddress'. If omitted, no sorting is applied. Only one of `sortByAsc` or `sortByDesc` can be used.",
+            "in": "query",
+            "name": "sortByAsc",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          },
+          {
+            "description": "Sort descending by 'buyVolumeUsd', 'sellVolumeUsd', 'buyCount', 'sellCount', or 'traderAddress'. If omitted, no sorting is applied. Only one of `sortByAsc` or `sortByDesc` can be used.",
+            "in": "query",
+            "name": "sortByDesc",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TradesTokenActivitySummaryResponse"
+                }
+              }
+            },
+            "description": "Per-trader activity summaries including buy/sell counts, volumes, PnL, and win/loss stats."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Invalid parameters — check that `resolution` is one of '1d', '7d', '30d', limit does not exceed 1000, and only one of `sortByAsc`/`sortByDesc` is set."
+          },
+          "402": {
+            "description": "Payment Required"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Unexpected server error. The response body includes an `id` field — provide this when contacting support."
+          }
+        },
+        "summary": "Token Traders Activity",
+        "tags": [
+          "Trades & Transfers"
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.003000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "x-extensions": {
+          "bazaar": {
+            "schema": {
+              "properties": {
+                "input": {
+                  "type": "object",
+                  "properties": {
+                    "mintAddress": {
+                      "format": "pubkey",
+                      "type": "string",
+                      "description": "The mint address of the token."
+                    },
+                    "buyCountGt": {
+                      "format": "int32",
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer",
+                      "description": "Only include traders with more than this many buy trades (exclusive). For example, `buyCountGt=5` returns traders with 6+ buys. If omitted, no minimum buy count filter is applied."
+                    },
+                    "sellCountGt": {
+                      "format": "int32",
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer",
+                      "description": "Only include traders with more than this many sell trades (exclusive). If omitted, no minimum sell count filter is applied."
+                    },
+                    "buyVolumeGt": {
+                      "nullable": true,
+                      "type": "string",
+                      "description": "Only include traders with buy volume greater than this value (exclusive, in token amount). If omitted, no minimum buy volume filter is applied."
+                    },
+                    "sellVolumeGt": {
+                      "nullable": true,
+                      "type": "string",
+                      "description": "Only include traders with sell volume greater than this value (exclusive, in token amount). If omitted, no minimum sell volume filter is applied."
+                    },
+                    "resolution": {
+                      "allOf": [
+                        {
+                          "description": "Represents the supported time-window resolutions for account/PnL queries.",
+                          "enum": [
+                            "1d",
+                            "7d",
+                            "30d"
+                          ],
+                          "type": "string"
+                        }
+                      ],
+                      "nullable": true,
+                      "description": "Time window for the activity summary. Possible values: '1d' (last day), '7d' (last 7 days), '30d' (last 30 days). Defaults to '1d'."
+                    },
+                    "limit": {
+                      "format": "int32",
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer",
+                      "description": "Maximum number of traders to return. Defaults to 1000."
+                    },
+                    "page": {
+                      "format": "int32",
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer",
+                      "description": "Page number to return (zero-indexed). Defaults to 0."
+                    },
+                    "sortByAsc": {
+                      "nullable": true,
+                      "type": "string",
+                      "description": "Sort ascending by 'buyVolumeUsd', 'sellVolumeUsd', 'buyCount', 'sellCount', or 'traderAddress'. If omitted, no sorting is applied. Only one of `sortByAsc` or `sortByDesc` can be used."
+                    },
+                    "sortByDesc": {
+                      "nullable": true,
+                      "type": "string",
+                      "description": "Sort descending by 'buyVolumeUsd', 'sellVolumeUsd', 'buyCount', 'sellCount', or 'traderAddress'. If omitted, no sorting is applied. Only one of `sortByAsc` or `sortByDesc` can be used."
+                    }
+                  },
+                  "required": [
+                    "mintAddress"
+                  ]
+                },
+                "output": {
+                  "$ref": "#/components/schemas/TradesTokenActivitySummaryResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v4/trades": {
+      "get": {
+        "description": "Solana API endpoint for fetching trade history, volume, and metrics for any supported Solana AMM or DEX program, filtered by program.",
+        "operationId": "get_trade_data_program_v4",
+        "parameters": [
+          {
+            "description": "The program on which the trade occurred",
+            "in": "query",
+            "name": "programAddress",
+            "required": false,
+            "schema": {
+              "allOf": [
+                {
+                  "format": "pubkey",
+                  "type": "string"
+                }
+              ],
+              "nullable": true
+            }
+          },
+          {
+            "description": "The public key of the base token",
+            "in": "query",
+            "name": "baseMintAddress",
+            "required": false,
+            "schema": {
+              "allOf": [
+                {
+                  "format": "pubkey",
+                  "type": "string"
+                }
+              ],
+              "nullable": true
+            }
+          },
+          {
+            "description": "The public key of the quote token",
+            "in": "query",
+            "name": "quoteMintAddress",
+            "required": false,
+            "schema": {
+              "allOf": [
+                {
+                  "format": "pubkey",
+                  "type": "string"
+                }
+              ],
+              "nullable": true
+            }
+          },
+          {
+            "description": "The public key of either the base or quote token",
+            "in": "query",
+            "name": "mintAddress",
+            "required": false,
+            "schema": {
+              "allOf": [
+                {
+                  "format": "pubkey",
+                  "type": "string"
+                }
+              ],
+              "nullable": true
+            }
+          },
+          {
+            "description": "Market id to filter with. If provided, the baseMintAddress and quoteMintAddress fields are ignored",
+            "in": "query",
+            "name": "marketAddress",
+            "required": false,
+            "schema": {
+              "allOf": [
+                {
+                  "format": "pubkey",
+                  "type": "string"
+                }
+              ],
+              "nullable": true
+            }
+          },
+          {
+            "description": "Authority public key to filter with",
+            "in": "query",
+            "name": "authorityAddress",
+            "required": false,
+            "schema": {
+              "allOf": [
+                {
+                  "format": "pubkey",
+                  "type": "string"
+                }
+              ],
+              "nullable": true
+            }
+          },
+          {
+            "description": "Resolution of the data. Possible values: 1h, 1d, 1w, 1m, 1y, or a string parseable to seconds",
+            "in": "query",
+            "name": "resolution",
+            "required": false,
+            "schema": {
+              "allOf": [
+                {
+                  "format": "resolution",
+                  "type": "string"
+                }
+              ],
+              "nullable": true
+            }
+          },
+          {
+            "description": "Start time of the data to return (unix timestamp)",
+            "in": "query",
+            "name": "timeStart",
+            "required": false,
+            "schema": {
+              "format": "int64",
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "End time of the data to return (unix timestamp)",
+            "in": "query",
+            "name": "timeEnd",
+            "required": false,
+            "schema": {
+              "format": "int64",
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Page selection, 0-indexed.",
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "format": "int32",
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Limit of the number of trades to return per page. Default/max is 1000.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "format": "int32",
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Sort ascending by 'price' or 'blockTime'. Only one of sort_by_asc or sort_by_desc can be used",
+            "in": "query",
+            "name": "sortByAsc",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          },
+          {
+            "description": "Sort descending by 'price' or 'blockTime'. Only one of sort_by_asc or sort_by_desc can be used",
+            "in": "query",
+            "name": "sortByDesc",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          },
+          {
+            "description": "The public key of the entity that pays for the trade, often used for retrieving trades associated with a specific trading account.",
+            "in": "query",
+            "name": "feePayerAddress",
+            "required": false,
+            "schema": {
+              "allOf": [
+                {
+                  "format": "pubkey",
+                  "type": "string"
+                }
+              ],
+              "nullable": true
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TradeDataProgramVecReturn"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "402": {
+            "description": "Payment Required"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Internal server error"
+          }
+        },
+        "summary": "Trade History",
+        "tags": [
+          "Trades & Transfers"
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.024000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "x-extensions": {
+          "bazaar": {
+            "schema": {
+              "properties": {
+                "input": {
+                  "type": "object",
+                  "properties": {
+                    "programAddress": {
+                      "allOf": [
+                        {
+                          "format": "pubkey",
+                          "type": "string"
+                        }
+                      ],
+                      "nullable": true,
+                      "description": "The program on which the trade occurred"
+                    },
+                    "baseMintAddress": {
+                      "allOf": [
+                        {
+                          "format": "pubkey",
+                          "type": "string"
+                        }
+                      ],
+                      "nullable": true,
+                      "description": "The public key of the base token"
+                    },
+                    "quoteMintAddress": {
+                      "allOf": [
+                        {
+                          "format": "pubkey",
+                          "type": "string"
+                        }
+                      ],
+                      "nullable": true,
+                      "description": "The public key of the quote token"
+                    },
+                    "mintAddress": {
+                      "allOf": [
+                        {
+                          "format": "pubkey",
+                          "type": "string"
+                        }
+                      ],
+                      "nullable": true,
+                      "description": "The public key of either the base or quote token"
+                    },
+                    "marketAddress": {
+                      "allOf": [
+                        {
+                          "format": "pubkey",
+                          "type": "string"
+                        }
+                      ],
+                      "nullable": true,
+                      "description": "Market id to filter with. If provided, the baseMintAddress and quoteMintAddress fields are ignored"
+                    },
+                    "authorityAddress": {
+                      "allOf": [
+                        {
+                          "format": "pubkey",
+                          "type": "string"
+                        }
+                      ],
+                      "nullable": true,
+                      "description": "Authority public key to filter with"
+                    },
+                    "resolution": {
+                      "allOf": [
+                        {
+                          "format": "resolution",
+                          "type": "string"
+                        }
+                      ],
+                      "nullable": true,
+                      "description": "Resolution of the data. Possible values: 1h, 1d, 1w, 1m, 1y, or a string parseable to seconds"
+                    },
+                    "timeStart": {
+                      "format": "int64",
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer",
+                      "description": "Start time of the data to return (unix timestamp)"
+                    },
+                    "timeEnd": {
+                      "format": "int64",
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer",
+                      "description": "End time of the data to return (unix timestamp)"
+                    },
+                    "page": {
+                      "format": "int32",
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer",
+                      "description": "Page selection, 0-indexed."
+                    },
+                    "limit": {
+                      "format": "int32",
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer",
+                      "description": "Limit of the number of trades to return per page. Default/max is 1000."
+                    },
+                    "sortByAsc": {
+                      "nullable": true,
+                      "type": "string",
+                      "description": "Sort ascending by 'price' or 'blockTime'. Only one of sort_by_asc or sort_by_desc can be used"
+                    },
+                    "sortByDesc": {
+                      "nullable": true,
+                      "type": "string",
+                      "description": "Sort descending by 'price' or 'blockTime'. Only one of sort_by_asc or sort_by_desc can be used"
+                    },
+                    "feePayerAddress": {
+                      "allOf": [
+                        {
+                          "format": "pubkey",
+                          "type": "string"
+                        }
+                      ],
+                      "nullable": true,
+                      "description": "The public key of the entity that pays for the trade, often used for retrieving trades associated with a specific trading account."
+                    }
+                  }
+                },
+                "output": {
+                  "$ref": "#/components/schemas/TradeDataProgramVecReturn"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v4/trading/swap": {
+      "post": {
+        "description": "Builds an unsigned swap transaction with slippage protection and fee deduction. Direct protocol integrations with Raydium, Meteora, Pumpfun, and others, with aggregator fallbacks for maximum route coverage.\n\nThis route is currently in beta and is subject to change.",
+        "operationId": "do_swap_proxy",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SwapProxyParams"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Swap"
+                }
+              }
+            },
+            "description": "Swap provided"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "402": {
+            "description": "Payment Required"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "No data matches provided query"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Internal server error"
+          }
+        },
+        "summary": "Build Swap",
+        "tags": [
+          "Trading"
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.003000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "x-extensions": {
+          "bazaar": {
+            "schema": {
+              "properties": {
+                "input": {
+                  "type": "object",
+                  "properties": {
+                    "body": {
+                      "$ref": "#/components/schemas/SwapProxyParams"
+                    }
+                  },
+                  "required": [
+                    "body"
+                  ]
+                },
+                "output": {
+                  "$ref": "#/components/schemas/Swap"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v4/trading/swap-quote": {
+      "get": {
+        "description": "Returns the expected output amount, swap rate, and slippage threshold for a given token pair and amount. Quotes are sourced through internal pool scanning using vetted liquidity criteria combined with external aggregators to maximize route coverage—prioritizing direct pools and vetted markets first.\n\nThis route is currently in beta and is subject to change.",
+        "operationId": "get_swap_quote_proxy",
+        "parameters": [
+          {
+            "description": "Amount of input token to swap (in UI units, e.g., 0.1 for 0.1 SOL)",
+            "in": "query",
+            "name": "amount",
+            "required": true,
+            "schema": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          {
+            "description": "Mint address of the input token",
+            "in": "query",
+            "name": "inputMintAddress",
+            "required": true,
+            "schema": {
+              "format": "pubkey",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Mint address of the output token",
+            "in": "query",
+            "name": "outputMintAddress",
+            "required": true,
+            "schema": {
+              "format": "pubkey",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Wallet address (used for personalized routing)",
+            "in": "query",
+            "name": "accountAddress",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          },
+          {
+            "description": "Slippage tolerance in percentage (default: 0.5)",
+            "in": "query",
+            "name": "slippage",
+            "required": false,
+            "schema": {
+              "format": "double",
+              "nullable": true,
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SwapQuote"
+                }
+              }
+            },
+            "description": "Swap quote provided"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "402": {
+            "description": "Payment Required"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "No data matches provided query"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Internal server error"
+          }
+        },
+        "summary": "Swap Quote",
+        "tags": [
+          "Trading"
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.003000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "x-extensions": {
+          "bazaar": {
+            "schema": {
+              "properties": {
+                "input": {
+                  "type": "object",
+                  "properties": {
+                    "amount": {
+                      "format": "double",
+                      "type": "number",
+                      "description": "Amount of input token to swap (in UI units, e.g., 0.1 for 0.1 SOL)"
+                    },
+                    "inputMintAddress": {
+                      "format": "pubkey",
+                      "type": "string",
+                      "description": "Mint address of the input token"
+                    },
+                    "outputMintAddress": {
+                      "format": "pubkey",
+                      "type": "string",
+                      "description": "Mint address of the output token"
+                    },
+                    "accountAddress": {
+                      "nullable": true,
+                      "type": "string",
+                      "description": "Wallet address (used for personalized routing)"
+                    },
+                    "slippage": {
+                      "format": "double",
+                      "nullable": true,
+                      "type": "number",
+                      "description": "Slippage tolerance in percentage (default: 0.5)"
+                    }
+                  },
+                  "required": [
+                    "amount",
+                    "inputMintAddress",
+                    "outputMintAddress"
+                  ]
+                },
+                "output": {
+                  "$ref": "#/components/schemas/SwapQuote"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v4/transfers": {
+      "get": {
+        "description": "**Replaces**: `GET /token/transfers`\n\nReturns on-chain transfer history with filtering by token, sender, receiver, time, and amount.",
+        "operationId": "get_token_transfers_v4",
+        "parameters": [
+          {
+            "description": "The public key of the token of interest",
+            "in": "query",
+            "name": "mintAddress",
+            "required": false,
+            "schema": {
+              "allOf": [
+                {
+                  "format": "pubkey",
+                  "type": "string"
+                }
+              ],
+              "nullable": true
+            }
+          },
+          {
+            "description": "Signature of the transaction",
+            "in": "query",
+            "name": "signature",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          },
+          {
+            "description": "The public key of the Calling program",
+            "in": "query",
+            "name": "callingProgramAddress",
+            "required": false,
+            "schema": {
+              "allOf": [
+                {
+                  "format": "pubkey",
+                  "type": "string"
+                }
+              ],
+              "nullable": true
+            }
+          },
+          {
+            "description": "Sender’s token account address",
+            "in": "query",
+            "name": "senderAccountAddress",
+            "required": false,
+            "schema": {
+              "allOf": [
+                {
+                  "format": "pubkey",
+                  "type": "string"
+                }
+              ],
+              "nullable": true
+            }
+          },
+          {
+            "description": "Sender’s public key",
+            "in": "query",
+            "name": "senderAddress",
+            "required": false,
+            "schema": {
+              "allOf": [
+                {
+                  "format": "pubkey",
+                  "type": "string"
+                }
+              ],
+              "nullable": true
+            }
+          },
+          {
+            "description": "Receiver’s token account address",
+            "in": "query",
+            "name": "receiverAccountAddress",
+            "required": false,
+            "schema": {
+              "allOf": [
+                {
+                  "format": "pubkey",
+                  "type": "string"
+                }
+              ],
+              "nullable": true
+            }
+          },
+          {
+            "description": "Receiver’s public key",
+            "in": "query",
+            "name": "receiverAddress",
+            "required": false,
+            "schema": {
+              "allOf": [
+                {
+                  "format": "pubkey",
+                  "type": "string"
+                }
+              ],
+              "nullable": true
+            }
+          },
+          {
+            "description": "Fee payer's public key",
+            "in": "query",
+            "name": "feePayerAddress",
+            "required": false,
+            "schema": {
+              "allOf": [
+                {
+                  "format": "pubkey",
+                  "type": "string"
+                }
+              ],
+              "nullable": true
+            }
+          },
+          {
+            "description": "Lower bound of the amount to filter with",
+            "in": "query",
+            "name": "minAmount",
+            "required": false,
+            "schema": {
+              "format": "int64",
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Upper bound of the amount to filter with",
+            "in": "query",
+            "name": "maxAmount",
+            "required": false,
+            "schema": {
+              "format": "int64",
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Start time of the data to return (unix timestamp)",
+            "in": "query",
+            "name": "timeStart",
+            "required": false,
+            "schema": {
+              "format": "int64",
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "End time of the data to return (unix timestamp)",
+            "in": "query",
+            "name": "timeEnd",
+            "required": false,
+            "schema": {
+              "format": "int64",
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Page selection, 0-indexed.",
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "format": "int32",
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Limit of the number of transfers to return per page. Default/max is 1000.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "format": "int32",
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Sort ascending by 'amount', 'slot', or 'blockTime'. Only one of sort_by_asc or sort_by_desc can be used",
+            "in": "query",
+            "name": "sortByAsc",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          },
+          {
+            "description": "Sort descending by 'amount', 'slot', or 'blockTime'. Only one of sort_by_asc or sort_by_desc can be used",
+            "in": "query",
+            "name": "sortByDesc",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TokenTransfersReturn"
+                }
+              }
+            },
+            "description": "Tokens info collected"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "402": {
+            "description": "Payment Required"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Internal server error"
+          }
+        },
+        "summary": "Transfer History",
+        "tags": [
+          "Trades & Transfers"
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.024000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "x-extensions": {
+          "bazaar": {
+            "schema": {
+              "properties": {
+                "input": {
+                  "type": "object",
+                  "properties": {
+                    "mintAddress": {
+                      "allOf": [
+                        {
+                          "format": "pubkey",
+                          "type": "string"
+                        }
+                      ],
+                      "nullable": true,
+                      "description": "The public key of the token of interest"
+                    },
+                    "signature": {
+                      "nullable": true,
+                      "type": "string",
+                      "description": "Signature of the transaction"
+                    },
+                    "callingProgramAddress": {
+                      "allOf": [
+                        {
+                          "format": "pubkey",
+                          "type": "string"
+                        }
+                      ],
+                      "nullable": true,
+                      "description": "The public key of the Calling program"
+                    },
+                    "senderAccountAddress": {
+                      "allOf": [
+                        {
+                          "format": "pubkey",
+                          "type": "string"
+                        }
+                      ],
+                      "nullable": true,
+                      "description": "Sender’s token account address"
+                    },
+                    "senderAddress": {
+                      "allOf": [
+                        {
+                          "format": "pubkey",
+                          "type": "string"
+                        }
+                      ],
+                      "nullable": true,
+                      "description": "Sender’s public key"
+                    },
+                    "receiverAccountAddress": {
+                      "allOf": [
+                        {
+                          "format": "pubkey",
+                          "type": "string"
+                        }
+                      ],
+                      "nullable": true,
+                      "description": "Receiver’s token account address"
+                    },
+                    "receiverAddress": {
+                      "allOf": [
+                        {
+                          "format": "pubkey",
+                          "type": "string"
+                        }
+                      ],
+                      "nullable": true,
+                      "description": "Receiver’s public key"
+                    },
+                    "feePayerAddress": {
+                      "allOf": [
+                        {
+                          "format": "pubkey",
+                          "type": "string"
+                        }
+                      ],
+                      "nullable": true,
+                      "description": "Fee payer's public key"
+                    },
+                    "minAmount": {
+                      "format": "int64",
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer",
+                      "description": "Lower bound of the amount to filter with"
+                    },
+                    "maxAmount": {
+                      "format": "int64",
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer",
+                      "description": "Upper bound of the amount to filter with"
+                    },
+                    "timeStart": {
+                      "format": "int64",
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer",
+                      "description": "Start time of the data to return (unix timestamp)"
+                    },
+                    "timeEnd": {
+                      "format": "int64",
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer",
+                      "description": "End time of the data to return (unix timestamp)"
+                    },
+                    "page": {
+                      "format": "int32",
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer",
+                      "description": "Page selection, 0-indexed."
+                    },
+                    "limit": {
+                      "format": "int32",
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer",
+                      "description": "Limit of the number of transfers to return per page. Default/max is 1000."
+                    },
+                    "sortByAsc": {
+                      "nullable": true,
+                      "type": "string",
+                      "description": "Sort ascending by 'amount', 'slot', or 'blockTime'. Only one of sort_by_asc or sort_by_desc can be used"
+                    },
+                    "sortByDesc": {
+                      "nullable": true,
+                      "type": "string",
+                      "description": "Sort descending by 'amount', 'slot', or 'blockTime'. Only one of sort_by_asc or sort_by_desc can be used"
+                    }
+                  }
+                },
+                "output": {
+                  "$ref": "#/components/schemas/TokenTransfersReturn"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v4/wallets/batch/dust-accounts": {
+      "post": {
+        "description": "Same as the single-wallet dust accounts endpoint, but accepts up to 10 wallet addresses in a single request.\nReturns a combined list of dust token accounts across all provided wallets.\nA maximum of 1000 token accounts can be returned across all wallets.\n\nUse this to scan multiple wallets at once — for example, a portfolio of wallets — for reclaimable rent.",
+        "operationId": "get_dust_accounts_many_v4",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DustAccountsManyParams"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DustAccountsResponse"
+                }
+              }
+            },
+            "description": "Combined list of dust token accounts across all provided wallets."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Invalid parameters — check that 1-10 wallet addresses are provided, limit does not exceed 1000, and only one of `sortByAsc`/`sortByDesc` is set."
+          },
+          "402": {
+            "description": "Payment Required"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Unexpected server error. The response body includes an `id` field — provide this when contacting support."
+          }
+        },
+        "summary": "Dust Accounts (Batch)",
+        "tags": [
+          "Wallets"
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.003000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "x-extensions": {
+          "bazaar": {
+            "schema": {
+              "properties": {
+                "input": {
+                  "type": "object",
+                  "properties": {
+                    "body": {
+                      "$ref": "#/components/schemas/DustAccountsManyParams"
+                    }
+                  },
+                  "required": [
+                    "body"
+                  ]
+                },
+                "output": {
+                  "$ref": "#/components/schemas/DustAccountsResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v4/wallets/batch/empty-accounts": {
+      "post": {
+        "description": "Same as the single-wallet empty accounts endpoint, but accepts up to 10 wallet addresses in a single request.\nReturns a combined list of zero-balance token accounts across all provided wallets.\nA maximum of 1000 token accounts can be returned across all wallets.\n\nUse this to scan multiple wallets at once — for example, a portfolio of wallets — for reclaimable rent.",
+        "operationId": "get_empty_accounts_many_v4",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EmptyAccountsManyParams"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EmptyAccountsResponse"
+                }
+              }
+            },
+            "description": "Combined list of empty token accounts across all provided wallets, plus totals for empty account count and reclaimable rent."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Invalid parameters — check that 1-10 wallet addresses are provided, limit does not exceed 1000, and only one of `sortByAsc`/`sortByDesc` is set."
+          },
+          "402": {
+            "description": "Payment Required"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Unexpected server error. The response body includes an `id` field — provide this when contacting support."
+          }
+        },
+        "summary": "Empty Accounts (Batch)",
+        "tags": [
+          "Wallets"
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.003000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "x-extensions": {
+          "bazaar": {
+            "schema": {
+              "properties": {
+                "input": {
+                  "type": "object",
+                  "properties": {
+                    "body": {
+                      "$ref": "#/components/schemas/EmptyAccountsManyParams"
+                    }
+                  },
+                  "required": [
+                    "body"
+                  ]
+                },
+                "output": {
+                  "$ref": "#/components/schemas/EmptyAccountsResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v4/wallets/batch/nft-balances": {
+      "post": {
+        "description": "Solana API endpoint for fetching multi-wallet NFT balances with collection metadata, floor prices, and aggregated portfolio values across multiple wallets.",
+        "operationId": "post_wallet_nfts_many_v4",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AccountParamsNftsMany"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WalletBalanceNftResultsMany"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "402": {
+            "description": "Payment Required"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Internal server error"
+          }
+        },
+        "summary": "NFT Balances (Batch)",
+        "tags": [
+          "Wallets"
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.030000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "x-extensions": {
+          "bazaar": {
+            "schema": {
+              "properties": {
+                "input": {
+                  "type": "object",
+                  "properties": {
+                    "body": {
+                      "$ref": "#/components/schemas/AccountParamsNftsMany"
+                    }
+                  },
+                  "required": [
+                    "body"
+                  ]
+                },
+                "output": {
+                  "$ref": "#/components/schemas/WalletBalanceNftResultsMany"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v4/wallets/batch/token-accounts-balance-ts": {
+      "post": {
+        "description": "Solana API endpoint for fetching multi-wallet token account history with raw balance snapshots for custom analytics and unaggregated time-series data.",
+        "operationId": "post_wallet_tokens_ts_raw_many_v4",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AccountTimeSeriesRawParamsMany"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WalletTimeSeriesRawManyReturn"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "402": {
+            "description": "Payment Required"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Internal server error"
+          }
+        },
+        "summary": "Token Accounts (Batch)",
+        "tags": [
+          "Wallets"
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.003000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "x-extensions": {
+          "bazaar": {
+            "schema": {
+              "properties": {
+                "input": {
+                  "type": "object",
+                  "properties": {
+                    "body": {
+                      "$ref": "#/components/schemas/AccountTimeSeriesRawParamsMany"
+                    }
+                  },
+                  "required": [
+                    "body"
+                  ]
+                },
+                "output": {
+                  "$ref": "#/components/schemas/WalletTimeSeriesRawManyReturn"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v4/wallets/batch/token-balances": {
+      "post": {
+        "description": "Solana API endpoint for fetching batch wallet token balances with SPL and Token-2022 assets, USD values, staking data, and aggregated portfolio metrics.",
+        "operationId": "post_wallet_tokens_many_v4",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AccountParamsTokensMany"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WalletBalanceTokenResultsMany"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "402": {
+            "description": "Payment Required"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Internal server error"
+          }
+        },
+        "summary": "Token Balances (Batch)",
+        "tags": [
+          "Wallets"
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.030000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "x-extensions": {
+          "bazaar": {
+            "schema": {
+              "properties": {
+                "input": {
+                  "type": "object",
+                  "properties": {
+                    "body": {
+                      "$ref": "#/components/schemas/AccountParamsTokensMany"
+                    }
+                  },
+                  "required": [
+                    "body"
+                  ]
+                },
+                "output": {
+                  "$ref": "#/components/schemas/WalletBalanceTokenResultsMany"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v4/wallets/batch/token-balances-ts": {
+      "post": {
+        "description": "Solana API endpoint for fetching historical token balance history with daily, weekly, or monthly portfolio snapshots and aggregated USD values.",
+        "operationId": "post_wallet_tokens_ts_many_v4",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AccountTimeSeriesParamsMany"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WalletBalanceTokenResultsTimeSeries"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "402": {
+            "description": "Payment Required"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Internal server error"
+          }
+        },
+        "summary": "Token Balance History (Batch)",
+        "tags": [
+          "Wallets"
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.030000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "x-extensions": {
+          "bazaar": {
+            "schema": {
+              "properties": {
+                "input": {
+                  "type": "object",
+                  "properties": {
+                    "body": {
+                      "$ref": "#/components/schemas/AccountTimeSeriesParamsMany"
+                    }
+                  },
+                  "required": [
+                    "body"
+                  ]
+                },
+                "output": {
+                  "$ref": "#/components/schemas/WalletBalanceTokenResultsTimeSeries"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v4/wallets/labeled-accounts": {
+      "get": {
+        "description": "**Replaces**: `GET /account/known-accounts`\n\nReturns labeled Solana accounts including CEX wallets, KOL wallets, treasuries, liquidity pools, and market makers.",
+        "operationId": "get_known_accounts_v4",
+        "parameters": [
+          {
+            "description": "The public key (pubKey) associated with the Solana account",
+            "in": "query",
+            "name": "accountAddress",
+            "required": false,
+            "schema": {
+              "allOf": [
+                {
+                  "format": "pubkey",
+                  "type": "string"
+                }
+              ],
+              "nullable": true
+            }
+          },
+          {
+            "description": "Friendly name of account",
+            "in": "query",
+            "name": "name",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          },
+          {
+            "description": "Category of account. Only accounts matching all labels will be returned (eg. labels=DEFI,NFT)",
+            "in": "query",
+            "name": "labels",
+            "required": false,
+            "schema": {
+              "items": {
+                "type": "string"
+              },
+              "nullable": true,
+              "type": "array"
+            }
+          },
+          {
+            "description": "Name of the business or entity that controls this account",
+            "in": "query",
+            "name": "entityName",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          },
+          {
+            "description": "Entity id to filter with (including as empty or null, such as \"entity_id=\" will filter programs without an entity_id)",
+            "in": "query",
+            "name": "entityId",
+            "required": false,
+            "schema": {
+              "format": "int32",
+              "nullable": true,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Sort list ascending. Only one of sort_by_asc or sort_by_desc can be used",
+            "in": "query",
+            "name": "sortByAsc",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          },
+          {
+            "description": "Sort by descending. Only one of sort_by_asc or sort_by_desc can be used",
+            "in": "query",
+            "name": "sortByDesc",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/KnownAccountVecReturn"
+                }
+              }
+            },
+            "description": "Accounts collected"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "402": {
+            "description": "Payment Required"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "No data could be found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Internal server error"
+          }
+        },
+        "summary": "Labeled Accounts",
+        "tags": [
+          "Wallets"
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.003000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "x-extensions": {
+          "bazaar": {
+            "schema": {
+              "properties": {
+                "input": {
+                  "type": "object",
+                  "properties": {
+                    "accountAddress": {
+                      "allOf": [
+                        {
+                          "format": "pubkey",
+                          "type": "string"
+                        }
+                      ],
+                      "nullable": true,
+                      "description": "The public key (pubKey) associated with the Solana account"
+                    },
+                    "name": {
+                      "nullable": true,
+                      "type": "string",
+                      "description": "Friendly name of account"
+                    },
+                    "labels": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "nullable": true,
+                      "type": "array",
+                      "description": "Category of account. Only accounts matching all labels will be returned (eg. labels=DEFI,NFT)"
+                    },
+                    "entityName": {
+                      "nullable": true,
+                      "type": "string",
+                      "description": "Name of the business or entity that controls this account"
+                    },
+                    "entityId": {
+                      "format": "int32",
+                      "nullable": true,
+                      "type": "integer",
+                      "description": "Entity id to filter with (including as empty or null, such as \"entity_id=\" will filter programs without an entity_id)"
+                    },
+                    "sortByAsc": {
+                      "nullable": true,
+                      "type": "string",
+                      "description": "Sort list ascending. Only one of sort_by_asc or sort_by_desc can be used"
+                    },
+                    "sortByDesc": {
+                      "nullable": true,
+                      "type": "string",
+                      "description": "Sort by descending. Only one of sort_by_asc or sort_by_desc can be used"
+                    }
+                  }
+                },
+                "output": {
+                  "$ref": "#/components/schemas/KnownAccountVecReturn"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v4/wallets/top-traders": {
+      "get": {
+        "description": "Solana API endpoint for fetching top traders on Solana ranked by PnL, win rate and volume. Power copy trading leaderboards and smart money discovery tools.",
+        "operationId": "get_top_traders_v4",
+        "parameters": [
+          {
+            "description": "Resolution of the data. Possible values: 1d, 7d, 30d. Default is \"1d\".",
+            "in": "query",
+            "name": "resolution",
+            "required": false,
+            "schema": {
+              "allOf": [
+                {
+                  "description": "Represents the supported time-window resolutions for account/PnL queries.",
+                  "enum": [
+                    "1d",
+                    "7d",
+                    "30d"
+                  ],
+                  "type": "string"
+                }
+              ],
+              "nullable": true
+            }
+          },
+          {
+            "description": "Optional ILIKE filter applied to both trader names and address fields for any match.",
+            "in": "query",
+            "name": "ilikeFilter",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          },
+          {
+            "description": "Represents the label type for trader categorization. Default is 'all'.",
+            "in": "query",
+            "name": "label",
+            "required": false,
+            "schema": {
+              "allOf": [
+                {
+                  "description": "Represents the label type for trader categorization.",
+                  "enum": [
+                    "All",
+                    "Kol"
+                  ],
+                  "type": "string"
+                }
+              ],
+              "nullable": true
+            }
+          },
+          {
+            "description": "The token mint address filter for tokens. Provides the token address to filter the requested data by.",
+            "in": "query",
+            "name": "mintAddress",
+            "required": false,
+            "schema": {
+              "allOf": [
+                {
+                  "format": "pubkey",
+                  "type": "string"
+                }
+              ],
+              "nullable": true
+            }
+          },
+          {
+            "description": "Sort ascending by 'realizedPnlUsd', 'unrealizedPnlUsd', 'winRate', 'tradesVolumeUsd', 'tradesCount', 'accountAddress'. Only one of sort_by_asc or sort_by_desc can be used.",
+            "in": "query",
+            "name": "sortByAsc",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          },
+          {
+            "description": "Sort descending by 'realizedPnlUsd', 'unrealizedPnlUsd', 'winRate', 'tradesVolumeUsd', 'tradesCount', 'accountAddress'. Only one of sort_by_asc or sort_by_desc can be used.",
+            "in": "query",
+            "name": "sortByDesc",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          },
+          {
+            "description": "The limit of entries to return. If not passed, a maximum of 1000 entries are returned.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "format": "int32",
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "The requested page.",
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "format": "int32",
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "A collection of items",
+                  "properties": {
+                    "data": {
+                      "items": {
+                        "description": "The top trader wallet identity and performance metrics.",
+                        "properties": {
+                          "accountAddress": {
+                            "description": "The public key (pubKey) associated with the Solana account.",
+                            "type": "string"
+                          },
+                          "accountLabels": {
+                            "description": "Custom account labels assigned internally by the Vybe system.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "accountLogoUrl": {
+                            "description": "The URL to the account's logo image (optional).",
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "accountName": {
+                            "description": "The display name of the account (optional).",
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "accountTwitterUrl": {
+                            "description": "The URL to the account's Twitter profile (optional).",
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "metrics": {
+                            "$ref": "#/components/schemas/AccountTopTraderMetrics"
+                          }
+                        },
+                        "required": [
+                          "accountAddress",
+                          "accountLabels",
+                          "metrics"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Top traders collection"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "402": {
+            "description": "Payment Required"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Internal server error"
+          }
+        },
+        "summary": "Top Traders",
+        "tags": [
+          "Wallets"
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.015000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "x-extensions": {
+          "bazaar": {
+            "schema": {
+              "properties": {
+                "input": {
+                  "type": "object",
+                  "properties": {
+                    "resolution": {
+                      "allOf": [
+                        {
+                          "description": "Represents the supported time-window resolutions for account/PnL queries.",
+                          "enum": [
+                            "1d",
+                            "7d",
+                            "30d"
+                          ],
+                          "type": "string"
+                        }
+                      ],
+                      "nullable": true,
+                      "description": "Resolution of the data. Possible values: 1d, 7d, 30d. Default is \"1d\"."
+                    },
+                    "ilikeFilter": {
+                      "nullable": true,
+                      "type": "string",
+                      "description": "Optional ILIKE filter applied to both trader names and address fields for any match."
+                    },
+                    "label": {
+                      "allOf": [
+                        {
+                          "description": "Represents the label type for trader categorization.",
+                          "enum": [
+                            "All",
+                            "Kol"
+                          ],
+                          "type": "string"
+                        }
+                      ],
+                      "nullable": true,
+                      "description": "Represents the label type for trader categorization. Default is 'all'."
+                    },
+                    "mintAddress": {
+                      "allOf": [
+                        {
+                          "format": "pubkey",
+                          "type": "string"
+                        }
+                      ],
+                      "nullable": true,
+                      "description": "The token mint address filter for tokens. Provides the token address to filter the requested data by."
+                    },
+                    "sortByAsc": {
+                      "nullable": true,
+                      "type": "string",
+                      "description": "Sort ascending by 'realizedPnlUsd', 'unrealizedPnlUsd', 'winRate', 'tradesVolumeUsd', 'tradesCount', 'accountAddress'. Only one of sort_by_asc or sort_by_desc can be used."
+                    },
+                    "sortByDesc": {
+                      "nullable": true,
+                      "type": "string",
+                      "description": "Sort descending by 'realizedPnlUsd', 'unrealizedPnlUsd', 'winRate', 'tradesVolumeUsd', 'tradesCount', 'accountAddress'. Only one of sort_by_asc or sort_by_desc can be used."
+                    },
+                    "limit": {
+                      "format": "int32",
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer",
+                      "description": "The limit of entries to return. If not passed, a maximum of 1000 entries are returned."
+                    },
+                    "page": {
+                      "format": "int32",
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer",
+                      "description": "The requested page."
+                    }
+                  }
+                },
+                "output": {
+                  "description": "A collection of items",
+                  "properties": {
+                    "data": {
+                      "items": {
+                        "description": "The top trader wallet identity and performance metrics.",
+                        "properties": {
+                          "accountAddress": {
+                            "description": "The public key (pubKey) associated with the Solana account.",
+                            "type": "string"
+                          },
+                          "accountLabels": {
+                            "description": "Custom account labels assigned internally by the Vybe system.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "accountLogoUrl": {
+                            "description": "The URL to the account's logo image (optional).",
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "accountName": {
+                            "description": "The display name of the account (optional).",
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "accountTwitterUrl": {
+                            "description": "The URL to the account's Twitter profile (optional).",
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "metrics": {
+                            "$ref": "#/components/schemas/AccountTopTraderMetrics"
+                          }
+                        },
+                        "required": [
+                          "accountAddress",
+                          "accountLabels",
+                          "metrics"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ],
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v4/wallets/util/close-token-accounts": {
+      "post": {
+        "description": "Closes zero-balance token accounts to reclaim rent. Supports manual or auto-discovery.\n\nThis route is currently in beta and is subject to change.",
+        "operationId": "close_token_accounts",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CloseTokenAccountsParam"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CloseTokenAccountsReturn"
+                }
+              }
+            },
+            "description": "Close accounts result"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "402": {
+            "description": "Payment Required"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "No data matches provided query"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Token account has non-zero balance "
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Internal server error"
+          }
+        },
+        "summary": "Close Token Accounts",
+        "tags": [
+          "Utilities"
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.003000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "x-extensions": {
+          "bazaar": {
+            "schema": {
+              "properties": {
+                "input": {
+                  "type": "object",
+                  "properties": {
+                    "body": {
+                      "$ref": "#/components/schemas/CloseTokenAccountsParam"
+                    }
+                  },
+                  "required": [
+                    "body"
+                  ]
+                },
+                "output": {
+                  "$ref": "#/components/schemas/CloseTokenAccountsReturn"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v4/wallets/util/withdraw-mev": {
+      "post": {
+        "description": "Withdraws MEV rewards from Jito-delegated stake accounts. Supports manual or auto-discovery.\n\nThis route is currently in beta and is subject to change.",
+        "operationId": "withdraw_mev",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WithdrawMevParam"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WithdrawMevReturn"
+                }
+              }
+            },
+            "description": "Withdraw MEV result"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "402": {
+            "description": "Payment Required"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "No data matches provided query"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Staking account has non-zero balance "
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Internal server error"
+          }
+        },
+        "summary": "Withdraw MEV",
+        "tags": [
+          "Utilities"
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.003000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "x-extensions": {
+          "bazaar": {
+            "schema": {
+              "properties": {
+                "input": {
+                  "type": "object",
+                  "properties": {
+                    "body": {
+                      "$ref": "#/components/schemas/WithdrawMevParam"
+                    }
+                  },
+                  "required": [
+                    "body"
+                  ]
+                },
+                "output": {
+                  "$ref": "#/components/schemas/WithdrawMevReturn"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v4/wallets/{ownerAddress}/counterparties": {
+      "get": {
+        "description": "Solana API endpoint for fetching wallet counterparties. Analyze transfer relationships, volumes and interactions with wallets or programs over time.",
+        "operationId": "get_wallet_counterparties_v4",
+        "parameters": [
+          {
+            "description": "The Solana wallet address to query.",
+            "in": "path",
+            "name": "ownerAddress",
+            "required": true,
+            "schema": {
+              "format": "pubkey",
+              "type": "string"
+            }
+          },
+          {
+            "description": "How to group counterparties. 'wallet' groups by the other wallet address involved in transfers. 'program' groups by the on-chain program that facilitated the transfer (e.g. a DEX). Defaults to 'wallet'.",
+            "in": "query",
+            "name": "group",
+            "required": false,
+            "schema": {
+              "allOf": [
+                {
+                  "enum": [
+                    "wallet",
+                    "program"
+                  ],
+                  "type": "string"
+                }
+              ],
+              "nullable": true
+            }
+          },
+          {
+            "description": "Maximum number of counterparties to return. Defaults to 1000.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "format": "int32",
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Page number to return (zero-indexed). Defaults to 0.",
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "format": "int32",
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Start of the time range (unix timestamp, seconds). Defaults to 24 hours ago.",
+            "in": "query",
+            "name": "timeStart",
+            "required": false,
+            "schema": {
+              "format": "int64",
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "End of the time range (unix timestamp, seconds). Defaults to the current time.",
+            "in": "query",
+            "name": "timeEnd",
+            "required": false,
+            "schema": {
+              "format": "int64",
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Sort ascending by 'totalTransfers', 'totalVolume', 'netVolume', 'sellTransfers', 'buyTransfers', 'sellVolume', or 'buyVolume'. If omitted, no sorting is applied. Only one of `sortByAsc` or `sortByDesc` can be used.",
+            "in": "query",
+            "name": "sortByAsc",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          },
+          {
+            "description": "Sort descending by 'totalTransfers', 'totalVolume', 'netVolume', 'sellTransfers', 'buyTransfers', 'sellVolume', or 'buyVolume'. If omitted, no sorting is applied. Only one of `sortByAsc` or `sortByDesc` can be used.",
+            "in": "query",
+            "name": "sortByDesc",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CounterpartyDataResponse"
+                }
+              }
+            },
+            "description": "List of counterparties with transfer counts, volumes, and top tokens for each."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Invalid parameters — check that `timeStart` < `timeEnd`, limit does not exceed 1000, and only one of `sortByAsc`/`sortByDesc` is set."
+          },
+          "402": {
+            "description": "Payment Required"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Unexpected server error. The response body includes an `id` field — provide this when contacting support."
+          }
+        },
+        "summary": "Wallet Counterparties",
+        "tags": [
+          "Wallets"
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.003000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "x-extensions": {
+          "bazaar": {
+            "schema": {
+              "properties": {
+                "input": {
+                  "type": "object",
+                  "properties": {
+                    "ownerAddress": {
+                      "format": "pubkey",
+                      "type": "string",
+                      "description": "The Solana wallet address to query."
+                    },
+                    "group": {
+                      "allOf": [
+                        {
+                          "enum": [
+                            "wallet",
+                            "program"
+                          ],
+                          "type": "string"
+                        }
+                      ],
+                      "nullable": true,
+                      "description": "How to group counterparties. 'wallet' groups by the other wallet address involved in transfers. 'program' groups by the on-chain program that facilitated the transfer (e.g. a DEX). Defaults to 'wallet'."
+                    },
+                    "limit": {
+                      "format": "int32",
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer",
+                      "description": "Maximum number of counterparties to return. Defaults to 1000."
+                    },
+                    "page": {
+                      "format": "int32",
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer",
+                      "description": "Page number to return (zero-indexed). Defaults to 0."
+                    },
+                    "timeStart": {
+                      "format": "int64",
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer",
+                      "description": "Start of the time range (unix timestamp, seconds). Defaults to 24 hours ago."
+                    },
+                    "timeEnd": {
+                      "format": "int64",
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer",
+                      "description": "End of the time range (unix timestamp, seconds). Defaults to the current time."
+                    },
+                    "sortByAsc": {
+                      "nullable": true,
+                      "type": "string",
+                      "description": "Sort ascending by 'totalTransfers', 'totalVolume', 'netVolume', 'sellTransfers', 'buyTransfers', 'sellVolume', or 'buyVolume'. If omitted, no sorting is applied. Only one of `sortByAsc` or `sortByDesc` can be used."
+                    },
+                    "sortByDesc": {
+                      "nullable": true,
+                      "type": "string",
+                      "description": "Sort descending by 'totalTransfers', 'totalVolume', 'netVolume', 'sellTransfers', 'buyTransfers', 'sellVolume', or 'buyVolume'. If omitted, no sorting is applied. Only one of `sortByAsc` or `sortByDesc` can be used."
+                    }
+                  },
+                  "required": [
+                    "ownerAddress"
+                  ]
+                },
+                "output": {
+                  "$ref": "#/components/schemas/CounterpartyDataResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v4/wallets/{ownerAddress}/defi-positions": {
+      "get": {
+        "description": "Returns LP positions, lending/borrowing, staking, and yield farming across DeFi protocols.\n\nThis route is currently in beta and is subject to change.",
+        "operationId": "get_defi_accounts_v4_proxy",
+        "parameters": [
+          {
+            "description": "The public key (pubKey) associated with the Solana account.",
+            "in": "path",
+            "name": "ownerAddress",
+            "required": true,
+            "schema": {
+              "format": "pubkey",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/ProxyUserDefiPlatformProxyReturn"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Defi positions"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "402": {
+            "description": "Payment Required"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "No data could be found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Internal server error"
+          }
+        },
+        "summary": "DeFi Positions",
+        "tags": [
+          "Wallets"
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.003000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "x-extensions": {
+          "bazaar": {
+            "schema": {
+              "properties": {
+                "input": {
+                  "type": "object",
+                  "properties": {
+                    "ownerAddress": {
+                      "format": "pubkey",
+                      "type": "string",
+                      "description": "The public key (pubKey) associated with the Solana account."
+                    }
+                  },
+                  "required": [
+                    "ownerAddress"
+                  ]
+                },
+                "output": {
+                  "items": {
+                    "$ref": "#/components/schemas/ProxyUserDefiPlatformProxyReturn"
+                  },
+                  "type": "array"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v4/wallets/{ownerAddress}/dust-accounts": {
+      "get": {
+        "description": "Solana API endpoint for fetching dust Token-2022 and SPL token accounts for a wallet. Returns reclaimable tokens to identify accounts for rent recovery.",
+        "operationId": "get_wallet_dust_accounts_v4",
+        "parameters": [
+          {
+            "description": "The Solana wallet address to query.",
+            "in": "path",
+            "name": "ownerAddress",
+            "required": true,
+            "schema": {
+              "format": "pubkey",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Maximum number of dust accounts to return. Defaults to 1000.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "format": "int32",
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Page number to return (zero-indexed). Defaults to 0.",
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "format": "int32",
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Sort ascending by 'tokenAccountAddress', 'mintAddress', 'name', 'symbol', 'balance', 'valueUsd', or 'rentUsd'. If omitted, no sorting is applied. Only one of `sortByAsc` or `sortByDesc` can be used.",
+            "in": "query",
+            "name": "sortByAsc",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          },
+          {
+            "description": "Sort descending by 'tokenAccountAddress', 'mintAddress', 'name', 'symbol', 'balance', 'valueUsd', or 'rentUsd'. If omitted, no sorting is applied. Only one of `sortByAsc` or `sortByDesc` can be used.",
+            "in": "query",
+            "name": "sortByDesc",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DustAccountsResponse"
+                }
+              }
+            },
+            "description": "List of dust token accounts with balances, values, rent amounts, and the reason each was flagged (LowValue or NoPrice)."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Invalid parameters — check that limit does not exceed 1000 and only one of `sortByAsc`/`sortByDesc` is set."
+          },
+          "402": {
+            "description": "Payment Required"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Unexpected server error. The response body includes an `id` field — provide this when contacting support."
+          }
+        },
+        "summary": "Dust Accounts",
+        "tags": [
+          "Wallets"
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.003000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "x-extensions": {
+          "bazaar": {
+            "schema": {
+              "properties": {
+                "input": {
+                  "type": "object",
+                  "properties": {
+                    "ownerAddress": {
+                      "format": "pubkey",
+                      "type": "string",
+                      "description": "The Solana wallet address to query."
+                    },
+                    "limit": {
+                      "format": "int32",
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer",
+                      "description": "Maximum number of dust accounts to return. Defaults to 1000."
+                    },
+                    "page": {
+                      "format": "int32",
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer",
+                      "description": "Page number to return (zero-indexed). Defaults to 0."
+                    },
+                    "sortByAsc": {
+                      "nullable": true,
+                      "type": "string",
+                      "description": "Sort ascending by 'tokenAccountAddress', 'mintAddress', 'name', 'symbol', 'balance', 'valueUsd', or 'rentUsd'. If omitted, no sorting is applied. Only one of `sortByAsc` or `sortByDesc` can be used."
+                    },
+                    "sortByDesc": {
+                      "nullable": true,
+                      "type": "string",
+                      "description": "Sort descending by 'tokenAccountAddress', 'mintAddress', 'name', 'symbol', 'balance', 'valueUsd', or 'rentUsd'. If omitted, no sorting is applied. Only one of `sortByAsc` or `sortByDesc` can be used."
+                    }
+                  },
+                  "required": [
+                    "ownerAddress"
+                  ]
+                },
+                "output": {
+                  "$ref": "#/components/schemas/DustAccountsResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v4/wallets/{ownerAddress}/empty-accounts": {
+      "get": {
+        "description": "Solana API endpoint for fetching empty Token-2022 and SPL token accounts for a wallet. Returns results to identify accounts eligible for rent cleanup.",
+        "operationId": "get_empty_accounts_v4",
+        "parameters": [
+          {
+            "description": "The Solana wallet address to query.",
+            "in": "path",
+            "name": "ownerAddress",
+            "required": true,
+            "schema": {
+              "format": "pubkey",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Maximum number of empty accounts to return. Defaults to 1000.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "format": "int32",
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Page number to return (zero-indexed). Defaults to 0.",
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "format": "int32",
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Sort ascending by 'tokenAccountAddress', 'mintAddress', 'name', 'symbol', 'decimals', or 'rentUsd'. If omitted, no sorting is applied. Only one of `sortByAsc` or `sortByDesc` can be used.",
+            "in": "query",
+            "name": "sortByAsc",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          },
+          {
+            "description": "Sort descending by 'tokenAccountAddress', 'mintAddress', 'name', 'symbol', 'decimals', or 'rentUsd'. If omitted, no sorting is applied. Only one of `sortByAsc` or `sortByDesc` can be used.",
+            "in": "query",
+            "name": "sortByDesc",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EmptyAccountsResponse"
+                }
+              }
+            },
+            "description": "List of empty token accounts with rent amounts, plus totals for empty account count and reclaimable rent."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Invalid parameters — check that limit does not exceed 1000 and only one of `sortByAsc`/`sortByDesc` is set."
+          },
+          "402": {
+            "description": "Payment Required"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Unexpected server error. The response body includes an `id` field — provide this when contacting support."
+          }
+        },
+        "summary": "Empty Accounts",
+        "tags": [
+          "Wallets"
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.003000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "x-extensions": {
+          "bazaar": {
+            "schema": {
+              "properties": {
+                "input": {
+                  "type": "object",
+                  "properties": {
+                    "ownerAddress": {
+                      "format": "pubkey",
+                      "type": "string",
+                      "description": "The Solana wallet address to query."
+                    },
+                    "limit": {
+                      "format": "int32",
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer",
+                      "description": "Maximum number of empty accounts to return. Defaults to 1000."
+                    },
+                    "page": {
+                      "format": "int32",
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer",
+                      "description": "Page number to return (zero-indexed). Defaults to 0."
+                    },
+                    "sortByAsc": {
+                      "nullable": true,
+                      "type": "string",
+                      "description": "Sort ascending by 'tokenAccountAddress', 'mintAddress', 'name', 'symbol', 'decimals', or 'rentUsd'. If omitted, no sorting is applied. Only one of `sortByAsc` or `sortByDesc` can be used."
+                    },
+                    "sortByDesc": {
+                      "nullable": true,
+                      "type": "string",
+                      "description": "Sort descending by 'tokenAccountAddress', 'mintAddress', 'name', 'symbol', 'decimals', or 'rentUsd'. If omitted, no sorting is applied. Only one of `sortByAsc` or `sortByDesc` can be used."
+                    }
+                  },
+                  "required": [
+                    "ownerAddress"
+                  ]
+                },
+                "output": {
+                  "$ref": "#/components/schemas/EmptyAccountsResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v4/wallets/{ownerAddress}/nft-balance": {
+      "get": {
+        "description": "**Replaces**: `GET /account/nft-balance/{ownerAddress}`\n\nReturns NFT holdings with collection metadata, floor prices, and estimated USD value.",
+        "operationId": "get_wallet_nfts_v4",
+        "parameters": [
+          {
+            "description": "The public key (pubKey) associated with the Solana account.",
+            "in": "path",
+            "name": "ownerAddress",
+            "required": true,
+            "schema": {
+              "format": "pubkey",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Whether or not we should include NFTs we do not track prices for.",
+            "in": "query",
+            "name": "includeNoPriceBalance",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "Sort ascending based on amount or value of positions. Only one of sort_by_asc or sort_by_desc can be used",
+            "in": "query",
+            "name": "sortByAsc",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          },
+          {
+            "description": "Sort descending based on amount or value of positions. Only one of sort_by_asc or sort_by_desc can be used",
+            "in": "query",
+            "name": "sortByDesc",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          },
+          {
+            "description": "The limit of entries to return. If not passed, first 1000 entries are returned (the maximum).",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "format": "int32",
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "The requested page.",
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "format": "int32",
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WalletBalanceNftResults"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "402": {
+            "description": "Payment Required"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Internal server error"
+          }
+        },
+        "summary": "NFT Balance",
+        "tags": [
+          "Wallets"
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.003000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "x-extensions": {
+          "bazaar": {
+            "schema": {
+              "properties": {
+                "input": {
+                  "type": "object",
+                  "properties": {
+                    "ownerAddress": {
+                      "format": "pubkey",
+                      "type": "string",
+                      "description": "The public key (pubKey) associated with the Solana account."
+                    },
+                    "includeNoPriceBalance": {
+                      "nullable": true,
+                      "type": "boolean",
+                      "description": "Whether or not we should include NFTs we do not track prices for."
+                    },
+                    "sortByAsc": {
+                      "nullable": true,
+                      "type": "string",
+                      "description": "Sort ascending based on amount or value of positions. Only one of sort_by_asc or sort_by_desc can be used"
+                    },
+                    "sortByDesc": {
+                      "nullable": true,
+                      "type": "string",
+                      "description": "Sort descending based on amount or value of positions. Only one of sort_by_asc or sort_by_desc can be used"
+                    },
+                    "limit": {
+                      "format": "int32",
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer",
+                      "description": "The limit of entries to return. If not passed, first 1000 entries are returned (the maximum)."
+                    },
+                    "page": {
+                      "format": "int32",
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer",
+                      "description": "The requested page."
+                    }
+                  },
+                  "required": [
+                    "ownerAddress"
+                  ]
+                },
+                "output": {
+                  "$ref": "#/components/schemas/WalletBalanceNftResults"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v4/wallets/{ownerAddress}/pnl": {
+      "get": {
+        "description": "Solana API endpoint for fetching wallet PnL with realized and unrealized profit, win rate, trade volume and per-token performance across vetted markets.",
+        "operationId": "get_wallet_pnl_v4",
+        "parameters": [
+          {
+            "description": "The public key (pubKey) associated with the Solana account.",
+            "in": "path",
+            "name": "ownerAddress",
+            "required": true,
+            "schema": {
+              "format": "pubkey",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Resolution of the data. Possible values: 1d, 7d, 30d, Full. Default is \"1d\".",
+            "in": "query",
+            "name": "resolution",
+            "required": false,
+            "schema": {
+              "allOf": [
+                {
+                  "description": "Represents the supported time-window resolutions for account/PnL queries.",
+                  "enum": [
+                    "1d",
+                    "7d",
+                    "30d",
+                    "Full"
+                  ],
+                  "type": "string"
+                }
+              ],
+              "nullable": true
+            }
+          },
+          {
+            "description": "The mint address filter for tokens. Provides the mint address to filter the requested data by.",
+            "in": "query",
+            "name": "mintAddress",
+            "required": false,
+            "schema": {
+              "allOf": [
+                {
+                  "format": "pubkey",
+                  "type": "string"
+                }
+              ],
+              "nullable": true
+            }
+          },
+          {
+            "description": "Sort ascending by 'mintAddress', 'tokenSymbol', 'buysTransactionCount', 'buysTokenAmount', 'buysVolumeUsd', 'sellsTransactionCount', 'sellsTokenAmount', 'sellsVolumeUsd', 'realizedPnlUsd', 'unrealizedPnlUsd'. Only one of sort_by_asc or sort_by_desc can be used.",
+            "in": "query",
+            "name": "sortByAsc",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          },
+          {
+            "description": "Sort descending by 'mintAddress', 'tokenSymbol', 'buysTransactionCount', 'buysTokenAmount', 'buysVolumeUsd', 'sellsTransactionCount', 'sellsTokenAmount', 'sellsVolumeUsd', 'realizedPnlUsd', 'unrealizedPnlUsd'. Only one of sort_by_asc or sort_by_desc can be used.",
+            "in": "query",
+            "name": "sortByDesc",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          },
+          {
+            "description": "The limit of entries to return. If not passed, first 1000 entries are returned (the maximum).",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "format": "int32",
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "The requested page.",
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "format": "int32",
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AccountTradesSummaryReturn"
+                }
+              }
+            },
+            "description": "Portfolio metrics and detailed per-token statistics"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "402": {
+            "description": "Payment Required"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Internal server error"
+          }
+        },
+        "summary": "Wallet PnL",
+        "tags": [
+          "Wallets"
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.015000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "x-extensions": {
+          "bazaar": {
+            "schema": {
+              "properties": {
+                "input": {
+                  "type": "object",
+                  "properties": {
+                    "ownerAddress": {
+                      "format": "pubkey",
+                      "type": "string",
+                      "description": "The public key (pubKey) associated with the Solana account."
+                    },
+                    "resolution": {
+                      "allOf": [
+                        {
+                          "description": "Represents the supported time-window resolutions for account/PnL queries.",
+                          "enum": [
+                            "1d",
+                            "7d",
+                            "30d",
+                            "Full"
+                          ],
+                          "type": "string"
+                        }
+                      ],
+                      "nullable": true,
+                      "description": "Resolution of the data. Possible values: 1d, 7d, 30d, Full. Default is \"1d\"."
+                    },
+                    "mintAddress": {
+                      "allOf": [
+                        {
+                          "format": "pubkey",
+                          "type": "string"
+                        }
+                      ],
+                      "nullable": true,
+                      "description": "The mint address filter for tokens. Provides the mint address to filter the requested data by."
+                    },
+                    "sortByAsc": {
+                      "nullable": true,
+                      "type": "string",
+                      "description": "Sort ascending by 'mintAddress', 'tokenSymbol', 'buysTransactionCount', 'buysTokenAmount', 'buysVolumeUsd', 'sellsTransactionCount', 'sellsTokenAmount', 'sellsVolumeUsd', 'realizedPnlUsd', 'unrealizedPnlUsd'. Only one of sort_by_asc or sort_by_desc can be used."
+                    },
+                    "sortByDesc": {
+                      "nullable": true,
+                      "type": "string",
+                      "description": "Sort descending by 'mintAddress', 'tokenSymbol', 'buysTransactionCount', 'buysTokenAmount', 'buysVolumeUsd', 'sellsTransactionCount', 'sellsTokenAmount', 'sellsVolumeUsd', 'realizedPnlUsd', 'unrealizedPnlUsd'. Only one of sort_by_asc or sort_by_desc can be used."
+                    },
+                    "limit": {
+                      "format": "int32",
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer",
+                      "description": "The limit of entries to return. If not passed, first 1000 entries are returned (the maximum)."
+                    },
+                    "page": {
+                      "format": "int32",
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer",
+                      "description": "The requested page."
+                    }
+                  },
+                  "required": [
+                    "ownerAddress"
+                  ]
+                },
+                "output": {
+                  "$ref": "#/components/schemas/AccountTradesSummaryReturn"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v4/wallets/{ownerAddress}/pnl-ts": {
+      "get": {
+        "description": "Solana API endpoint for fetching wallet PnL timeseries data. Returns realized PnL by day, week or month for tracking wallet performance over time.",
+        "operationId": "get_pnl_timeseries_v4",
+        "parameters": [
+          {
+            "description": "The Solana wallet address to query.",
+            "in": "path",
+            "name": "ownerAddress",
+            "required": true,
+            "schema": {
+              "format": "pubkey",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Time bucket size for each data point. Possible values: '1d' (daily), '1w' (weekly), '1mo' (monthly). Defaults to '1d'.",
+            "in": "query",
+            "name": "resolution",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          },
+          {
+            "description": "Start of the time range (unix timestamp, seconds). Defaults to the earliest complete period for the chosen resolution: 30 days ago for '1d', 12 weeks ago for '1w', or 12 months ago for '1mo'.",
+            "in": "query",
+            "name": "timeStart",
+            "required": false,
+            "schema": {
+              "format": "int64",
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "End of the time range (unix timestamp, seconds). Defaults to the end of the latest complete period.",
+            "in": "query",
+            "name": "timeEnd",
+            "required": false,
+            "schema": {
+              "format": "int64",
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PnlTimeseriesResponse"
+                }
+              }
+            },
+            "description": "Array of timestamp + PnL pairs, one per time bucket in the requested range."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Invalid parameters — check that the resolution is one of '1d', '1w', '1mo', and that `timeStart` < `timeEnd`."
+          },
+          "402": {
+            "description": "Payment Required"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Unexpected server error. The response body includes an `id` field — provide this when contacting support."
+          }
+        },
+        "summary": "Wallet PnL Timeseries",
+        "tags": [
+          "Wallets"
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.003000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "x-extensions": {
+          "bazaar": {
+            "schema": {
+              "properties": {
+                "input": {
+                  "type": "object",
+                  "properties": {
+                    "ownerAddress": {
+                      "format": "pubkey",
+                      "type": "string",
+                      "description": "The Solana wallet address to query."
+                    },
+                    "resolution": {
+                      "nullable": true,
+                      "type": "string",
+                      "description": "Time bucket size for each data point. Possible values: '1d' (daily), '1w' (weekly), '1mo' (monthly). Defaults to '1d'."
+                    },
+                    "timeStart": {
+                      "format": "int64",
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer",
+                      "description": "Start of the time range (unix timestamp, seconds). Defaults to the earliest complete period for the chosen resolution: 30 days ago for '1d', 12 weeks ago for '1w', or 12 months ago for '1mo'."
+                    },
+                    "timeEnd": {
+                      "format": "int64",
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer",
+                      "description": "End of the time range (unix timestamp, seconds). Defaults to the end of the latest complete period."
+                    }
+                  },
+                  "required": [
+                    "ownerAddress"
+                  ]
+                },
+                "output": {
+                  "$ref": "#/components/schemas/PnlTimeseriesResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v4/wallets/{ownerAddress}/token-accounts-balance-ts": {
+      "get": {
+        "description": "**Replaces**: `GET /account/token-balance-ts-raw/{ownerAddress}`\n\nProvides granular token-account-level balance history without aggregation for advanced analytics.",
+        "operationId": "get_wallet_tokens_ts_raw_v4",
+        "parameters": [
+          {
+            "description": "The public key (pubKey) associated with the Solana account.",
+            "in": "path",
+            "name": "ownerAddress",
+            "required": true,
+            "schema": {
+              "format": "pubkey",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Whether Vybe's token filter should restrict the tokens that are returned. If false, all priced tokens are included. Default is true.",
+            "in": "query",
+            "name": "vybeTokenFilter",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "Number of previous days to include in the data (from today's date), up to 30 days (default 14).",
+            "in": "query",
+            "name": "days",
+            "required": false,
+            "schema": {
+              "format": "int32",
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Sort ascending based on 'amount', 'amountScaled', 'ownerAddress', 'priceUsd', 'valueUsd', or 'mintAddress'. Only one of sort_by_asc or sort_by_desc can be used",
+            "in": "query",
+            "name": "sortByAsc",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          },
+          {
+            "description": "Sort descending based on 'amount', 'amountScaled', 'ownerAddress', 'priceUsd', 'valueUsd', or 'mintAddress'. Only one of sort_by_asc or sort_by_desc can be used",
+            "in": "query",
+            "name": "sortByDesc",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          },
+          {
+            "description": "Limit of entries to return (per day). If not passed, first 1000 entries are returned (the maximum).",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "format": "int32",
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "The requested page.",
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "format": "int32",
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WalletTimeSeriesRawReturn"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "402": {
+            "description": "Payment Required"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Internal server error"
+          }
+        },
+        "summary": "Token Account History",
+        "tags": [
+          "Wallets"
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.003000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "x-extensions": {
+          "bazaar": {
+            "schema": {
+              "properties": {
+                "input": {
+                  "type": "object",
+                  "properties": {
+                    "ownerAddress": {
+                      "format": "pubkey",
+                      "type": "string",
+                      "description": "The public key (pubKey) associated with the Solana account."
+                    },
+                    "vybeTokenFilter": {
+                      "nullable": true,
+                      "type": "boolean",
+                      "description": "Whether Vybe's token filter should restrict the tokens that are returned. If false, all priced tokens are included. Default is true."
+                    },
+                    "days": {
+                      "format": "int32",
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer",
+                      "description": "Number of previous days to include in the data (from today's date), up to 30 days (default 14)."
+                    },
+                    "sortByAsc": {
+                      "nullable": true,
+                      "type": "string",
+                      "description": "Sort ascending based on 'amount', 'amountScaled', 'ownerAddress', 'priceUsd', 'valueUsd', or 'mintAddress'. Only one of sort_by_asc or sort_by_desc can be used"
+                    },
+                    "sortByDesc": {
+                      "nullable": true,
+                      "type": "string",
+                      "description": "Sort descending based on 'amount', 'amountScaled', 'ownerAddress', 'priceUsd', 'valueUsd', or 'mintAddress'. Only one of sort_by_asc or sort_by_desc can be used"
+                    },
+                    "limit": {
+                      "format": "int32",
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer",
+                      "description": "Limit of entries to return (per day). If not passed, first 1000 entries are returned (the maximum)."
+                    },
+                    "page": {
+                      "format": "int32",
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer",
+                      "description": "The requested page."
+                    }
+                  },
+                  "required": [
+                    "ownerAddress"
+                  ]
+                },
+                "output": {
+                  "$ref": "#/components/schemas/WalletTimeSeriesRawReturn"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v4/wallets/{ownerAddress}/token-balance": {
+      "get": {
+        "description": "**Replaces**: `GET /account/token-balance/{ownerAddress}`\n\nReturns SOL & SPL token holdings with amounts, USD values, metadata, and native stake amount for a wallet.\nA maximum of 10,000 token accounts can be requested.",
+        "operationId": "get_wallet_tokens_v4",
+        "parameters": [
+          {
+            "description": "The public key (pubKey) associated with the Solana account.",
+            "in": "path",
+            "name": "ownerAddress",
+            "required": true,
+            "schema": {
+              "format": "pubkey",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Whether or not we should include tokens we do not track prices for. Filtering is applied after limiting.",
+            "in": "query",
+            "name": "includeNoPriceBalance",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "Sort ascending based on amount or value of positions. Only one of sort_by_asc or sort_by_desc can be used",
+            "in": "query",
+            "name": "sortByAsc",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          },
+          {
+            "description": "Sort descending based on amount or value of positions. Only one of sort_by_asc or sort_by_desc can be used",
+            "in": "query",
+            "name": "sortByDesc",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          },
+          {
+            "description": "Whether tokens returned should be restricted to verified tokens only. Default is false.",
+            "in": "query",
+            "name": "onlyVerified",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "Whether Vybe's token filter should restrict the tokens that are returned. Default is true.",
+            "in": "query",
+            "name": "vybeTokenFilter",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "The minimum amount of total value in USD for an asset to be considered in the results. Overrides `includeNoPriceBalance`. Defaults to no limit.",
+            "in": "query",
+            "name": "minAssetValue",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          },
+          {
+            "description": "The maximum amount of total value in USD for an asset to be considered in the results. Overrides `includeNoPriceBalance`. Defaults to no limit.",
+            "in": "query",
+            "name": "maxAssetValue",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          },
+          {
+            "description": "The allowable mints, if any, to filter the results by.",
+            "in": "query",
+            "name": "mintAddresses",
+            "required": false,
+            "schema": {
+              "items": {
+                "format": "pubkey",
+                "type": "string"
+              },
+              "nullable": true,
+              "type": "array"
+            }
+          },
+          {
+            "description": "The limit of entries to return. If not passed, first 1000 entries are returned (the maximum).",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "format": "int32",
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "The requested page.",
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "format": "int32",
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WalletBalanceTokenResults"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "402": {
+            "description": "Payment Required"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Internal server error"
+          }
+        },
+        "summary": "Token Balances",
+        "tags": [
+          "Wallets"
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.003000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "x-extensions": {
+          "bazaar": {
+            "schema": {
+              "properties": {
+                "input": {
+                  "type": "object",
+                  "properties": {
+                    "ownerAddress": {
+                      "format": "pubkey",
+                      "type": "string",
+                      "description": "The public key (pubKey) associated with the Solana account."
+                    },
+                    "includeNoPriceBalance": {
+                      "nullable": true,
+                      "type": "boolean",
+                      "description": "Whether or not we should include tokens we do not track prices for. Filtering is applied after limiting."
+                    },
+                    "sortByAsc": {
+                      "nullable": true,
+                      "type": "string",
+                      "description": "Sort ascending based on amount or value of positions. Only one of sort_by_asc or sort_by_desc can be used"
+                    },
+                    "sortByDesc": {
+                      "nullable": true,
+                      "type": "string",
+                      "description": "Sort descending based on amount or value of positions. Only one of sort_by_asc or sort_by_desc can be used"
+                    },
+                    "onlyVerified": {
+                      "nullable": true,
+                      "type": "boolean",
+                      "description": "Whether tokens returned should be restricted to verified tokens only. Default is false."
+                    },
+                    "vybeTokenFilter": {
+                      "nullable": true,
+                      "type": "boolean",
+                      "description": "Whether Vybe's token filter should restrict the tokens that are returned. Default is true."
+                    },
+                    "minAssetValue": {
+                      "nullable": true,
+                      "type": "string",
+                      "description": "The minimum amount of total value in USD for an asset to be considered in the results. Overrides `includeNoPriceBalance`. Defaults to no limit."
+                    },
+                    "maxAssetValue": {
+                      "nullable": true,
+                      "type": "string",
+                      "description": "The maximum amount of total value in USD for an asset to be considered in the results. Overrides `includeNoPriceBalance`. Defaults to no limit."
+                    },
+                    "mintAddresses": {
+                      "items": {
+                        "format": "pubkey",
+                        "type": "string"
+                      },
+                      "nullable": true,
+                      "type": "array",
+                      "description": "The allowable mints, if any, to filter the results by."
+                    },
+                    "limit": {
+                      "format": "int32",
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer",
+                      "description": "The limit of entries to return. If not passed, first 1000 entries are returned (the maximum)."
+                    },
+                    "page": {
+                      "format": "int32",
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer",
+                      "description": "The requested page."
+                    }
+                  },
+                  "required": [
+                    "ownerAddress"
+                  ]
+                },
+                "output": {
+                  "$ref": "#/components/schemas/WalletBalanceTokenResults"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v4/wallets/{ownerAddress}/token-balance-ts": {
+      "get": {
+        "description": "**Replaces**: `GET /account/token-balance-ts/{address}`\n\nTrack historical token balances and portfolio value over time.",
+        "operationId": "get_wallet_tokens_ts_v4",
+        "parameters": [
+          {
+            "description": "The public key (pubKey) associated with the Solana account.",
+            "in": "path",
+            "name": "ownerAddress",
+            "required": true,
+            "schema": {
+              "format": "pubkey",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Bucketing of the data. Possible values: daily ('1d'), weekly ('1w'), monthly ('1mo'). Default is \"daily\". One data point per bucket is returned.",
+            "in": "query",
+            "name": "resolution",
+            "required": false,
+            "schema": {
+              "allOf": [
+                {
+                  "enum": [
+                    "1d",
+                    "1w",
+                    "1mo"
+                  ],
+                  "type": "string"
+                }
+              ],
+              "nullable": true
+            }
+          },
+          {
+            "description": "Number of previous days to include in the data (from today's date).\nAllowed values depend on the resolution:\n- For \"1d\": 1 to 30 days (default is 14 days)\n- For \"1w\": 1 to 90 days (default is 30 days)\n- For \"1mo\": 1 to 365 days (default is 90 days)",
+            "in": "query",
+            "name": "days",
+            "required": false,
+            "schema": {
+              "format": "int32",
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Whether Vybe's token filter should restrict the tokens that are returned. If false, all priced tokens are included. Default is true.",
+            "in": "query",
+            "name": "vybeTokenFilter",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WalletBalanceTokenResultsTimeSeries"
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "402": {
+            "description": "Payment Required"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Internal server error"
+          }
+        },
+        "summary": "Token Balance History",
+        "tags": [
+          "Wallets"
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.015000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "x-extensions": {
+          "bazaar": {
+            "schema": {
+              "properties": {
+                "input": {
+                  "type": "object",
+                  "properties": {
+                    "ownerAddress": {
+                      "format": "pubkey",
+                      "type": "string",
+                      "description": "The public key (pubKey) associated with the Solana account."
+                    },
+                    "resolution": {
+                      "allOf": [
+                        {
+                          "enum": [
+                            "1d",
+                            "1w",
+                            "1mo"
+                          ],
+                          "type": "string"
+                        }
+                      ],
+                      "nullable": true,
+                      "description": "Bucketing of the data. Possible values: daily ('1d'), weekly ('1w'), monthly ('1mo'). Default is \"daily\". One data point per bucket is returned."
+                    },
+                    "days": {
+                      "format": "int32",
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer",
+                      "description": "Number of previous days to include in the data (from today's date).\nAllowed values depend on the resolution:\n- For \"1d\": 1 to 30 days (default is 14 days)\n- For \"1w\": 1 to 90 days (default is 30 days)\n- For \"1mo\": 1 to 365 days (default is 90 days)"
+                    },
+                    "vybeTokenFilter": {
+                      "nullable": true,
+                      "type": "boolean",
+                      "description": "Whether Vybe's token filter should restrict the tokens that are returned. If false, all priced tokens are included. Default is true."
+                    }
+                  },
+                  "required": [
+                    "ownerAddress"
+                  ]
+                },
+                "output": {
+                  "$ref": "#/components/schemas/WalletBalanceTokenResultsTimeSeries"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v4/wallets/{ownerAddress}/transfer-volume-usd": {
+      "get": {
+        "description": "Returns the total USD-denominated transfer volume for a wallet within a time window,\nsplit into sent (`valueSender`) and received (`valueReceiver`) totals.\nDefaults to the last 24 hours if no time range is specified.\n\nUse this to gauge a wallet's overall transfer activity — for example, to assess\nwhether a wallet is actively moving funds or to compare inflow vs outflow.",
+        "operationId": "get_transfer_volume_usd_v4",
+        "parameters": [
+          {
+            "description": "The Solana wallet address to query.",
+            "in": "path",
+            "name": "ownerAddress",
+            "required": true,
+            "schema": {
+              "format": "pubkey",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Start of the time range (unix timestamp, seconds). Defaults to 24 hours ago.",
+            "in": "query",
+            "name": "timeStart",
+            "required": false,
+            "schema": {
+              "format": "int64",
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "End of the time range (unix timestamp, seconds). Defaults to the current time.",
+            "in": "query",
+            "name": "timeEnd",
+            "required": false,
+            "schema": {
+              "format": "int64",
+              "minimum": 0,
+              "nullable": true,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/TransferVolumeUsd"
+                    }
+                  ],
+                  "nullable": true
+                }
+              }
+            },
+            "description": "Sent and received transfer volumes in USD, or `null` if the wallet had no transfer activity in the given range."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Invalid parameters — check that `timeStart` < `timeEnd`."
+          },
+          "402": {
+            "description": "Payment Required"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            },
+            "description": "Unexpected server error. The response body includes an `id` field — provide this when contacting support."
+          }
+        },
+        "summary": "Transfer Volume USD",
+        "tags": [
+          "Wallets"
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.003000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "x-extensions": {
+          "bazaar": {
+            "schema": {
+              "properties": {
+                "input": {
+                  "type": "object",
+                  "properties": {
+                    "ownerAddress": {
+                      "format": "pubkey",
+                      "type": "string",
+                      "description": "The Solana wallet address to query."
+                    },
+                    "timeStart": {
+                      "format": "int64",
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer",
+                      "description": "Start of the time range (unix timestamp, seconds). Defaults to 24 hours ago."
+                    },
+                    "timeEnd": {
+                      "format": "int64",
+                      "minimum": 0,
+                      "nullable": true,
+                      "type": "integer",
+                      "description": "End of the time range (unix timestamp, seconds). Defaults to the current time."
+                    }
+                  },
+                  "required": [
+                    "ownerAddress"
+                  ]
+                },
+                "output": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/TransferVolumeUsd"
+                    }
+                  ],
+                  "nullable": true
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "servers": [
+    {
+      "url": "https://x402-api.vybenetwork.xyz",
+      "description": "Vybe Solana analytics API (x402 pay-per-call)"
+    }
+  ]
+}

--- a/providers/vybenetwork/solana-analytics/openapi.json
+++ b/providers/vybenetwork/solana-analytics/openapi.json
@@ -8382,7 +8382,7 @@
             "description": "Market not found"
           }
         },
-        "summary": "Market List",
+        "summary": "List Solana DEX markets by program address",
         "tags": [
           "Markets"
         ],
@@ -8521,7 +8521,7 @@
             "description": "Market not found"
           }
         },
-        "summary": "Market Details",
+        "summary": "Get details for a specific Solana DEX market",
         "tags": [
           "Markets"
         ],
@@ -8700,7 +8700,7 @@
             "description": "Internal server error"
           }
         },
-        "summary": "Market Price Candles",
+        "summary": "Get OHLCV price candles for a DEX market",
         "tags": [
           "Markets"
         ],
@@ -8849,7 +8849,7 @@
             "description": "Payment Required"
           }
         },
-        "summary": "Pyth Price Feeds",
+        "summary": "List available Pyth oracle price feeds",
         "tags": [
           "Oracle (Pyth)"
         ],
@@ -9035,7 +9035,7 @@
             "description": "Internal server error"
           }
         },
-        "summary": "Pyth Price Candles",
+        "summary": "Get OHLCV candles for a Pyth price feed",
         "tags": [
           "Oracle (Pyth)"
         ],
@@ -9180,7 +9180,7 @@
             "description": "Internal server error"
           }
         },
-        "summary": "Pyth Current Price",
+        "summary": "Get the current price from a Pyth feed",
         "tags": [
           "Oracle (Pyth)"
         ],
@@ -9346,7 +9346,7 @@
             "description": "Internal server error"
           }
         },
-        "summary": "Pyth Price History",
+        "summary": "Get historical prices for a Pyth feed",
         "tags": [
           "Oracle (Pyth)"
         ],
@@ -9487,7 +9487,7 @@
             "description": "Internal server error"
           }
         },
-        "summary": "Pyth Product",
+        "summary": "Get product metadata for a Pyth oracle feed",
         "tags": [
           "Oracle (Pyth)"
         ],
@@ -9659,7 +9659,7 @@
             "description": "Internal server error"
           }
         },
-        "summary": "Labeled Programs",
+        "summary": "List labeled accounts for a Solana program",
         "tags": [
           "Programs"
         ],
@@ -9756,7 +9756,7 @@
             "description": "Payment Required"
           }
         },
-        "summary": "Supported DEXs",
+        "summary": "List supported Solana DEXes and program IDs",
         "tags": [
           "Reference (Metadata)"
         ],
@@ -9886,7 +9886,7 @@
             "description": "Internal server error"
           }
         },
-        "summary": "Instruction Names",
+        "summary": "List known Solana instruction names by program",
         "tags": [
           "Reference (Metadata)"
         ],
@@ -10061,7 +10061,7 @@
             "description": "Internal server error"
           }
         },
-        "summary": "Token List",
+        "summary": "List Solana tokens tracked by Vybe",
         "tags": [
           "Tokens"
         ],
@@ -10190,7 +10190,7 @@
             "description": "Internal server error"
           }
         },
-        "summary": "Token Details",
+        "summary": "Get details and metadata for a Solana token",
         "tags": [
           "Tokens"
         ],
@@ -10369,7 +10369,7 @@
             "description": "Internal server error"
           }
         },
-        "summary": "Token Candles",
+        "summary": "Get OHLCV price candles for a Solana token",
         "tags": [
           "Tokens"
         ],
@@ -10588,7 +10588,7 @@
             "description": "Internal server error"
           }
         },
-        "summary": "Holder Count History",
+        "summary": "Get holder-count history for a Solana token",
         "tags": [
           "Tokens"
         ],
@@ -10715,7 +10715,7 @@
             "description": "Unexpected server error. The response body includes an `id` field — provide this when contacting support."
           }
         },
-        "summary": "Token Liquidity",
+        "summary": "Get current liquidity for a Solana token",
         "tags": [
           "Tokens"
         ],
@@ -11091,7 +11091,7 @@
             "description": "Internal server error"
           }
         },
-        "summary": "Top Holders",
+        "summary": "List the top holders of a Solana token",
         "tags": [
           "Tokens"
         ],
@@ -11444,7 +11444,7 @@
             "description": "Unexpected server error. The response body includes an `id` field — provide this when contacting support."
           }
         },
-        "summary": "Trade Volume Timeseries",
+        "summary": "Get trade-volume history for a token",
         "tags": [
           "Trades & Transfers"
         ],
@@ -11669,7 +11669,7 @@
             "description": "Unexpected server error. The response body includes an `id` field — provide this when contacting support."
           }
         },
-        "summary": "Token Traders Activity",
+        "summary": "List trader activity for a Solana token",
         "tags": [
           "Trades & Transfers"
         ],
@@ -12003,7 +12003,7 @@
             "description": "Internal server error"
           }
         },
-        "summary": "Trade History",
+        "summary": "List recent DEX trades on Solana",
         "tags": [
           "Trades & Transfers"
         ],
@@ -12214,7 +12214,7 @@
             "description": "Internal server error"
           }
         },
-        "summary": "Build Swap",
+        "summary": "Build a Solana token swap transaction",
         "tags": [
           "Trading"
         ],
@@ -12356,7 +12356,7 @@
             "description": "Internal server error"
           }
         },
-        "summary": "Swap Quote",
+        "summary": "Get a quote for a Solana token swap",
         "tags": [
           "Trading"
         ],
@@ -12669,7 +12669,7 @@
             "description": "Internal server error"
           }
         },
-        "summary": "Transfer History",
+        "summary": "List SPL token transfers on Solana",
         "tags": [
           "Trades & Transfers"
         ],
@@ -12879,7 +12879,7 @@
             "description": "Unexpected server error. The response body includes an `id` field — provide this when contacting support."
           }
         },
-        "summary": "Dust Accounts (Batch)",
+        "summary": "List dust token accounts for multiple wallets",
         "tags": [
           "Wallets"
         ],
@@ -12968,7 +12968,7 @@
             "description": "Unexpected server error. The response body includes an `id` field — provide this when contacting support."
           }
         },
-        "summary": "Empty Accounts (Batch)",
+        "summary": "List empty token accounts for multiple wallets",
         "tags": [
           "Wallets"
         ],
@@ -13057,7 +13057,7 @@
             "description": "Internal server error"
           }
         },
-        "summary": "NFT Balances (Batch)",
+        "summary": "Get NFT balances for multiple wallets",
         "tags": [
           "Wallets"
         ],
@@ -13146,7 +13146,7 @@
             "description": "Internal server error"
           }
         },
-        "summary": "Token Accounts (Batch)",
+        "summary": "Get token-account balance history for wallets",
         "tags": [
           "Wallets"
         ],
@@ -13235,7 +13235,7 @@
             "description": "Internal server error"
           }
         },
-        "summary": "Token Balances (Batch)",
+        "summary": "Get token balances for multiple wallets",
         "tags": [
           "Wallets"
         ],
@@ -13494,7 +13494,7 @@
             "description": "Internal server error"
           }
         },
-        "summary": "Labeled Accounts",
+        "summary": "List labeled Solana wallet accounts",
         "tags": [
           "Wallets"
         ],
@@ -13780,7 +13780,7 @@
             "description": "Internal server error"
           }
         },
-        "summary": "Top Traders",
+        "summary": "List the top traders by realized PnL",
         "tags": [
           "Wallets"
         ],
@@ -14000,7 +14000,7 @@
             "description": "Internal server error"
           }
         },
-        "summary": "Close Token Accounts",
+        "summary": "Build a transaction to close token accounts",
         "tags": [
           "Utilities"
         ],
@@ -14109,7 +14109,7 @@
             "description": "Internal server error"
           }
         },
-        "summary": "Withdraw MEV",
+        "summary": "Build a transaction to withdraw MEV rewards",
         "tags": [
           "Utilities"
         ],
@@ -14286,7 +14286,7 @@
             "description": "Unexpected server error. The response body includes an `id` field — provide this when contacting support."
           }
         },
-        "summary": "Wallet Counterparties",
+        "summary": "List transfer counterparties for a wallet",
         "tags": [
           "Wallets"
         ],
@@ -14443,7 +14443,7 @@
             "description": "Internal server error"
           }
         },
-        "summary": "DeFi Positions",
+        "summary": "List DeFi positions held by a wallet",
         "tags": [
           "Wallets"
         ],
@@ -14583,7 +14583,7 @@
             "description": "Unexpected server error. The response body includes an `id` field — provide this when contacting support."
           }
         },
-        "summary": "Dust Accounts",
+        "summary": "List dust token accounts for a wallet",
         "tags": [
           "Wallets"
         ],
@@ -14744,7 +14744,7 @@
             "description": "Unexpected server error. The response body includes an `id` field — provide this when contacting support."
           }
         },
-        "summary": "Empty Accounts",
+        "summary": "List empty token accounts for a wallet",
         "tags": [
           "Wallets"
         ],
@@ -14915,7 +14915,7 @@
             "description": "Internal server error"
           }
         },
-        "summary": "NFT Balance",
+        "summary": "Get NFT holdings for a Solana wallet",
         "tags": [
           "Wallets"
         ],
@@ -15127,7 +15127,7 @@
             "description": "Internal server error"
           }
         },
-        "summary": "Wallet PnL",
+        "summary": "Get realized and unrealized PnL for a wallet",
         "tags": [
           "Wallets"
         ],
@@ -15304,7 +15304,7 @@
             "description": "Unexpected server error. The response body includes an `id` field — provide this when contacting support."
           }
         },
-        "summary": "Wallet PnL Timeseries",
+        "summary": "Get realized PnL history for a wallet",
         "tags": [
           "Wallets"
         ],
@@ -15482,7 +15482,7 @@
             "description": "Internal server error"
           }
         },
-        "summary": "Token Account History",
+        "summary": "Get token-account balance history for a wallet",
         "tags": [
           "Wallets"
         ],
@@ -15719,7 +15719,7 @@
             "description": "Internal server error"
           }
         },
-        "summary": "Token Balances",
+        "summary": "Get current token balances for a wallet",
         "tags": [
           "Wallets"
         ],
@@ -15911,7 +15911,7 @@
             "description": "Internal server error"
           }
         },
-        "summary": "Token Balance History",
+        "summary": "Get token-balance history for a wallet",
         "tags": [
           "Wallets"
         ],
@@ -16059,7 +16059,7 @@
             "description": "Unexpected server error. The response body includes an `id` field — provide this when contacting support."
           }
         },
-        "summary": "Transfer Volume USD",
+        "summary": "Get USD transfer volume for a wallet",
         "tags": [
           "Wallets"
         ],


### PR DESCRIPTION
Adds [Vybe Network](https://docs.vybenetwork.com/)'s Solana analytics API at `https://x402-api.vybenetwork.xyz` to the registry.

## What it offers

Full surface of the Vybe Solana analytics REST API (46 endpoints) under pay-per-call USDC via x402 — same paths and response shapes as the [Vybe API Reference](https://docs.vybenetwork.com/reference). Token details, top holders, market candles, wallet PnL, top traders, transfers, trades, Pyth oracle feeds, WebSocket streaming.

## Multi-chain

Every 402 challenge advertises **both Solana mainnet and Base mainnet**. Clients pick the chain they're funded on; the gateway settles via Coinbase's CDP facilitator on either. Same USDC dollar amount per call regardless of chain. The CDP signer set is already on pay-skills' known-facilitators allowlist.

## Pricing

| Tier | USDC | Routes |
|------|------|--------|
| default | $0.012 | most token / wallet / markets reads |
| 30 cr | $0.015 | OHLCV candles |
| 50 cr | $0.018 | wallet PnL, top traders, time-series counters |
| 80 cr | $0.024 | top holders, transfers, trades, active users, TVL |
| 100 cr | $0.030 | batch wallet endpoints (POST) |

Live authoritative table at `GET https://x402-api.vybenetwork.xyz/`.

## Validation

```
$ pay catalog check providers/vybenetwork/solana-analytics/PAY.md
PAY.md check successful
46 endpoints tested across 1 provider
46/46 gates compatible with Solana
```

## Files

- `providers/vybenetwork/solana-analytics/PAY.md` — provider entry
- `providers/vybenetwork/solana-analytics/openapi.json` — snapshot of the live OpenAPI doc (~510 KB), co-located per CONTRIBUTING.md