### PR TITLE
Add Concierge Agent market intelligence API (conc-exe/concierge-agent)

### DIFF
--- a/providers/conc-exe/concierge-agent/PAY.md
+++ b/providers/conc-exe/concierge-agent/PAY.md
@@ -5,7 +5,7 @@ description: "Pay-per-call market intelligence for AI agents — Concierge chat,
 use_case: "Use for autonomous agent market research, DeFi desk queries, airdrop hunting, exchange listing rumors, momentum scans, trading plan generation, wallet snapshots, and macro intelligence without API keys or subscriptions."
 category: finance
 service_url: https://conc-exe.xyz
-version: v1
+version: "4.0.0"
 openapi:
   path: openapi.json
 ---

--- a/providers/conc-exe/concierge-agent/PAY.md
+++ b/providers/conc-exe/concierge-agent/PAY.md
@@ -1,0 +1,41 @@
+---
+name: concierge-agent
+title: "Concierge Agent"
+description: "Pay-per-call market intelligence for AI agents — Concierge chat, DeFi intel (TVL, yields, whales, wallet, verdict), Alpha desks (airdrop, listing, momentum), and Lounge wire. x402 USDC on Solana, no API keys."
+use_case: "Use for autonomous agent market research, DeFi desk queries, airdrop hunting, exchange listing rumors, momentum scans, trading plan generation, wallet snapshots, and macro intelligence without API keys or subscriptions."
+category: finance
+service_url: https://conc-exe.xyz
+version: v1
+openapi:
+  path: openapi.json
+---
+
+Concierge Agent is **market intelligence as a service** for autonomous agents and builders. Twelve pay-per-call routes on `https://conc-exe.xyz` — settlement via **x402 USDC** (PayAI facilitator on Solana mainnet; Base also supported).
+
+**Concierge AI** — natural-language desk (`POST /api/concierge`) for macro, geo, technicals, and trading plans.
+
+**DeFi Intel** — structured JSON: TVL (DeFi Llama), yields (Meteora DLMM, Jupiter), whale positioning (Binance), wallet snapshots (Helius), desk verdict with optional Lounge insider overlay.
+
+**Alpha Intel** — insider-first synthesis for airdrop candidates, exchange listing rumors, and large-move momentum scans.
+
+**Lounge** — unlock wire headlines and creator RWA signals.
+
+Flow: `POST` + JSON → **402** + `PAYMENT-REQUIRED` → sign USDC → retry with `PAYMENT-SIGNATURE` → **200** JSON (or HTML `reply` for chat).
+
+x402 USDC payment accepted on Solana mainnet ($0.10 per call; $1.00 signal publish).
+
+## Spend-aware usage
+
+- Prefer **Intel routes** (`/api/concierge-intel-*`) when you need structured JSON for agent pipelines — cheaper than parsing HTML from chat.
+- Use **`/api/concierge-intel-tvl`** with `{}` for the cheapest DeFi snapshot.
+- Use **`/api/concierge-intel-verdict`** once per theme instead of chaining whales + yields + chat separately.
+- Alpha routes (`airdrop`, `listing`, `momentum`) weight Lounge insider signals first — set `includeInsider: true` (default) for best alpha quality.
+- Cap `limit` on Alpha bodies to the smallest number that answers the task (1–8, default 5).
+- Call from **server-side or agent runtime** — browser CORS is limited to the Lounge origin.
+
+## Discovery
+
+- OpenAPI: `https://conc-exe.xyz/openapi.json`
+- x402 fan-out: `https://conc-exe.xyz/.well-known/x402`
+- Builder docs: `https://conc-exe.xyz/docs/builders`
+- Endpoint catalog: `https://conc-exe.xyz/agent/endpoints`

--- a/providers/conc-exe/concierge-agent/PAY.md
+++ b/providers/conc-exe/concierge-agent/PAY.md
@@ -37,7 +37,7 @@ x402 USDC payment accepted on Solana mainnet ($0.02–$0.25 per call; $0.02 secu
 - Use **`/api/concierge-intel-verdict`** once per theme instead of chaining whales + yields + chat separately.
 - Alpha routes (`airdrop`, `listing`, `momentum`, `scalp`) weight Lounge insider signals first — set `includeInsider: true` (default) for best alpha quality.
 - Cap `limit` on Alpha bodies to the smallest number that answers the task (1–8, default 5).
-- For authorized security posture: scope check free, then `security-scan` ($0.10) or scout routes ($0.02). Always pass `allowlist` + `authorized: true`.
+- For authorized security posture: scope check free, then `security-scan` ($0.10) or scout routes ($0.02). Always pass `allowlist` + `authorized: true`. Free Concierge self-audit: `POST /api/concierge-security-scan` with `{"target":"https://conc-exe.xyz","authorized":true,"selfAudit":true}` (no payment).
 - Call from **server-side or agent runtime** — browser CORS is limited to the Lounge origin.
 
 ## Discovery

--- a/providers/conc-exe/concierge-agent/PAY.md
+++ b/providers/conc-exe/concierge-agent/PAY.md
@@ -1,41 +1,50 @@
 ---
 name: concierge-agent
 title: "Concierge Agent"
-description: "Pay-per-call market intelligence for AI agents — Concierge chat, DeFi intel (TVL, yields, whales, wallet, verdict), Alpha desks (airdrop, listing, momentum), and Lounge wire. x402 USDC on Solana, no API keys."
-use_case: "Use for autonomous agent market research, DeFi desk queries, airdrop hunting, exchange listing rumors, momentum scans, trading plan generation, wallet snapshots, and macro intelligence without API keys or subscriptions."
+description: "Pay-per-call market intelligence and Security Desk for AI agents — Concierge chat, macro & wire research, DeFi intel, Alpha desks, Lounge wire, and passive security scans. x402 USDC on Solana, no API keys."
+use_case: "Agent market research and authorized passive security posture — macro, wire, DeFi intel, alpha desks, wallet snapshots, website security scan. Callable from Poncho/x402scan. No API keys or subscriptions."
 category: finance
 service_url: https://conc-exe.xyz
-version: "4.0.0"
+version: "4.2.0"
 openapi:
   path: openapi.json
 ---
 
-Concierge Agent is **market intelligence as a service** for autonomous agents and builders. Twelve pay-per-call routes on `https://conc-exe.xyz` — settlement via **x402 USDC** (PayAI facilitator on Solana mainnet; Base also supported).
+Concierge Agent is **market intelligence + Concierge Resources + Security Desk as a service** for autonomous agents and builders. **24 pay-per-call routes** on `https://conc-exe.xyz` — settlement via **x402 USDC or TCX** ([PayAI facilitator](https://facilitator.payai.network) primary; [Dexter](https://x402.dexter.cash) fallback + [OpenDexter](https://dexter.cash/opendexter) discovery). Listed on [x402scan](https://www.x402scan.com/) and callable from [Poncho](https://tryponcho.com/) — **no Concierge API key**.
 
 **Concierge AI** — natural-language desk (`POST /api/concierge`) for macro, geo, technicals, and trading plans.
 
+**Research** — structured JSON for agent marketplaces: `intel-macro` (SPX, VIX, DXY, Fear & Greed, Treasury yields) and `intel-wire` (headline digest from RSS + Lounge memory).
+
 **DeFi Intel** — structured JSON: TVL (DeFi Llama), yields (Meteora DLMM, Jupiter), whale positioning (Binance), wallet snapshots (Helius), desk verdict with optional Lounge insider overlay.
 
-**Alpha Intel** — insider-first synthesis for airdrop candidates, exchange listing rumors, and large-move momentum scans.
+**Alpha Intel** — insider-first synthesis for airdrop candidates, exchange listing rumors, momentum scans, and scalp desk (5m/15m).
 
 **Lounge** — unlock wire headlines and creator RWA signals.
 
+**Security Desk** — passive authorized scans: unified `security-scan` ($0.10), scout `security-readiness` / `security-headers` ($0.02), free `security-scope`, free `conc-exe.xyz` self-audit (`selfAudit: true`). Docs: https://conc-exe.xyz/docs/api/security · skill `/skills/concierge-security/SKILL.md`.
+
 Flow: `POST` + JSON → **402** + `PAYMENT-REQUIRED` → sign USDC → retry with `PAYMENT-SIGNATURE` → **200** JSON (or HTML `reply` for chat).
 
-x402 USDC payment accepted on Solana mainnet ($0.10 per call; $1.00 signal publish).
+x402 USDC payment accepted on Solana mainnet ($0.02–$0.25 per call; $0.02 security scout; $1.00 signal publish).
 
 ## Spend-aware usage
 
 - Prefer **Intel routes** (`/api/concierge-intel-*`) when you need structured JSON for agent pipelines — cheaper than parsing HTML from chat.
+- Use **`/api/concierge-intel-macro`** with `{}` for macro desk snapshots (Poncho research prompts).
+- Use **`/api/concierge-intel-wire`** for headline digests — filter with `category` or `message`.
 - Use **`/api/concierge-intel-tvl`** with `{}` for the cheapest DeFi snapshot.
 - Use **`/api/concierge-intel-verdict`** once per theme instead of chaining whales + yields + chat separately.
-- Alpha routes (`airdrop`, `listing`, `momentum`) weight Lounge insider signals first — set `includeInsider: true` (default) for best alpha quality.
+- Alpha routes (`airdrop`, `listing`, `momentum`, `scalp`) weight Lounge insider signals first — set `includeInsider: true` (default) for best alpha quality.
 - Cap `limit` on Alpha bodies to the smallest number that answers the task (1–8, default 5).
+- For authorized security posture: scope check free, then `security-scan` ($0.10) or scout routes ($0.02). Always pass `allowlist` + `authorized: true`.
 - Call from **server-side or agent runtime** — browser CORS is limited to the Lounge origin.
 
 ## Discovery
 
 - OpenAPI: `https://conc-exe.xyz/openapi.json`
-- x402 fan-out: `https://conc-exe.xyz/.well-known/x402`
-- Builder docs: `https://conc-exe.xyz/docs/builders`
-- Endpoint catalog: `https://conc-exe.xyz/agent/endpoints`
+- x402: `https://conc-exe.xyz/.well-known/x402`
+- Docs: `https://conc-exe.xyz/docs` · Agent: `https://conc-exe.xyz/agent` · Security: `https://conc-exe.xyz/docs/api/security`
+- Skills: `/skills/concierge-intel/SKILL.md` · `/skills/concierge-security/SKILL.md`
+- Agent identity / ERC-8004 (Base Identity Registry mint): `https://conc-exe.xyz/docs/api/agent-identity` · Lounge: `https://conc-exe.xyz/lounge#agent-identity`
+- Agent SDK: `https://conc-exe.xyz/docs/sdk/agent` · MCP: `https://conc-exe.xyz/api/mcp`

--- a/providers/conc-exe/concierge-agent/PAY.md
+++ b/providers/conc-exe/concierge-agent/PAY.md
@@ -26,7 +26,7 @@ Concierge Agent is **market intelligence + Concierge Resources + Security Desk a
 
 Flow: `POST` + JSON → **402** + `PAYMENT-REQUIRED` → sign USDC → retry with `PAYMENT-SIGNATURE` → **200** JSON (or HTML `reply` for chat).
 
-x402 USDC payment accepted on Solana mainnet ($0.02–$0.25 per call; $0.02 security scout; $1.00 signal publish).
+x402 USDC payment accepted on Solana mainnet ($0.02–$0.25 per call; $0.02 security scout and signal publish).
 
 ## Spend-aware usage
 

--- a/providers/conc-exe/concierge-agent/openapi.json
+++ b/providers/conc-exe/concierge-agent/openapi.json
@@ -65,6 +65,12 @@
               }
             },
             {
+              "x402": {
+                "network": "base",
+                "facilitator": "https://facilitator.payai.network"
+              }
+            },
+            {
               "mpp": {
                 "method": "solana",
                 "intent": "charge",
@@ -211,6 +217,12 @@
             {
               "x402": {
                 "network": "solana",
+                "facilitator": "https://facilitator.payai.network"
+              }
+            },
+            {
+              "x402": {
+                "network": "base",
                 "facilitator": "https://facilitator.payai.network"
               }
             },
@@ -402,6 +414,12 @@
               }
             },
             {
+              "x402": {
+                "network": "base",
+                "facilitator": "https://facilitator.payai.network"
+              }
+            },
+            {
               "mpp": {
                 "method": "solana",
                 "intent": "charge",
@@ -560,6 +578,12 @@
               }
             },
             {
+              "x402": {
+                "network": "base",
+                "facilitator": "https://facilitator.payai.network"
+              }
+            },
+            {
               "mpp": {
                 "method": "solana",
                 "intent": "charge",
@@ -692,6 +716,12 @@
             {
               "x402": {
                 "network": "solana",
+                "facilitator": "https://facilitator.payai.network"
+              }
+            },
+            {
+              "x402": {
+                "network": "base",
                 "facilitator": "https://facilitator.payai.network"
               }
             },
@@ -858,6 +888,12 @@
               }
             },
             {
+              "x402": {
+                "network": "base",
+                "facilitator": "https://facilitator.payai.network"
+              }
+            },
+            {
               "mpp": {
                 "method": "solana",
                 "intent": "charge",
@@ -1010,6 +1046,12 @@
             {
               "x402": {
                 "network": "solana",
+                "facilitator": "https://facilitator.payai.network"
+              }
+            },
+            {
+              "x402": {
+                "network": "base",
                 "facilitator": "https://facilitator.payai.network"
               }
             },
@@ -1169,6 +1211,12 @@
             {
               "x402": {
                 "network": "solana",
+                "facilitator": "https://facilitator.payai.network"
+              }
+            },
+            {
+              "x402": {
+                "network": "base",
                 "facilitator": "https://facilitator.payai.network"
               }
             },
@@ -1335,6 +1383,12 @@
               }
             },
             {
+              "x402": {
+                "network": "base",
+                "facilitator": "https://facilitator.payai.network"
+              }
+            },
+            {
               "mpp": {
                 "method": "solana",
                 "intent": "charge",
@@ -1490,6 +1544,12 @@
               }
             },
             {
+              "x402": {
+                "network": "base",
+                "facilitator": "https://facilitator.payai.network"
+              }
+            },
+            {
               "mpp": {
                 "method": "solana",
                 "intent": "charge",
@@ -1632,6 +1692,12 @@
               }
             },
             {
+              "x402": {
+                "network": "base",
+                "facilitator": "https://facilitator.payai.network"
+              }
+            },
+            {
               "mpp": {
                 "method": "solana",
                 "intent": "charge",
@@ -1753,15 +1819,20 @@
               "schema": {
                 "type": "object",
                 "additionalProperties": false,
+                "minProperties": 1,
+                "description": "At least one of solAddress, evmAddress, or message (with address) is required.",
                 "properties": {
                   "solAddress": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Solana wallet address"
                   },
                   "evmAddress": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "EVM wallet address (0x…)"
                   },
                   "message": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Optional context; may include an address"
                   }
                 },
                 "required": []
@@ -1784,6 +1855,12 @@
             {
               "x402": {
                 "network": "solana",
+                "facilitator": "https://facilitator.payai.network"
+              }
+            },
+            {
+              "x402": {
+                "network": "base",
                 "facilitator": "https://facilitator.payai.network"
               }
             },
@@ -1945,6 +2022,12 @@
             {
               "x402": {
                 "network": "solana",
+                "facilitator": "https://facilitator.payai.network"
+              }
+            },
+            {
+              "x402": {
+                "network": "base",
                 "facilitator": "https://facilitator.payai.network"
               }
             },
@@ -2111,6 +2194,12 @@
               }
             },
             {
+              "x402": {
+                "network": "base",
+                "facilitator": "https://facilitator.payai.network"
+              }
+            },
+            {
               "mpp": {
                 "method": "solana",
                 "intent": "charge",
@@ -2265,6 +2354,12 @@
             {
               "x402": {
                 "network": "solana",
+                "facilitator": "https://facilitator.payai.network"
+              }
+            },
+            {
+              "x402": {
+                "network": "base",
                 "facilitator": "https://facilitator.payai.network"
               }
             },
@@ -2435,6 +2530,12 @@
             {
               "x402": {
                 "network": "solana",
+                "facilitator": "https://facilitator.payai.network"
+              }
+            },
+            {
+              "x402": {
+                "network": "base",
                 "facilitator": "https://facilitator.payai.network"
               }
             },
@@ -2615,6 +2716,12 @@
               }
             },
             {
+              "x402": {
+                "network": "base",
+                "facilitator": "https://facilitator.payai.network"
+              }
+            },
+            {
               "mpp": {
                 "method": "solana",
                 "intent": "charge",
@@ -2663,7 +2770,18 @@
                     "candidates": {
                       "type": "array",
                       "items": {
-                        "type": "object"
+                        "type": "object",
+                        "properties": {
+                          "asset": {
+                            "type": "string"
+                          },
+                          "thesis": {
+                            "type": "string"
+                          },
+                          "conviction": {
+                            "type": "string"
+                          }
+                        }
                       }
                     }
                   },
@@ -2767,6 +2885,12 @@
               }
             },
             {
+              "x402": {
+                "network": "base",
+                "facilitator": "https://facilitator.payai.network"
+              }
+            },
+            {
               "mpp": {
                 "method": "solana",
                 "intent": "charge",
@@ -2815,7 +2939,18 @@
                     "candidates": {
                       "type": "array",
                       "items": {
-                        "type": "object"
+                        "type": "object",
+                        "properties": {
+                          "asset": {
+                            "type": "string"
+                          },
+                          "thesis": {
+                            "type": "string"
+                          },
+                          "conviction": {
+                            "type": "string"
+                          }
+                        }
                       }
                     }
                   },
@@ -2928,6 +3063,12 @@
               }
             },
             {
+              "x402": {
+                "network": "base",
+                "facilitator": "https://facilitator.payai.network"
+              }
+            },
+            {
               "mpp": {
                 "method": "solana",
                 "intent": "charge",
@@ -2991,6 +3132,9 @@
                             ]
                           },
                           "thesis": {
+                            "type": "string"
+                          },
+                          "conviction": {
                             "type": "string"
                           }
                         }
@@ -3098,6 +3242,12 @@
               }
             },
             {
+              "x402": {
+                "network": "base",
+                "facilitator": "https://facilitator.payai.network"
+              }
+            },
+            {
               "mpp": {
                 "method": "solana",
                 "intent": "charge",
@@ -3161,6 +3311,9 @@
                             ]
                           },
                           "thesis": {
+                            "type": "string"
+                          },
+                          "conviction": {
                             "type": "string"
                           }
                         }
@@ -3260,7 +3413,9 @@
     }
   },
   "x-discovery": {
-    "ownershipProofs": [],
+    "ownershipProofs": [
+      "0xb85c83cc448edca8eb724f5d79b523faff9375a7"
+    ],
     "x402scan": "https://www.x402scan.com/resources/register",
     "mppscan": "https://www.mppscan.com/",
     "mppscanRegister": "https://www.mppscan.com/register",

--- a/providers/conc-exe/concierge-agent/openapi.json
+++ b/providers/conc-exe/concierge-agent/openapi.json
@@ -1,0 +1,3318 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Concierge Agent API",
+    "version": "4.0.0",
+    "description": "Market intelligence as a service — twelve pay-per-call endpoints. Concierge AI, DeFi intel, Alpha desks (airdrop, listing, momentum), and Lounge RWA signals. No API keys. x402 + MPP discovery; USDC settlement on Solana and Base via PayAI.",
+    "x-guidance": "Concierge Agent is a pay-per-call market intelligence API. No API keys — payment is the only gate. Discover endpoints via GET /openapi.json. Each paid route accepts POST with application/json after x402 USDC settlement on Solana or Base (PayAI facilitator). Flow: POST without PAYMENT-SIGNATURE → 402 + PAYMENT-REQUIRED header → pay → retry with PAYMENT-SIGNATURE (base64 payment payload). Intel routes: /api/concierge-intel-tvl (empty body ok), intel-yields (chain/project), intel-whales (symbols), intel-wallet (solAddress/evmAddress), intel-verdict (message, includeInsider), intel-airdrop|intel-listing|intel-momentum (message, chain, limit, includeInsider). Concierge chat: POST /api/concierge with mode chat|enhance|image and message. Lounge: /api/news-open, /api/lounge-signal-publish ($1), /api/lounge-signal-open. CLI: npx agentcash discover <origin> · npx agentcash check <origin>/api/concierge-intel-tvl pay.sh: pay --sandbox curl <origin>/api/concierge-intel-tvl -d '{}' · pay skills search market intelligence",
+    "x-marketplace-tags": [
+      "AI",
+      "Trading",
+      "Search",
+      "Crypto",
+      "RWA"
+    ],
+    "contact": {
+      "name": "Concierge Agent",
+      "url": "https://conc-exe.xyz/docs",
+      "email": "support@conc-exe.xyz"
+    }
+  },
+  "x-service-info": {
+    "name": "Concierge Agent",
+    "description": "Market intelligence as a service — pay-per-call Concierge AI, DeFi intel APIs, and Lounge RWA signals. USDC on Solana or Base via x402 (MPP-compatible discovery).",
+    "tags": [
+      "AI",
+      "Trading",
+      "Search",
+      "Crypto",
+      "RWA"
+    ],
+    "iconUrl": "https://conc-exe.xyz/images/the-concierge-logo.png",
+    "protocols": [
+      "x402",
+      "mpp"
+    ],
+    "facilitator": "PayAI",
+    "networks": [
+      "solana",
+      "base"
+    ]
+  },
+  "servers": [
+    {
+      "url": "https://conc-exe.xyz",
+      "description": "Concierge Agent"
+    }
+  ],
+  "paths": {
+    "/api/news-open": {
+      "post": {
+        "operationId": "news",
+        "summary": "Open news article",
+        "description": "Unlock one wire headline and receive the canonical article URL.",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.100000"
+          },
+          "protocols": [
+            {
+              "x402": {
+                "network": "solana",
+                "facilitator": "https://facilitator.payai.network"
+              }
+            },
+            {
+              "mpp": {
+                "method": "solana",
+                "intent": "charge",
+                "currency": "USDC"
+              }
+            }
+          ],
+          "offers": [
+            {
+              "protocol": "x402",
+              "amount": "100000",
+              "currency": "USDC",
+              "intent": "charge",
+              "description": "$0.10 USDC via PayAI (Solana or Base)"
+            },
+            {
+              "protocol": "mpp",
+              "amount": "100000",
+              "currency": "USDC",
+              "intent": "charge",
+              "description": "$0.10 USDC — x402 settlement compatible with MPP clients"
+            }
+          ]
+        },
+        "tags": [
+          "Search",
+          "Trading",
+          "RWA"
+        ],
+        "responses": {
+          "200": {
+            "description": "Success after payment",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "url": {
+                      "type": "string",
+                      "description": "Canonical article URL"
+                    },
+                    "unlocked": {
+                      "type": "boolean"
+                    },
+                    "title": {
+                      "type": "string"
+                    },
+                    "source": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "url",
+                    "unlocked"
+                  ]
+                },
+                "example": {
+                  "url": "https://www.bbc.com/news/example",
+                  "unlocked": true,
+                  "title": "Example",
+                  "source": "BBC"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "Base64 JSON x402 payment requirements (MPP-compatible)",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "priceUsdc": {
+                      "type": "number"
+                    },
+                    "resource": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "servers": [
+          {
+            "url": "https://conc-exe.xyz/api/news-open"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "url": {
+                    "type": "string",
+                    "description": "Article URL (http/https)"
+                  },
+                  "title": {
+                    "type": "string",
+                    "description": "Headline title"
+                  },
+                  "source": {
+                    "type": "string",
+                    "description": "Publisher name"
+                  }
+                },
+                "required": [
+                  "url"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/concierge": {
+      "post": {
+        "operationId": "concierge",
+        "summary": "Concierge AI message",
+        "description": "One Concierge AI turn (chat, enhance, or image analysis).",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.100000"
+          },
+          "protocols": [
+            {
+              "x402": {
+                "network": "solana",
+                "facilitator": "https://facilitator.payai.network"
+              }
+            },
+            {
+              "mpp": {
+                "method": "solana",
+                "intent": "charge",
+                "currency": "USDC"
+              }
+            }
+          ],
+          "offers": [
+            {
+              "protocol": "x402",
+              "amount": "100000",
+              "currency": "USDC",
+              "intent": "charge",
+              "description": "$0.10 USDC via PayAI (Solana or Base)"
+            },
+            {
+              "protocol": "mpp",
+              "amount": "100000",
+              "currency": "USDC",
+              "intent": "charge",
+              "description": "$0.10 USDC — x402 settlement compatible with MPP clients"
+            }
+          ]
+        },
+        "tags": [
+          "AI",
+          "Trading",
+          "RWA"
+        ],
+        "responses": {
+          "200": {
+            "description": "Success after payment",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "reply": {
+                      "type": "string",
+                      "description": "HTML analysis from Concierge"
+                    },
+                    "topics": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "required": [
+                    "reply"
+                  ]
+                },
+                "example": {
+                  "reply": "<p>Analysis…</p>",
+                  "topics": [
+                    "crypto",
+                    "macro"
+                  ]
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "Base64 JSON x402 payment requirements (MPP-compatible)",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "priceUsdc": {
+                      "type": "number"
+                    },
+                    "resource": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "servers": [
+          {
+            "url": "https://conc-exe.xyz/api/concierge"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "mode": {
+                    "type": "string",
+                    "enum": [
+                      "chat",
+                      "enhance",
+                      "image"
+                    ],
+                    "description": "Concierge mode"
+                  },
+                  "message": {
+                    "type": "string",
+                    "description": "User message"
+                  },
+                  "history": {
+                    "type": "array",
+                    "description": "Prior chat turns",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "role": {
+                          "type": "string",
+                          "enum": [
+                            "user",
+                            "model"
+                          ]
+                        },
+                        "text": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "role",
+                        "text"
+                      ]
+                    }
+                  },
+                  "market": {
+                    "type": "array",
+                    "description": "Optional market ticks from UI"
+                  },
+                  "signal": {
+                    "type": "object",
+                    "description": "Optional signal draft for enhance mode",
+                    "properties": {
+                      "title": {
+                        "type": "string"
+                      },
+                      "summary": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "required": [
+                  "message"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/lounge-signal-publish": {
+      "post": {
+        "operationId": "signal_publish",
+        "summary": "Publish creator signal",
+        "description": "Publish one RWA intelligence signal to the Executive Lounge feed (anti-spam fee).",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "1.000000"
+          },
+          "protocols": [
+            {
+              "x402": {
+                "network": "solana",
+                "facilitator": "https://facilitator.payai.network"
+              }
+            },
+            {
+              "mpp": {
+                "method": "solana",
+                "intent": "charge",
+                "currency": "USDC"
+              }
+            }
+          ],
+          "offers": [
+            {
+              "protocol": "x402",
+              "amount": "1000000",
+              "currency": "USDC",
+              "intent": "charge",
+              "description": "$1.00 USDC via PayAI (Solana or Base)"
+            },
+            {
+              "protocol": "mpp",
+              "amount": "1000000",
+              "currency": "USDC",
+              "intent": "charge",
+              "description": "$1.00 USDC — x402 settlement compatible with MPP clients"
+            }
+          ]
+        },
+        "tags": [
+          "Crypto",
+          "RWA"
+        ],
+        "responses": {
+          "200": {
+            "description": "Success after payment",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "published": {
+                      "type": "boolean"
+                    },
+                    "title": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "published"
+                  ]
+                },
+                "example": {
+                  "id": "sig_abc123",
+                  "published": true,
+                  "title": "BTC thesis"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "Base64 JSON x402 payment requirements (MPP-compatible)",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "priceUsdc": {
+                      "type": "number"
+                    },
+                    "resource": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "servers": [
+          {
+            "url": "https://conc-exe.xyz/api/lounge-signal-publish"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "title": {
+                    "type": "string"
+                  },
+                  "summary": {
+                    "type": "string"
+                  },
+                  "categories": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "creatorWallet": {
+                    "type": "string"
+                  },
+                  "creatorChain": {
+                    "type": "string",
+                    "enum": [
+                      "sol",
+                      "evm"
+                    ]
+                  }
+                },
+                "required": [
+                  "title",
+                  "summary",
+                  "categories",
+                  "creatorWallet",
+                  "creatorChain"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/lounge-signal-open": {
+      "post": {
+        "operationId": "signal_open",
+        "summary": "Unlock creator signal",
+        "description": "Unlock full intelligence summary for one Lounge RWA creator signal.",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.100000"
+          },
+          "protocols": [
+            {
+              "x402": {
+                "network": "solana",
+                "facilitator": "https://facilitator.payai.network"
+              }
+            },
+            {
+              "mpp": {
+                "method": "solana",
+                "intent": "charge",
+                "currency": "USDC"
+              }
+            }
+          ],
+          "offers": [
+            {
+              "protocol": "x402",
+              "amount": "100000",
+              "currency": "USDC",
+              "intent": "charge",
+              "description": "$0.10 USDC via PayAI (Solana or Base)"
+            },
+            {
+              "protocol": "mpp",
+              "amount": "100000",
+              "currency": "USDC",
+              "intent": "charge",
+              "description": "$0.10 USDC — x402 settlement compatible with MPP clients"
+            }
+          ]
+        },
+        "tags": [
+          "Crypto",
+          "RWA"
+        ],
+        "responses": {
+          "200": {
+            "description": "Success after payment",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "signalId": {
+                      "type": "string"
+                    },
+                    "summary": {
+                      "type": "string"
+                    },
+                    "title": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "signalId",
+                    "summary"
+                  ]
+                },
+                "example": {
+                  "signalId": "sig_abc123",
+                  "summary": "Full intelligence summary…",
+                  "title": "BTC thesis"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "Base64 JSON x402 payment requirements (MPP-compatible)",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "priceUsdc": {
+                      "type": "number"
+                    },
+                    "resource": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "servers": [
+          {
+            "url": "https://conc-exe.xyz/api/lounge-signal-open"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "signalId": {
+                    "type": "string",
+                    "description": "Published signal id"
+                  }
+                },
+                "required": [
+                  "signalId"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/concierge-intel-tvl": {
+      "post": {
+        "operationId": "intel_tvl",
+        "summary": "Concierge Intel — TVL",
+        "description": "Chain TVL snapshot and top DeFi protocols (DeFi Llama). JSON for agents.",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.100000"
+          },
+          "protocols": [
+            {
+              "x402": {
+                "network": "solana",
+                "facilitator": "https://facilitator.payai.network"
+              }
+            },
+            {
+              "mpp": {
+                "method": "solana",
+                "intent": "charge",
+                "currency": "USDC"
+              }
+            }
+          ],
+          "offers": [
+            {
+              "protocol": "x402",
+              "amount": "100000",
+              "currency": "USDC",
+              "intent": "charge",
+              "description": "$0.10 USDC via PayAI (Solana or Base)"
+            },
+            {
+              "protocol": "mpp",
+              "amount": "100000",
+              "currency": "USDC",
+              "intent": "charge",
+              "description": "$0.10 USDC — x402 settlement compatible with MPP clients"
+            }
+          ]
+        },
+        "tags": [
+          "AI",
+          "Crypto",
+          "Trading"
+        ],
+        "responses": {
+          "200": {
+            "description": "Success after payment",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "chains": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "tvl": {
+                            "type": "number"
+                          }
+                        }
+                      }
+                    },
+                    "topProtocols": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "tvl": {
+                            "type": "number"
+                          },
+                          "category": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "required": [
+                    "ok"
+                  ]
+                },
+                "example": {
+                  "ok": true,
+                  "chains": [
+                    {
+                      "name": "Solana",
+                      "tvl": 4200000000
+                    }
+                  ],
+                  "topProtocols": []
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "Base64 JSON x402 payment requirements (MPP-compatible)",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "priceUsdc": {
+                      "type": "number"
+                    },
+                    "resource": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "servers": [
+          {
+            "url": "https://conc-exe.xyz/api/concierge-intel-tvl"
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "message": {
+                    "type": "string",
+                    "description": "Optional context for logging"
+                  }
+                },
+                "required": []
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "operationId": "intel_tvl_get",
+        "summary": "Concierge Intel — TVL (GET probe)",
+        "description": "Chain TVL snapshot and top DeFi protocols (DeFi Llama). JSON for agents. Probes return 402 without payment; use POST with JSON body after settlement.",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.100000"
+          },
+          "protocols": [
+            {
+              "x402": {
+                "network": "solana",
+                "facilitator": "https://facilitator.payai.network"
+              }
+            },
+            {
+              "mpp": {
+                "method": "solana",
+                "intent": "charge",
+                "currency": "USDC"
+              }
+            }
+          ],
+          "offers": [
+            {
+              "protocol": "x402",
+              "amount": "100000",
+              "currency": "USDC",
+              "intent": "charge",
+              "description": "$0.10 USDC via PayAI (Solana or Base)"
+            },
+            {
+              "protocol": "mpp",
+              "amount": "100000",
+              "currency": "USDC",
+              "intent": "charge",
+              "description": "$0.10 USDC — x402 settlement compatible with MPP clients"
+            }
+          ]
+        },
+        "tags": [
+          "AI",
+          "Crypto",
+          "Trading"
+        ],
+        "responses": {
+          "200": {
+            "description": "Success after payment",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "chains": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "tvl": {
+                            "type": "number"
+                          }
+                        }
+                      }
+                    },
+                    "topProtocols": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "tvl": {
+                            "type": "number"
+                          },
+                          "category": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "required": [
+                    "ok"
+                  ]
+                },
+                "example": {
+                  "ok": true,
+                  "chains": [
+                    {
+                      "name": "Solana",
+                      "tvl": 4200000000
+                    }
+                  ],
+                  "topProtocols": []
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "Base64 JSON x402 payment requirements (MPP-compatible)",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "priceUsdc": {
+                      "type": "number"
+                    },
+                    "resource": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "servers": [
+          {
+            "url": "https://conc-exe.xyz/api/concierge-intel-tvl"
+          }
+        ],
+        "parameters": [
+          {
+            "name": "message",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/api/concierge-intel-yields": {
+      "post": {
+        "operationId": "intel_yields",
+        "summary": "Concierge Intel — Yields",
+        "description": "Screened yield pools on Solana/EVM (Jupiter, Meteora, DLMM, major venues).",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.100000"
+          },
+          "protocols": [
+            {
+              "x402": {
+                "network": "solana",
+                "facilitator": "https://facilitator.payai.network"
+              }
+            },
+            {
+              "mpp": {
+                "method": "solana",
+                "intent": "charge",
+                "currency": "USDC"
+              }
+            }
+          ],
+          "offers": [
+            {
+              "protocol": "x402",
+              "amount": "100000",
+              "currency": "USDC",
+              "intent": "charge",
+              "description": "$0.10 USDC via PayAI (Solana or Base)"
+            },
+            {
+              "protocol": "mpp",
+              "amount": "100000",
+              "currency": "USDC",
+              "intent": "charge",
+              "description": "$0.10 USDC — x402 settlement compatible with MPP clients"
+            }
+          ]
+        },
+        "tags": [
+          "AI",
+          "Crypto",
+          "Trading"
+        ],
+        "responses": {
+          "200": {
+            "description": "Success after payment",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "pools": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "project": {
+                            "type": "string"
+                          },
+                          "chain": {
+                            "type": "string"
+                          },
+                          "apy": {
+                            "type": "number"
+                          },
+                          "symbol": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "required": [
+                    "ok"
+                  ]
+                },
+                "example": {
+                  "ok": true,
+                  "pools": [
+                    {
+                      "project": "meteora",
+                      "chain": "solana",
+                      "apy": 12.4,
+                      "symbol": "SOL-USDC"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "Base64 JSON x402 payment requirements (MPP-compatible)",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "priceUsdc": {
+                      "type": "number"
+                    },
+                    "resource": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "servers": [
+          {
+            "url": "https://conc-exe.xyz/api/concierge-intel-yields"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "chain": {
+                    "type": "string",
+                    "description": "solana | ethereum | base | arbitrum"
+                  },
+                  "project": {
+                    "type": "string",
+                    "description": "Filter project id substring"
+                  },
+                  "message": {
+                    "type": "string"
+                  }
+                },
+                "required": []
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "operationId": "intel_yields_get",
+        "summary": "Concierge Intel — Yields (GET probe)",
+        "description": "Screened yield pools on Solana/EVM (Jupiter, Meteora, DLMM, major venues). Probes return 402 without payment; use POST with JSON body after settlement.",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.100000"
+          },
+          "protocols": [
+            {
+              "x402": {
+                "network": "solana",
+                "facilitator": "https://facilitator.payai.network"
+              }
+            },
+            {
+              "mpp": {
+                "method": "solana",
+                "intent": "charge",
+                "currency": "USDC"
+              }
+            }
+          ],
+          "offers": [
+            {
+              "protocol": "x402",
+              "amount": "100000",
+              "currency": "USDC",
+              "intent": "charge",
+              "description": "$0.10 USDC via PayAI (Solana or Base)"
+            },
+            {
+              "protocol": "mpp",
+              "amount": "100000",
+              "currency": "USDC",
+              "intent": "charge",
+              "description": "$0.10 USDC — x402 settlement compatible with MPP clients"
+            }
+          ]
+        },
+        "tags": [
+          "AI",
+          "Crypto",
+          "Trading"
+        ],
+        "responses": {
+          "200": {
+            "description": "Success after payment",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "pools": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "project": {
+                            "type": "string"
+                          },
+                          "chain": {
+                            "type": "string"
+                          },
+                          "apy": {
+                            "type": "number"
+                          },
+                          "symbol": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "required": [
+                    "ok"
+                  ]
+                },
+                "example": {
+                  "ok": true,
+                  "pools": [
+                    {
+                      "project": "meteora",
+                      "chain": "solana",
+                      "apy": 12.4,
+                      "symbol": "SOL-USDC"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "Base64 JSON x402 payment requirements (MPP-compatible)",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "priceUsdc": {
+                      "type": "number"
+                    },
+                    "resource": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "servers": [
+          {
+            "url": "https://conc-exe.xyz/api/concierge-intel-yields"
+          }
+        ],
+        "parameters": [
+          {
+            "name": "chain",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "project",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "message",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/api/concierge-intel-whales": {
+      "post": {
+        "operationId": "intel_whales",
+        "summary": "Concierge Intel — Whales",
+        "description": "Binance top-trader long/short ratios (BTC/ETH/SOL derivatives proxy).",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.100000"
+          },
+          "protocols": [
+            {
+              "x402": {
+                "network": "solana",
+                "facilitator": "https://facilitator.payai.network"
+              }
+            },
+            {
+              "mpp": {
+                "method": "solana",
+                "intent": "charge",
+                "currency": "USDC"
+              }
+            }
+          ],
+          "offers": [
+            {
+              "protocol": "x402",
+              "amount": "100000",
+              "currency": "USDC",
+              "intent": "charge",
+              "description": "$0.10 USDC via PayAI (Solana or Base)"
+            },
+            {
+              "protocol": "mpp",
+              "amount": "100000",
+              "currency": "USDC",
+              "intent": "charge",
+              "description": "$0.10 USDC — x402 settlement compatible with MPP clients"
+            }
+          ]
+        },
+        "tags": [
+          "AI",
+          "Crypto",
+          "Trading"
+        ],
+        "responses": {
+          "200": {
+            "description": "Success after payment",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "positioning": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "symbol": {
+                            "type": "string"
+                          },
+                          "longShortRatio": {
+                            "type": "number"
+                          },
+                          "bias": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "required": [
+                    "ok"
+                  ]
+                },
+                "example": {
+                  "ok": true,
+                  "positioning": [
+                    {
+                      "symbol": "BTC",
+                      "longShortRatio": 1.12,
+                      "bias": "long"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "Base64 JSON x402 payment requirements (MPP-compatible)",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "priceUsdc": {
+                      "type": "number"
+                    },
+                    "resource": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "servers": [
+          {
+            "url": "https://conc-exe.xyz/api/concierge-intel-whales"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "symbols": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "enum": [
+                        "BTC",
+                        "ETH",
+                        "SOL"
+                      ]
+                    }
+                  }
+                },
+                "required": []
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "operationId": "intel_whales_get",
+        "summary": "Concierge Intel — Whales (GET probe)",
+        "description": "Binance top-trader long/short ratios (BTC/ETH/SOL derivatives proxy). Probes return 402 without payment; use POST with JSON body after settlement.",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.100000"
+          },
+          "protocols": [
+            {
+              "x402": {
+                "network": "solana",
+                "facilitator": "https://facilitator.payai.network"
+              }
+            },
+            {
+              "mpp": {
+                "method": "solana",
+                "intent": "charge",
+                "currency": "USDC"
+              }
+            }
+          ],
+          "offers": [
+            {
+              "protocol": "x402",
+              "amount": "100000",
+              "currency": "USDC",
+              "intent": "charge",
+              "description": "$0.10 USDC via PayAI (Solana or Base)"
+            },
+            {
+              "protocol": "mpp",
+              "amount": "100000",
+              "currency": "USDC",
+              "intent": "charge",
+              "description": "$0.10 USDC — x402 settlement compatible with MPP clients"
+            }
+          ]
+        },
+        "tags": [
+          "AI",
+          "Crypto",
+          "Trading"
+        ],
+        "responses": {
+          "200": {
+            "description": "Success after payment",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "positioning": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "symbol": {
+                            "type": "string"
+                          },
+                          "longShortRatio": {
+                            "type": "number"
+                          },
+                          "bias": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "required": [
+                    "ok"
+                  ]
+                },
+                "example": {
+                  "ok": true,
+                  "positioning": [
+                    {
+                      "symbol": "BTC",
+                      "longShortRatio": 1.12,
+                      "bias": "long"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "Base64 JSON x402 payment requirements (MPP-compatible)",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "priceUsdc": {
+                      "type": "number"
+                    },
+                    "resource": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "servers": [
+          {
+            "url": "https://conc-exe.xyz/api/concierge-intel-whales"
+          }
+        ],
+        "parameters": [
+          {
+            "name": "symbols",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array"
+            }
+          }
+        ]
+      }
+    },
+    "/api/concierge-intel-wallet": {
+      "post": {
+        "operationId": "intel_wallet",
+        "summary": "Concierge Intel — Wallet",
+        "description": "Wallet snapshot for Solana (Helius) or EVM address acknowledgment.",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.100000"
+          },
+          "protocols": [
+            {
+              "x402": {
+                "network": "solana",
+                "facilitator": "https://facilitator.payai.network"
+              }
+            },
+            {
+              "mpp": {
+                "method": "solana",
+                "intent": "charge",
+                "currency": "USDC"
+              }
+            }
+          ],
+          "offers": [
+            {
+              "protocol": "x402",
+              "amount": "100000",
+              "currency": "USDC",
+              "intent": "charge",
+              "description": "$0.10 USDC via PayAI (Solana or Base)"
+            },
+            {
+              "protocol": "mpp",
+              "amount": "100000",
+              "currency": "USDC",
+              "intent": "charge",
+              "description": "$0.10 USDC — x402 settlement compatible with MPP clients"
+            }
+          ]
+        },
+        "tags": [
+          "AI",
+          "Crypto",
+          "Trading"
+        ],
+        "responses": {
+          "200": {
+            "description": "Success after payment",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "wallet": {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "chain": {
+                          "type": "string"
+                        },
+                        "address": {
+                          "type": "string"
+                        },
+                        "tokens": {
+                          "type": "array",
+                          "items": {
+                            "type": "object"
+                          }
+                        }
+                      },
+                      "required": [
+                        "chain",
+                        "address"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "ok"
+                  ]
+                },
+                "example": {
+                  "ok": true,
+                  "wallet": {
+                    "chain": "solana",
+                    "address": "7hum…",
+                    "tokens": []
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "Base64 JSON x402 payment requirements (MPP-compatible)",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "priceUsdc": {
+                      "type": "number"
+                    },
+                    "resource": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "servers": [
+          {
+            "url": "https://conc-exe.xyz/api/concierge-intel-wallet"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "solAddress": {
+                    "type": "string"
+                  },
+                  "evmAddress": {
+                    "type": "string"
+                  },
+                  "message": {
+                    "type": "string"
+                  }
+                },
+                "required": []
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "operationId": "intel_wallet_get",
+        "summary": "Concierge Intel — Wallet (GET probe)",
+        "description": "Wallet snapshot for Solana (Helius) or EVM address acknowledgment. Probes return 402 without payment; use POST with JSON body after settlement.",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.100000"
+          },
+          "protocols": [
+            {
+              "x402": {
+                "network": "solana",
+                "facilitator": "https://facilitator.payai.network"
+              }
+            },
+            {
+              "mpp": {
+                "method": "solana",
+                "intent": "charge",
+                "currency": "USDC"
+              }
+            }
+          ],
+          "offers": [
+            {
+              "protocol": "x402",
+              "amount": "100000",
+              "currency": "USDC",
+              "intent": "charge",
+              "description": "$0.10 USDC via PayAI (Solana or Base)"
+            },
+            {
+              "protocol": "mpp",
+              "amount": "100000",
+              "currency": "USDC",
+              "intent": "charge",
+              "description": "$0.10 USDC — x402 settlement compatible with MPP clients"
+            }
+          ]
+        },
+        "tags": [
+          "AI",
+          "Crypto",
+          "Trading"
+        ],
+        "responses": {
+          "200": {
+            "description": "Success after payment",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "wallet": {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "chain": {
+                          "type": "string"
+                        },
+                        "address": {
+                          "type": "string"
+                        },
+                        "tokens": {
+                          "type": "array",
+                          "items": {
+                            "type": "object"
+                          }
+                        }
+                      },
+                      "required": [
+                        "chain",
+                        "address"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "ok"
+                  ]
+                },
+                "example": {
+                  "ok": true,
+                  "wallet": {
+                    "chain": "solana",
+                    "address": "7hum…",
+                    "tokens": []
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "Base64 JSON x402 payment requirements (MPP-compatible)",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "priceUsdc": {
+                      "type": "number"
+                    },
+                    "resource": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "servers": [
+          {
+            "url": "https://conc-exe.xyz/api/concierge-intel-wallet"
+          }
+        ],
+        "parameters": [
+          {
+            "name": "solAddress",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "evmAddress",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "message",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/api/concierge-intel-verdict": {
+      "post": {
+        "operationId": "intel_verdict",
+        "summary": "Concierge Intel — Verdict",
+        "description": "Structured desk verdict with Fear & Greed, positioning, yields, and optional Lounge insider signals.",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.100000"
+          },
+          "protocols": [
+            {
+              "x402": {
+                "network": "solana",
+                "facilitator": "https://facilitator.payai.network"
+              }
+            },
+            {
+              "mpp": {
+                "method": "solana",
+                "intent": "charge",
+                "currency": "USDC"
+              }
+            }
+          ],
+          "offers": [
+            {
+              "protocol": "x402",
+              "amount": "100000",
+              "currency": "USDC",
+              "intent": "charge",
+              "description": "$0.10 USDC via PayAI (Solana or Base)"
+            },
+            {
+              "protocol": "mpp",
+              "amount": "100000",
+              "currency": "USDC",
+              "intent": "charge",
+              "description": "$0.10 USDC — x402 settlement compatible with MPP clients"
+            }
+          ]
+        },
+        "tags": [
+          "AI",
+          "Crypto",
+          "Trading",
+          "RWA"
+        ],
+        "responses": {
+          "200": {
+            "description": "Success after payment",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "verdict": {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "signal": {
+                          "type": "string",
+                          "enum": [
+                            "snipe",
+                            "watch",
+                            "follow",
+                            "avoid",
+                            "rebalance"
+                          ]
+                        },
+                        "confidence": {
+                          "type": "string"
+                        },
+                        "summary": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "signal"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "ok",
+                    "verdict"
+                  ]
+                },
+                "example": {
+                  "ok": true,
+                  "verdict": {
+                    "signal": "watch",
+                    "confidence": "medium",
+                    "summary": "Desk bias neutral…"
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "Base64 JSON x402 payment requirements (MPP-compatible)",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "priceUsdc": {
+                      "type": "number"
+                    },
+                    "resource": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "servers": [
+          {
+            "url": "https://conc-exe.xyz/api/concierge-intel-verdict"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "message": {
+                    "type": "string",
+                    "description": "Question or theme for verdict"
+                  },
+                  "includeInsider": {
+                    "type": "boolean",
+                    "description": "Include Lounge creator signals (default true)"
+                  }
+                },
+                "required": [
+                  "message"
+                ]
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "operationId": "intel_verdict_get",
+        "summary": "Concierge Intel — Verdict (GET probe)",
+        "description": "Structured desk verdict with Fear & Greed, positioning, yields, and optional Lounge insider signals. Probes return 402 without payment; use POST with JSON body after settlement.",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.100000"
+          },
+          "protocols": [
+            {
+              "x402": {
+                "network": "solana",
+                "facilitator": "https://facilitator.payai.network"
+              }
+            },
+            {
+              "mpp": {
+                "method": "solana",
+                "intent": "charge",
+                "currency": "USDC"
+              }
+            }
+          ],
+          "offers": [
+            {
+              "protocol": "x402",
+              "amount": "100000",
+              "currency": "USDC",
+              "intent": "charge",
+              "description": "$0.10 USDC via PayAI (Solana or Base)"
+            },
+            {
+              "protocol": "mpp",
+              "amount": "100000",
+              "currency": "USDC",
+              "intent": "charge",
+              "description": "$0.10 USDC — x402 settlement compatible with MPP clients"
+            }
+          ]
+        },
+        "tags": [
+          "AI",
+          "Crypto",
+          "Trading",
+          "RWA"
+        ],
+        "responses": {
+          "200": {
+            "description": "Success after payment",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "verdict": {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "signal": {
+                          "type": "string",
+                          "enum": [
+                            "snipe",
+                            "watch",
+                            "follow",
+                            "avoid",
+                            "rebalance"
+                          ]
+                        },
+                        "confidence": {
+                          "type": "string"
+                        },
+                        "summary": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "signal"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "ok",
+                    "verdict"
+                  ]
+                },
+                "example": {
+                  "ok": true,
+                  "verdict": {
+                    "signal": "watch",
+                    "confidence": "medium",
+                    "summary": "Desk bias neutral…"
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "Base64 JSON x402 payment requirements (MPP-compatible)",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "priceUsdc": {
+                      "type": "number"
+                    },
+                    "resource": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "servers": [
+          {
+            "url": "https://conc-exe.xyz/api/concierge-intel-verdict"
+          }
+        ],
+        "parameters": [
+          {
+            "name": "message",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "includeInsider",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ]
+      }
+    },
+    "/api/concierge-intel-airdrop": {
+      "post": {
+        "operationId": "intel_airdrop",
+        "summary": "Concierge Intel — Airdrop",
+        "description": "Potential airdrop candidates — Lounge insider signals first, institutional/onchain/narrative/KOL overlay.",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.100000"
+          },
+          "protocols": [
+            {
+              "x402": {
+                "network": "solana",
+                "facilitator": "https://facilitator.payai.network"
+              }
+            },
+            {
+              "mpp": {
+                "method": "solana",
+                "intent": "charge",
+                "currency": "USDC"
+              }
+            }
+          ],
+          "offers": [
+            {
+              "protocol": "x402",
+              "amount": "100000",
+              "currency": "USDC",
+              "intent": "charge",
+              "description": "$0.10 USDC via PayAI (Solana or Base)"
+            },
+            {
+              "protocol": "mpp",
+              "amount": "100000",
+              "currency": "USDC",
+              "intent": "charge",
+              "description": "$0.10 USDC — x402 settlement compatible with MPP clients"
+            }
+          ]
+        },
+        "tags": [
+          "AI",
+          "Crypto",
+          "Trading",
+          "RWA"
+        ],
+        "responses": {
+          "200": {
+            "description": "Success after payment",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "summary": {
+                      "type": "string"
+                    },
+                    "candidates": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "asset": {
+                            "type": "string"
+                          },
+                          "thesis": {
+                            "type": "string"
+                          },
+                          "conviction": {
+                            "type": "string"
+                          },
+                          "insiderWeight": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "required": [
+                    "ok",
+                    "candidates"
+                  ]
+                },
+                "example": {
+                  "ok": true,
+                  "summary": "Two Solana protocols show insider + narrative airdrop overlap.",
+                  "candidates": [
+                    {
+                      "asset": "EXAMPLE",
+                      "thesis": "Creator signal + TVL growth — monitor points program.",
+                      "conviction": "medium",
+                      "insiderWeight": "primary"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "Base64 JSON x402 payment requirements (MPP-compatible)",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "priceUsdc": {
+                      "type": "number"
+                    },
+                    "resource": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "servers": [
+          {
+            "url": "https://conc-exe.xyz/api/concierge-intel-airdrop"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "message": {
+                    "type": "string",
+                    "description": "Focus theme or protocol name"
+                  },
+                  "chain": {
+                    "type": "string",
+                    "description": "Optional chain filter (solana, ethereum, base)"
+                  },
+                  "limit": {
+                    "type": "number",
+                    "description": "Max candidates 1–8 (default 5)"
+                  },
+                  "includeInsider": {
+                    "type": "boolean",
+                    "description": "Include Lounge insider signals (default true)"
+                  }
+                },
+                "required": []
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "operationId": "intel_airdrop_get",
+        "summary": "Concierge Intel — Airdrop (GET probe)",
+        "description": "Potential airdrop candidates — Lounge insider signals first, institutional/onchain/narrative/KOL overlay. Probes return 402 without payment; use POST with JSON body after settlement.",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.100000"
+          },
+          "protocols": [
+            {
+              "x402": {
+                "network": "solana",
+                "facilitator": "https://facilitator.payai.network"
+              }
+            },
+            {
+              "mpp": {
+                "method": "solana",
+                "intent": "charge",
+                "currency": "USDC"
+              }
+            }
+          ],
+          "offers": [
+            {
+              "protocol": "x402",
+              "amount": "100000",
+              "currency": "USDC",
+              "intent": "charge",
+              "description": "$0.10 USDC via PayAI (Solana or Base)"
+            },
+            {
+              "protocol": "mpp",
+              "amount": "100000",
+              "currency": "USDC",
+              "intent": "charge",
+              "description": "$0.10 USDC — x402 settlement compatible with MPP clients"
+            }
+          ]
+        },
+        "tags": [
+          "AI",
+          "Crypto",
+          "Trading",
+          "RWA"
+        ],
+        "responses": {
+          "200": {
+            "description": "Success after payment",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "summary": {
+                      "type": "string"
+                    },
+                    "candidates": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "asset": {
+                            "type": "string"
+                          },
+                          "thesis": {
+                            "type": "string"
+                          },
+                          "conviction": {
+                            "type": "string"
+                          },
+                          "insiderWeight": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "required": [
+                    "ok",
+                    "candidates"
+                  ]
+                },
+                "example": {
+                  "ok": true,
+                  "summary": "Two Solana protocols show insider + narrative airdrop overlap.",
+                  "candidates": [
+                    {
+                      "asset": "EXAMPLE",
+                      "thesis": "Creator signal + TVL growth — monitor points program.",
+                      "conviction": "medium",
+                      "insiderWeight": "primary"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "Base64 JSON x402 payment requirements (MPP-compatible)",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "priceUsdc": {
+                      "type": "number"
+                    },
+                    "resource": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "servers": [
+          {
+            "url": "https://conc-exe.xyz/api/concierge-intel-airdrop"
+          }
+        ],
+        "parameters": [
+          {
+            "name": "message",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "chain",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "includeInsider",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ]
+      }
+    },
+    "/api/concierge-intel-listing": {
+      "post": {
+        "operationId": "intel_listing",
+        "summary": "Concierge Intel — Listing",
+        "description": "Potential exchange listing candidates — insider-first alpha desk synthesis for agents.",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.100000"
+          },
+          "protocols": [
+            {
+              "x402": {
+                "network": "solana",
+                "facilitator": "https://facilitator.payai.network"
+              }
+            },
+            {
+              "mpp": {
+                "method": "solana",
+                "intent": "charge",
+                "currency": "USDC"
+              }
+            }
+          ],
+          "offers": [
+            {
+              "protocol": "x402",
+              "amount": "100000",
+              "currency": "USDC",
+              "intent": "charge",
+              "description": "$0.10 USDC via PayAI (Solana or Base)"
+            },
+            {
+              "protocol": "mpp",
+              "amount": "100000",
+              "currency": "USDC",
+              "intent": "charge",
+              "description": "$0.10 USDC — x402 settlement compatible with MPP clients"
+            }
+          ]
+        },
+        "tags": [
+          "AI",
+          "Crypto",
+          "Trading",
+          "RWA"
+        ],
+        "responses": {
+          "200": {
+            "description": "Success after payment",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "summary": {
+                      "type": "string"
+                    },
+                    "candidates": {
+                      "type": "array",
+                      "items": {
+                        "type": "object"
+                      }
+                    }
+                  },
+                  "required": [
+                    "ok",
+                    "candidates"
+                  ]
+                },
+                "example": {
+                  "ok": true,
+                  "summary": "Listing desk scan complete.",
+                  "candidates": [
+                    {
+                      "asset": "TOKEN",
+                      "thesis": "Volume + headline listing rumor.",
+                      "conviction": "low"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "Base64 JSON x402 payment requirements (MPP-compatible)",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "priceUsdc": {
+                      "type": "number"
+                    },
+                    "resource": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "servers": [
+          {
+            "url": "https://conc-exe.xyz/api/concierge-intel-listing"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "message": {
+                    "type": "string",
+                    "description": "Token or listing catalyst focus"
+                  },
+                  "chain": {
+                    "type": "string"
+                  },
+                  "limit": {
+                    "type": "number"
+                  },
+                  "includeInsider": {
+                    "type": "boolean"
+                  }
+                },
+                "required": []
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "operationId": "intel_listing_get",
+        "summary": "Concierge Intel — Listing (GET probe)",
+        "description": "Potential exchange listing candidates — insider-first alpha desk synthesis for agents. Probes return 402 without payment; use POST with JSON body after settlement.",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.100000"
+          },
+          "protocols": [
+            {
+              "x402": {
+                "network": "solana",
+                "facilitator": "https://facilitator.payai.network"
+              }
+            },
+            {
+              "mpp": {
+                "method": "solana",
+                "intent": "charge",
+                "currency": "USDC"
+              }
+            }
+          ],
+          "offers": [
+            {
+              "protocol": "x402",
+              "amount": "100000",
+              "currency": "USDC",
+              "intent": "charge",
+              "description": "$0.10 USDC via PayAI (Solana or Base)"
+            },
+            {
+              "protocol": "mpp",
+              "amount": "100000",
+              "currency": "USDC",
+              "intent": "charge",
+              "description": "$0.10 USDC — x402 settlement compatible with MPP clients"
+            }
+          ]
+        },
+        "tags": [
+          "AI",
+          "Crypto",
+          "Trading",
+          "RWA"
+        ],
+        "responses": {
+          "200": {
+            "description": "Success after payment",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "summary": {
+                      "type": "string"
+                    },
+                    "candidates": {
+                      "type": "array",
+                      "items": {
+                        "type": "object"
+                      }
+                    }
+                  },
+                  "required": [
+                    "ok",
+                    "candidates"
+                  ]
+                },
+                "example": {
+                  "ok": true,
+                  "summary": "Listing desk scan complete.",
+                  "candidates": [
+                    {
+                      "asset": "TOKEN",
+                      "thesis": "Volume + headline listing rumor.",
+                      "conviction": "low"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "Base64 JSON x402 payment requirements (MPP-compatible)",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "priceUsdc": {
+                      "type": "number"
+                    },
+                    "resource": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "servers": [
+          {
+            "url": "https://conc-exe.xyz/api/concierge-intel-listing"
+          }
+        ],
+        "parameters": [
+          {
+            "name": "message",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "chain",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "includeInsider",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ]
+      }
+    },
+    "/api/concierge-intel-momentum": {
+      "post": {
+        "operationId": "intel_momentum",
+        "summary": "Concierge Intel — Momentum",
+        "description": "Large-move candidates (up or down) — insider, derivatives positioning, narrative synthesis.",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.100000"
+          },
+          "protocols": [
+            {
+              "x402": {
+                "network": "solana",
+                "facilitator": "https://facilitator.payai.network"
+              }
+            },
+            {
+              "mpp": {
+                "method": "solana",
+                "intent": "charge",
+                "currency": "USDC"
+              }
+            }
+          ],
+          "offers": [
+            {
+              "protocol": "x402",
+              "amount": "100000",
+              "currency": "USDC",
+              "intent": "charge",
+              "description": "$0.10 USDC via PayAI (Solana or Base)"
+            },
+            {
+              "protocol": "mpp",
+              "amount": "100000",
+              "currency": "USDC",
+              "intent": "charge",
+              "description": "$0.10 USDC — x402 settlement compatible with MPP clients"
+            }
+          ]
+        },
+        "tags": [
+          "AI",
+          "Crypto",
+          "Trading",
+          "RWA"
+        ],
+        "responses": {
+          "200": {
+            "description": "Success after payment",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "summary": {
+                      "type": "string"
+                    },
+                    "candidates": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "asset": {
+                            "type": "string"
+                          },
+                          "direction": {
+                            "type": "string",
+                            "enum": [
+                              "up",
+                              "down",
+                              "neutral",
+                              "watch"
+                            ]
+                          },
+                          "thesis": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "required": [
+                    "ok",
+                    "candidates"
+                  ]
+                },
+                "example": {
+                  "ok": true,
+                  "summary": "Momentum desk: crowded positioning watchlist.",
+                  "candidates": [
+                    {
+                      "asset": "BTC",
+                      "direction": "down",
+                      "thesis": "Crowded long — liq risk on dips.",
+                      "conviction": "medium"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "Base64 JSON x402 payment requirements (MPP-compatible)",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "priceUsdc": {
+                      "type": "number"
+                    },
+                    "resource": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "servers": [
+          {
+            "url": "https://conc-exe.xyz/api/concierge-intel-momentum"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "message": {
+                    "type": "string",
+                    "description": "Asset or momentum theme"
+                  },
+                  "chain": {
+                    "type": "string"
+                  },
+                  "limit": {
+                    "type": "number"
+                  },
+                  "includeInsider": {
+                    "type": "boolean"
+                  }
+                },
+                "required": []
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "operationId": "intel_momentum_get",
+        "summary": "Concierge Intel — Momentum (GET probe)",
+        "description": "Large-move candidates (up or down) — insider, derivatives positioning, narrative synthesis. Probes return 402 without payment; use POST with JSON body after settlement.",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.100000"
+          },
+          "protocols": [
+            {
+              "x402": {
+                "network": "solana",
+                "facilitator": "https://facilitator.payai.network"
+              }
+            },
+            {
+              "mpp": {
+                "method": "solana",
+                "intent": "charge",
+                "currency": "USDC"
+              }
+            }
+          ],
+          "offers": [
+            {
+              "protocol": "x402",
+              "amount": "100000",
+              "currency": "USDC",
+              "intent": "charge",
+              "description": "$0.10 USDC via PayAI (Solana or Base)"
+            },
+            {
+              "protocol": "mpp",
+              "amount": "100000",
+              "currency": "USDC",
+              "intent": "charge",
+              "description": "$0.10 USDC — x402 settlement compatible with MPP clients"
+            }
+          ]
+        },
+        "tags": [
+          "AI",
+          "Crypto",
+          "Trading",
+          "RWA"
+        ],
+        "responses": {
+          "200": {
+            "description": "Success after payment",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "summary": {
+                      "type": "string"
+                    },
+                    "candidates": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "asset": {
+                            "type": "string"
+                          },
+                          "direction": {
+                            "type": "string",
+                            "enum": [
+                              "up",
+                              "down",
+                              "neutral",
+                              "watch"
+                            ]
+                          },
+                          "thesis": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "required": [
+                    "ok",
+                    "candidates"
+                  ]
+                },
+                "example": {
+                  "ok": true,
+                  "summary": "Momentum desk: crowded positioning watchlist.",
+                  "candidates": [
+                    {
+                      "asset": "BTC",
+                      "direction": "down",
+                      "thesis": "Crowded long — liq risk on dips.",
+                      "conviction": "medium"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "Base64 JSON x402 payment requirements (MPP-compatible)",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "priceUsdc": {
+                      "type": "number"
+                    },
+                    "resource": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "servers": [
+          {
+            "url": "https://conc-exe.xyz/api/concierge-intel-momentum"
+          }
+        ],
+        "parameters": [
+          {
+            "name": "message",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "chain",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "includeInsider",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "x-discovery": {
+    "ownershipProofs": [],
+    "x402scan": "https://www.x402scan.com/resources/register",
+    "mppscan": "https://www.mppscan.com/",
+    "mppscanRegister": "https://www.mppscan.com/register",
+    "mppscanServer": "https://conc-exe.xyz/go/mppscan",
+    "mppscanProfileLink": "https://conc-exe.xyz/go/mppscan",
+    "mppscanDiscovery": "https://www.mppscan.com/discovery",
+    "agentcashDiscover": "npx -y @agentcash/discovery@latest discover https://conc-exe.xyz",
+    "agentcashCheckIntel": "npx -y @agentcash/discovery@latest check https://conc-exe.xyz/api/concierge-intel-tvl",
+    "paysh": "https://pay.sh/",
+    "payshCatalog": "https://pay.sh/api/catalog",
+    "payshDocs": "https://pay.sh/docs/overview/index.md",
+    "payshContribute": "https://github.com/solana-foundation/pay-skills/blob/main/CONTRIBUTING.md",
+    "payshProviderFqn": "conc-exe/concierge-agent",
+    "payshSkillsSearch": "pay skills search \"market intelligence\"",
+    "payshCurlIntel": "pay curl https://conc-exe.xyz/api/concierge-intel-verdict -d '{\"message\":\"Solana DeFi outlook\",\"includeInsider\":true}'",
+    "payshCurlConcierge": "pay curl https://conc-exe.xyz/api/concierge -d '{\"mode\":\"chat\",\"message\":\"BTC outlook\"}'",
+    "payshSandboxCurl": "pay --sandbox curl https://conc-exe.xyz/api/concierge-intel-tvl -d '{}'",
+    "serviceName": "Concierge Agent",
+    "description": "Market intelligence as a service — pay-per-call Concierge AI, DeFi intel APIs, and Lounge RWA signals. USDC on Solana or Base via x402 (MPP-compatible discovery).",
+    "tags": [
+      "AI",
+      "Trading",
+      "Search",
+      "Crypto",
+      "RWA"
+    ],
+    "iconUrl": "https://conc-exe.xyz/images/the-concierge-logo.png",
+    "protocols": [
+      "x402",
+      "mpp"
+    ]
+  },
+  "tags": [
+    {
+      "name": "news",
+      "description": "Wire article unlock"
+    },
+    {
+      "name": "concierge",
+      "description": "Concierge AI"
+    },
+    {
+      "name": "intel",
+      "description": "Concierge DeFi intelligence APIs"
+    },
+    {
+      "name": "creator",
+      "description": "Creator signals & RWA"
+    },
+    {
+      "name": "rwa",
+      "description": "Real World Asset intelligence certificates"
+    }
+  ]
+}

--- a/providers/conc-exe/concierge-agent/openapi.json
+++ b/providers/conc-exe/concierge-agent/openapi.json
@@ -2,15 +2,18 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Concierge Agent API",
-    "version": "4.0.0",
-    "description": "Market intelligence as a service — twelve pay-per-call endpoints. Concierge AI, DeFi intel, Alpha desks (airdrop, listing, momentum), and Lounge RWA signals. No API keys. x402 + MPP discovery; USDC settlement on Solana and Base via PayAI.",
-    "x-guidance": "Concierge Agent is a pay-per-call market intelligence API. No API keys — payment is the only gate. Discover endpoints via GET /openapi.json. Each paid route accepts POST with application/json after x402 USDC settlement on Solana or Base (PayAI facilitator). Flow: POST without PAYMENT-SIGNATURE → 402 + PAYMENT-REQUIRED header → pay → retry with PAYMENT-SIGNATURE (base64 payment payload). Intel routes: /api/concierge-intel-tvl (empty body ok), intel-yields (chain/project), intel-whales (symbols), intel-wallet (solAddress/evmAddress), intel-verdict (message, includeInsider), intel-airdrop|intel-listing|intel-momentum (message, chain, limit, includeInsider). Concierge chat: POST /api/concierge with mode chat|enhance|image and message. Lounge: /api/news-open, /api/lounge-signal-publish ($1), /api/lounge-signal-open. CLI: npx agentcash discover <origin> · npx agentcash check <origin>/api/concierge-intel-tvl pay.sh: pay --sandbox curl <origin>/api/concierge-intel-tvl -d '{}' · pay skills search market intelligence",
+    "version": "4.2.0",
+    "description": "Market intelligence + Concierge Resources — 24 pay-per-call endpoints. Creative AI (chat, image, scaffold), macro & wire research, DeFi intel, Alpha desks, Lounge RWA signals, and passive security scans. No API keys. x402 + MPP discovery; USDC or TCX on Solana and Base.",
+    "x-guidance": "Concierge Agent is a pay-per-call market intelligence API. No API keys — payment is the only gate. Discover endpoints via GET /openapi.json. Each paid route accepts POST with application/json after x402 USDC settlement on Solana, Base, or Arbitrum (PayAI (primary) · Dexter (fallback)). Flow: POST without PAYMENT-SIGNATURE → 402 + PAYMENT-REQUIRED header → pay → retry with PAYMENT-SIGNATURE (base64 payment payload). Intel routes: raw tier $0.02 — intel-tvl, intel-macro, intel-wire, intel-whales. Signal tier $0.10 — yields, wallet, verdict, alpha desks, scalp, intel-meteora. Bundle $0.25 — intel-desk-brief. Free GET — /api/concierge-intel-accuracy. MCP — POST /api/mcp (tools/list, tools/call). intel-meteora (sortByApy, poolHint, limit), intel-desk-brief (message, includeInsider). TCX holders: X-Soon-Holder-Wallet + raw tier = free calls post-launch. Concierge chat: POST /api/concierge with mode chat|enhance|image and message. Lounge: /api/news-open, /api/lounge-signal-publish ($0.02), /api/lounge-signal-open. CLI: npx agentcash discover <origin> · npx agentcash check <origin>/api/concierge-intel-tvl OpenDexter: npx -y @dexterai/opendexter · x402_search for Dexter marketplace discovery pay.sh: pay --sandbox curl <origin>/api/concierge-intel-tvl -d '{}' · pay skills search market intelligence Idempotency: optional Idempotency-Key header on POST mutating routes. Reuse the same PAYMENT-SIGNATURE after a successful x402 settlement — facilitators will not double-charge the same on-chain payment. Rate limits: soft limit 120 requests/minute per IP on /api/* — responses include X-RateLimit-Limit; 429 returns Retry-After. Discovery index: GET /.well-known/api-catalog (RFC 9727 linkset) · GET /llms.txt · GET /.well-known/agent-card.json",
     "x-marketplace-tags": [
       "AI",
+      "Research",
+      "News",
       "Trading",
       "Search",
       "Crypto",
-      "RWA"
+      "RWA",
+      "Utility"
     ],
     "contact": {
       "name": "Concierge Agent",
@@ -20,13 +23,16 @@
   },
   "x-service-info": {
     "name": "Concierge Agent",
-    "description": "Market intelligence as a service — pay-per-call Concierge AI, DeFi intel APIs, and Lounge RWA signals. USDC on Solana or Base via x402 (MPP-compatible discovery).",
+    "description": "Market intelligence + Concierge Resources — 24 pay-per-call routes: creative AI (chat, image, scaffold), macro & wire research, DeFi intel, Lounge RWA signals, and passive security scans. USDC or TCX via x402 (MPP-compatible discovery).",
     "tags": [
       "AI",
+      "Research",
+      "News",
       "Trading",
       "Search",
       "Crypto",
-      "RWA"
+      "RWA",
+      "Utility"
     ],
     "iconUrl": "https://conc-exe.xyz/images/the-concierge-logo.png",
     "protocols": [
@@ -34,9 +40,13 @@
       "mpp"
     ],
     "facilitator": "PayAI",
+    "facilitatorUrl": "https://facilitator.payai.network",
+    "fallbackFacilitator": "Dexter",
+    "fallbackFacilitatorUrl": "https://x402.dexter.cash",
     "networks": [
       "solana",
-      "base"
+      "base",
+      "arbitrum"
     ]
   },
   "servers": [
@@ -61,13 +71,43 @@
             {
               "x402": {
                 "network": "solana",
-                "facilitator": "https://facilitator.payai.network"
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
               }
             },
             {
               "x402": {
                 "network": "base",
-                "facilitator": "https://facilitator.payai.network"
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "arbitrum",
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "solana",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "x402": {
+                "network": "base",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "x402": {
+                "network": "arbitrum",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
               }
             },
             {
@@ -84,7 +124,7 @@
               "amount": "100000",
               "currency": "USDC",
               "intent": "charge",
-              "description": "$0.10 USDC via PayAI (Solana or Base)"
+              "description": "$0.10 USDC via PayAI (primary; Dexter fallback on Solana/Base)"
             },
             {
               "protocol": "mpp",
@@ -97,8 +137,38 @@
         },
         "tags": [
           "Search",
-          "Trading",
+          "News",
+          "Research",
           "RWA"
+        ],
+        "parameters": [
+          {
+            "name": "X-Agent-Id",
+            "in": "header",
+            "required": false,
+            "description": "Registered agent identity (agt_…) for attribution and discovery",
+            "schema": {
+              "type": "string",
+              "pattern": "^agt_[a-zA-Z0-9]+$",
+              "example": "agt_demo0001"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "description": "Optional client-generated key (UUID recommended). Reuse the same key when retrying after network failures. For paid routes, also reuse the same PAYMENT-SIGNATURE — facilitators treat a settled payment as idempotent.",
+            "schema": {
+              "type": "string",
+              "maxLength": 128,
+              "example": "550e8400-e29b-41d4-a716-446655440000"
+            }
+          }
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
         ],
         "responses": {
           "200": {
@@ -137,6 +207,20 @@
               }
             }
           },
+          "400": {
+            "description": "Invalid request body or parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Invalid JSON body",
+                  "code": "invalid_request"
+                }
+              }
+            }
+          },
           "402": {
             "description": "Payment Required",
             "headers": {
@@ -145,23 +229,111 @@
                 "schema": {
                   "type": "string"
                 }
+              },
+              "X-RateLimit-Limit": {
+                "description": "Soft rate limit per IP per minute",
+                "schema": {
+                  "type": "integer",
+                  "example": 120
+                }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Requests remaining in the current window",
+                "schema": {
+                  "type": "integer",
+                  "example": 119
+                }
+              },
+              "Retry-After": {
+                "description": "Seconds until the rate-limit window resets (also sent on 429)",
+                "schema": {
+                  "type": "integer",
+                  "example": 60
+                }
               }
             },
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    },
-                    "priceUsdc": {
-                      "type": "number"
-                    },
-                    "resource": {
-                      "type": "string"
-                    }
-                  }
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Payment required",
+                  "code": "payment_required",
+                  "priceUsdc": 0.1,
+                  "resource": "news"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "HTTP method not allowed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Method not allowed",
+                  "code": "method_not_allowed"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded — back off and retry after Retry-After seconds",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the client may retry",
+                "schema": {
+                  "type": "integer",
+                  "example": 60
+                }
+              },
+              "X-RateLimit-Limit": {
+                "description": "Maximum requests per window",
+                "schema": {
+                  "type": "integer",
+                  "example": 120
+                }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Requests remaining (0 when rate limited)",
+                "schema": {
+                  "type": "integer",
+                  "example": 0
+                }
+              },
+              "RateLimit-Remaining": {
+                "description": "Requests remaining (0 when rate limited)",
+                "schema": {
+                  "type": "integer",
+                  "example": 0
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Too many requests — retry after the Retry-After interval",
+                  "code": "rate_limited"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Concierge could not process this request. Try a shorter question.",
+                  "code": "internal_error"
                 }
               }
             }
@@ -196,6 +368,11 @@
                 "required": [
                   "url"
                 ]
+              },
+              "example": {
+                "url": "https://www.bbc.com/news/example",
+                "title": "Example headline",
+                "source": "BBC"
               }
             }
           }
@@ -217,13 +394,43 @@
             {
               "x402": {
                 "network": "solana",
-                "facilitator": "https://facilitator.payai.network"
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
               }
             },
             {
               "x402": {
                 "network": "base",
-                "facilitator": "https://facilitator.payai.network"
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "arbitrum",
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "solana",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "x402": {
+                "network": "base",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "x402": {
+                "network": "arbitrum",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
               }
             },
             {
@@ -240,7 +447,7 @@
               "amount": "100000",
               "currency": "USDC",
               "intent": "charge",
-              "description": "$0.10 USDC via PayAI (Solana or Base)"
+              "description": "$0.10 USDC via PayAI (primary; Dexter fallback on Solana/Base)"
             },
             {
               "protocol": "mpp",
@@ -253,8 +460,38 @@
         },
         "tags": [
           "AI",
+          "Research",
           "Trading",
           "RWA"
+        ],
+        "parameters": [
+          {
+            "name": "X-Agent-Id",
+            "in": "header",
+            "required": false,
+            "description": "Registered agent identity (agt_…) for attribution and discovery",
+            "schema": {
+              "type": "string",
+              "pattern": "^agt_[a-zA-Z0-9]+$",
+              "example": "agt_demo0001"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "description": "Optional client-generated key (UUID recommended). Reuse the same key when retrying after network failures. For paid routes, also reuse the same PAYMENT-SIGNATURE — facilitators treat a settled payment as idempotent.",
+            "schema": {
+              "type": "string",
+              "maxLength": 128,
+              "example": "550e8400-e29b-41d4-a716-446655440000"
+            }
+          }
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
         ],
         "responses": {
           "200": {
@@ -290,6 +527,20 @@
               }
             }
           },
+          "400": {
+            "description": "Invalid request body or parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Invalid JSON body",
+                  "code": "invalid_request"
+                }
+              }
+            }
+          },
           "402": {
             "description": "Payment Required",
             "headers": {
@@ -298,23 +549,111 @@
                 "schema": {
                   "type": "string"
                 }
+              },
+              "X-RateLimit-Limit": {
+                "description": "Soft rate limit per IP per minute",
+                "schema": {
+                  "type": "integer",
+                  "example": 120
+                }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Requests remaining in the current window",
+                "schema": {
+                  "type": "integer",
+                  "example": 119
+                }
+              },
+              "Retry-After": {
+                "description": "Seconds until the rate-limit window resets (also sent on 429)",
+                "schema": {
+                  "type": "integer",
+                  "example": 60
+                }
               }
             },
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    },
-                    "priceUsdc": {
-                      "type": "number"
-                    },
-                    "resource": {
-                      "type": "string"
-                    }
-                  }
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Payment required",
+                  "code": "payment_required",
+                  "priceUsdc": 0.1,
+                  "resource": "concierge"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "HTTP method not allowed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Method not allowed",
+                  "code": "method_not_allowed"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded — back off and retry after Retry-After seconds",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the client may retry",
+                "schema": {
+                  "type": "integer",
+                  "example": 60
+                }
+              },
+              "X-RateLimit-Limit": {
+                "description": "Maximum requests per window",
+                "schema": {
+                  "type": "integer",
+                  "example": 120
+                }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Requests remaining (0 when rate limited)",
+                "schema": {
+                  "type": "integer",
+                  "example": 0
+                }
+              },
+              "RateLimit-Remaining": {
+                "description": "Requests remaining (0 when rate limited)",
+                "schema": {
+                  "type": "integer",
+                  "example": 0
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Too many requests — retry after the Retry-After interval",
+                  "code": "rate_limited"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Concierge could not process this request. Try a shorter question.",
+                  "code": "internal_error"
                 }
               }
             }
@@ -389,6 +728,12 @@
                 "required": [
                   "message"
                 ]
+              },
+              "example": {
+                "mode": "chat",
+                "message": "What is the macro outlook for BTC?",
+                "history": [],
+                "market": []
               }
             }
           }
@@ -399,24 +744,54 @@
       "post": {
         "operationId": "signal_publish",
         "summary": "Publish creator signal",
-        "description": "Publish one RWA intelligence signal to the Executive Lounge feed (anti-spam fee).",
+        "description": "Publish one RWA intelligence signal to the Executive Lounge feed (minimum settlement fee).",
         "x-payment-info": {
           "price": {
             "mode": "fixed",
             "currency": "USD",
-            "amount": "1.000000"
+            "amount": "0.020000"
           },
           "protocols": [
             {
               "x402": {
                 "network": "solana",
-                "facilitator": "https://facilitator.payai.network"
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
               }
             },
             {
               "x402": {
                 "network": "base",
-                "facilitator": "https://facilitator.payai.network"
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "arbitrum",
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "solana",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "x402": {
+                "network": "base",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "x402": {
+                "network": "arbitrum",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
               }
             },
             {
@@ -430,23 +805,52 @@
           "offers": [
             {
               "protocol": "x402",
-              "amount": "1000000",
+              "amount": "20000",
               "currency": "USDC",
               "intent": "charge",
-              "description": "$1.00 USDC via PayAI (Solana or Base)"
+              "description": "$0.02 USDC via PayAI (primary; Dexter fallback on Solana/Base)"
             },
             {
               "protocol": "mpp",
-              "amount": "1000000",
+              "amount": "20000",
               "currency": "USDC",
               "intent": "charge",
-              "description": "$1.00 USDC — x402 settlement compatible with MPP clients"
+              "description": "$0.02 USDC — x402 settlement compatible with MPP clients"
             }
           ]
         },
         "tags": [
           "Crypto",
           "RWA"
+        ],
+        "parameters": [
+          {
+            "name": "X-Agent-Id",
+            "in": "header",
+            "required": false,
+            "description": "Registered agent identity (agt_…) for attribution and discovery",
+            "schema": {
+              "type": "string",
+              "pattern": "^agt_[a-zA-Z0-9]+$",
+              "example": "agt_demo0001"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "description": "Optional client-generated key (UUID recommended). Reuse the same key when retrying after network failures. For paid routes, also reuse the same PAYMENT-SIGNATURE — facilitators treat a settled payment as idempotent.",
+            "schema": {
+              "type": "string",
+              "maxLength": 128,
+              "example": "550e8400-e29b-41d4-a716-446655440000"
+            }
+          }
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
         ],
         "responses": {
           "200": {
@@ -480,6 +884,20 @@
               }
             }
           },
+          "400": {
+            "description": "Invalid request body or parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Invalid JSON body",
+                  "code": "invalid_request"
+                }
+              }
+            }
+          },
           "402": {
             "description": "Payment Required",
             "headers": {
@@ -488,23 +906,111 @@
                 "schema": {
                   "type": "string"
                 }
+              },
+              "X-RateLimit-Limit": {
+                "description": "Soft rate limit per IP per minute",
+                "schema": {
+                  "type": "integer",
+                  "example": 120
+                }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Requests remaining in the current window",
+                "schema": {
+                  "type": "integer",
+                  "example": 119
+                }
+              },
+              "Retry-After": {
+                "description": "Seconds until the rate-limit window resets (also sent on 429)",
+                "schema": {
+                  "type": "integer",
+                  "example": 60
+                }
               }
             },
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    },
-                    "priceUsdc": {
-                      "type": "number"
-                    },
-                    "resource": {
-                      "type": "string"
-                    }
-                  }
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Payment required",
+                  "code": "payment_required",
+                  "priceUsdc": 0.02,
+                  "resource": "signal-publish"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "HTTP method not allowed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Method not allowed",
+                  "code": "method_not_allowed"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded — back off and retry after Retry-After seconds",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the client may retry",
+                "schema": {
+                  "type": "integer",
+                  "example": 60
+                }
+              },
+              "X-RateLimit-Limit": {
+                "description": "Maximum requests per window",
+                "schema": {
+                  "type": "integer",
+                  "example": 120
+                }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Requests remaining (0 when rate limited)",
+                "schema": {
+                  "type": "integer",
+                  "example": 0
+                }
+              },
+              "RateLimit-Remaining": {
+                "description": "Requests remaining (0 when rate limited)",
+                "schema": {
+                  "type": "integer",
+                  "example": 0
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Too many requests — retry after the Retry-After interval",
+                  "code": "rate_limited"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Concierge could not process this request. Try a shorter question.",
+                  "code": "internal_error"
                 }
               }
             }
@@ -553,6 +1059,16 @@
                   "creatorWallet",
                   "creatorChain"
                 ]
+              },
+              "example": {
+                "title": "BTC dominance roll-down thesis",
+                "summary": "Dominance stalled at resistance; risk-curve rotation over 1–2 weeks.",
+                "categories": [
+                  "Crypto",
+                  "Macro"
+                ],
+                "creatorWallet": "0x0000000000000000000000000000000000000000",
+                "creatorChain": "evm"
               }
             }
           }
@@ -574,13 +1090,43 @@
             {
               "x402": {
                 "network": "solana",
-                "facilitator": "https://facilitator.payai.network"
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
               }
             },
             {
               "x402": {
                 "network": "base",
-                "facilitator": "https://facilitator.payai.network"
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "arbitrum",
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "solana",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "x402": {
+                "network": "base",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "x402": {
+                "network": "arbitrum",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
               }
             },
             {
@@ -597,7 +1143,7 @@
               "amount": "100000",
               "currency": "USDC",
               "intent": "charge",
-              "description": "$0.10 USDC via PayAI (Solana or Base)"
+              "description": "$0.10 USDC via PayAI (primary; Dexter fallback on Solana/Base)"
             },
             {
               "protocol": "mpp",
@@ -611,6 +1157,35 @@
         "tags": [
           "Crypto",
           "RWA"
+        ],
+        "parameters": [
+          {
+            "name": "X-Agent-Id",
+            "in": "header",
+            "required": false,
+            "description": "Registered agent identity (agt_…) for attribution and discovery",
+            "schema": {
+              "type": "string",
+              "pattern": "^agt_[a-zA-Z0-9]+$",
+              "example": "agt_demo0001"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "description": "Optional client-generated key (UUID recommended). Reuse the same key when retrying after network failures. For paid routes, also reuse the same PAYMENT-SIGNATURE — facilitators treat a settled payment as idempotent.",
+            "schema": {
+              "type": "string",
+              "maxLength": 128,
+              "example": "550e8400-e29b-41d4-a716-446655440000"
+            }
+          }
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
         ],
         "responses": {
           "200": {
@@ -644,6 +1219,20 @@
               }
             }
           },
+          "400": {
+            "description": "Invalid request body or parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Invalid JSON body",
+                  "code": "invalid_request"
+                }
+              }
+            }
+          },
           "402": {
             "description": "Payment Required",
             "headers": {
@@ -652,23 +1241,111 @@
                 "schema": {
                   "type": "string"
                 }
+              },
+              "X-RateLimit-Limit": {
+                "description": "Soft rate limit per IP per minute",
+                "schema": {
+                  "type": "integer",
+                  "example": 120
+                }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Requests remaining in the current window",
+                "schema": {
+                  "type": "integer",
+                  "example": 119
+                }
+              },
+              "Retry-After": {
+                "description": "Seconds until the rate-limit window resets (also sent on 429)",
+                "schema": {
+                  "type": "integer",
+                  "example": 60
+                }
               }
             },
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    },
-                    "priceUsdc": {
-                      "type": "number"
-                    },
-                    "resource": {
-                      "type": "string"
-                    }
-                  }
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Payment required",
+                  "code": "payment_required",
+                  "priceUsdc": 0.1,
+                  "resource": "signal-open"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "HTTP method not allowed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Method not allowed",
+                  "code": "method_not_allowed"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded — back off and retry after Retry-After seconds",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the client may retry",
+                "schema": {
+                  "type": "integer",
+                  "example": 60
+                }
+              },
+              "X-RateLimit-Limit": {
+                "description": "Maximum requests per window",
+                "schema": {
+                  "type": "integer",
+                  "example": 120
+                }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Requests remaining (0 when rate limited)",
+                "schema": {
+                  "type": "integer",
+                  "example": 0
+                }
+              },
+              "RateLimit-Remaining": {
+                "description": "Requests remaining (0 when rate limited)",
+                "schema": {
+                  "type": "integer",
+                  "example": 0
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Too many requests — retry after the Retry-After interval",
+                  "code": "rate_limited"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Concierge could not process this request. Try a shorter question.",
+                  "code": "internal_error"
                 }
               }
             }
@@ -695,6 +1372,9 @@
                 "required": [
                   "signalId"
                 ]
+              },
+              "example": {
+                "signalId": "sig_example000000000000000000000000"
               }
             }
           }
@@ -710,19 +1390,49 @@
           "price": {
             "mode": "fixed",
             "currency": "USD",
-            "amount": "0.100000"
+            "amount": "0.020000"
           },
           "protocols": [
             {
               "x402": {
                 "network": "solana",
-                "facilitator": "https://facilitator.payai.network"
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
               }
             },
             {
               "x402": {
                 "network": "base",
-                "facilitator": "https://facilitator.payai.network"
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "arbitrum",
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "solana",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "x402": {
+                "network": "base",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "x402": {
+                "network": "arbitrum",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
               }
             },
             {
@@ -736,17 +1446,17 @@
           "offers": [
             {
               "protocol": "x402",
-              "amount": "100000",
+              "amount": "20000",
               "currency": "USDC",
               "intent": "charge",
-              "description": "$0.10 USDC via PayAI (Solana or Base)"
+              "description": "$0.02 USDC via PayAI (primary; Dexter fallback on Solana/Base)"
             },
             {
               "protocol": "mpp",
-              "amount": "100000",
+              "amount": "20000",
               "currency": "USDC",
               "intent": "charge",
-              "description": "$0.10 USDC — x402 settlement compatible with MPP clients"
+              "description": "$0.02 USDC — x402 settlement compatible with MPP clients"
             }
           ]
         },
@@ -754,6 +1464,35 @@
           "AI",
           "Crypto",
           "Trading"
+        ],
+        "parameters": [
+          {
+            "name": "X-Agent-Id",
+            "in": "header",
+            "required": false,
+            "description": "Registered agent identity (agt_…) for attribution and discovery",
+            "schema": {
+              "type": "string",
+              "pattern": "^agt_[a-zA-Z0-9]+$",
+              "example": "agt_demo0001"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "description": "Optional client-generated key (UUID recommended). Reuse the same key when retrying after network failures. For paid routes, also reuse the same PAYMENT-SIGNATURE — facilitators treat a settled payment as idempotent.",
+            "schema": {
+              "type": "string",
+              "maxLength": 128,
+              "example": "550e8400-e29b-41d4-a716-446655440000"
+            }
+          }
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
         ],
         "responses": {
           "200": {
@@ -816,6 +1555,20 @@
               }
             }
           },
+          "400": {
+            "description": "Invalid request body or parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Invalid JSON body",
+                  "code": "invalid_request"
+                }
+              }
+            }
+          },
           "402": {
             "description": "Payment Required",
             "headers": {
@@ -824,23 +1577,111 @@
                 "schema": {
                   "type": "string"
                 }
+              },
+              "X-RateLimit-Limit": {
+                "description": "Soft rate limit per IP per minute",
+                "schema": {
+                  "type": "integer",
+                  "example": 120
+                }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Requests remaining in the current window",
+                "schema": {
+                  "type": "integer",
+                  "example": 119
+                }
+              },
+              "Retry-After": {
+                "description": "Seconds until the rate-limit window resets (also sent on 429)",
+                "schema": {
+                  "type": "integer",
+                  "example": 60
+                }
               }
             },
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    },
-                    "priceUsdc": {
-                      "type": "number"
-                    },
-                    "resource": {
-                      "type": "string"
-                    }
-                  }
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Payment required",
+                  "code": "payment_required",
+                  "priceUsdc": 0.02,
+                  "resource": "intel-tvl"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "HTTP method not allowed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Method not allowed",
+                  "code": "method_not_allowed"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded — back off and retry after Retry-After seconds",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the client may retry",
+                "schema": {
+                  "type": "integer",
+                  "example": 60
+                }
+              },
+              "X-RateLimit-Limit": {
+                "description": "Maximum requests per window",
+                "schema": {
+                  "type": "integer",
+                  "example": 120
+                }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Requests remaining (0 when rate limited)",
+                "schema": {
+                  "type": "integer",
+                  "example": 0
+                }
+              },
+              "RateLimit-Remaining": {
+                "description": "Requests remaining (0 when rate limited)",
+                "schema": {
+                  "type": "integer",
+                  "example": 0
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Too many requests — retry after the Retry-After interval",
+                  "code": "rate_limited"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Concierge could not process this request. Try a shorter question.",
+                  "code": "internal_error"
                 }
               }
             }
@@ -865,7 +1706,8 @@
                   }
                 },
                 "required": []
-              }
+              },
+              "example": {}
             }
           }
         }
@@ -878,19 +1720,49 @@
           "price": {
             "mode": "fixed",
             "currency": "USD",
-            "amount": "0.100000"
+            "amount": "0.020000"
           },
           "protocols": [
             {
               "x402": {
                 "network": "solana",
-                "facilitator": "https://facilitator.payai.network"
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
               }
             },
             {
               "x402": {
                 "network": "base",
-                "facilitator": "https://facilitator.payai.network"
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "arbitrum",
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "solana",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "x402": {
+                "network": "base",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "x402": {
+                "network": "arbitrum",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
               }
             },
             {
@@ -904,17 +1776,17 @@
           "offers": [
             {
               "protocol": "x402",
-              "amount": "100000",
+              "amount": "20000",
               "currency": "USDC",
               "intent": "charge",
-              "description": "$0.10 USDC via PayAI (Solana or Base)"
+              "description": "$0.02 USDC via PayAI (primary; Dexter fallback on Solana/Base)"
             },
             {
               "protocol": "mpp",
-              "amount": "100000",
+              "amount": "20000",
               "currency": "USDC",
               "intent": "charge",
-              "description": "$0.10 USDC — x402 settlement compatible with MPP clients"
+              "description": "$0.02 USDC — x402 settlement compatible with MPP clients"
             }
           ]
         },
@@ -922,6 +1794,32 @@
           "AI",
           "Crypto",
           "Trading"
+        ],
+        "parameters": [
+          {
+            "name": "X-Agent-Id",
+            "in": "header",
+            "required": false,
+            "description": "Registered agent identity (agt_…) for attribution and discovery",
+            "schema": {
+              "type": "string",
+              "pattern": "^agt_[a-zA-Z0-9]+$",
+              "example": "agt_demo0001"
+            }
+          },
+          {
+            "name": "message",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
         ],
         "responses": {
           "200": {
@@ -984,6 +1882,20 @@
               }
             }
           },
+          "400": {
+            "description": "Invalid request body or parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Invalid JSON body",
+                  "code": "invalid_request"
+                }
+              }
+            }
+          },
           "402": {
             "description": "Payment Required",
             "headers": {
@@ -992,23 +1904,111 @@
                 "schema": {
                   "type": "string"
                 }
+              },
+              "X-RateLimit-Limit": {
+                "description": "Soft rate limit per IP per minute",
+                "schema": {
+                  "type": "integer",
+                  "example": 120
+                }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Requests remaining in the current window",
+                "schema": {
+                  "type": "integer",
+                  "example": 119
+                }
+              },
+              "Retry-After": {
+                "description": "Seconds until the rate-limit window resets (also sent on 429)",
+                "schema": {
+                  "type": "integer",
+                  "example": 60
+                }
               }
             },
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    },
-                    "priceUsdc": {
-                      "type": "number"
-                    },
-                    "resource": {
-                      "type": "string"
-                    }
-                  }
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Payment required",
+                  "code": "payment_required",
+                  "priceUsdc": 0.02,
+                  "resource": "intel-tvl"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "HTTP method not allowed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Method not allowed",
+                  "code": "method_not_allowed"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded — back off and retry after Retry-After seconds",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the client may retry",
+                "schema": {
+                  "type": "integer",
+                  "example": 60
+                }
+              },
+              "X-RateLimit-Limit": {
+                "description": "Maximum requests per window",
+                "schema": {
+                  "type": "integer",
+                  "example": 120
+                }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Requests remaining (0 when rate limited)",
+                "schema": {
+                  "type": "integer",
+                  "example": 0
+                }
+              },
+              "RateLimit-Remaining": {
+                "description": "Requests remaining (0 when rate limited)",
+                "schema": {
+                  "type": "integer",
+                  "example": 0
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Too many requests — retry after the Retry-After interval",
+                  "code": "rate_limited"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Concierge could not process this request. Try a shorter question.",
+                  "code": "internal_error"
                 }
               }
             }
@@ -1019,16 +2019,26 @@
             "url": "https://conc-exe.xyz/api/concierge-intel-tvl"
           }
         ],
-        "parameters": [
-          {
-            "name": "message",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string"
+        "requestBody": {
+          "required": false,
+          "description": "GET probes omit a body and return 402. Example documents the POST JSON payload to send after x402 settlement.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "message": {
+                    "type": "string",
+                    "description": "Optional context for logging"
+                  }
+                },
+                "required": []
+              },
+              "example": {}
             }
           }
-        ]
+        }
       }
     },
     "/api/concierge-intel-yields": {
@@ -1046,13 +2056,43 @@
             {
               "x402": {
                 "network": "solana",
-                "facilitator": "https://facilitator.payai.network"
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
               }
             },
             {
               "x402": {
                 "network": "base",
-                "facilitator": "https://facilitator.payai.network"
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "arbitrum",
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "solana",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "x402": {
+                "network": "base",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "x402": {
+                "network": "arbitrum",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
               }
             },
             {
@@ -1069,7 +2109,7 @@
               "amount": "100000",
               "currency": "USDC",
               "intent": "charge",
-              "description": "$0.10 USDC via PayAI (Solana or Base)"
+              "description": "$0.10 USDC via PayAI (primary; Dexter fallback on Solana/Base)"
             },
             {
               "protocol": "mpp",
@@ -1084,6 +2124,35 @@
           "AI",
           "Crypto",
           "Trading"
+        ],
+        "parameters": [
+          {
+            "name": "X-Agent-Id",
+            "in": "header",
+            "required": false,
+            "description": "Registered agent identity (agt_…) for attribution and discovery",
+            "schema": {
+              "type": "string",
+              "pattern": "^agt_[a-zA-Z0-9]+$",
+              "example": "agt_demo0001"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "description": "Optional client-generated key (UUID recommended). Reuse the same key when retrying after network failures. For paid routes, also reuse the same PAYMENT-SIGNATURE — facilitators treat a settled payment as idempotent.",
+            "schema": {
+              "type": "string",
+              "maxLength": 128,
+              "example": "550e8400-e29b-41d4-a716-446655440000"
+            }
+          }
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
         ],
         "responses": {
           "200": {
@@ -1136,6 +2205,20 @@
               }
             }
           },
+          "400": {
+            "description": "Invalid request body or parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Invalid JSON body",
+                  "code": "invalid_request"
+                }
+              }
+            }
+          },
           "402": {
             "description": "Payment Required",
             "headers": {
@@ -1144,23 +2227,111 @@
                 "schema": {
                   "type": "string"
                 }
+              },
+              "X-RateLimit-Limit": {
+                "description": "Soft rate limit per IP per minute",
+                "schema": {
+                  "type": "integer",
+                  "example": 120
+                }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Requests remaining in the current window",
+                "schema": {
+                  "type": "integer",
+                  "example": 119
+                }
+              },
+              "Retry-After": {
+                "description": "Seconds until the rate-limit window resets (also sent on 429)",
+                "schema": {
+                  "type": "integer",
+                  "example": 60
+                }
               }
             },
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    },
-                    "priceUsdc": {
-                      "type": "number"
-                    },
-                    "resource": {
-                      "type": "string"
-                    }
-                  }
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Payment required",
+                  "code": "payment_required",
+                  "priceUsdc": 0.1,
+                  "resource": "intel-yields"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "HTTP method not allowed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Method not allowed",
+                  "code": "method_not_allowed"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded — back off and retry after Retry-After seconds",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the client may retry",
+                "schema": {
+                  "type": "integer",
+                  "example": 60
+                }
+              },
+              "X-RateLimit-Limit": {
+                "description": "Maximum requests per window",
+                "schema": {
+                  "type": "integer",
+                  "example": 120
+                }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Requests remaining (0 when rate limited)",
+                "schema": {
+                  "type": "integer",
+                  "example": 0
+                }
+              },
+              "RateLimit-Remaining": {
+                "description": "Requests remaining (0 when rate limited)",
+                "schema": {
+                  "type": "integer",
+                  "example": 0
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Too many requests — retry after the Retry-After interval",
+                  "code": "rate_limited"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Concierge could not process this request. Try a shorter question.",
+                  "code": "internal_error"
                 }
               }
             }
@@ -1192,6 +2363,10 @@
                   }
                 },
                 "required": []
+              },
+              "example": {
+                "chain": "solana",
+                "project": "meteora"
               }
             }
           }
@@ -1211,13 +2386,43 @@
             {
               "x402": {
                 "network": "solana",
-                "facilitator": "https://facilitator.payai.network"
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
               }
             },
             {
               "x402": {
                 "network": "base",
-                "facilitator": "https://facilitator.payai.network"
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "arbitrum",
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "solana",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "x402": {
+                "network": "base",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "x402": {
+                "network": "arbitrum",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
               }
             },
             {
@@ -1234,7 +2439,7 @@
               "amount": "100000",
               "currency": "USDC",
               "intent": "charge",
-              "description": "$0.10 USDC via PayAI (Solana or Base)"
+              "description": "$0.10 USDC via PayAI (primary; Dexter fallback on Solana/Base)"
             },
             {
               "protocol": "mpp",
@@ -1249,6 +2454,50 @@
           "AI",
           "Crypto",
           "Trading"
+        ],
+        "parameters": [
+          {
+            "name": "X-Agent-Id",
+            "in": "header",
+            "required": false,
+            "description": "Registered agent identity (agt_…) for attribution and discovery",
+            "schema": {
+              "type": "string",
+              "pattern": "^agt_[a-zA-Z0-9]+$",
+              "example": "agt_demo0001"
+            }
+          },
+          {
+            "name": "chain",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "solana"
+          },
+          {
+            "name": "project",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "meteora"
+          },
+          {
+            "name": "message",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
         ],
         "responses": {
           "200": {
@@ -1301,6 +2550,20 @@
               }
             }
           },
+          "400": {
+            "description": "Invalid request body or parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Invalid JSON body",
+                  "code": "invalid_request"
+                }
+              }
+            }
+          },
           "402": {
             "description": "Payment Required",
             "headers": {
@@ -1309,23 +2572,111 @@
                 "schema": {
                   "type": "string"
                 }
+              },
+              "X-RateLimit-Limit": {
+                "description": "Soft rate limit per IP per minute",
+                "schema": {
+                  "type": "integer",
+                  "example": 120
+                }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Requests remaining in the current window",
+                "schema": {
+                  "type": "integer",
+                  "example": 119
+                }
+              },
+              "Retry-After": {
+                "description": "Seconds until the rate-limit window resets (also sent on 429)",
+                "schema": {
+                  "type": "integer",
+                  "example": 60
+                }
               }
             },
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    },
-                    "priceUsdc": {
-                      "type": "number"
-                    },
-                    "resource": {
-                      "type": "string"
-                    }
-                  }
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Payment required",
+                  "code": "payment_required",
+                  "priceUsdc": 0.1,
+                  "resource": "intel-yields"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "HTTP method not allowed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Method not allowed",
+                  "code": "method_not_allowed"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded — back off and retry after Retry-After seconds",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the client may retry",
+                "schema": {
+                  "type": "integer",
+                  "example": 60
+                }
+              },
+              "X-RateLimit-Limit": {
+                "description": "Maximum requests per window",
+                "schema": {
+                  "type": "integer",
+                  "example": 120
+                }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Requests remaining (0 when rate limited)",
+                "schema": {
+                  "type": "integer",
+                  "example": 0
+                }
+              },
+              "RateLimit-Remaining": {
+                "description": "Requests remaining (0 when rate limited)",
+                "schema": {
+                  "type": "integer",
+                  "example": 0
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Too many requests — retry after the Retry-After interval",
+                  "code": "rate_limited"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Concierge could not process this request. Try a shorter question.",
+                  "code": "internal_error"
                 }
               }
             }
@@ -1336,32 +2687,36 @@
             "url": "https://conc-exe.xyz/api/concierge-intel-yields"
           }
         ],
-        "parameters": [
-          {
-            "name": "chain",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "project",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "message",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string"
+        "requestBody": {
+          "required": false,
+          "description": "GET probes omit a body and return 402. Example documents the POST JSON payload to send after x402 settlement.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "chain": {
+                    "type": "string",
+                    "description": "solana | ethereum | base | arbitrum"
+                  },
+                  "project": {
+                    "type": "string",
+                    "description": "Filter project id substring"
+                  },
+                  "message": {
+                    "type": "string"
+                  }
+                },
+                "required": []
+              },
+              "example": {
+                "chain": "solana",
+                "project": "meteora"
+              }
             }
           }
-        ]
+        }
       }
     },
     "/api/concierge-intel-whales": {
@@ -1373,19 +2728,49 @@
           "price": {
             "mode": "fixed",
             "currency": "USD",
-            "amount": "0.100000"
+            "amount": "0.020000"
           },
           "protocols": [
             {
               "x402": {
                 "network": "solana",
-                "facilitator": "https://facilitator.payai.network"
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
               }
             },
             {
               "x402": {
                 "network": "base",
-                "facilitator": "https://facilitator.payai.network"
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "arbitrum",
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "solana",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "x402": {
+                "network": "base",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "x402": {
+                "network": "arbitrum",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
               }
             },
             {
@@ -1399,17 +2784,17 @@
           "offers": [
             {
               "protocol": "x402",
-              "amount": "100000",
+              "amount": "20000",
               "currency": "USDC",
               "intent": "charge",
-              "description": "$0.10 USDC via PayAI (Solana or Base)"
+              "description": "$0.02 USDC via PayAI (primary; Dexter fallback on Solana/Base)"
             },
             {
               "protocol": "mpp",
-              "amount": "100000",
+              "amount": "20000",
               "currency": "USDC",
               "intent": "charge",
-              "description": "$0.10 USDC — x402 settlement compatible with MPP clients"
+              "description": "$0.02 USDC — x402 settlement compatible with MPP clients"
             }
           ]
         },
@@ -1417,6 +2802,35 @@
           "AI",
           "Crypto",
           "Trading"
+        ],
+        "parameters": [
+          {
+            "name": "X-Agent-Id",
+            "in": "header",
+            "required": false,
+            "description": "Registered agent identity (agt_…) for attribution and discovery",
+            "schema": {
+              "type": "string",
+              "pattern": "^agt_[a-zA-Z0-9]+$",
+              "example": "agt_demo0001"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "description": "Optional client-generated key (UUID recommended). Reuse the same key when retrying after network failures. For paid routes, also reuse the same PAYMENT-SIGNATURE — facilitators treat a settled payment as idempotent.",
+            "schema": {
+              "type": "string",
+              "maxLength": 128,
+              "example": "550e8400-e29b-41d4-a716-446655440000"
+            }
+          }
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
         ],
         "responses": {
           "200": {
@@ -1465,6 +2879,20 @@
               }
             }
           },
+          "400": {
+            "description": "Invalid request body or parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Invalid JSON body",
+                  "code": "invalid_request"
+                }
+              }
+            }
+          },
           "402": {
             "description": "Payment Required",
             "headers": {
@@ -1473,23 +2901,111 @@
                 "schema": {
                   "type": "string"
                 }
+              },
+              "X-RateLimit-Limit": {
+                "description": "Soft rate limit per IP per minute",
+                "schema": {
+                  "type": "integer",
+                  "example": 120
+                }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Requests remaining in the current window",
+                "schema": {
+                  "type": "integer",
+                  "example": 119
+                }
+              },
+              "Retry-After": {
+                "description": "Seconds until the rate-limit window resets (also sent on 429)",
+                "schema": {
+                  "type": "integer",
+                  "example": 60
+                }
               }
             },
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    },
-                    "priceUsdc": {
-                      "type": "number"
-                    },
-                    "resource": {
-                      "type": "string"
-                    }
-                  }
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Payment required",
+                  "code": "payment_required",
+                  "priceUsdc": 0.02,
+                  "resource": "intel-whales"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "HTTP method not allowed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Method not allowed",
+                  "code": "method_not_allowed"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded — back off and retry after Retry-After seconds",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the client may retry",
+                "schema": {
+                  "type": "integer",
+                  "example": 60
+                }
+              },
+              "X-RateLimit-Limit": {
+                "description": "Maximum requests per window",
+                "schema": {
+                  "type": "integer",
+                  "example": 120
+                }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Requests remaining (0 when rate limited)",
+                "schema": {
+                  "type": "integer",
+                  "example": 0
+                }
+              },
+              "RateLimit-Remaining": {
+                "description": "Requests remaining (0 when rate limited)",
+                "schema": {
+                  "type": "integer",
+                  "example": 0
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Too many requests — retry after the Retry-After interval",
+                  "code": "rate_limited"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Concierge could not process this request. Try a shorter question.",
+                  "code": "internal_error"
                 }
               }
             }
@@ -1521,6 +3037,13 @@
                   }
                 },
                 "required": []
+              },
+              "example": {
+                "symbols": [
+                  "BTC",
+                  "ETH",
+                  "SOL"
+                ]
               }
             }
           }
@@ -1534,19 +3057,49 @@
           "price": {
             "mode": "fixed",
             "currency": "USD",
-            "amount": "0.100000"
+            "amount": "0.020000"
           },
           "protocols": [
             {
               "x402": {
                 "network": "solana",
-                "facilitator": "https://facilitator.payai.network"
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
               }
             },
             {
               "x402": {
                 "network": "base",
-                "facilitator": "https://facilitator.payai.network"
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "arbitrum",
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "solana",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "x402": {
+                "network": "base",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "x402": {
+                "network": "arbitrum",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
               }
             },
             {
@@ -1560,17 +3113,17 @@
           "offers": [
             {
               "protocol": "x402",
-              "amount": "100000",
+              "amount": "20000",
               "currency": "USDC",
               "intent": "charge",
-              "description": "$0.10 USDC via PayAI (Solana or Base)"
+              "description": "$0.02 USDC via PayAI (primary; Dexter fallback on Solana/Base)"
             },
             {
               "protocol": "mpp",
-              "amount": "100000",
+              "amount": "20000",
               "currency": "USDC",
               "intent": "charge",
-              "description": "$0.10 USDC — x402 settlement compatible with MPP clients"
+              "description": "$0.02 USDC — x402 settlement compatible with MPP clients"
             }
           ]
         },
@@ -1578,6 +3131,37 @@
           "AI",
           "Crypto",
           "Trading"
+        ],
+        "parameters": [
+          {
+            "name": "X-Agent-Id",
+            "in": "header",
+            "required": false,
+            "description": "Registered agent identity (agt_…) for attribution and discovery",
+            "schema": {
+              "type": "string",
+              "pattern": "^agt_[a-zA-Z0-9]+$",
+              "example": "agt_demo0001"
+            }
+          },
+          {
+            "name": "symbols",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array"
+            },
+            "example": [
+              "BTC",
+              "ETH",
+              "SOL"
+            ]
+          }
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
         ],
         "responses": {
           "200": {
@@ -1626,6 +3210,20 @@
               }
             }
           },
+          "400": {
+            "description": "Invalid request body or parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Invalid JSON body",
+                  "code": "invalid_request"
+                }
+              }
+            }
+          },
           "402": {
             "description": "Payment Required",
             "headers": {
@@ -1634,23 +3232,111 @@
                 "schema": {
                   "type": "string"
                 }
+              },
+              "X-RateLimit-Limit": {
+                "description": "Soft rate limit per IP per minute",
+                "schema": {
+                  "type": "integer",
+                  "example": 120
+                }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Requests remaining in the current window",
+                "schema": {
+                  "type": "integer",
+                  "example": 119
+                }
+              },
+              "Retry-After": {
+                "description": "Seconds until the rate-limit window resets (also sent on 429)",
+                "schema": {
+                  "type": "integer",
+                  "example": 60
+                }
               }
             },
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    },
-                    "priceUsdc": {
-                      "type": "number"
-                    },
-                    "resource": {
-                      "type": "string"
-                    }
-                  }
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Payment required",
+                  "code": "payment_required",
+                  "priceUsdc": 0.02,
+                  "resource": "intel-whales"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "HTTP method not allowed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Method not allowed",
+                  "code": "method_not_allowed"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded — back off and retry after Retry-After seconds",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the client may retry",
+                "schema": {
+                  "type": "integer",
+                  "example": 60
+                }
+              },
+              "X-RateLimit-Limit": {
+                "description": "Maximum requests per window",
+                "schema": {
+                  "type": "integer",
+                  "example": 120
+                }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Requests remaining (0 when rate limited)",
+                "schema": {
+                  "type": "integer",
+                  "example": 0
+                }
+              },
+              "RateLimit-Remaining": {
+                "description": "Requests remaining (0 when rate limited)",
+                "schema": {
+                  "type": "integer",
+                  "example": 0
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Too many requests — retry after the Retry-After interval",
+                  "code": "rate_limited"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Concierge could not process this request. Try a shorter question.",
+                  "code": "internal_error"
                 }
               }
             }
@@ -1661,16 +3347,39 @@
             "url": "https://conc-exe.xyz/api/concierge-intel-whales"
           }
         ],
-        "parameters": [
-          {
-            "name": "symbols",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "array"
+        "requestBody": {
+          "required": false,
+          "description": "GET probes omit a body and return 402. Example documents the POST JSON payload to send after x402 settlement.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "symbols": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "enum": [
+                        "BTC",
+                        "ETH",
+                        "SOL"
+                      ]
+                    }
+                  }
+                },
+                "required": []
+              },
+              "example": {
+                "symbols": [
+                  "BTC",
+                  "ETH",
+                  "SOL"
+                ]
+              }
             }
           }
-        ]
+        }
       }
     },
     "/api/concierge-intel-wallet": {
@@ -1688,13 +3397,43 @@
             {
               "x402": {
                 "network": "solana",
-                "facilitator": "https://facilitator.payai.network"
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
               }
             },
             {
               "x402": {
                 "network": "base",
-                "facilitator": "https://facilitator.payai.network"
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "arbitrum",
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "solana",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "x402": {
+                "network": "base",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "x402": {
+                "network": "arbitrum",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
               }
             },
             {
@@ -1711,7 +3450,7 @@
               "amount": "100000",
               "currency": "USDC",
               "intent": "charge",
-              "description": "$0.10 USDC via PayAI (Solana or Base)"
+              "description": "$0.10 USDC via PayAI (primary; Dexter fallback on Solana/Base)"
             },
             {
               "protocol": "mpp",
@@ -1726,6 +3465,35 @@
           "AI",
           "Crypto",
           "Trading"
+        ],
+        "parameters": [
+          {
+            "name": "X-Agent-Id",
+            "in": "header",
+            "required": false,
+            "description": "Registered agent identity (agt_…) for attribution and discovery",
+            "schema": {
+              "type": "string",
+              "pattern": "^agt_[a-zA-Z0-9]+$",
+              "example": "agt_demo0001"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "description": "Optional client-generated key (UUID recommended). Reuse the same key when retrying after network failures. For paid routes, also reuse the same PAYMENT-SIGNATURE — facilitators treat a settled payment as idempotent.",
+            "schema": {
+              "type": "string",
+              "maxLength": 128,
+              "example": "550e8400-e29b-41d4-a716-446655440000"
+            }
+          }
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
         ],
         "responses": {
           "200": {
@@ -1777,6 +3545,20 @@
               }
             }
           },
+          "400": {
+            "description": "Invalid request body or parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Invalid JSON body",
+                  "code": "invalid_request"
+                }
+              }
+            }
+          },
           "402": {
             "description": "Payment Required",
             "headers": {
@@ -1785,23 +3567,111 @@
                 "schema": {
                   "type": "string"
                 }
+              },
+              "X-RateLimit-Limit": {
+                "description": "Soft rate limit per IP per minute",
+                "schema": {
+                  "type": "integer",
+                  "example": 120
+                }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Requests remaining in the current window",
+                "schema": {
+                  "type": "integer",
+                  "example": 119
+                }
+              },
+              "Retry-After": {
+                "description": "Seconds until the rate-limit window resets (also sent on 429)",
+                "schema": {
+                  "type": "integer",
+                  "example": 60
+                }
               }
             },
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    },
-                    "priceUsdc": {
-                      "type": "number"
-                    },
-                    "resource": {
-                      "type": "string"
-                    }
-                  }
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Payment required",
+                  "code": "payment_required",
+                  "priceUsdc": 0.1,
+                  "resource": "intel-wallet"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "HTTP method not allowed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Method not allowed",
+                  "code": "method_not_allowed"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded — back off and retry after Retry-After seconds",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the client may retry",
+                "schema": {
+                  "type": "integer",
+                  "example": 60
+                }
+              },
+              "X-RateLimit-Limit": {
+                "description": "Maximum requests per window",
+                "schema": {
+                  "type": "integer",
+                  "example": 120
+                }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Requests remaining (0 when rate limited)",
+                "schema": {
+                  "type": "integer",
+                  "example": 0
+                }
+              },
+              "RateLimit-Remaining": {
+                "description": "Requests remaining (0 when rate limited)",
+                "schema": {
+                  "type": "integer",
+                  "example": 0
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Too many requests — retry after the Retry-After interval",
+                  "code": "rate_limited"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Concierge could not process this request. Try a shorter question.",
+                  "code": "internal_error"
                 }
               }
             }
@@ -1836,6 +3706,10 @@
                   }
                 },
                 "required": []
+              },
+              "example": {
+                "solAddress": "7hum…",
+                "message": "optional context"
               }
             }
           }
@@ -1855,13 +3729,43 @@
             {
               "x402": {
                 "network": "solana",
-                "facilitator": "https://facilitator.payai.network"
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
               }
             },
             {
               "x402": {
                 "network": "base",
-                "facilitator": "https://facilitator.payai.network"
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "arbitrum",
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "solana",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "x402": {
+                "network": "base",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "x402": {
+                "network": "arbitrum",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
               }
             },
             {
@@ -1878,7 +3782,7 @@
               "amount": "100000",
               "currency": "USDC",
               "intent": "charge",
-              "description": "$0.10 USDC via PayAI (Solana or Base)"
+              "description": "$0.10 USDC via PayAI (primary; Dexter fallback on Solana/Base)"
             },
             {
               "protocol": "mpp",
@@ -1893,6 +3797,50 @@
           "AI",
           "Crypto",
           "Trading"
+        ],
+        "parameters": [
+          {
+            "name": "X-Agent-Id",
+            "in": "header",
+            "required": false,
+            "description": "Registered agent identity (agt_…) for attribution and discovery",
+            "schema": {
+              "type": "string",
+              "pattern": "^agt_[a-zA-Z0-9]+$",
+              "example": "agt_demo0001"
+            }
+          },
+          {
+            "name": "solAddress",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "7hum…"
+          },
+          {
+            "name": "evmAddress",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "message",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "optional context"
+          }
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
         ],
         "responses": {
           "200": {
@@ -1944,6 +3892,20 @@
               }
             }
           },
+          "400": {
+            "description": "Invalid request body or parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Invalid JSON body",
+                  "code": "invalid_request"
+                }
+              }
+            }
+          },
           "402": {
             "description": "Payment Required",
             "headers": {
@@ -1952,23 +3914,111 @@
                 "schema": {
                   "type": "string"
                 }
+              },
+              "X-RateLimit-Limit": {
+                "description": "Soft rate limit per IP per minute",
+                "schema": {
+                  "type": "integer",
+                  "example": 120
+                }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Requests remaining in the current window",
+                "schema": {
+                  "type": "integer",
+                  "example": 119
+                }
+              },
+              "Retry-After": {
+                "description": "Seconds until the rate-limit window resets (also sent on 429)",
+                "schema": {
+                  "type": "integer",
+                  "example": 60
+                }
               }
             },
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    },
-                    "priceUsdc": {
-                      "type": "number"
-                    },
-                    "resource": {
-                      "type": "string"
-                    }
-                  }
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Payment required",
+                  "code": "payment_required",
+                  "priceUsdc": 0.1,
+                  "resource": "intel-wallet"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "HTTP method not allowed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Method not allowed",
+                  "code": "method_not_allowed"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded — back off and retry after Retry-After seconds",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the client may retry",
+                "schema": {
+                  "type": "integer",
+                  "example": 60
+                }
+              },
+              "X-RateLimit-Limit": {
+                "description": "Maximum requests per window",
+                "schema": {
+                  "type": "integer",
+                  "example": 120
+                }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Requests remaining (0 when rate limited)",
+                "schema": {
+                  "type": "integer",
+                  "example": 0
+                }
+              },
+              "RateLimit-Remaining": {
+                "description": "Requests remaining (0 when rate limited)",
+                "schema": {
+                  "type": "integer",
+                  "example": 0
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Too many requests — retry after the Retry-After interval",
+                  "code": "rate_limited"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Concierge could not process this request. Try a shorter question.",
+                  "code": "internal_error"
                 }
               }
             }
@@ -1979,32 +4029,39 @@
             "url": "https://conc-exe.xyz/api/concierge-intel-wallet"
           }
         ],
-        "parameters": [
-          {
-            "name": "solAddress",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "evmAddress",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "message",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string"
+        "requestBody": {
+          "required": false,
+          "description": "GET probes omit a body and return 402. Example documents the POST JSON payload to send after x402 settlement.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": false,
+                "minProperties": 1,
+                "description": "At least one of solAddress, evmAddress, or message (with address) is required.",
+                "properties": {
+                  "solAddress": {
+                    "type": "string",
+                    "description": "Solana wallet address"
+                  },
+                  "evmAddress": {
+                    "type": "string",
+                    "description": "EVM wallet address (0x…)"
+                  },
+                  "message": {
+                    "type": "string",
+                    "description": "Optional context; may include an address"
+                  }
+                },
+                "required": []
+              },
+              "example": {
+                "solAddress": "7hum…",
+                "message": "optional context"
+              }
             }
           }
-        ]
+        }
       }
     },
     "/api/concierge-intel-verdict": {
@@ -2022,13 +4079,43 @@
             {
               "x402": {
                 "network": "solana",
-                "facilitator": "https://facilitator.payai.network"
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
               }
             },
             {
               "x402": {
                 "network": "base",
-                "facilitator": "https://facilitator.payai.network"
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "arbitrum",
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "solana",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "x402": {
+                "network": "base",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "x402": {
+                "network": "arbitrum",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
               }
             },
             {
@@ -2045,7 +4132,7 @@
               "amount": "100000",
               "currency": "USDC",
               "intent": "charge",
-              "description": "$0.10 USDC via PayAI (Solana or Base)"
+              "description": "$0.10 USDC via PayAI (primary; Dexter fallback on Solana/Base)"
             },
             {
               "protocol": "mpp",
@@ -2061,6 +4148,35 @@
           "Crypto",
           "Trading",
           "RWA"
+        ],
+        "parameters": [
+          {
+            "name": "X-Agent-Id",
+            "in": "header",
+            "required": false,
+            "description": "Registered agent identity (agt_…) for attribution and discovery",
+            "schema": {
+              "type": "string",
+              "pattern": "^agt_[a-zA-Z0-9]+$",
+              "example": "agt_demo0001"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "description": "Optional client-generated key (UUID recommended). Reuse the same key when retrying after network failures. For paid routes, also reuse the same PAYMENT-SIGNATURE — facilitators treat a settled payment as idempotent.",
+            "schema": {
+              "type": "string",
+              "maxLength": 128,
+              "example": "550e8400-e29b-41d4-a716-446655440000"
+            }
+          }
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
         ],
         "responses": {
           "200": {
@@ -2116,6 +4232,20 @@
               }
             }
           },
+          "400": {
+            "description": "Invalid request body or parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Invalid JSON body",
+                  "code": "invalid_request"
+                }
+              }
+            }
+          },
           "402": {
             "description": "Payment Required",
             "headers": {
@@ -2124,23 +4254,111 @@
                 "schema": {
                   "type": "string"
                 }
+              },
+              "X-RateLimit-Limit": {
+                "description": "Soft rate limit per IP per minute",
+                "schema": {
+                  "type": "integer",
+                  "example": 120
+                }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Requests remaining in the current window",
+                "schema": {
+                  "type": "integer",
+                  "example": 119
+                }
+              },
+              "Retry-After": {
+                "description": "Seconds until the rate-limit window resets (also sent on 429)",
+                "schema": {
+                  "type": "integer",
+                  "example": 60
+                }
               }
             },
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    },
-                    "priceUsdc": {
-                      "type": "number"
-                    },
-                    "resource": {
-                      "type": "string"
-                    }
-                  }
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Payment required",
+                  "code": "payment_required",
+                  "priceUsdc": 0.1,
+                  "resource": "intel-verdict"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "HTTP method not allowed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Method not allowed",
+                  "code": "method_not_allowed"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded — back off and retry after Retry-After seconds",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the client may retry",
+                "schema": {
+                  "type": "integer",
+                  "example": 60
+                }
+              },
+              "X-RateLimit-Limit": {
+                "description": "Maximum requests per window",
+                "schema": {
+                  "type": "integer",
+                  "example": 120
+                }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Requests remaining (0 when rate limited)",
+                "schema": {
+                  "type": "integer",
+                  "example": 0
+                }
+              },
+              "RateLimit-Remaining": {
+                "description": "Requests remaining (0 when rate limited)",
+                "schema": {
+                  "type": "integer",
+                  "example": 0
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Too many requests — retry after the Retry-After interval",
+                  "code": "rate_limited"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Concierge could not process this request. Try a shorter question.",
+                  "code": "internal_error"
                 }
               }
             }
@@ -2171,6 +4389,10 @@
                 "required": [
                   "message"
                 ]
+              },
+              "example": {
+                "message": "DeFi outlook on Solana",
+                "includeInsider": true
               }
             }
           }
@@ -2190,13 +4412,43 @@
             {
               "x402": {
                 "network": "solana",
-                "facilitator": "https://facilitator.payai.network"
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
               }
             },
             {
               "x402": {
                 "network": "base",
-                "facilitator": "https://facilitator.payai.network"
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "arbitrum",
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "solana",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "x402": {
+                "network": "base",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "x402": {
+                "network": "arbitrum",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
               }
             },
             {
@@ -2213,7 +4465,7 @@
               "amount": "100000",
               "currency": "USDC",
               "intent": "charge",
-              "description": "$0.10 USDC via PayAI (Solana or Base)"
+              "description": "$0.10 USDC via PayAI (primary; Dexter fallback on Solana/Base)"
             },
             {
               "protocol": "mpp",
@@ -2229,6 +4481,42 @@
           "Crypto",
           "Trading",
           "RWA"
+        ],
+        "parameters": [
+          {
+            "name": "X-Agent-Id",
+            "in": "header",
+            "required": false,
+            "description": "Registered agent identity (agt_…) for attribution and discovery",
+            "schema": {
+              "type": "string",
+              "pattern": "^agt_[a-zA-Z0-9]+$",
+              "example": "agt_demo0001"
+            }
+          },
+          {
+            "name": "message",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "DeFi outlook on Solana"
+          },
+          {
+            "name": "includeInsider",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            },
+            "example": true
+          }
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
         ],
         "responses": {
           "200": {
@@ -2284,6 +4572,20 @@
               }
             }
           },
+          "400": {
+            "description": "Invalid request body or parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Invalid JSON body",
+                  "code": "invalid_request"
+                }
+              }
+            }
+          },
           "402": {
             "description": "Payment Required",
             "headers": {
@@ -2292,23 +4594,111 @@
                 "schema": {
                   "type": "string"
                 }
+              },
+              "X-RateLimit-Limit": {
+                "description": "Soft rate limit per IP per minute",
+                "schema": {
+                  "type": "integer",
+                  "example": 120
+                }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Requests remaining in the current window",
+                "schema": {
+                  "type": "integer",
+                  "example": 119
+                }
+              },
+              "Retry-After": {
+                "description": "Seconds until the rate-limit window resets (also sent on 429)",
+                "schema": {
+                  "type": "integer",
+                  "example": 60
+                }
               }
             },
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    },
-                    "priceUsdc": {
-                      "type": "number"
-                    },
-                    "resource": {
-                      "type": "string"
-                    }
-                  }
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Payment required",
+                  "code": "payment_required",
+                  "priceUsdc": 0.1,
+                  "resource": "intel-verdict"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "HTTP method not allowed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Method not allowed",
+                  "code": "method_not_allowed"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded — back off and retry after Retry-After seconds",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the client may retry",
+                "schema": {
+                  "type": "integer",
+                  "example": 60
+                }
+              },
+              "X-RateLimit-Limit": {
+                "description": "Maximum requests per window",
+                "schema": {
+                  "type": "integer",
+                  "example": 120
+                }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Requests remaining (0 when rate limited)",
+                "schema": {
+                  "type": "integer",
+                  "example": 0
+                }
+              },
+              "RateLimit-Remaining": {
+                "description": "Requests remaining (0 when rate limited)",
+                "schema": {
+                  "type": "integer",
+                  "example": 0
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Too many requests — retry after the Retry-After interval",
+                  "code": "rate_limited"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Concierge could not process this request. Try a shorter question.",
+                  "code": "internal_error"
                 }
               }
             }
@@ -2319,24 +4709,35 @@
             "url": "https://conc-exe.xyz/api/concierge-intel-verdict"
           }
         ],
-        "parameters": [
-          {
-            "name": "message",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "includeInsider",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean"
+        "requestBody": {
+          "required": false,
+          "description": "GET probes omit a body and return 402. Example documents the POST JSON payload to send after x402 settlement.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "message": {
+                    "type": "string",
+                    "description": "Question or theme for verdict"
+                  },
+                  "includeInsider": {
+                    "type": "boolean",
+                    "description": "Include Lounge creator signals (default true)"
+                  }
+                },
+                "required": [
+                  "message"
+                ]
+              },
+              "example": {
+                "message": "DeFi outlook on Solana",
+                "includeInsider": true
+              }
             }
           }
-        ]
+        }
       }
     },
     "/api/concierge-intel-airdrop": {
@@ -2354,13 +4755,43 @@
             {
               "x402": {
                 "network": "solana",
-                "facilitator": "https://facilitator.payai.network"
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
               }
             },
             {
               "x402": {
                 "network": "base",
-                "facilitator": "https://facilitator.payai.network"
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "arbitrum",
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "solana",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "x402": {
+                "network": "base",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "x402": {
+                "network": "arbitrum",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
               }
             },
             {
@@ -2377,7 +4808,7 @@
               "amount": "100000",
               "currency": "USDC",
               "intent": "charge",
-              "description": "$0.10 USDC via PayAI (Solana or Base)"
+              "description": "$0.10 USDC via PayAI (primary; Dexter fallback on Solana/Base)"
             },
             {
               "protocol": "mpp",
@@ -2393,6 +4824,35 @@
           "Crypto",
           "Trading",
           "RWA"
+        ],
+        "parameters": [
+          {
+            "name": "X-Agent-Id",
+            "in": "header",
+            "required": false,
+            "description": "Registered agent identity (agt_…) for attribution and discovery",
+            "schema": {
+              "type": "string",
+              "pattern": "^agt_[a-zA-Z0-9]+$",
+              "example": "agt_demo0001"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "description": "Optional client-generated key (UUID recommended). Reuse the same key when retrying after network failures. For paid routes, also reuse the same PAYMENT-SIGNATURE — facilitators treat a settled payment as idempotent.",
+            "schema": {
+              "type": "string",
+              "maxLength": 128,
+              "example": "550e8400-e29b-41d4-a716-446655440000"
+            }
+          }
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
         ],
         "responses": {
           "200": {
@@ -2450,6 +4910,20 @@
               }
             }
           },
+          "400": {
+            "description": "Invalid request body or parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Invalid JSON body",
+                  "code": "invalid_request"
+                }
+              }
+            }
+          },
           "402": {
             "description": "Payment Required",
             "headers": {
@@ -2458,23 +4932,111 @@
                 "schema": {
                   "type": "string"
                 }
+              },
+              "X-RateLimit-Limit": {
+                "description": "Soft rate limit per IP per minute",
+                "schema": {
+                  "type": "integer",
+                  "example": 120
+                }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Requests remaining in the current window",
+                "schema": {
+                  "type": "integer",
+                  "example": 119
+                }
+              },
+              "Retry-After": {
+                "description": "Seconds until the rate-limit window resets (also sent on 429)",
+                "schema": {
+                  "type": "integer",
+                  "example": 60
+                }
               }
             },
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    },
-                    "priceUsdc": {
-                      "type": "number"
-                    },
-                    "resource": {
-                      "type": "string"
-                    }
-                  }
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Payment required",
+                  "code": "payment_required",
+                  "priceUsdc": 0.1,
+                  "resource": "intel-airdrop"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "HTTP method not allowed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Method not allowed",
+                  "code": "method_not_allowed"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded — back off and retry after Retry-After seconds",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the client may retry",
+                "schema": {
+                  "type": "integer",
+                  "example": 60
+                }
+              },
+              "X-RateLimit-Limit": {
+                "description": "Maximum requests per window",
+                "schema": {
+                  "type": "integer",
+                  "example": 120
+                }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Requests remaining (0 when rate limited)",
+                "schema": {
+                  "type": "integer",
+                  "example": 0
+                }
+              },
+              "RateLimit-Remaining": {
+                "description": "Requests remaining (0 when rate limited)",
+                "schema": {
+                  "type": "integer",
+                  "example": 0
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Too many requests — retry after the Retry-After interval",
+                  "code": "rate_limited"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Concierge could not process this request. Try a shorter question.",
+                  "code": "internal_error"
                 }
               }
             }
@@ -2511,6 +5073,11 @@
                   }
                 },
                 "required": []
+              },
+              "example": {
+                "message": "Solana ecosystem airdrop farming",
+                "limit": 5,
+                "includeInsider": true
               }
             }
           }
@@ -2530,13 +5097,43 @@
             {
               "x402": {
                 "network": "solana",
-                "facilitator": "https://facilitator.payai.network"
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
               }
             },
             {
               "x402": {
                 "network": "base",
-                "facilitator": "https://facilitator.payai.network"
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "arbitrum",
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "solana",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "x402": {
+                "network": "base",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "x402": {
+                "network": "arbitrum",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
               }
             },
             {
@@ -2553,7 +5150,7 @@
               "amount": "100000",
               "currency": "USDC",
               "intent": "charge",
-              "description": "$0.10 USDC via PayAI (Solana or Base)"
+              "description": "$0.10 USDC via PayAI (primary; Dexter fallback on Solana/Base)"
             },
             {
               "protocol": "mpp",
@@ -2569,6 +5166,59 @@
           "Crypto",
           "Trading",
           "RWA"
+        ],
+        "parameters": [
+          {
+            "name": "X-Agent-Id",
+            "in": "header",
+            "required": false,
+            "description": "Registered agent identity (agt_…) for attribution and discovery",
+            "schema": {
+              "type": "string",
+              "pattern": "^agt_[a-zA-Z0-9]+$",
+              "example": "agt_demo0001"
+            }
+          },
+          {
+            "name": "message",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "Solana ecosystem airdrop farming"
+          },
+          {
+            "name": "chain",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "number"
+            },
+            "example": 5
+          },
+          {
+            "name": "includeInsider",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            },
+            "example": true
+          }
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
         ],
         "responses": {
           "200": {
@@ -2626,6 +5276,20 @@
               }
             }
           },
+          "400": {
+            "description": "Invalid request body or parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Invalid JSON body",
+                  "code": "invalid_request"
+                }
+              }
+            }
+          },
           "402": {
             "description": "Payment Required",
             "headers": {
@@ -2634,23 +5298,111 @@
                 "schema": {
                   "type": "string"
                 }
+              },
+              "X-RateLimit-Limit": {
+                "description": "Soft rate limit per IP per minute",
+                "schema": {
+                  "type": "integer",
+                  "example": 120
+                }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Requests remaining in the current window",
+                "schema": {
+                  "type": "integer",
+                  "example": 119
+                }
+              },
+              "Retry-After": {
+                "description": "Seconds until the rate-limit window resets (also sent on 429)",
+                "schema": {
+                  "type": "integer",
+                  "example": 60
+                }
               }
             },
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    },
-                    "priceUsdc": {
-                      "type": "number"
-                    },
-                    "resource": {
-                      "type": "string"
-                    }
-                  }
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Payment required",
+                  "code": "payment_required",
+                  "priceUsdc": 0.1,
+                  "resource": "intel-airdrop"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "HTTP method not allowed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Method not allowed",
+                  "code": "method_not_allowed"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded — back off and retry after Retry-After seconds",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the client may retry",
+                "schema": {
+                  "type": "integer",
+                  "example": 60
+                }
+              },
+              "X-RateLimit-Limit": {
+                "description": "Maximum requests per window",
+                "schema": {
+                  "type": "integer",
+                  "example": 120
+                }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Requests remaining (0 when rate limited)",
+                "schema": {
+                  "type": "integer",
+                  "example": 0
+                }
+              },
+              "RateLimit-Remaining": {
+                "description": "Requests remaining (0 when rate limited)",
+                "schema": {
+                  "type": "integer",
+                  "example": 0
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Too many requests — retry after the Retry-After interval",
+                  "code": "rate_limited"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Concierge could not process this request. Try a shorter question.",
+                  "code": "internal_error"
                 }
               }
             }
@@ -2661,40 +5413,42 @@
             "url": "https://conc-exe.xyz/api/concierge-intel-airdrop"
           }
         ],
-        "parameters": [
-          {
-            "name": "message",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "chain",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "number"
-            }
-          },
-          {
-            "name": "includeInsider",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean"
+        "requestBody": {
+          "required": false,
+          "description": "GET probes omit a body and return 402. Example documents the POST JSON payload to send after x402 settlement.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "message": {
+                    "type": "string",
+                    "description": "Focus theme or protocol name"
+                  },
+                  "chain": {
+                    "type": "string",
+                    "description": "Optional chain filter (solana, ethereum, base)"
+                  },
+                  "limit": {
+                    "type": "number",
+                    "description": "Max candidates 1–8 (default 5)"
+                  },
+                  "includeInsider": {
+                    "type": "boolean",
+                    "description": "Include Lounge insider signals (default true)"
+                  }
+                },
+                "required": []
+              },
+              "example": {
+                "message": "Solana ecosystem airdrop farming",
+                "limit": 5,
+                "includeInsider": true
+              }
             }
           }
-        ]
+        }
       }
     },
     "/api/concierge-intel-listing": {
@@ -2712,13 +5466,43 @@
             {
               "x402": {
                 "network": "solana",
-                "facilitator": "https://facilitator.payai.network"
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
               }
             },
             {
               "x402": {
                 "network": "base",
-                "facilitator": "https://facilitator.payai.network"
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "arbitrum",
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "solana",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "x402": {
+                "network": "base",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "x402": {
+                "network": "arbitrum",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
               }
             },
             {
@@ -2735,7 +5519,7 @@
               "amount": "100000",
               "currency": "USDC",
               "intent": "charge",
-              "description": "$0.10 USDC via PayAI (Solana or Base)"
+              "description": "$0.10 USDC via PayAI (primary; Dexter fallback on Solana/Base)"
             },
             {
               "protocol": "mpp",
@@ -2751,6 +5535,35 @@
           "Crypto",
           "Trading",
           "RWA"
+        ],
+        "parameters": [
+          {
+            "name": "X-Agent-Id",
+            "in": "header",
+            "required": false,
+            "description": "Registered agent identity (agt_…) for attribution and discovery",
+            "schema": {
+              "type": "string",
+              "pattern": "^agt_[a-zA-Z0-9]+$",
+              "example": "agt_demo0001"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "description": "Optional client-generated key (UUID recommended). Reuse the same key when retrying after network failures. For paid routes, also reuse the same PAYMENT-SIGNATURE — facilitators treat a settled payment as idempotent.",
+            "schema": {
+              "type": "string",
+              "maxLength": 128,
+              "example": "550e8400-e29b-41d4-a716-446655440000"
+            }
+          }
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
         ],
         "responses": {
           "200": {
@@ -2804,6 +5617,20 @@
               }
             }
           },
+          "400": {
+            "description": "Invalid request body or parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Invalid JSON body",
+                  "code": "invalid_request"
+                }
+              }
+            }
+          },
           "402": {
             "description": "Payment Required",
             "headers": {
@@ -2812,23 +5639,111 @@
                 "schema": {
                   "type": "string"
                 }
+              },
+              "X-RateLimit-Limit": {
+                "description": "Soft rate limit per IP per minute",
+                "schema": {
+                  "type": "integer",
+                  "example": 120
+                }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Requests remaining in the current window",
+                "schema": {
+                  "type": "integer",
+                  "example": 119
+                }
+              },
+              "Retry-After": {
+                "description": "Seconds until the rate-limit window resets (also sent on 429)",
+                "schema": {
+                  "type": "integer",
+                  "example": 60
+                }
               }
             },
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    },
-                    "priceUsdc": {
-                      "type": "number"
-                    },
-                    "resource": {
-                      "type": "string"
-                    }
-                  }
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Payment required",
+                  "code": "payment_required",
+                  "priceUsdc": 0.1,
+                  "resource": "intel-listing"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "HTTP method not allowed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Method not allowed",
+                  "code": "method_not_allowed"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded — back off and retry after Retry-After seconds",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the client may retry",
+                "schema": {
+                  "type": "integer",
+                  "example": 60
+                }
+              },
+              "X-RateLimit-Limit": {
+                "description": "Maximum requests per window",
+                "schema": {
+                  "type": "integer",
+                  "example": 120
+                }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Requests remaining (0 when rate limited)",
+                "schema": {
+                  "type": "integer",
+                  "example": 0
+                }
+              },
+              "RateLimit-Remaining": {
+                "description": "Requests remaining (0 when rate limited)",
+                "schema": {
+                  "type": "integer",
+                  "example": 0
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Too many requests — retry after the Retry-After interval",
+                  "code": "rate_limited"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Concierge could not process this request. Try a shorter question.",
+                  "code": "internal_error"
                 }
               }
             }
@@ -2862,6 +5777,10 @@
                   }
                 },
                 "required": []
+              },
+              "example": {
+                "message": "Potential Binance listings",
+                "limit": 5
               }
             }
           }
@@ -2881,13 +5800,43 @@
             {
               "x402": {
                 "network": "solana",
-                "facilitator": "https://facilitator.payai.network"
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
               }
             },
             {
               "x402": {
                 "network": "base",
-                "facilitator": "https://facilitator.payai.network"
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "arbitrum",
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "solana",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "x402": {
+                "network": "base",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "x402": {
+                "network": "arbitrum",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
               }
             },
             {
@@ -2904,7 +5853,7 @@
               "amount": "100000",
               "currency": "USDC",
               "intent": "charge",
-              "description": "$0.10 USDC via PayAI (Solana or Base)"
+              "description": "$0.10 USDC via PayAI (primary; Dexter fallback on Solana/Base)"
             },
             {
               "protocol": "mpp",
@@ -2920,6 +5869,58 @@
           "Crypto",
           "Trading",
           "RWA"
+        ],
+        "parameters": [
+          {
+            "name": "X-Agent-Id",
+            "in": "header",
+            "required": false,
+            "description": "Registered agent identity (agt_…) for attribution and discovery",
+            "schema": {
+              "type": "string",
+              "pattern": "^agt_[a-zA-Z0-9]+$",
+              "example": "agt_demo0001"
+            }
+          },
+          {
+            "name": "message",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "Potential Binance listings"
+          },
+          {
+            "name": "chain",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "number"
+            },
+            "example": 5
+          },
+          {
+            "name": "includeInsider",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
         ],
         "responses": {
           "200": {
@@ -2973,6 +5974,20 @@
               }
             }
           },
+          "400": {
+            "description": "Invalid request body or parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Invalid JSON body",
+                  "code": "invalid_request"
+                }
+              }
+            }
+          },
           "402": {
             "description": "Payment Required",
             "headers": {
@@ -2981,23 +5996,111 @@
                 "schema": {
                   "type": "string"
                 }
+              },
+              "X-RateLimit-Limit": {
+                "description": "Soft rate limit per IP per minute",
+                "schema": {
+                  "type": "integer",
+                  "example": 120
+                }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Requests remaining in the current window",
+                "schema": {
+                  "type": "integer",
+                  "example": 119
+                }
+              },
+              "Retry-After": {
+                "description": "Seconds until the rate-limit window resets (also sent on 429)",
+                "schema": {
+                  "type": "integer",
+                  "example": 60
+                }
               }
             },
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    },
-                    "priceUsdc": {
-                      "type": "number"
-                    },
-                    "resource": {
-                      "type": "string"
-                    }
-                  }
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Payment required",
+                  "code": "payment_required",
+                  "priceUsdc": 0.1,
+                  "resource": "intel-listing"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "HTTP method not allowed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Method not allowed",
+                  "code": "method_not_allowed"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded — back off and retry after Retry-After seconds",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the client may retry",
+                "schema": {
+                  "type": "integer",
+                  "example": 60
+                }
+              },
+              "X-RateLimit-Limit": {
+                "description": "Maximum requests per window",
+                "schema": {
+                  "type": "integer",
+                  "example": 120
+                }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Requests remaining (0 when rate limited)",
+                "schema": {
+                  "type": "integer",
+                  "example": 0
+                }
+              },
+              "RateLimit-Remaining": {
+                "description": "Requests remaining (0 when rate limited)",
+                "schema": {
+                  "type": "integer",
+                  "example": 0
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Too many requests — retry after the Retry-After interval",
+                  "code": "rate_limited"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Concierge could not process this request. Try a shorter question.",
+                  "code": "internal_error"
                 }
               }
             }
@@ -3008,47 +6111,45 @@
             "url": "https://conc-exe.xyz/api/concierge-intel-listing"
           }
         ],
-        "parameters": [
-          {
-            "name": "message",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "chain",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "number"
-            }
-          },
-          {
-            "name": "includeInsider",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean"
+        "requestBody": {
+          "required": false,
+          "description": "GET probes omit a body and return 402. Example documents the POST JSON payload to send after x402 settlement.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "message": {
+                    "type": "string",
+                    "description": "Token or listing catalyst focus"
+                  },
+                  "chain": {
+                    "type": "string"
+                  },
+                  "limit": {
+                    "type": "number"
+                  },
+                  "includeInsider": {
+                    "type": "boolean"
+                  }
+                },
+                "required": []
+              },
+              "example": {
+                "message": "Potential Binance listings",
+                "limit": 5
+              }
             }
           }
-        ]
+        }
       }
     },
     "/api/concierge-intel-momentum": {
       "post": {
         "operationId": "intel_momentum",
         "summary": "Concierge Intel — Momentum",
-        "description": "Large-move candidates (up or down) — insider, derivatives positioning, narrative synthesis.",
+        "description": "Large-move candidates (up or down). Set theme:robinhood for Robinhood Chain meme desk (Pump.fun cross-chain in SOL).",
         "x-payment-info": {
           "price": {
             "mode": "fixed",
@@ -3059,13 +6160,43 @@
             {
               "x402": {
                 "network": "solana",
-                "facilitator": "https://facilitator.payai.network"
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
               }
             },
             {
               "x402": {
                 "network": "base",
-                "facilitator": "https://facilitator.payai.network"
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "arbitrum",
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "solana",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "x402": {
+                "network": "base",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "x402": {
+                "network": "arbitrum",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
               }
             },
             {
@@ -3082,7 +6213,7 @@
               "amount": "100000",
               "currency": "USDC",
               "intent": "charge",
-              "description": "$0.10 USDC via PayAI (Solana or Base)"
+              "description": "$0.10 USDC via PayAI (primary; Dexter fallback on Solana/Base)"
             },
             {
               "protocol": "mpp",
@@ -3098,6 +6229,35 @@
           "Crypto",
           "Trading",
           "RWA"
+        ],
+        "parameters": [
+          {
+            "name": "X-Agent-Id",
+            "in": "header",
+            "required": false,
+            "description": "Registered agent identity (agt_…) for attribution and discovery",
+            "schema": {
+              "type": "string",
+              "pattern": "^agt_[a-zA-Z0-9]+$",
+              "example": "agt_demo0001"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "description": "Optional client-generated key (UUID recommended). Reuse the same key when retrying after network failures. For paid routes, also reuse the same PAYMENT-SIGNATURE — facilitators treat a settled payment as idempotent.",
+            "schema": {
+              "type": "string",
+              "maxLength": 128,
+              "example": "550e8400-e29b-41d4-a716-446655440000"
+            }
+          }
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
         ],
         "responses": {
           "200": {
@@ -3161,6 +6321,20 @@
               }
             }
           },
+          "400": {
+            "description": "Invalid request body or parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Invalid JSON body",
+                  "code": "invalid_request"
+                }
+              }
+            }
+          },
           "402": {
             "description": "Payment Required",
             "headers": {
@@ -3169,23 +6343,111 @@
                 "schema": {
                   "type": "string"
                 }
+              },
+              "X-RateLimit-Limit": {
+                "description": "Soft rate limit per IP per minute",
+                "schema": {
+                  "type": "integer",
+                  "example": 120
+                }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Requests remaining in the current window",
+                "schema": {
+                  "type": "integer",
+                  "example": 119
+                }
+              },
+              "Retry-After": {
+                "description": "Seconds until the rate-limit window resets (also sent on 429)",
+                "schema": {
+                  "type": "integer",
+                  "example": 60
+                }
               }
             },
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    },
-                    "priceUsdc": {
-                      "type": "number"
-                    },
-                    "resource": {
-                      "type": "string"
-                    }
-                  }
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Payment required",
+                  "code": "payment_required",
+                  "priceUsdc": 0.1,
+                  "resource": "intel-momentum"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "HTTP method not allowed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Method not allowed",
+                  "code": "method_not_allowed"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded — back off and retry after Retry-After seconds",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the client may retry",
+                "schema": {
+                  "type": "integer",
+                  "example": 60
+                }
+              },
+              "X-RateLimit-Limit": {
+                "description": "Maximum requests per window",
+                "schema": {
+                  "type": "integer",
+                  "example": 120
+                }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Requests remaining (0 when rate limited)",
+                "schema": {
+                  "type": "integer",
+                  "example": 0
+                }
+              },
+              "RateLimit-Remaining": {
+                "description": "Requests remaining (0 when rate limited)",
+                "schema": {
+                  "type": "integer",
+                  "example": 0
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Too many requests — retry after the Retry-After interval",
+                  "code": "rate_limited"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Concierge could not process this request. Try a shorter question.",
+                  "code": "internal_error"
                 }
               }
             }
@@ -3219,6 +6481,11 @@
                   }
                 },
                 "required": []
+              },
+              "example": {
+                "message": "BTC altcoin volatility catalysts",
+                "limit": 5,
+                "includeInsider": true
               }
             }
           }
@@ -3227,7 +6494,7 @@
       "get": {
         "operationId": "intel_momentum_get",
         "summary": "Concierge Intel — Momentum (GET probe)",
-        "description": "Large-move candidates (up or down) — insider, derivatives positioning, narrative synthesis. Probes return 402 without payment; use POST with JSON body after settlement.",
+        "description": "Large-move candidates (up or down). Set theme:robinhood for Robinhood Chain meme desk (Pump.fun cross-chain in SOL). Probes return 402 without payment; use POST with JSON body after settlement.",
         "x-payment-info": {
           "price": {
             "mode": "fixed",
@@ -3238,13 +6505,43 @@
             {
               "x402": {
                 "network": "solana",
-                "facilitator": "https://facilitator.payai.network"
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
               }
             },
             {
               "x402": {
                 "network": "base",
-                "facilitator": "https://facilitator.payai.network"
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "arbitrum",
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "solana",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "x402": {
+                "network": "base",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "x402": {
+                "network": "arbitrum",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
               }
             },
             {
@@ -3261,7 +6558,7 @@
               "amount": "100000",
               "currency": "USDC",
               "intent": "charge",
-              "description": "$0.10 USDC via PayAI (Solana or Base)"
+              "description": "$0.10 USDC via PayAI (primary; Dexter fallback on Solana/Base)"
             },
             {
               "protocol": "mpp",
@@ -3277,6 +6574,59 @@
           "Crypto",
           "Trading",
           "RWA"
+        ],
+        "parameters": [
+          {
+            "name": "X-Agent-Id",
+            "in": "header",
+            "required": false,
+            "description": "Registered agent identity (agt_…) for attribution and discovery",
+            "schema": {
+              "type": "string",
+              "pattern": "^agt_[a-zA-Z0-9]+$",
+              "example": "agt_demo0001"
+            }
+          },
+          {
+            "name": "message",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "BTC altcoin volatility catalysts"
+          },
+          {
+            "name": "chain",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "number"
+            },
+            "example": 5
+          },
+          {
+            "name": "includeInsider",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            },
+            "example": true
+          }
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
         ],
         "responses": {
           "200": {
@@ -3340,6 +6690,20 @@
               }
             }
           },
+          "400": {
+            "description": "Invalid request body or parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Invalid JSON body",
+                  "code": "invalid_request"
+                }
+              }
+            }
+          },
           "402": {
             "description": "Payment Required",
             "headers": {
@@ -3348,23 +6712,111 @@
                 "schema": {
                   "type": "string"
                 }
+              },
+              "X-RateLimit-Limit": {
+                "description": "Soft rate limit per IP per minute",
+                "schema": {
+                  "type": "integer",
+                  "example": 120
+                }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Requests remaining in the current window",
+                "schema": {
+                  "type": "integer",
+                  "example": 119
+                }
+              },
+              "Retry-After": {
+                "description": "Seconds until the rate-limit window resets (also sent on 429)",
+                "schema": {
+                  "type": "integer",
+                  "example": 60
+                }
               }
             },
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    },
-                    "priceUsdc": {
-                      "type": "number"
-                    },
-                    "resource": {
-                      "type": "string"
-                    }
-                  }
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Payment required",
+                  "code": "payment_required",
+                  "priceUsdc": 0.1,
+                  "resource": "intel-momentum"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "HTTP method not allowed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Method not allowed",
+                  "code": "method_not_allowed"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded — back off and retry after Retry-After seconds",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the client may retry",
+                "schema": {
+                  "type": "integer",
+                  "example": 60
+                }
+              },
+              "X-RateLimit-Limit": {
+                "description": "Maximum requests per window",
+                "schema": {
+                  "type": "integer",
+                  "example": 120
+                }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Requests remaining (0 when rate limited)",
+                "schema": {
+                  "type": "integer",
+                  "example": 0
+                }
+              },
+              "RateLimit-Remaining": {
+                "description": "Requests remaining (0 when rate limited)",
+                "schema": {
+                  "type": "integer",
+                  "example": 0
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Too many requests — retry after the Retry-After interval",
+                  "code": "rate_limited"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Concierge could not process this request. Try a shorter question.",
+                  "code": "internal_error"
                 }
               }
             }
@@ -3375,7 +6827,1241 @@
             "url": "https://conc-exe.xyz/api/concierge-intel-momentum"
           }
         ],
+        "requestBody": {
+          "required": false,
+          "description": "GET probes omit a body and return 402. Example documents the POST JSON payload to send after x402 settlement.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "message": {
+                    "type": "string",
+                    "description": "Asset or momentum theme"
+                  },
+                  "chain": {
+                    "type": "string"
+                  },
+                  "limit": {
+                    "type": "number"
+                  },
+                  "includeInsider": {
+                    "type": "boolean"
+                  }
+                },
+                "required": []
+              },
+              "example": {
+                "message": "BTC altcoin volatility catalysts",
+                "limit": 5,
+                "includeInsider": true
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/concierge-intel-scalp": {
+      "post": {
+        "operationId": "intel_scalp",
+        "summary": "Concierge Intel — Scalp",
+        "description": "BTC/ETH/BNB/SOL USDT scalping desk — 5m & 15m Binance klines, RSI/EMA, perp overlay for agents.",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.100000"
+          },
+          "protocols": [
+            {
+              "x402": {
+                "network": "solana",
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "base",
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "arbitrum",
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "solana",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "x402": {
+                "network": "base",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "x402": {
+                "network": "arbitrum",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "mpp": {
+                "method": "solana",
+                "intent": "charge",
+                "currency": "USDC"
+              }
+            }
+          ],
+          "offers": [
+            {
+              "protocol": "x402",
+              "amount": "100000",
+              "currency": "USDC",
+              "intent": "charge",
+              "description": "$0.10 USDC via PayAI (primary; Dexter fallback on Solana/Base)"
+            },
+            {
+              "protocol": "mpp",
+              "amount": "100000",
+              "currency": "USDC",
+              "intent": "charge",
+              "description": "$0.10 USDC — x402 settlement compatible with MPP clients"
+            }
+          ]
+        },
+        "tags": [
+          "AI",
+          "Crypto",
+          "Trading"
+        ],
         "parameters": [
+          {
+            "name": "X-Agent-Id",
+            "in": "header",
+            "required": false,
+            "description": "Registered agent identity (agt_…) for attribution and discovery",
+            "schema": {
+              "type": "string",
+              "pattern": "^agt_[a-zA-Z0-9]+$",
+              "example": "agt_demo0001"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "description": "Optional client-generated key (UUID recommended). Reuse the same key when retrying after network failures. For paid routes, also reuse the same PAYMENT-SIGNATURE — facilitators treat a settled payment as idempotent.",
+            "schema": {
+              "type": "string",
+              "maxLength": 128,
+              "example": "550e8400-e29b-41d4-a716-446655440000"
+            }
+          }
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success after payment",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "assets": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "symbol": {
+                            "type": "string"
+                          },
+                          "pair": {
+                            "type": "string"
+                          },
+                          "intervals": {
+                            "type": "array"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "required": [
+                    "ok",
+                    "assets"
+                  ]
+                },
+                "example": {
+                  "ok": true,
+                  "filters": {
+                    "symbols": [
+                      "BTC"
+                    ],
+                    "intervals": [
+                      "5m",
+                      "15m"
+                    ],
+                    "pairs": [
+                      "BTC/USDT"
+                    ]
+                  },
+                  "assets": [
+                    {
+                      "symbol": "BTC",
+                      "pair": "BTCUSDT",
+                      "intervals": [
+                        {
+                          "interval": "15m",
+                          "ta": {
+                            "rsi14": 52,
+                            "trend": "neutral",
+                            "lastClose": 60781
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request body or parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Invalid JSON body",
+                  "code": "invalid_request"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "Base64 JSON x402 payment requirements (MPP-compatible)",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-RateLimit-Limit": {
+                "description": "Soft rate limit per IP per minute",
+                "schema": {
+                  "type": "integer",
+                  "example": 120
+                }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Requests remaining in the current window",
+                "schema": {
+                  "type": "integer",
+                  "example": 119
+                }
+              },
+              "Retry-After": {
+                "description": "Seconds until the rate-limit window resets (also sent on 429)",
+                "schema": {
+                  "type": "integer",
+                  "example": 60
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Payment required",
+                  "code": "payment_required",
+                  "priceUsdc": 0.1,
+                  "resource": "intel-scalp"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "HTTP method not allowed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Method not allowed",
+                  "code": "method_not_allowed"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded — back off and retry after Retry-After seconds",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the client may retry",
+                "schema": {
+                  "type": "integer",
+                  "example": 60
+                }
+              },
+              "X-RateLimit-Limit": {
+                "description": "Maximum requests per window",
+                "schema": {
+                  "type": "integer",
+                  "example": 120
+                }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Requests remaining (0 when rate limited)",
+                "schema": {
+                  "type": "integer",
+                  "example": 0
+                }
+              },
+              "RateLimit-Remaining": {
+                "description": "Requests remaining (0 when rate limited)",
+                "schema": {
+                  "type": "integer",
+                  "example": 0
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Too many requests — retry after the Retry-After interval",
+                  "code": "rate_limited"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Concierge could not process this request. Try a shorter question.",
+                  "code": "internal_error"
+                }
+              }
+            }
+          }
+        },
+        "servers": [
+          {
+            "url": "https://conc-exe.xyz/api/concierge-intel-scalp"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "message": {
+                    "type": "string",
+                    "description": "Scalp context (e.g. BTC 15m entry)"
+                  },
+                  "symbols": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "enum": [
+                        "BTC",
+                        "ETH",
+                        "BNB",
+                        "SOL"
+                      ]
+                    }
+                  },
+                  "intervals": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "enum": [
+                        "5m",
+                        "15m"
+                      ]
+                    }
+                  }
+                },
+                "required": []
+              },
+              "example": {
+                "message": "scalp BTC 15m",
+                "symbols": [
+                  "BTC"
+                ],
+                "intervals": [
+                  "5m",
+                  "15m"
+                ]
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "operationId": "intel_scalp_get",
+        "summary": "Concierge Intel — Scalp (GET probe)",
+        "description": "BTC/ETH/BNB/SOL USDT scalping desk — 5m & 15m Binance klines, RSI/EMA, perp overlay for agents. Probes return 402 without payment; use POST with JSON body after settlement.",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.100000"
+          },
+          "protocols": [
+            {
+              "x402": {
+                "network": "solana",
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "base",
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "arbitrum",
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "solana",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "x402": {
+                "network": "base",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "x402": {
+                "network": "arbitrum",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "mpp": {
+                "method": "solana",
+                "intent": "charge",
+                "currency": "USDC"
+              }
+            }
+          ],
+          "offers": [
+            {
+              "protocol": "x402",
+              "amount": "100000",
+              "currency": "USDC",
+              "intent": "charge",
+              "description": "$0.10 USDC via PayAI (primary; Dexter fallback on Solana/Base)"
+            },
+            {
+              "protocol": "mpp",
+              "amount": "100000",
+              "currency": "USDC",
+              "intent": "charge",
+              "description": "$0.10 USDC — x402 settlement compatible with MPP clients"
+            }
+          ]
+        },
+        "tags": [
+          "AI",
+          "Crypto",
+          "Trading"
+        ],
+        "parameters": [
+          {
+            "name": "X-Agent-Id",
+            "in": "header",
+            "required": false,
+            "description": "Registered agent identity (agt_…) for attribution and discovery",
+            "schema": {
+              "type": "string",
+              "pattern": "^agt_[a-zA-Z0-9]+$",
+              "example": "agt_demo0001"
+            }
+          },
+          {
+            "name": "message",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "scalp BTC 15m"
+          },
+          {
+            "name": "symbols",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array"
+            },
+            "example": [
+              "BTC"
+            ]
+          },
+          {
+            "name": "intervals",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array"
+            },
+            "example": [
+              "5m",
+              "15m"
+            ]
+          }
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success after payment",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "assets": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "symbol": {
+                            "type": "string"
+                          },
+                          "pair": {
+                            "type": "string"
+                          },
+                          "intervals": {
+                            "type": "array"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "required": [
+                    "ok",
+                    "assets"
+                  ]
+                },
+                "example": {
+                  "ok": true,
+                  "filters": {
+                    "symbols": [
+                      "BTC"
+                    ],
+                    "intervals": [
+                      "5m",
+                      "15m"
+                    ],
+                    "pairs": [
+                      "BTC/USDT"
+                    ]
+                  },
+                  "assets": [
+                    {
+                      "symbol": "BTC",
+                      "pair": "BTCUSDT",
+                      "intervals": [
+                        {
+                          "interval": "15m",
+                          "ta": {
+                            "rsi14": 52,
+                            "trend": "neutral",
+                            "lastClose": 60781
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request body or parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Invalid JSON body",
+                  "code": "invalid_request"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "Base64 JSON x402 payment requirements (MPP-compatible)",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-RateLimit-Limit": {
+                "description": "Soft rate limit per IP per minute",
+                "schema": {
+                  "type": "integer",
+                  "example": 120
+                }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Requests remaining in the current window",
+                "schema": {
+                  "type": "integer",
+                  "example": 119
+                }
+              },
+              "Retry-After": {
+                "description": "Seconds until the rate-limit window resets (also sent on 429)",
+                "schema": {
+                  "type": "integer",
+                  "example": 60
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Payment required",
+                  "code": "payment_required",
+                  "priceUsdc": 0.1,
+                  "resource": "intel-scalp"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "HTTP method not allowed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Method not allowed",
+                  "code": "method_not_allowed"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded — back off and retry after Retry-After seconds",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the client may retry",
+                "schema": {
+                  "type": "integer",
+                  "example": 60
+                }
+              },
+              "X-RateLimit-Limit": {
+                "description": "Maximum requests per window",
+                "schema": {
+                  "type": "integer",
+                  "example": 120
+                }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Requests remaining (0 when rate limited)",
+                "schema": {
+                  "type": "integer",
+                  "example": 0
+                }
+              },
+              "RateLimit-Remaining": {
+                "description": "Requests remaining (0 when rate limited)",
+                "schema": {
+                  "type": "integer",
+                  "example": 0
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Too many requests — retry after the Retry-After interval",
+                  "code": "rate_limited"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Concierge could not process this request. Try a shorter question.",
+                  "code": "internal_error"
+                }
+              }
+            }
+          }
+        },
+        "servers": [
+          {
+            "url": "https://conc-exe.xyz/api/concierge-intel-scalp"
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "description": "GET probes omit a body and return 402. Example documents the POST JSON payload to send after x402 settlement.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "message": {
+                    "type": "string",
+                    "description": "Scalp context (e.g. BTC 15m entry)"
+                  },
+                  "symbols": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "enum": [
+                        "BTC",
+                        "ETH",
+                        "BNB",
+                        "SOL"
+                      ]
+                    }
+                  },
+                  "intervals": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "enum": [
+                        "5m",
+                        "15m"
+                      ]
+                    }
+                  }
+                },
+                "required": []
+              },
+              "example": {
+                "message": "scalp BTC 15m",
+                "symbols": [
+                  "BTC"
+                ],
+                "intervals": [
+                  "5m",
+                  "15m"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/concierge-intel-macro": {
+      "post": {
+        "operationId": "intel_macro",
+        "summary": "Concierge Intel — Macro",
+        "description": "Macro snapshot — SPX, VIX, DXY, gold, BTC/ETH marks, Fear & Greed, Treasury yields, and central-bank calendar.",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.020000"
+          },
+          "protocols": [
+            {
+              "x402": {
+                "network": "solana",
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "base",
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "arbitrum",
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "solana",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "x402": {
+                "network": "base",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "x402": {
+                "network": "arbitrum",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "mpp": {
+                "method": "solana",
+                "intent": "charge",
+                "currency": "USDC"
+              }
+            }
+          ],
+          "offers": [
+            {
+              "protocol": "x402",
+              "amount": "20000",
+              "currency": "USDC",
+              "intent": "charge",
+              "description": "$0.02 USDC via PayAI (primary; Dexter fallback on Solana/Base)"
+            },
+            {
+              "protocol": "mpp",
+              "amount": "20000",
+              "currency": "USDC",
+              "intent": "charge",
+              "description": "$0.02 USDC — x402 settlement compatible with MPP clients"
+            }
+          ]
+        },
+        "tags": [
+          "Research",
+          "News",
+          "Utility"
+        ],
+        "parameters": [
+          {
+            "name": "X-Agent-Id",
+            "in": "header",
+            "required": false,
+            "description": "Registered agent identity (agt_…) for attribution and discovery",
+            "schema": {
+              "type": "string",
+              "pattern": "^agt_[a-zA-Z0-9]+$",
+              "example": "agt_demo0001"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "description": "Optional client-generated key (UUID recommended). Reuse the same key when retrying after network failures. For paid routes, also reuse the same PAYMENT-SIGNATURE — facilitators treat a settled payment as idempotent.",
+            "schema": {
+              "type": "string",
+              "maxLength": 128,
+              "example": "550e8400-e29b-41d4-a716-446655440000"
+            }
+          }
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success after payment",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "marks": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "symbol": {
+                            "type": "string"
+                          },
+                          "price": {
+                            "type": "string"
+                          },
+                          "change24h": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "sentiment": {
+                      "type": "object",
+                      "properties": {
+                        "index": {
+                          "type": "number"
+                        },
+                        "label": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "macro": {
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "ok"
+                  ]
+                },
+                "example": {
+                  "ok": true,
+                  "marks": [
+                    {
+                      "symbol": "SPX",
+                      "price": "5,240.10",
+                      "change24h": "+0.42%"
+                    }
+                  ],
+                  "sentiment": {
+                    "index": 62,
+                    "label": "Greed"
+                  },
+                  "macro": {
+                    "upcomingEvents": [
+                      {
+                        "label": "FOMC decision",
+                        "when": "2026-03-18"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request body or parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Invalid JSON body",
+                  "code": "invalid_request"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "Base64 JSON x402 payment requirements (MPP-compatible)",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-RateLimit-Limit": {
+                "description": "Soft rate limit per IP per minute",
+                "schema": {
+                  "type": "integer",
+                  "example": 120
+                }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Requests remaining in the current window",
+                "schema": {
+                  "type": "integer",
+                  "example": 119
+                }
+              },
+              "Retry-After": {
+                "description": "Seconds until the rate-limit window resets (also sent on 429)",
+                "schema": {
+                  "type": "integer",
+                  "example": 60
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Payment required",
+                  "code": "payment_required",
+                  "priceUsdc": 0.02,
+                  "resource": "intel-macro"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "HTTP method not allowed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Method not allowed",
+                  "code": "method_not_allowed"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded — back off and retry after Retry-After seconds",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the client may retry",
+                "schema": {
+                  "type": "integer",
+                  "example": 60
+                }
+              },
+              "X-RateLimit-Limit": {
+                "description": "Maximum requests per window",
+                "schema": {
+                  "type": "integer",
+                  "example": 120
+                }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Requests remaining (0 when rate limited)",
+                "schema": {
+                  "type": "integer",
+                  "example": 0
+                }
+              },
+              "RateLimit-Remaining": {
+                "description": "Requests remaining (0 when rate limited)",
+                "schema": {
+                  "type": "integer",
+                  "example": 0
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Too many requests — retry after the Retry-After interval",
+                  "code": "rate_limited"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Concierge could not process this request. Try a shorter question.",
+                  "code": "internal_error"
+                }
+              }
+            }
+          }
+        },
+        "servers": [
+          {
+            "url": "https://conc-exe.xyz/api/concierge-intel-macro"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "message": {
+                    "type": "string",
+                    "description": "Optional context for logging"
+                  }
+                },
+                "required": []
+              },
+              "example": {}
+            }
+          }
+        }
+      },
+      "get": {
+        "operationId": "intel_macro_get",
+        "summary": "Concierge Intel — Macro (GET probe)",
+        "description": "Macro snapshot — SPX, VIX, DXY, gold, BTC/ETH marks, Fear & Greed, Treasury yields, and central-bank calendar. Probes return 402 without payment; use POST with JSON body after settlement.",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.020000"
+          },
+          "protocols": [
+            {
+              "x402": {
+                "network": "solana",
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "base",
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "arbitrum",
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "solana",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "x402": {
+                "network": "base",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "x402": {
+                "network": "arbitrum",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "mpp": {
+                "method": "solana",
+                "intent": "charge",
+                "currency": "USDC"
+              }
+            }
+          ],
+          "offers": [
+            {
+              "protocol": "x402",
+              "amount": "20000",
+              "currency": "USDC",
+              "intent": "charge",
+              "description": "$0.02 USDC via PayAI (primary; Dexter fallback on Solana/Base)"
+            },
+            {
+              "protocol": "mpp",
+              "amount": "20000",
+              "currency": "USDC",
+              "intent": "charge",
+              "description": "$0.02 USDC — x402 settlement compatible with MPP clients"
+            }
+          ]
+        },
+        "tags": [
+          "Research",
+          "News",
+          "Utility"
+        ],
+        "parameters": [
+          {
+            "name": "X-Agent-Id",
+            "in": "header",
+            "required": false,
+            "description": "Registered agent identity (agt_…) for attribution and discovery",
+            "schema": {
+              "type": "string",
+              "pattern": "^agt_[a-zA-Z0-9]+$",
+              "example": "agt_demo0001"
+            }
+          },
           {
             "name": "message",
             "in": "query",
@@ -3383,14 +8069,698 @@
             "schema": {
               "type": "string"
             }
+          }
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success after payment",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "marks": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "symbol": {
+                            "type": "string"
+                          },
+                          "price": {
+                            "type": "string"
+                          },
+                          "change24h": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "sentiment": {
+                      "type": "object",
+                      "properties": {
+                        "index": {
+                          "type": "number"
+                        },
+                        "label": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "macro": {
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "ok"
+                  ]
+                },
+                "example": {
+                  "ok": true,
+                  "marks": [
+                    {
+                      "symbol": "SPX",
+                      "price": "5,240.10",
+                      "change24h": "+0.42%"
+                    }
+                  ],
+                  "sentiment": {
+                    "index": 62,
+                    "label": "Greed"
+                  },
+                  "macro": {
+                    "upcomingEvents": [
+                      {
+                        "label": "FOMC decision",
+                        "when": "2026-03-18"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request body or parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Invalid JSON body",
+                  "code": "invalid_request"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "Base64 JSON x402 payment requirements (MPP-compatible)",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-RateLimit-Limit": {
+                "description": "Soft rate limit per IP per minute",
+                "schema": {
+                  "type": "integer",
+                  "example": 120
+                }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Requests remaining in the current window",
+                "schema": {
+                  "type": "integer",
+                  "example": 119
+                }
+              },
+              "Retry-After": {
+                "description": "Seconds until the rate-limit window resets (also sent on 429)",
+                "schema": {
+                  "type": "integer",
+                  "example": 60
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Payment required",
+                  "code": "payment_required",
+                  "priceUsdc": 0.02,
+                  "resource": "intel-macro"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "HTTP method not allowed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Method not allowed",
+                  "code": "method_not_allowed"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded — back off and retry after Retry-After seconds",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the client may retry",
+                "schema": {
+                  "type": "integer",
+                  "example": 60
+                }
+              },
+              "X-RateLimit-Limit": {
+                "description": "Maximum requests per window",
+                "schema": {
+                  "type": "integer",
+                  "example": 120
+                }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Requests remaining (0 when rate limited)",
+                "schema": {
+                  "type": "integer",
+                  "example": 0
+                }
+              },
+              "RateLimit-Remaining": {
+                "description": "Requests remaining (0 when rate limited)",
+                "schema": {
+                  "type": "integer",
+                  "example": 0
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Too many requests — retry after the Retry-After interval",
+                  "code": "rate_limited"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Concierge could not process this request. Try a shorter question.",
+                  "code": "internal_error"
+                }
+              }
+            }
+          }
+        },
+        "servers": [
+          {
+            "url": "https://conc-exe.xyz/api/concierge-intel-macro"
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "description": "GET probes omit a body and return 402. Example documents the POST JSON payload to send after x402 settlement.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "message": {
+                    "type": "string",
+                    "description": "Optional context for logging"
+                  }
+                },
+                "required": []
+              },
+              "example": {}
+            }
+          }
+        }
+      }
+    },
+    "/api/concierge-intel-wire": {
+      "post": {
+        "operationId": "intel_wire",
+        "summary": "Concierge Intel — Wire",
+        "description": "Wire headline digest — live RSS plus persisted Lounge feed; optional category or message filter.",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.020000"
+          },
+          "protocols": [
+            {
+              "x402": {
+                "network": "solana",
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "base",
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "arbitrum",
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "solana",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "x402": {
+                "network": "base",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "x402": {
+                "network": "arbitrum",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "mpp": {
+                "method": "solana",
+                "intent": "charge",
+                "currency": "USDC"
+              }
+            }
+          ],
+          "offers": [
+            {
+              "protocol": "x402",
+              "amount": "20000",
+              "currency": "USDC",
+              "intent": "charge",
+              "description": "$0.02 USDC via PayAI (primary; Dexter fallback on Solana/Base)"
+            },
+            {
+              "protocol": "mpp",
+              "amount": "20000",
+              "currency": "USDC",
+              "intent": "charge",
+              "description": "$0.02 USDC — x402 settlement compatible with MPP clients"
+            }
+          ]
+        },
+        "tags": [
+          "News",
+          "Research",
+          "Search"
+        ],
+        "parameters": [
+          {
+            "name": "X-Agent-Id",
+            "in": "header",
+            "required": false,
+            "description": "Registered agent identity (agt_…) for attribution and discovery",
+            "schema": {
+              "type": "string",
+              "pattern": "^agt_[a-zA-Z0-9]+$",
+              "example": "agt_demo0001"
+            }
           },
           {
-            "name": "chain",
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "description": "Optional client-generated key (UUID recommended). Reuse the same key when retrying after network failures. For paid routes, also reuse the same PAYMENT-SIGNATURE — facilitators treat a settled payment as idempotent.",
+            "schema": {
+              "type": "string",
+              "maxLength": 128,
+              "example": "550e8400-e29b-41d4-a716-446655440000"
+            }
+          }
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success after payment",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "headlines": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "title": {
+                            "type": "string"
+                          },
+                          "source": {
+                            "type": "string"
+                          },
+                          "category": {
+                            "type": "string"
+                          },
+                          "url": {
+                            "type": "string"
+                          },
+                          "origin": {
+                            "type": "string",
+                            "enum": [
+                              "live",
+                              "lounge"
+                            ]
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "required": [
+                    "ok",
+                    "headlines"
+                  ]
+                },
+                "example": {
+                  "ok": true,
+                  "headlines": [
+                    {
+                      "title": "Oil supply risk rises on shipping disruption",
+                      "source": "Reuters",
+                      "category": "Geopolitics",
+                      "origin": "lounge"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request body or parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Invalid JSON body",
+                  "code": "invalid_request"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "Base64 JSON x402 payment requirements (MPP-compatible)",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-RateLimit-Limit": {
+                "description": "Soft rate limit per IP per minute",
+                "schema": {
+                  "type": "integer",
+                  "example": 120
+                }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Requests remaining in the current window",
+                "schema": {
+                  "type": "integer",
+                  "example": 119
+                }
+              },
+              "Retry-After": {
+                "description": "Seconds until the rate-limit window resets (also sent on 429)",
+                "schema": {
+                  "type": "integer",
+                  "example": 60
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Payment required",
+                  "code": "payment_required",
+                  "priceUsdc": 0.02,
+                  "resource": "intel-wire"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "HTTP method not allowed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Method not allowed",
+                  "code": "method_not_allowed"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded — back off and retry after Retry-After seconds",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the client may retry",
+                "schema": {
+                  "type": "integer",
+                  "example": 60
+                }
+              },
+              "X-RateLimit-Limit": {
+                "description": "Maximum requests per window",
+                "schema": {
+                  "type": "integer",
+                  "example": 120
+                }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Requests remaining (0 when rate limited)",
+                "schema": {
+                  "type": "integer",
+                  "example": 0
+                }
+              },
+              "RateLimit-Remaining": {
+                "description": "Requests remaining (0 when rate limited)",
+                "schema": {
+                  "type": "integer",
+                  "example": 0
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Too many requests — retry after the Retry-After interval",
+                  "code": "rate_limited"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Concierge could not process this request. Try a shorter question.",
+                  "code": "internal_error"
+                }
+              }
+            }
+          }
+        },
+        "servers": [
+          {
+            "url": "https://conc-exe.xyz/api/concierge-intel-wire"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "message": {
+                    "type": "string",
+                    "description": "Relevance filter for Lounge wire memory"
+                  },
+                  "category": {
+                    "type": "string",
+                    "description": "Category filter (Macro, Geopolitics, Crypto, …)"
+                  },
+                  "limit": {
+                    "type": "number",
+                    "description": "Max headlines 1–20 (default 10)"
+                  }
+                },
+                "required": []
+              },
+              "example": {
+                "category": "Geopolitics",
+                "limit": 8,
+                "message": "Middle East oil supply"
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "operationId": "intel_wire_get",
+        "summary": "Concierge Intel — Wire (GET probe)",
+        "description": "Wire headline digest — live RSS plus persisted Lounge feed; optional category or message filter. Probes return 402 without payment; use POST with JSON body after settlement.",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.020000"
+          },
+          "protocols": [
+            {
+              "x402": {
+                "network": "solana",
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "base",
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "arbitrum",
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "solana",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "x402": {
+                "network": "base",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "x402": {
+                "network": "arbitrum",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "mpp": {
+                "method": "solana",
+                "intent": "charge",
+                "currency": "USDC"
+              }
+            }
+          ],
+          "offers": [
+            {
+              "protocol": "x402",
+              "amount": "20000",
+              "currency": "USDC",
+              "intent": "charge",
+              "description": "$0.02 USDC via PayAI (primary; Dexter fallback on Solana/Base)"
+            },
+            {
+              "protocol": "mpp",
+              "amount": "20000",
+              "currency": "USDC",
+              "intent": "charge",
+              "description": "$0.02 USDC — x402 settlement compatible with MPP clients"
+            }
+          ]
+        },
+        "tags": [
+          "News",
+          "Research",
+          "Search"
+        ],
+        "parameters": [
+          {
+            "name": "X-Agent-Id",
+            "in": "header",
+            "required": false,
+            "description": "Registered agent identity (agt_…) for attribution and discovery",
+            "schema": {
+              "type": "string",
+              "pattern": "^agt_[a-zA-Z0-9]+$",
+              "example": "agt_demo0001"
+            }
+          },
+          {
+            "name": "message",
             "in": "query",
             "required": false,
             "schema": {
               "type": "string"
-            }
+            },
+            "example": "Middle East oil supply"
+          },
+          {
+            "name": "category",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "Geopolitics"
           },
           {
             "name": "limit",
@@ -3398,7 +8768,1363 @@
             "required": false,
             "schema": {
               "type": "number"
+            },
+            "example": 8
+          }
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success after payment",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "headlines": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "title": {
+                            "type": "string"
+                          },
+                          "source": {
+                            "type": "string"
+                          },
+                          "category": {
+                            "type": "string"
+                          },
+                          "url": {
+                            "type": "string"
+                          },
+                          "origin": {
+                            "type": "string",
+                            "enum": [
+                              "live",
+                              "lounge"
+                            ]
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "required": [
+                    "ok",
+                    "headlines"
+                  ]
+                },
+                "example": {
+                  "ok": true,
+                  "headlines": [
+                    {
+                      "title": "Oil supply risk rises on shipping disruption",
+                      "source": "Reuters",
+                      "category": "Geopolitics",
+                      "origin": "lounge"
+                    }
+                  ]
+                }
+              }
             }
+          },
+          "400": {
+            "description": "Invalid request body or parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Invalid JSON body",
+                  "code": "invalid_request"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "Base64 JSON x402 payment requirements (MPP-compatible)",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-RateLimit-Limit": {
+                "description": "Soft rate limit per IP per minute",
+                "schema": {
+                  "type": "integer",
+                  "example": 120
+                }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Requests remaining in the current window",
+                "schema": {
+                  "type": "integer",
+                  "example": 119
+                }
+              },
+              "Retry-After": {
+                "description": "Seconds until the rate-limit window resets (also sent on 429)",
+                "schema": {
+                  "type": "integer",
+                  "example": 60
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Payment required",
+                  "code": "payment_required",
+                  "priceUsdc": 0.02,
+                  "resource": "intel-wire"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "HTTP method not allowed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Method not allowed",
+                  "code": "method_not_allowed"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded — back off and retry after Retry-After seconds",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the client may retry",
+                "schema": {
+                  "type": "integer",
+                  "example": 60
+                }
+              },
+              "X-RateLimit-Limit": {
+                "description": "Maximum requests per window",
+                "schema": {
+                  "type": "integer",
+                  "example": 120
+                }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Requests remaining (0 when rate limited)",
+                "schema": {
+                  "type": "integer",
+                  "example": 0
+                }
+              },
+              "RateLimit-Remaining": {
+                "description": "Requests remaining (0 when rate limited)",
+                "schema": {
+                  "type": "integer",
+                  "example": 0
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Too many requests — retry after the Retry-After interval",
+                  "code": "rate_limited"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Concierge could not process this request. Try a shorter question.",
+                  "code": "internal_error"
+                }
+              }
+            }
+          }
+        },
+        "servers": [
+          {
+            "url": "https://conc-exe.xyz/api/concierge-intel-wire"
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "description": "GET probes omit a body and return 402. Example documents the POST JSON payload to send after x402 settlement.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "message": {
+                    "type": "string",
+                    "description": "Relevance filter for Lounge wire memory"
+                  },
+                  "category": {
+                    "type": "string",
+                    "description": "Category filter (Macro, Geopolitics, Crypto, …)"
+                  },
+                  "limit": {
+                    "type": "number",
+                    "description": "Max headlines 1–20 (default 10)"
+                  }
+                },
+                "required": []
+              },
+              "example": {
+                "category": "Geopolitics",
+                "limit": 8,
+                "message": "Middle East oil supply"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/concierge-intel-meteora": {
+      "post": {
+        "operationId": "intel_meteora",
+        "summary": "Concierge Intel — Meteora DLMM",
+        "description": "Meteora DLMM pool deep-dive — TVL, APY, bin step, volume, IL risk flags (Solana-native moat).",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.100000"
+          },
+          "protocols": [
+            {
+              "x402": {
+                "network": "solana",
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "base",
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "arbitrum",
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "solana",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "x402": {
+                "network": "base",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "x402": {
+                "network": "arbitrum",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "mpp": {
+                "method": "solana",
+                "intent": "charge",
+                "currency": "USDC"
+              }
+            }
+          ],
+          "offers": [
+            {
+              "protocol": "x402",
+              "amount": "100000",
+              "currency": "USDC",
+              "intent": "charge",
+              "description": "$0.10 USDC via PayAI (primary; Dexter fallback on Solana/Base)"
+            },
+            {
+              "protocol": "mpp",
+              "amount": "100000",
+              "currency": "USDC",
+              "intent": "charge",
+              "description": "$0.10 USDC — x402 settlement compatible with MPP clients"
+            }
+          ]
+        },
+        "tags": [
+          "AI",
+          "Crypto",
+          "Trading",
+          "Utility"
+        ],
+        "parameters": [
+          {
+            "name": "X-Agent-Id",
+            "in": "header",
+            "required": false,
+            "description": "Registered agent identity (agt_…) for attribution and discovery",
+            "schema": {
+              "type": "string",
+              "pattern": "^agt_[a-zA-Z0-9]+$",
+              "example": "agt_demo0001"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "description": "Optional client-generated key (UUID recommended). Reuse the same key when retrying after network failures. For paid routes, also reuse the same PAYMENT-SIGNATURE — facilitators treat a settled payment as idempotent.",
+            "schema": {
+              "type": "string",
+              "maxLength": 128,
+              "example": "550e8400-e29b-41d4-a716-446655440000"
+            }
+          }
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success after payment",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "pools": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "apy": {
+                            "type": "string"
+                          },
+                          "tvlUsd": {
+                            "type": "string"
+                          },
+                          "riskFlags": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "required": [
+                    "ok",
+                    "pools"
+                  ]
+                },
+                "example": {
+                  "ok": true,
+                  "pools": [
+                    {
+                      "name": "SOL-USDC",
+                      "apy": "24.50%",
+                      "tvlUsd": "$12.4M",
+                      "riskFlags": []
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request body or parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Invalid JSON body",
+                  "code": "invalid_request"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "Base64 JSON x402 payment requirements (MPP-compatible)",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-RateLimit-Limit": {
+                "description": "Soft rate limit per IP per minute",
+                "schema": {
+                  "type": "integer",
+                  "example": 120
+                }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Requests remaining in the current window",
+                "schema": {
+                  "type": "integer",
+                  "example": 119
+                }
+              },
+              "Retry-After": {
+                "description": "Seconds until the rate-limit window resets (also sent on 429)",
+                "schema": {
+                  "type": "integer",
+                  "example": 60
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Payment required",
+                  "code": "payment_required",
+                  "priceUsdc": 0.1,
+                  "resource": "intel-meteora"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "HTTP method not allowed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Method not allowed",
+                  "code": "method_not_allowed"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded — back off and retry after Retry-After seconds",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the client may retry",
+                "schema": {
+                  "type": "integer",
+                  "example": 60
+                }
+              },
+              "X-RateLimit-Limit": {
+                "description": "Maximum requests per window",
+                "schema": {
+                  "type": "integer",
+                  "example": 120
+                }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Requests remaining (0 when rate limited)",
+                "schema": {
+                  "type": "integer",
+                  "example": 0
+                }
+              },
+              "RateLimit-Remaining": {
+                "description": "Requests remaining (0 when rate limited)",
+                "schema": {
+                  "type": "integer",
+                  "example": 0
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Too many requests — retry after the Retry-After interval",
+                  "code": "rate_limited"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Concierge could not process this request. Try a shorter question.",
+                  "code": "internal_error"
+                }
+              }
+            }
+          }
+        },
+        "servers": [
+          {
+            "url": "https://conc-exe.xyz/api/concierge-intel-meteora"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "sortByApy": {
+                    "type": "boolean",
+                    "description": "Sort by APY instead of TVL"
+                  },
+                  "limit": {
+                    "type": "number",
+                    "description": "Max pools 1–20"
+                  },
+                  "poolHint": {
+                    "type": "string",
+                    "description": "Substring filter on pool name"
+                  }
+                },
+                "required": []
+              },
+              "example": {
+                "sortByApy": true,
+                "limit": 8,
+                "poolHint": "SOL"
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "operationId": "intel_meteora_get",
+        "summary": "Concierge Intel — Meteora DLMM (GET probe)",
+        "description": "Meteora DLMM pool deep-dive — TVL, APY, bin step, volume, IL risk flags (Solana-native moat). Probes return 402 without payment; use POST with JSON body after settlement.",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.100000"
+          },
+          "protocols": [
+            {
+              "x402": {
+                "network": "solana",
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "base",
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "arbitrum",
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "solana",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "x402": {
+                "network": "base",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "x402": {
+                "network": "arbitrum",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "mpp": {
+                "method": "solana",
+                "intent": "charge",
+                "currency": "USDC"
+              }
+            }
+          ],
+          "offers": [
+            {
+              "protocol": "x402",
+              "amount": "100000",
+              "currency": "USDC",
+              "intent": "charge",
+              "description": "$0.10 USDC via PayAI (primary; Dexter fallback on Solana/Base)"
+            },
+            {
+              "protocol": "mpp",
+              "amount": "100000",
+              "currency": "USDC",
+              "intent": "charge",
+              "description": "$0.10 USDC — x402 settlement compatible with MPP clients"
+            }
+          ]
+        },
+        "tags": [
+          "AI",
+          "Crypto",
+          "Trading",
+          "Utility"
+        ],
+        "parameters": [
+          {
+            "name": "X-Agent-Id",
+            "in": "header",
+            "required": false,
+            "description": "Registered agent identity (agt_…) for attribution and discovery",
+            "schema": {
+              "type": "string",
+              "pattern": "^agt_[a-zA-Z0-9]+$",
+              "example": "agt_demo0001"
+            }
+          },
+          {
+            "name": "sortByApy",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            },
+            "example": true
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "number"
+            },
+            "example": 8
+          },
+          {
+            "name": "poolHint",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "SOL"
+          }
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success after payment",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "pools": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "apy": {
+                            "type": "string"
+                          },
+                          "tvlUsd": {
+                            "type": "string"
+                          },
+                          "riskFlags": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "required": [
+                    "ok",
+                    "pools"
+                  ]
+                },
+                "example": {
+                  "ok": true,
+                  "pools": [
+                    {
+                      "name": "SOL-USDC",
+                      "apy": "24.50%",
+                      "tvlUsd": "$12.4M",
+                      "riskFlags": []
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request body or parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Invalid JSON body",
+                  "code": "invalid_request"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "Base64 JSON x402 payment requirements (MPP-compatible)",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-RateLimit-Limit": {
+                "description": "Soft rate limit per IP per minute",
+                "schema": {
+                  "type": "integer",
+                  "example": 120
+                }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Requests remaining in the current window",
+                "schema": {
+                  "type": "integer",
+                  "example": 119
+                }
+              },
+              "Retry-After": {
+                "description": "Seconds until the rate-limit window resets (also sent on 429)",
+                "schema": {
+                  "type": "integer",
+                  "example": 60
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Payment required",
+                  "code": "payment_required",
+                  "priceUsdc": 0.1,
+                  "resource": "intel-meteora"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "HTTP method not allowed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Method not allowed",
+                  "code": "method_not_allowed"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded — back off and retry after Retry-After seconds",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the client may retry",
+                "schema": {
+                  "type": "integer",
+                  "example": 60
+                }
+              },
+              "X-RateLimit-Limit": {
+                "description": "Maximum requests per window",
+                "schema": {
+                  "type": "integer",
+                  "example": 120
+                }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Requests remaining (0 when rate limited)",
+                "schema": {
+                  "type": "integer",
+                  "example": 0
+                }
+              },
+              "RateLimit-Remaining": {
+                "description": "Requests remaining (0 when rate limited)",
+                "schema": {
+                  "type": "integer",
+                  "example": 0
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Too many requests — retry after the Retry-After interval",
+                  "code": "rate_limited"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Concierge could not process this request. Try a shorter question.",
+                  "code": "internal_error"
+                }
+              }
+            }
+          }
+        },
+        "servers": [
+          {
+            "url": "https://conc-exe.xyz/api/concierge-intel-meteora"
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "description": "GET probes omit a body and return 402. Example documents the POST JSON payload to send after x402 settlement.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "sortByApy": {
+                    "type": "boolean",
+                    "description": "Sort by APY instead of TVL"
+                  },
+                  "limit": {
+                    "type": "number",
+                    "description": "Max pools 1–20"
+                  },
+                  "poolHint": {
+                    "type": "string",
+                    "description": "Substring filter on pool name"
+                  }
+                },
+                "required": []
+              },
+              "example": {
+                "sortByApy": true,
+                "limit": 8,
+                "poolHint": "SOL"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/concierge-intel-desk-brief": {
+      "post": {
+        "operationId": "intel_desk_brief",
+        "summary": "Concierge Intel — Desk brief",
+        "description": "Composite brief — macro + Meteora yields + desk verdict + optional Lounge insider overlay.",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.250000"
+          },
+          "protocols": [
+            {
+              "x402": {
+                "network": "solana",
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "base",
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "arbitrum",
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "solana",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "x402": {
+                "network": "base",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "x402": {
+                "network": "arbitrum",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "mpp": {
+                "method": "solana",
+                "intent": "charge",
+                "currency": "USDC"
+              }
+            }
+          ],
+          "offers": [
+            {
+              "protocol": "x402",
+              "amount": "250000",
+              "currency": "USDC",
+              "intent": "charge",
+              "description": "$0.25 USDC via PayAI (primary; Dexter fallback on Solana/Base)"
+            },
+            {
+              "protocol": "mpp",
+              "amount": "250000",
+              "currency": "USDC",
+              "intent": "charge",
+              "description": "$0.25 USDC — x402 settlement compatible with MPP clients"
+            }
+          ]
+        },
+        "tags": [
+          "AI",
+          "Research",
+          "Trading",
+          "RWA"
+        ],
+        "parameters": [
+          {
+            "name": "X-Agent-Id",
+            "in": "header",
+            "required": false,
+            "description": "Registered agent identity (agt_…) for attribution and discovery",
+            "schema": {
+              "type": "string",
+              "pattern": "^agt_[a-zA-Z0-9]+$",
+              "example": "agt_demo0001"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "description": "Optional client-generated key (UUID recommended). Reuse the same key when retrying after network failures. For paid routes, also reuse the same PAYMENT-SIGNATURE — facilitators treat a settled payment as idempotent.",
+            "schema": {
+              "type": "string",
+              "maxLength": 128,
+              "example": "550e8400-e29b-41d4-a716-446655440000"
+            }
+          }
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success after payment",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "brief": {
+                      "type": "object",
+                      "properties": {
+                        "headline": {
+                          "type": "string"
+                        },
+                        "signal": {
+                          "type": "string"
+                        },
+                        "confidence": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  },
+                  "required": [
+                    "ok",
+                    "brief"
+                  ]
+                },
+                "example": {
+                  "ok": true,
+                  "brief": {
+                    "headline": "Constructive risk-on with Solana yield rotation",
+                    "signal": "watch",
+                    "confidence": "medium"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request body or parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Invalid JSON body",
+                  "code": "invalid_request"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "Base64 JSON x402 payment requirements (MPP-compatible)",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-RateLimit-Limit": {
+                "description": "Soft rate limit per IP per minute",
+                "schema": {
+                  "type": "integer",
+                  "example": 120
+                }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Requests remaining in the current window",
+                "schema": {
+                  "type": "integer",
+                  "example": 119
+                }
+              },
+              "Retry-After": {
+                "description": "Seconds until the rate-limit window resets (also sent on 429)",
+                "schema": {
+                  "type": "integer",
+                  "example": 60
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Payment required",
+                  "code": "payment_required",
+                  "priceUsdc": 0.25,
+                  "resource": "intel-desk-brief"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "HTTP method not allowed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Method not allowed",
+                  "code": "method_not_allowed"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded — back off and retry after Retry-After seconds",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the client may retry",
+                "schema": {
+                  "type": "integer",
+                  "example": 60
+                }
+              },
+              "X-RateLimit-Limit": {
+                "description": "Maximum requests per window",
+                "schema": {
+                  "type": "integer",
+                  "example": 120
+                }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Requests remaining (0 when rate limited)",
+                "schema": {
+                  "type": "integer",
+                  "example": 0
+                }
+              },
+              "RateLimit-Remaining": {
+                "description": "Requests remaining (0 when rate limited)",
+                "schema": {
+                  "type": "integer",
+                  "example": 0
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Too many requests — retry after the Retry-After interval",
+                  "code": "rate_limited"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Concierge could not process this request. Try a shorter question.",
+                  "code": "internal_error"
+                }
+              }
+            }
+          }
+        },
+        "servers": [
+          {
+            "url": "https://conc-exe.xyz/api/concierge-intel-desk-brief"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "message": {
+                    "type": "string",
+                    "description": "Desk brief context"
+                  },
+                  "includeInsider": {
+                    "type": "boolean",
+                    "description": "Include Lounge creator signals"
+                  }
+                },
+                "required": []
+              },
+              "example": {
+                "message": "morning Solana desk brief",
+                "includeInsider": true
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "operationId": "intel_desk_brief_get",
+        "summary": "Concierge Intel — Desk brief (GET probe)",
+        "description": "Composite brief — macro + Meteora yields + desk verdict + optional Lounge insider overlay. Probes return 402 without payment; use POST with JSON body after settlement.",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.250000"
+          },
+          "protocols": [
+            {
+              "x402": {
+                "network": "solana",
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "base",
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "arbitrum",
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "solana",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "x402": {
+                "network": "base",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "x402": {
+                "network": "arbitrum",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "mpp": {
+                "method": "solana",
+                "intent": "charge",
+                "currency": "USDC"
+              }
+            }
+          ],
+          "offers": [
+            {
+              "protocol": "x402",
+              "amount": "250000",
+              "currency": "USDC",
+              "intent": "charge",
+              "description": "$0.25 USDC via PayAI (primary; Dexter fallback on Solana/Base)"
+            },
+            {
+              "protocol": "mpp",
+              "amount": "250000",
+              "currency": "USDC",
+              "intent": "charge",
+              "description": "$0.25 USDC — x402 settlement compatible with MPP clients"
+            }
+          ]
+        },
+        "tags": [
+          "AI",
+          "Research",
+          "Trading",
+          "RWA"
+        ],
+        "parameters": [
+          {
+            "name": "X-Agent-Id",
+            "in": "header",
+            "required": false,
+            "description": "Registered agent identity (agt_…) for attribution and discovery",
+            "schema": {
+              "type": "string",
+              "pattern": "^agt_[a-zA-Z0-9]+$",
+              "example": "agt_demo0001"
+            }
+          },
+          {
+            "name": "message",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "morning Solana desk brief"
           },
           {
             "name": "includeInsider",
@@ -3406,9 +10132,3193 @@
             "required": false,
             "schema": {
               "type": "boolean"
+            },
+            "example": true
+          }
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success after payment",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "brief": {
+                      "type": "object",
+                      "properties": {
+                        "headline": {
+                          "type": "string"
+                        },
+                        "signal": {
+                          "type": "string"
+                        },
+                        "confidence": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  },
+                  "required": [
+                    "ok",
+                    "brief"
+                  ]
+                },
+                "example": {
+                  "ok": true,
+                  "brief": {
+                    "headline": "Constructive risk-on with Solana yield rotation",
+                    "signal": "watch",
+                    "confidence": "medium"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request body or parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Invalid JSON body",
+                  "code": "invalid_request"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "Base64 JSON x402 payment requirements (MPP-compatible)",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-RateLimit-Limit": {
+                "description": "Soft rate limit per IP per minute",
+                "schema": {
+                  "type": "integer",
+                  "example": 120
+                }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Requests remaining in the current window",
+                "schema": {
+                  "type": "integer",
+                  "example": 119
+                }
+              },
+              "Retry-After": {
+                "description": "Seconds until the rate-limit window resets (also sent on 429)",
+                "schema": {
+                  "type": "integer",
+                  "example": 60
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Payment required",
+                  "code": "payment_required",
+                  "priceUsdc": 0.25,
+                  "resource": "intel-desk-brief"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "HTTP method not allowed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Method not allowed",
+                  "code": "method_not_allowed"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded — back off and retry after Retry-After seconds",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the client may retry",
+                "schema": {
+                  "type": "integer",
+                  "example": 60
+                }
+              },
+              "X-RateLimit-Limit": {
+                "description": "Maximum requests per window",
+                "schema": {
+                  "type": "integer",
+                  "example": 120
+                }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Requests remaining (0 when rate limited)",
+                "schema": {
+                  "type": "integer",
+                  "example": 0
+                }
+              },
+              "RateLimit-Remaining": {
+                "description": "Requests remaining (0 when rate limited)",
+                "schema": {
+                  "type": "integer",
+                  "example": 0
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Too many requests — retry after the Retry-After interval",
+                  "code": "rate_limited"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Concierge could not process this request. Try a shorter question.",
+                  "code": "internal_error"
+                }
+              }
             }
           }
-        ]
+        },
+        "servers": [
+          {
+            "url": "https://conc-exe.xyz/api/concierge-intel-desk-brief"
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "description": "GET probes omit a body and return 402. Example documents the POST JSON payload to send after x402 settlement.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "message": {
+                    "type": "string",
+                    "description": "Desk brief context"
+                  },
+                  "includeInsider": {
+                    "type": "boolean",
+                    "description": "Include Lounge creator signals"
+                  }
+                },
+                "required": []
+              },
+              "example": {
+                "message": "morning Solana desk brief",
+                "includeInsider": true
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/concierge-intel-a2a-pipeline": {
+      "post": {
+        "operationId": "intel_a2a_pipeline",
+        "summary": "Concierge Intel — A2A pipeline",
+        "description": "Agent-to-agent orchestration — desk brief plus machine-readable A2A handoff and delegate routing to peer agents.",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.250000"
+          },
+          "protocols": [
+            {
+              "x402": {
+                "network": "solana",
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "base",
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "arbitrum",
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "solana",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "x402": {
+                "network": "base",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "x402": {
+                "network": "arbitrum",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "mpp": {
+                "method": "solana",
+                "intent": "charge",
+                "currency": "USDC"
+              }
+            }
+          ],
+          "offers": [
+            {
+              "protocol": "x402",
+              "amount": "250000",
+              "currency": "USDC",
+              "intent": "charge",
+              "description": "$0.25 USDC via PayAI (primary; Dexter fallback on Solana/Base)"
+            },
+            {
+              "protocol": "mpp",
+              "amount": "250000",
+              "currency": "USDC",
+              "intent": "charge",
+              "description": "$0.25 USDC — x402 settlement compatible with MPP clients"
+            }
+          ]
+        },
+        "tags": [
+          "AI",
+          "Research",
+          "Trading",
+          "RWA",
+          "Utility"
+        ],
+        "parameters": [
+          {
+            "name": "X-Agent-Id",
+            "in": "header",
+            "required": false,
+            "description": "Registered agent identity (agt_…) for attribution and discovery",
+            "schema": {
+              "type": "string",
+              "pattern": "^agt_[a-zA-Z0-9]+$",
+              "example": "agt_demo0001"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "description": "Optional client-generated key (UUID recommended). Reuse the same key when retrying after network failures. For paid routes, also reuse the same PAYMENT-SIGNATURE — facilitators treat a settled payment as idempotent.",
+            "schema": {
+              "type": "string",
+              "maxLength": 128,
+              "example": "550e8400-e29b-41d4-a716-446655440000"
+            }
+          }
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success after payment",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "a2a": {
+                      "type": "object",
+                      "properties": {
+                        "handoff": {
+                          "type": "string",
+                          "description": "Machine-readable A2A| line"
+                        },
+                        "delegate": {
+                          "type": "array",
+                          "items": {
+                            "type": "object"
+                          }
+                        },
+                        "mesh": {
+                          "type": "string",
+                          "format": "uri"
+                        }
+                      }
+                    }
+                  },
+                  "required": [
+                    "ok",
+                    "a2a"
+                  ]
+                },
+                "example": {
+                  "ok": true,
+                  "a2a": {
+                    "schema": "concierge-a2a-v1",
+                    "handoff": "A2A|asset=BTC|class=crypto|tf=24h|bias=neutral|conviction=M|signal=watch|regime=mixed|src=concierge",
+                    "delegate": [
+                      {
+                        "action": "call",
+                        "target": "concierge",
+                        "endpoint": "https://conc-exe.xyz/api/concierge-intel-wire",
+                        "priceUsdc": 0.02,
+                        "reason": "Neutral desk — scan wire headlines for near-term catalysts"
+                      }
+                    ],
+                    "mesh": "https://conc-exe.xyz/api/agent-a2a-mesh"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request body or parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Invalid JSON body",
+                  "code": "invalid_request"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "Base64 JSON x402 payment requirements (MPP-compatible)",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-RateLimit-Limit": {
+                "description": "Soft rate limit per IP per minute",
+                "schema": {
+                  "type": "integer",
+                  "example": 120
+                }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Requests remaining in the current window",
+                "schema": {
+                  "type": "integer",
+                  "example": 119
+                }
+              },
+              "Retry-After": {
+                "description": "Seconds until the rate-limit window resets (also sent on 429)",
+                "schema": {
+                  "type": "integer",
+                  "example": 60
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Payment required",
+                  "code": "payment_required",
+                  "priceUsdc": 0.25,
+                  "resource": "intel-a2a-pipeline"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "HTTP method not allowed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Method not allowed",
+                  "code": "method_not_allowed"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded — back off and retry after Retry-After seconds",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the client may retry",
+                "schema": {
+                  "type": "integer",
+                  "example": 60
+                }
+              },
+              "X-RateLimit-Limit": {
+                "description": "Maximum requests per window",
+                "schema": {
+                  "type": "integer",
+                  "example": 120
+                }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Requests remaining (0 when rate limited)",
+                "schema": {
+                  "type": "integer",
+                  "example": 0
+                }
+              },
+              "RateLimit-Remaining": {
+                "description": "Requests remaining (0 when rate limited)",
+                "schema": {
+                  "type": "integer",
+                  "example": 0
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Too many requests — retry after the Retry-After interval",
+                  "code": "rate_limited"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Concierge could not process this request. Try a shorter question.",
+                  "code": "internal_error"
+                }
+              }
+            }
+          }
+        },
+        "servers": [
+          {
+            "url": "https://conc-exe.xyz/api/concierge-intel-a2a-pipeline"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "message": {
+                    "type": "string",
+                    "description": "Desk / orchestration context for downstream agents"
+                  },
+                  "includeInsider": {
+                    "type": "boolean",
+                    "description": "Include Lounge creator signals in verdict"
+                  }
+                },
+                "required": []
+              },
+              "example": {
+                "message": "Solana desk A2A orchestration",
+                "includeInsider": true
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "operationId": "intel_a2a_pipeline_get",
+        "summary": "Concierge Intel — A2A pipeline (GET probe)",
+        "description": "Agent-to-agent orchestration — desk brief plus machine-readable A2A handoff and delegate routing to peer agents. Probes return 402 without payment; use POST with JSON body after settlement.",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.250000"
+          },
+          "protocols": [
+            {
+              "x402": {
+                "network": "solana",
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "base",
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "arbitrum",
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "solana",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "x402": {
+                "network": "base",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "x402": {
+                "network": "arbitrum",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "mpp": {
+                "method": "solana",
+                "intent": "charge",
+                "currency": "USDC"
+              }
+            }
+          ],
+          "offers": [
+            {
+              "protocol": "x402",
+              "amount": "250000",
+              "currency": "USDC",
+              "intent": "charge",
+              "description": "$0.25 USDC via PayAI (primary; Dexter fallback on Solana/Base)"
+            },
+            {
+              "protocol": "mpp",
+              "amount": "250000",
+              "currency": "USDC",
+              "intent": "charge",
+              "description": "$0.25 USDC — x402 settlement compatible with MPP clients"
+            }
+          ]
+        },
+        "tags": [
+          "AI",
+          "Research",
+          "Trading",
+          "RWA",
+          "Utility"
+        ],
+        "parameters": [
+          {
+            "name": "X-Agent-Id",
+            "in": "header",
+            "required": false,
+            "description": "Registered agent identity (agt_…) for attribution and discovery",
+            "schema": {
+              "type": "string",
+              "pattern": "^agt_[a-zA-Z0-9]+$",
+              "example": "agt_demo0001"
+            }
+          },
+          {
+            "name": "message",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "Solana desk A2A orchestration"
+          },
+          {
+            "name": "includeInsider",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            },
+            "example": true
+          }
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success after payment",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "a2a": {
+                      "type": "object",
+                      "properties": {
+                        "handoff": {
+                          "type": "string",
+                          "description": "Machine-readable A2A| line"
+                        },
+                        "delegate": {
+                          "type": "array",
+                          "items": {
+                            "type": "object"
+                          }
+                        },
+                        "mesh": {
+                          "type": "string",
+                          "format": "uri"
+                        }
+                      }
+                    }
+                  },
+                  "required": [
+                    "ok",
+                    "a2a"
+                  ]
+                },
+                "example": {
+                  "ok": true,
+                  "a2a": {
+                    "schema": "concierge-a2a-v1",
+                    "handoff": "A2A|asset=BTC|class=crypto|tf=24h|bias=neutral|conviction=M|signal=watch|regime=mixed|src=concierge",
+                    "delegate": [
+                      {
+                        "action": "call",
+                        "target": "concierge",
+                        "endpoint": "https://conc-exe.xyz/api/concierge-intel-wire",
+                        "priceUsdc": 0.02,
+                        "reason": "Neutral desk — scan wire headlines for near-term catalysts"
+                      }
+                    ],
+                    "mesh": "https://conc-exe.xyz/api/agent-a2a-mesh"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request body or parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Invalid JSON body",
+                  "code": "invalid_request"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "Base64 JSON x402 payment requirements (MPP-compatible)",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-RateLimit-Limit": {
+                "description": "Soft rate limit per IP per minute",
+                "schema": {
+                  "type": "integer",
+                  "example": 120
+                }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Requests remaining in the current window",
+                "schema": {
+                  "type": "integer",
+                  "example": 119
+                }
+              },
+              "Retry-After": {
+                "description": "Seconds until the rate-limit window resets (also sent on 429)",
+                "schema": {
+                  "type": "integer",
+                  "example": 60
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Payment required",
+                  "code": "payment_required",
+                  "priceUsdc": 0.25,
+                  "resource": "intel-a2a-pipeline"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "HTTP method not allowed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Method not allowed",
+                  "code": "method_not_allowed"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded — back off and retry after Retry-After seconds",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the client may retry",
+                "schema": {
+                  "type": "integer",
+                  "example": 60
+                }
+              },
+              "X-RateLimit-Limit": {
+                "description": "Maximum requests per window",
+                "schema": {
+                  "type": "integer",
+                  "example": 120
+                }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Requests remaining (0 when rate limited)",
+                "schema": {
+                  "type": "integer",
+                  "example": 0
+                }
+              },
+              "RateLimit-Remaining": {
+                "description": "Requests remaining (0 when rate limited)",
+                "schema": {
+                  "type": "integer",
+                  "example": 0
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Too many requests — retry after the Retry-After interval",
+                  "code": "rate_limited"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Concierge could not process this request. Try a shorter question.",
+                  "code": "internal_error"
+                }
+              }
+            }
+          }
+        },
+        "servers": [
+          {
+            "url": "https://conc-exe.xyz/api/concierge-intel-a2a-pipeline"
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "description": "GET probes omit a body and return 402. Example documents the POST JSON payload to send after x402 settlement.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "message": {
+                    "type": "string",
+                    "description": "Desk / orchestration context for downstream agents"
+                  },
+                  "includeInsider": {
+                    "type": "boolean",
+                    "description": "Include Lounge creator signals in verdict"
+                  }
+                },
+                "required": []
+              },
+              "example": {
+                "message": "Solana desk A2A orchestration",
+                "includeInsider": true
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/concierge-security-readiness": {
+      "post": {
+        "operationId": "security_readiness",
+        "summary": "Concierge Security — API readiness",
+        "description": "Passive agent-readiness audit for an authorized external API — OpenAPI, discovery, headers. Concierge platform hosts are blocked.",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.020000"
+          },
+          "protocols": [
+            {
+              "x402": {
+                "network": "solana",
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "base",
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "arbitrum",
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "solana",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "x402": {
+                "network": "base",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "x402": {
+                "network": "arbitrum",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "mpp": {
+                "method": "solana",
+                "intent": "charge",
+                "currency": "USDC"
+              }
+            }
+          ],
+          "offers": [
+            {
+              "protocol": "x402",
+              "amount": "20000",
+              "currency": "USDC",
+              "intent": "charge",
+              "description": "$0.02 USDC via PayAI (primary; Dexter fallback on Solana/Base)"
+            },
+            {
+              "protocol": "mpp",
+              "amount": "20000",
+              "currency": "USDC",
+              "intent": "charge",
+              "description": "$0.02 USDC — x402 settlement compatible with MPP clients"
+            }
+          ]
+        },
+        "tags": [
+          "Utility",
+          "Research",
+          "AI"
+        ],
+        "parameters": [
+          {
+            "name": "X-Agent-Id",
+            "in": "header",
+            "required": false,
+            "description": "Registered agent identity (agt_…) for attribution and discovery",
+            "schema": {
+              "type": "string",
+              "pattern": "^agt_[a-zA-Z0-9]+$",
+              "example": "agt_demo0001"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "description": "Optional client-generated key (UUID recommended). Reuse the same key when retrying after network failures. For paid routes, also reuse the same PAYMENT-SIGNATURE — facilitators treat a settled payment as idempotent.",
+            "schema": {
+              "type": "string",
+              "maxLength": 128,
+              "example": "550e8400-e29b-41d4-a716-446655440000"
+            }
+          }
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success after payment",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "kind": {
+                      "type": "string"
+                    },
+                    "target": {
+                      "type": "object"
+                    },
+                    "scores": {
+                      "type": "object"
+                    },
+                    "dimensions": {
+                      "type": "array",
+                      "items": {
+                        "type": "object"
+                      }
+                    },
+                    "disclaimer": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "ok",
+                    "kind",
+                    "target"
+                  ]
+                },
+                "example": {
+                  "ok": true,
+                  "kind": "security-readiness",
+                  "target": {
+                    "origin": "https://api.example.com",
+                    "hostname": "api.example.com"
+                  },
+                  "scores": {
+                    "mean": 2.1,
+                    "max": 3,
+                    "dimensions": 4
+                  },
+                  "dimensions": [
+                    {
+                      "id": "spec-presence",
+                      "name": "OpenAPI spec presence",
+                      "score": 2,
+                      "label": "present"
+                    }
+                  ],
+                  "disclaimer": "Passive audit only — no exploitation."
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request body or parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Invalid JSON body",
+                  "code": "invalid_request"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "Base64 JSON x402 payment requirements (MPP-compatible)",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-RateLimit-Limit": {
+                "description": "Soft rate limit per IP per minute",
+                "schema": {
+                  "type": "integer",
+                  "example": 120
+                }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Requests remaining in the current window",
+                "schema": {
+                  "type": "integer",
+                  "example": 119
+                }
+              },
+              "Retry-After": {
+                "description": "Seconds until the rate-limit window resets (also sent on 429)",
+                "schema": {
+                  "type": "integer",
+                  "example": 60
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Payment required",
+                  "code": "payment_required",
+                  "priceUsdc": 0.02,
+                  "resource": "security-readiness"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "HTTP method not allowed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Method not allowed",
+                  "code": "method_not_allowed"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded — back off and retry after Retry-After seconds",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the client may retry",
+                "schema": {
+                  "type": "integer",
+                  "example": 60
+                }
+              },
+              "X-RateLimit-Limit": {
+                "description": "Maximum requests per window",
+                "schema": {
+                  "type": "integer",
+                  "example": 120
+                }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Requests remaining (0 when rate limited)",
+                "schema": {
+                  "type": "integer",
+                  "example": 0
+                }
+              },
+              "RateLimit-Remaining": {
+                "description": "Requests remaining (0 when rate limited)",
+                "schema": {
+                  "type": "integer",
+                  "example": 0
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Too many requests — retry after the Retry-After interval",
+                  "code": "rate_limited"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Concierge could not process this request. Try a shorter question.",
+                  "code": "internal_error"
+                }
+              }
+            }
+          }
+        },
+        "servers": [
+          {
+            "url": "https://conc-exe.xyz/api/concierge-security-readiness"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "target": {
+                    "type": "string",
+                    "description": "Authorized external https origin (never conc-exe.xyz)"
+                  },
+                  "allowlist": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Optional hostname allowlist"
+                  },
+                  "authorized": {
+                    "type": "boolean",
+                    "description": "Must be true — caller attests permission"
+                  }
+                },
+                "required": [
+                  "target",
+                  "authorized"
+                ]
+              },
+              "example": {
+                "target": "https://api.example.com",
+                "allowlist": [
+                  "*.example.com"
+                ],
+                "authorized": true
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/concierge-security-headers": {
+      "post": {
+        "operationId": "security_headers",
+        "summary": "Concierge Security — HTTP headers",
+        "description": "Passive HTTP security header review for an authorized external target. No exploitation; platform hosts blocked.",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.020000"
+          },
+          "protocols": [
+            {
+              "x402": {
+                "network": "solana",
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "base",
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "arbitrum",
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "solana",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "x402": {
+                "network": "base",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "x402": {
+                "network": "arbitrum",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "mpp": {
+                "method": "solana",
+                "intent": "charge",
+                "currency": "USDC"
+              }
+            }
+          ],
+          "offers": [
+            {
+              "protocol": "x402",
+              "amount": "20000",
+              "currency": "USDC",
+              "intent": "charge",
+              "description": "$0.02 USDC via PayAI (primary; Dexter fallback on Solana/Base)"
+            },
+            {
+              "protocol": "mpp",
+              "amount": "20000",
+              "currency": "USDC",
+              "intent": "charge",
+              "description": "$0.02 USDC — x402 settlement compatible with MPP clients"
+            }
+          ]
+        },
+        "tags": [
+          "Utility",
+          "Research"
+        ],
+        "parameters": [
+          {
+            "name": "X-Agent-Id",
+            "in": "header",
+            "required": false,
+            "description": "Registered agent identity (agt_…) for attribution and discovery",
+            "schema": {
+              "type": "string",
+              "pattern": "^agt_[a-zA-Z0-9]+$",
+              "example": "agt_demo0001"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "description": "Optional client-generated key (UUID recommended). Reuse the same key when retrying after network failures. For paid routes, also reuse the same PAYMENT-SIGNATURE — facilitators treat a settled payment as idempotent.",
+            "schema": {
+              "type": "string",
+              "maxLength": 128,
+              "example": "550e8400-e29b-41d4-a716-446655440000"
+            }
+          }
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success after payment",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "kind": {
+                      "type": "string"
+                    },
+                    "target": {
+                      "type": "object"
+                    },
+                    "checks": {
+                      "type": "array",
+                      "items": {
+                        "type": "object"
+                      }
+                    },
+                    "summary": {
+                      "type": "object"
+                    },
+                    "disclaimer": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "ok",
+                    "kind",
+                    "target"
+                  ]
+                },
+                "example": {
+                  "ok": true,
+                  "kind": "security-headers",
+                  "target": {
+                    "origin": "https://app.example.com",
+                    "hostname": "app.example.com"
+                  },
+                  "summary": {
+                    "present": 4,
+                    "total": 6,
+                    "grade": "moderate"
+                  },
+                  "checks": [
+                    {
+                      "id": "x-content-type-options",
+                      "header": "x-content-type-options",
+                      "present": true
+                    }
+                  ],
+                  "disclaimer": "Passive header review only."
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request body or parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Invalid JSON body",
+                  "code": "invalid_request"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "Base64 JSON x402 payment requirements (MPP-compatible)",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-RateLimit-Limit": {
+                "description": "Soft rate limit per IP per minute",
+                "schema": {
+                  "type": "integer",
+                  "example": 120
+                }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Requests remaining in the current window",
+                "schema": {
+                  "type": "integer",
+                  "example": 119
+                }
+              },
+              "Retry-After": {
+                "description": "Seconds until the rate-limit window resets (also sent on 429)",
+                "schema": {
+                  "type": "integer",
+                  "example": 60
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Payment required",
+                  "code": "payment_required",
+                  "priceUsdc": 0.02,
+                  "resource": "security-headers"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "HTTP method not allowed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Method not allowed",
+                  "code": "method_not_allowed"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded — back off and retry after Retry-After seconds",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the client may retry",
+                "schema": {
+                  "type": "integer",
+                  "example": 60
+                }
+              },
+              "X-RateLimit-Limit": {
+                "description": "Maximum requests per window",
+                "schema": {
+                  "type": "integer",
+                  "example": 120
+                }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Requests remaining (0 when rate limited)",
+                "schema": {
+                  "type": "integer",
+                  "example": 0
+                }
+              },
+              "RateLimit-Remaining": {
+                "description": "Requests remaining (0 when rate limited)",
+                "schema": {
+                  "type": "integer",
+                  "example": 0
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Too many requests — retry after the Retry-After interval",
+                  "code": "rate_limited"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Concierge could not process this request. Try a shorter question.",
+                  "code": "internal_error"
+                }
+              }
+            }
+          }
+        },
+        "servers": [
+          {
+            "url": "https://conc-exe.xyz/api/concierge-security-headers"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "target": {
+                    "type": "string",
+                    "description": "Authorized external https origin (never conc-exe.xyz)"
+                  },
+                  "allowlist": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Optional hostname allowlist"
+                  },
+                  "authorized": {
+                    "type": "boolean",
+                    "description": "Must be true — caller attests permission"
+                  }
+                },
+                "required": [
+                  "target",
+                  "authorized"
+                ]
+              },
+              "example": {
+                "target": "https://app.example.com",
+                "allowlist": [
+                  "*.example.com"
+                ],
+                "authorized": true
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/concierge-security-scan": {
+      "post": {
+        "operationId": "security_scan",
+        "summary": "Concierge Security — Website scan",
+        "description": "Unified passive security breakdown for an authorized external website — readiness, HTTP headers, Concierge Surface Review (exposure findings), grade, and recommendations. No exploit payloads.",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.100000"
+          },
+          "protocols": [
+            {
+              "x402": {
+                "network": "solana",
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "base",
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "arbitrum",
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "solana",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "x402": {
+                "network": "base",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "x402": {
+                "network": "arbitrum",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "mpp": {
+                "method": "solana",
+                "intent": "charge",
+                "currency": "USDC"
+              }
+            }
+          ],
+          "offers": [
+            {
+              "protocol": "x402",
+              "amount": "100000",
+              "currency": "USDC",
+              "intent": "charge",
+              "description": "$0.10 USDC via PayAI (primary; Dexter fallback on Solana/Base)"
+            },
+            {
+              "protocol": "mpp",
+              "amount": "100000",
+              "currency": "USDC",
+              "intent": "charge",
+              "description": "$0.10 USDC — x402 settlement compatible with MPP clients"
+            }
+          ]
+        },
+        "tags": [
+          "Utility",
+          "Research",
+          "AI"
+        ],
+        "parameters": [
+          {
+            "name": "X-Agent-Id",
+            "in": "header",
+            "required": false,
+            "description": "Registered agent identity (agt_…) for attribution and discovery",
+            "schema": {
+              "type": "string",
+              "pattern": "^agt_[a-zA-Z0-9]+$",
+              "example": "agt_demo0001"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "description": "Optional client-generated key (UUID recommended). Reuse the same key when retrying after network failures. For paid routes, also reuse the same PAYMENT-SIGNATURE — facilitators treat a settled payment as idempotent.",
+            "schema": {
+              "type": "string",
+              "maxLength": 128,
+              "example": "550e8400-e29b-41d4-a716-446655440000"
+            }
+          }
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success after payment",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "kind": {
+                      "type": "string"
+                    },
+                    "target": {
+                      "type": "object"
+                    },
+                    "summary": {
+                      "type": "object",
+                      "properties": {
+                        "overallGrade": {
+                          "type": "string"
+                        },
+                        "readinessScore": {
+                          "type": "number"
+                        },
+                        "headersGrade": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "breakdown": {
+                      "type": "object"
+                    },
+                    "recommendations": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "disclaimer": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "ok",
+                    "kind",
+                    "target",
+                    "summary"
+                  ]
+                },
+                "example": {
+                  "ok": true,
+                  "kind": "security-scan",
+                  "target": {
+                    "origin": "https://api.example.com",
+                    "hostname": "api.example.com"
+                  },
+                  "summary": {
+                    "overallGrade": "B",
+                    "readinessScore": 2.1,
+                    "readinessMax": 3,
+                    "headersGrade": "moderate",
+                    "headersPresent": 4,
+                    "headersTotal": 6,
+                    "discoveryFiles": 2,
+                    "mcpReachable": false
+                  },
+                  "breakdown": {},
+                  "recommendations": [
+                    "Add strict-transport-security — max-age with includeSubDomains on HTTPS"
+                  ],
+                  "disclaimer": "Passive security breakdown only."
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request body or parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Invalid JSON body",
+                  "code": "invalid_request"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "Base64 JSON x402 payment requirements (MPP-compatible)",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-RateLimit-Limit": {
+                "description": "Soft rate limit per IP per minute",
+                "schema": {
+                  "type": "integer",
+                  "example": 120
+                }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Requests remaining in the current window",
+                "schema": {
+                  "type": "integer",
+                  "example": 119
+                }
+              },
+              "Retry-After": {
+                "description": "Seconds until the rate-limit window resets (also sent on 429)",
+                "schema": {
+                  "type": "integer",
+                  "example": 60
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Payment required",
+                  "code": "payment_required",
+                  "priceUsdc": 0.1,
+                  "resource": "security-scan"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "HTTP method not allowed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Method not allowed",
+                  "code": "method_not_allowed"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded — back off and retry after Retry-After seconds",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the client may retry",
+                "schema": {
+                  "type": "integer",
+                  "example": 60
+                }
+              },
+              "X-RateLimit-Limit": {
+                "description": "Maximum requests per window",
+                "schema": {
+                  "type": "integer",
+                  "example": 120
+                }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Requests remaining (0 when rate limited)",
+                "schema": {
+                  "type": "integer",
+                  "example": 0
+                }
+              },
+              "RateLimit-Remaining": {
+                "description": "Requests remaining (0 when rate limited)",
+                "schema": {
+                  "type": "integer",
+                  "example": 0
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Too many requests — retry after the Retry-After interval",
+                  "code": "rate_limited"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Concierge could not process this request. Try a shorter question.",
+                  "code": "internal_error"
+                }
+              }
+            }
+          }
+        },
+        "servers": [
+          {
+            "url": "https://conc-exe.xyz/api/concierge-security-scan"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "target": {
+                    "type": "string",
+                    "description": "Authorized external https URL (never conc-exe.xyz)"
+                  },
+                  "allowlist": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Hostname allowlist (*.example.com)"
+                  },
+                  "authorized": {
+                    "type": "boolean",
+                    "description": "Must be true — caller attests permission"
+                  }
+                },
+                "required": [
+                  "target",
+                  "authorized"
+                ]
+              },
+              "example": {
+                "target": "https://api.example.com",
+                "allowlist": [
+                  "*.example.com"
+                ],
+                "authorized": true
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/resource-chat": {
+      "post": {
+        "operationId": "resource_chat",
+        "summary": "Concierge Resources — Chat",
+        "description": "Agent-friendly Concierge chat — one turn, JSON reply. TCX credits or x402.",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.050000"
+          },
+          "protocols": [
+            {
+              "x402": {
+                "network": "solana",
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "base",
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "arbitrum",
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "solana",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "x402": {
+                "network": "base",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "x402": {
+                "network": "arbitrum",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "mpp": {
+                "method": "solana",
+                "intent": "charge",
+                "currency": "USDC"
+              }
+            }
+          ],
+          "offers": [
+            {
+              "protocol": "x402",
+              "amount": "50000",
+              "currency": "USDC",
+              "intent": "charge",
+              "description": "$0.05 USDC via PayAI (primary; Dexter fallback on Solana/Base)"
+            },
+            {
+              "protocol": "mpp",
+              "amount": "50000",
+              "currency": "USDC",
+              "intent": "charge",
+              "description": "$0.05 USDC — x402 settlement compatible with MPP clients"
+            }
+          ]
+        },
+        "tags": [
+          "AI",
+          "Utility"
+        ],
+        "parameters": [
+          {
+            "name": "X-Agent-Id",
+            "in": "header",
+            "required": false,
+            "description": "Registered agent identity (agt_…) for attribution and discovery",
+            "schema": {
+              "type": "string",
+              "pattern": "^agt_[a-zA-Z0-9]+$",
+              "example": "agt_demo0001"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "description": "Optional client-generated key (UUID recommended). Reuse the same key when retrying after network failures. For paid routes, also reuse the same PAYMENT-SIGNATURE — facilitators treat a settled payment as idempotent.",
+            "schema": {
+              "type": "string",
+              "maxLength": 128,
+              "example": "550e8400-e29b-41d4-a716-446655440000"
+            }
+          }
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success after payment",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "kind": {
+                      "type": "string"
+                    },
+                    "slug": {
+                      "type": "string"
+                    },
+                    "reply": {
+                      "type": "string"
+                    },
+                    "topics": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "required": [
+                    "ok",
+                    "kind",
+                    "reply"
+                  ]
+                },
+                "example": {
+                  "ok": true,
+                  "kind": "resource-chat",
+                  "slug": "resource-chat",
+                  "reply": "<p>Solana DeFi remains constructive…</p>",
+                  "topics": [
+                    "crypto",
+                    "defi"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request body or parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Invalid JSON body",
+                  "code": "invalid_request"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "Base64 JSON x402 payment requirements (MPP-compatible)",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-RateLimit-Limit": {
+                "description": "Soft rate limit per IP per minute",
+                "schema": {
+                  "type": "integer",
+                  "example": 120
+                }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Requests remaining in the current window",
+                "schema": {
+                  "type": "integer",
+                  "example": 119
+                }
+              },
+              "Retry-After": {
+                "description": "Seconds until the rate-limit window resets (also sent on 429)",
+                "schema": {
+                  "type": "integer",
+                  "example": 60
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Payment required",
+                  "code": "payment_required",
+                  "priceUsdc": 0.05,
+                  "resource": "resource-chat"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "HTTP method not allowed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Method not allowed",
+                  "code": "method_not_allowed"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded — back off and retry after Retry-After seconds",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the client may retry",
+                "schema": {
+                  "type": "integer",
+                  "example": 60
+                }
+              },
+              "X-RateLimit-Limit": {
+                "description": "Maximum requests per window",
+                "schema": {
+                  "type": "integer",
+                  "example": 120
+                }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Requests remaining (0 when rate limited)",
+                "schema": {
+                  "type": "integer",
+                  "example": 0
+                }
+              },
+              "RateLimit-Remaining": {
+                "description": "Requests remaining (0 when rate limited)",
+                "schema": {
+                  "type": "integer",
+                  "example": 0
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Too many requests — retry after the Retry-After interval",
+                  "code": "rate_limited"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Concierge could not process this request. Try a shorter question.",
+                  "code": "internal_error"
+                }
+              }
+            }
+          }
+        },
+        "servers": [
+          {
+            "url": "https://conc-exe.xyz/api/resource-chat"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "message": {
+                    "type": "string",
+                    "description": "User message (max 4000 chars)"
+                  },
+                  "history": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "role": {
+                          "type": "string",
+                          "enum": [
+                            "user",
+                            "model"
+                          ]
+                        },
+                        "text": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "role",
+                        "text"
+                      ]
+                    }
+                  }
+                },
+                "required": [
+                  "message"
+                ]
+              },
+              "example": {
+                "message": "Summarize Solana DeFi outlook in 3 bullets",
+                "history": []
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/resource-image": {
+      "post": {
+        "operationId": "resource_image",
+        "summary": "Concierge Resources — Image",
+        "description": "Generate one image from a text prompt. Returns base64 data URLs.",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.100000"
+          },
+          "protocols": [
+            {
+              "x402": {
+                "network": "solana",
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "base",
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "arbitrum",
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "solana",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "x402": {
+                "network": "base",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "x402": {
+                "network": "arbitrum",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "mpp": {
+                "method": "solana",
+                "intent": "charge",
+                "currency": "USDC"
+              }
+            }
+          ],
+          "offers": [
+            {
+              "protocol": "x402",
+              "amount": "100000",
+              "currency": "USDC",
+              "intent": "charge",
+              "description": "$0.10 USDC via PayAI (primary; Dexter fallback on Solana/Base)"
+            },
+            {
+              "protocol": "mpp",
+              "amount": "100000",
+              "currency": "USDC",
+              "intent": "charge",
+              "description": "$0.10 USDC — x402 settlement compatible with MPP clients"
+            }
+          ]
+        },
+        "tags": [
+          "AI",
+          "Utility"
+        ],
+        "parameters": [
+          {
+            "name": "X-Agent-Id",
+            "in": "header",
+            "required": false,
+            "description": "Registered agent identity (agt_…) for attribution and discovery",
+            "schema": {
+              "type": "string",
+              "pattern": "^agt_[a-zA-Z0-9]+$",
+              "example": "agt_demo0001"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "description": "Optional client-generated key (UUID recommended). Reuse the same key when retrying after network failures. For paid routes, also reuse the same PAYMENT-SIGNATURE — facilitators treat a settled payment as idempotent.",
+            "schema": {
+              "type": "string",
+              "maxLength": 128,
+              "example": "550e8400-e29b-41d4-a716-446655440000"
+            }
+          }
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success after payment",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "kind": {
+                      "type": "string"
+                    },
+                    "prompt": {
+                      "type": "string"
+                    },
+                    "images": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "count": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "ok",
+                    "kind",
+                    "images"
+                  ]
+                },
+                "example": {
+                  "ok": true,
+                  "kind": "resource-image",
+                  "prompt": "Minimal dark dashboard hero",
+                  "images": [
+                    "data:image/png;base64,iVBORw0KGgo="
+                  ],
+                  "count": 1
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request body or parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Invalid JSON body",
+                  "code": "invalid_request"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "Base64 JSON x402 payment requirements (MPP-compatible)",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-RateLimit-Limit": {
+                "description": "Soft rate limit per IP per minute",
+                "schema": {
+                  "type": "integer",
+                  "example": 120
+                }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Requests remaining in the current window",
+                "schema": {
+                  "type": "integer",
+                  "example": 119
+                }
+              },
+              "Retry-After": {
+                "description": "Seconds until the rate-limit window resets (also sent on 429)",
+                "schema": {
+                  "type": "integer",
+                  "example": 60
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Payment required",
+                  "code": "payment_required",
+                  "priceUsdc": 0.1,
+                  "resource": "resource-image"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "HTTP method not allowed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Method not allowed",
+                  "code": "method_not_allowed"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded — back off and retry after Retry-After seconds",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the client may retry",
+                "schema": {
+                  "type": "integer",
+                  "example": 60
+                }
+              },
+              "X-RateLimit-Limit": {
+                "description": "Maximum requests per window",
+                "schema": {
+                  "type": "integer",
+                  "example": 120
+                }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Requests remaining (0 when rate limited)",
+                "schema": {
+                  "type": "integer",
+                  "example": 0
+                }
+              },
+              "RateLimit-Remaining": {
+                "description": "Requests remaining (0 when rate limited)",
+                "schema": {
+                  "type": "integer",
+                  "example": 0
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Too many requests — retry after the Retry-After interval",
+                  "code": "rate_limited"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Concierge could not process this request. Try a shorter question.",
+                  "code": "internal_error"
+                }
+              }
+            }
+          }
+        },
+        "servers": [
+          {
+            "url": "https://conc-exe.xyz/api/resource-image"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "message": {
+                    "type": "string",
+                    "description": "Image prompt (max 4000 chars)"
+                  }
+                },
+                "required": [
+                  "message"
+                ]
+              },
+              "example": {
+                "message": "Minimal dark dashboard hero — gold accents, abstract market chart"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/resource-scaffold": {
+      "post": {
+        "operationId": "resource_scaffold",
+        "summary": "Concierge Resources — Scaffold",
+        "description": "Generate a single-file HTML page from a text brief — landing page or micro-site.",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.100000"
+          },
+          "protocols": [
+            {
+              "x402": {
+                "network": "solana",
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "base",
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "arbitrum",
+                "facilitator": "https://facilitator.payai.network",
+                "role": "primary"
+              }
+            },
+            {
+              "x402": {
+                "network": "solana",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "x402": {
+                "network": "base",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "x402": {
+                "network": "arbitrum",
+                "facilitator": "https://x402.dexter.cash",
+                "role": "fallback"
+              }
+            },
+            {
+              "mpp": {
+                "method": "solana",
+                "intent": "charge",
+                "currency": "USDC"
+              }
+            }
+          ],
+          "offers": [
+            {
+              "protocol": "x402",
+              "amount": "100000",
+              "currency": "USDC",
+              "intent": "charge",
+              "description": "$0.10 USDC via PayAI (primary; Dexter fallback on Solana/Base)"
+            },
+            {
+              "protocol": "mpp",
+              "amount": "100000",
+              "currency": "USDC",
+              "intent": "charge",
+              "description": "$0.10 USDC — x402 settlement compatible with MPP clients"
+            }
+          ]
+        },
+        "tags": [
+          "AI",
+          "Utility"
+        ],
+        "parameters": [
+          {
+            "name": "X-Agent-Id",
+            "in": "header",
+            "required": false,
+            "description": "Registered agent identity (agt_…) for attribution and discovery",
+            "schema": {
+              "type": "string",
+              "pattern": "^agt_[a-zA-Z0-9]+$",
+              "example": "agt_demo0001"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "description": "Optional client-generated key (UUID recommended). Reuse the same key when retrying after network failures. For paid routes, also reuse the same PAYMENT-SIGNATURE — facilitators treat a settled payment as idempotent.",
+            "schema": {
+              "type": "string",
+              "maxLength": 128,
+              "example": "550e8400-e29b-41d4-a716-446655440000"
+            }
+          }
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success after payment",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "kind": {
+                      "type": "string"
+                    },
+                    "slug": {
+                      "type": "string"
+                    },
+                    "title": {
+                      "type": "string"
+                    },
+                    "html": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "ok",
+                    "kind",
+                    "html"
+                  ]
+                },
+                "example": {
+                  "ok": true,
+                  "kind": "resource-scaffold",
+                  "slug": "crypto-intel-newsletter",
+                  "title": "Crypto Intel Newsletter",
+                  "html": "<!DOCTYPE html><html><head><title>Newsletter</title></head><body></body></html>"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request body or parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Invalid JSON body",
+                  "code": "invalid_request"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "Base64 JSON x402 payment requirements (MPP-compatible)",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-RateLimit-Limit": {
+                "description": "Soft rate limit per IP per minute",
+                "schema": {
+                  "type": "integer",
+                  "example": 120
+                }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Requests remaining in the current window",
+                "schema": {
+                  "type": "integer",
+                  "example": 119
+                }
+              },
+              "Retry-After": {
+                "description": "Seconds until the rate-limit window resets (also sent on 429)",
+                "schema": {
+                  "type": "integer",
+                  "example": 60
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Payment required",
+                  "code": "payment_required",
+                  "priceUsdc": 0.1,
+                  "resource": "resource-scaffold"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "HTTP method not allowed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Method not allowed",
+                  "code": "method_not_allowed"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded — back off and retry after Retry-After seconds",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the client may retry",
+                "schema": {
+                  "type": "integer",
+                  "example": 60
+                }
+              },
+              "X-RateLimit-Limit": {
+                "description": "Maximum requests per window",
+                "schema": {
+                  "type": "integer",
+                  "example": 120
+                }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Requests remaining (0 when rate limited)",
+                "schema": {
+                  "type": "integer",
+                  "example": 0
+                }
+              },
+              "RateLimit-Remaining": {
+                "description": "Requests remaining (0 when rate limited)",
+                "schema": {
+                  "type": "integer",
+                  "example": 0
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Too many requests — retry after the Retry-After interval",
+                  "code": "rate_limited"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Concierge could not process this request. Try a shorter question.",
+                  "code": "internal_error"
+                }
+              }
+            }
+          }
+        },
+        "servers": [
+          {
+            "url": "https://conc-exe.xyz/api/resource-scaffold"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "message": {
+                    "type": "string",
+                    "description": "Site brief (max 4000 chars)"
+                  }
+                },
+                "required": [
+                  "message"
+                ]
+              },
+              "example": {
+                "message": "Landing page for a crypto intel newsletter — dark theme, hero, pricing, CTA"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/concierge-intel-accuracy": {
+      "get": {
+        "operationId": "getConciergeIntelAccuracy",
+        "summary": "Verdict accuracy leaderboard (free)",
+        "description": "Public trust signal scoring paid intel-verdict snapshots against 24h BTC price move. No x402 payment required. Poll before routing agents to intel-verdict or for procurement due diligence.",
+        "tags": [
+          "intel"
+        ],
+        "security": [],
+        "parameters": [
+          {
+            "name": "X-Agent-Id",
+            "in": "header",
+            "required": false,
+            "description": "Registered agent identity (agt_…) for attribution and discovery",
+            "schema": {
+              "type": "string",
+              "pattern": "^agt_[a-zA-Z0-9]+$",
+              "example": "agt_demo0001"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "description": "No body required — free GET endpoint.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": false,
+                "maxProperties": 0
+              },
+              "example": {}
+            }
+          }
+        },
+        "externalDocs": {
+          "description": "B2B integration case study",
+          "url": "https://conc-exe.xyz/docs/builders/case-study"
+        },
+        "responses": {
+          "200": {
+            "description": "Accuracy leaderboard — evaluated counts, hit rate, recent snapshots",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IntelAccuracyResponse"
+                },
+                "example": {
+                  "ok": true,
+                  "dataAsOf": "2026-06-20T12:00:00.000Z",
+                  "methodology": "Each paid intel-verdict records BTC mark + signal. After 24h, hit if snipe/follow + BTC ≥+1%, avoid + BTC ≤−1%, watch/rebalance if |move| <2%.",
+                  "evaluated": {
+                    "total": 12,
+                    "hits": 8,
+                    "misses": 4,
+                    "inconclusive": 0,
+                    "hitRatePct": 66.7
+                  },
+                  "bySignal": {
+                    "snipe": {
+                      "total": 4,
+                      "hits": 3,
+                      "hitRatePct": 75
+                    },
+                    "watch": {
+                      "total": 3,
+                      "hits": 2,
+                      "hitRatePct": 66.7
+                    }
+                  },
+                  "recent": []
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request body or parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Invalid JSON body",
+                  "code": "invalid_request"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "HTTP method not allowed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Method not allowed",
+                  "code": "method_not_allowed"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded — back off and retry after Retry-After seconds",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds until the client may retry",
+                "schema": {
+                  "type": "integer",
+                  "example": 60
+                }
+              },
+              "X-RateLimit-Limit": {
+                "description": "Maximum requests per window",
+                "schema": {
+                  "type": "integer",
+                  "example": 120
+                }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Requests remaining (0 when rate limited)",
+                "schema": {
+                  "type": "integer",
+                  "example": 0
+                }
+              },
+              "RateLimit-Remaining": {
+                "description": "Requests remaining (0 when rate limited)",
+                "schema": {
+                  "type": "integer",
+                  "example": 0
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Too many requests — retry after the Retry-After interval",
+                  "code": "rate_limited"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "example": {
+                  "error": "Concierge could not process this request. Try a shorter question.",
+                  "code": "internal_error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/concierge-security-scope": {
+      "post": {
+        "operationId": "conciergeSecurityScope",
+        "summary": "Validate security probe scope (free)",
+        "description": "Validates that a target is outside Concierge platform infrastructure and optionally matches a hostname allowlist. No outbound probing. conc-exe.xyz and project Vercel hosts are always forbidden. Public free endpoint — no payment required.",
+        "tags": [
+          "security"
+        ],
+        "security": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                  "target"
+                ],
+                "properties": {
+                  "target": {
+                    "type": "string",
+                    "description": "External https origin to validate"
+                  },
+                  "allowlist": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Optional hostname allowlist (*.example.com)"
+                  }
+                }
+              },
+              "example": {
+                "target": "https://api.example.com",
+                "allowlist": [
+                  "*.example.com"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Target passed platform guard and allowlist",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                },
+                "example": {
+                  "ok": true,
+                  "kind": "security-scope",
+                  "target": {
+                    "origin": "https://api.example.com",
+                    "hostname": "api.example.com"
+                  },
+                  "platformGuard": {
+                    "passed": true
+                  },
+                  "allowlistMatched": true
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid target or allowlist mismatch"
+          },
+          "403": {
+            "description": "Platform scope forbidden — Concierge infrastructure cannot be probed"
+          }
+        }
       }
     }
   },
@@ -3424,6 +13334,19 @@
     "mppscanDiscovery": "https://www.mppscan.com/discovery",
     "agentcashDiscover": "npx -y @agentcash/discovery@latest discover https://conc-exe.xyz",
     "agentcashCheckIntel": "npx -y @agentcash/discovery@latest check https://conc-exe.xyz/api/concierge-intel-tvl",
+    "dexter": "https://dexter.cash/",
+    "dexterDocs": "https://docs.dexter.cash/",
+    "dexterFacilitator": "https://x402.dexter.cash",
+    "dexterFacilitatorDocs": "https://docs.dexter.cash/docs/facilitator-and-chains/",
+    "dexterSupported": "https://x402.dexter.cash/supported",
+    "openDexter": "https://dexter.cash/opendexter",
+    "openDexterMcp": "https://open.dexter.cash/mcp",
+    "openDexterNpm": "https://www.npmjs.com/package/@dexterai/opendexter",
+    "dexterSellers": "https://dexter.cash/sellers",
+    "dexterMarketplaceApi": "https://api.dexter.cash/api/facilitator/marketplace/resources?search=concierge&limit=10",
+    "dexterSearchIntel": "x402_search(query: \"market intelligence\", network: \"solana\")",
+    "openDexterInstall": "npx -y @dexterai/opendexter",
+    "dexterProbeIntel": "https://conc-exe.xyz/api/concierge-intel-tvl",
     "paysh": "https://pay.sh/",
     "payshCatalog": "https://pay.sh/api/catalog",
     "payshDocs": "https://pay.sh/docs/overview/index.md",
@@ -3433,19 +13356,44 @@
     "payshCurlIntel": "pay curl https://conc-exe.xyz/api/concierge-intel-verdict -d '{\"message\":\"Solana DeFi outlook\",\"includeInsider\":true}'",
     "payshCurlConcierge": "pay curl https://conc-exe.xyz/api/concierge -d '{\"mode\":\"chat\",\"message\":\"BTC outlook\"}'",
     "payshSandboxCurl": "pay --sandbox curl https://conc-exe.xyz/api/concierge-intel-tvl -d '{}'",
+    "oobe": "https://www.oobeprotocol.ai/",
+    "oobeExplorer": "https://explorer.oobeprotocol.ai/",
+    "oobeSapDocs": "https://explorer.oobeprotocol.ai/docs",
+    "oobeX402Docs": "https://explorer.oobeprotocol.ai/docs/cli/x402",
+    "oobeIntegrationGuide": "https://conc-exe.xyz/docs/integration/oobe",
+    "oobeSapToolsManifest": "https://conc-exe.xyz/distribution/oobe/sap-tools-manifest.json",
+    "oobeSkill": "https://conc-exe.xyz/skills/concierge-oobe/SKILL.md",
+    "oobePayCurlVerdict": "pay curl https://conc-exe.xyz/api/concierge-intel-verdict -d '{\"message\":\"Solana DeFi outlook\",\"includeInsider\":true}'",
+    "oobePayCurlMeteora": "pay curl https://conc-exe.xyz/api/concierge-intel-meteora -d '{\"sortByApy\":true,\"limit\":8,\"poolHint\":\"SOL\"}'",
+    "gemma": "https://deepmind.google/models/gemma/gemma-4/",
+    "litertLm": "https://ai.google.dev/edge/litert-lm",
+    "gemmaIntegrationGuide": "https://conc-exe.xyz/docs/integration/gemma",
+    "gemmaLitertManifest": "https://conc-exe.xyz/distribution/gemma/litert-tools-manifest.json",
+    "gemmaEdgePreset": "https://conc-exe.xyz/distribution/gemma/concierge-edge-preset.py",
+    "gemmaEdgeSkill": "https://conc-exe.xyz/skills/concierge-edge/SKILL.md",
+    "gemmaPayCurlMacro": "pay curl https://conc-exe.xyz/api/concierge-intel-macro -d '{}'",
+    "gemmaPayCurlVerdict": "pay curl https://conc-exe.xyz/api/concierge-intel-verdict -d '{\"message\":\"Solana DeFi outlook\",\"includeInsider\":true}'",
     "serviceName": "Concierge Agent",
-    "description": "Market intelligence as a service — pay-per-call Concierge AI, DeFi intel APIs, and Lounge RWA signals. USDC on Solana or Base via x402 (MPP-compatible discovery).",
+    "description": "Market intelligence + Concierge Resources — 24 pay-per-call routes: creative AI (chat, image, scaffold), macro & wire research, DeFi intel, Lounge RWA signals, and passive security scans. USDC or TCX via x402 (MPP-compatible discovery).",
     "tags": [
       "AI",
+      "Research",
+      "News",
       "Trading",
       "Search",
       "Crypto",
-      "RWA"
+      "RWA",
+      "Utility"
     ],
     "iconUrl": "https://conc-exe.xyz/images/the-concierge-logo.png",
+    "facilitator": "PayAI",
+    "facilitatorUrl": "https://facilitator.payai.network",
+    "fallbackFacilitator": "Dexter",
+    "fallbackFacilitatorUrl": "https://x402.dexter.cash",
     "protocols": [
       "x402",
-      "mpp"
+      "mpp",
+      "SAP"
     ]
   },
   "tags": [
@@ -3462,12 +13410,135 @@
       "description": "Concierge DeFi intelligence APIs"
     },
     {
+      "name": "research",
+      "description": "Macro snapshot and wire headline digest"
+    },
+    {
       "name": "creator",
       "description": "Creator signals & RWA"
     },
     {
       "name": "rwa",
       "description": "Real World Asset intelligence certificates"
+    },
+    {
+      "name": "security",
+      "description": "Passive security desk — external targets only; platform hosts blocked"
     }
-  ]
+  ],
+  "components": {
+    "schemas": {
+      "ApiError": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "error"
+        ],
+        "properties": {
+          "error": {
+            "type": "string",
+            "description": "Human-readable error message"
+          },
+          "code": {
+            "type": "string",
+            "description": "Stable machine-readable error code when available",
+            "enum": [
+              "invalid_request",
+              "payment_required",
+              "payment_failed",
+              "rate_limited",
+              "method_not_allowed",
+              "not_found",
+              "internal_error"
+            ]
+          },
+          "detail": {
+            "type": "string",
+            "description": "Additional context (may mirror error in dev)"
+          },
+          "resource": {
+            "type": "string",
+            "description": "x402 resource kind when payment-related"
+          },
+          "priceUsdc": {
+            "type": "number",
+            "description": "Quoted USDC price on 402 responses"
+          }
+        }
+      },
+      "IntelAccuracyResponse": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "ok",
+          "dataAsOf",
+          "methodology",
+          "evaluated",
+          "bySignal",
+          "recent"
+        ],
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "const": true
+          },
+          "dataAsOf": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "methodology": {
+            "type": "string"
+          },
+          "evaluated": {
+            "type": "object",
+            "properties": {
+              "total": {
+                "type": "integer"
+              },
+              "hits": {
+                "type": "integer"
+              },
+              "misses": {
+                "type": "integer"
+              },
+              "inconclusive": {
+                "type": "integer"
+              },
+              "hitRatePct": {
+                "type": [
+                  "number",
+                  "null"
+                ]
+              }
+            }
+          },
+          "bySignal": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "recent": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          }
+        }
+      }
+    },
+    "securitySchemes": {
+      "x402Payment": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "PAYMENT-SIGNATURE",
+        "description": "Base64 x402 payment payload after USDC settlement. Omit on first request to receive 402 + PAYMENT-REQUIRED."
+      },
+      "soonHolder": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-Soon-Holder-Wallet",
+        "description": "Post-launch: Solana wallet with SOON Deluxe balance for free raw-tier intel calls (no PAYMENT-SIGNATURE)."
+      }
+    }
+  }
 }

--- a/providers/conc-exe/concierge-agent/openapi.json
+++ b/providers/conc-exe/concierge-agent/openapi.json
@@ -11740,7 +11740,7 @@
       "post": {
         "operationId": "security_scan",
         "summary": "Concierge Security — Website scan",
-        "description": "Unified passive security breakdown for an authorized external website — readiness, HTTP headers, Concierge Surface Review (exposure findings), grade, and recommendations. No exploit payloads.",
+        "description": "Unified passive security breakdown for an authorized external website — readiness, HTTP headers, Concierge Surface Review (exposure findings), grade, and recommendations. No exploit payloads. Free platform self-audit: target https://conc-exe.xyz with selfAudit: true and authorized: true (skips x402).",
         "x-payment-info": {
           "price": {
             "mode": "fixed",
@@ -12074,19 +12074,24 @@
                 "properties": {
                   "target": {
                     "type": "string",
-                    "description": "Authorized external https URL (never conc-exe.xyz)"
+                    "description": "Authorized external https URL. For free platform self-audit only, use https://conc-exe.xyz with selfAudit: true; otherwise never conc-exe.xyz."
                   },
                   "allowlist": {
                     "type": "array",
                     "items": {
                       "type": "string"
                     },
-                    "description": "Hostname allowlist (*.example.com)"
+                    "description": "Hostname allowlist (*.example.com). Optional for selfAudit of conc-exe.xyz."
                   },
                   "authorized": {
                     "type": "boolean",
                     "const": true,
                     "description": "Must be true — caller attests permission"
+                  },
+                  "selfAudit": {
+                    "type": "boolean",
+                    "const": true,
+                    "description": "When true with target https://conc-exe.xyz (or www), runs free platform self-audit and skips x402 settlement"
                   }
                 },
                 "required": [
@@ -12100,6 +12105,26 @@
                   "*.example.com"
                 ],
                 "authorized": true
+              },
+              "examples": {
+                "paidExternalScan": {
+                  "summary": "Paid external website scan",
+                  "value": {
+                    "target": "https://api.example.com",
+                    "allowlist": [
+                      "*.example.com"
+                    ],
+                    "authorized": true
+                  }
+                },
+                "freeSelfAudit": {
+                  "summary": "Free Concierge platform self-audit",
+                  "value": {
+                    "target": "https://conc-exe.xyz",
+                    "authorized": true,
+                    "selfAudit": true
+                  }
+                }
               }
             }
           }

--- a/providers/conc-exe/concierge-agent/openapi.json
+++ b/providers/conc-exe/concierge-agent/openapi.json
@@ -11363,6 +11363,7 @@
                   },
                   "authorized": {
                     "type": "boolean",
+                    "const": true,
                     "description": "Must be true — caller attests permission"
                   }
                 },
@@ -11714,6 +11715,7 @@
                   },
                   "authorized": {
                     "type": "boolean",
+                    "const": true,
                     "description": "Must be true — caller attests permission"
                   }
                 },
@@ -12083,6 +12085,7 @@
                   },
                   "authorized": {
                     "type": "boolean",
+                    "const": true,
                     "description": "Must be true — caller attests permission"
                   }
                 },


### PR DESCRIPTION
## Summary
- Adds **Concierge Agent** (`conc-exe/concierge-agent`) — 24 pay-per-call x402 routes on `https://conc-exe.xyz`
- Concierge AI, macro and wire research, DeFi and alpha intel, Concierge Resources, Lounge signals, and Security Desk
- Settlement: USDC on Solana, Base, and Arbitrum via PayAI with Dexter fallback; optional TCX on Solana
- OpenAPI 3.1 snapshot with 24 paid routes + 2 free discovery endpoints and MPP-compatible `x-payment-info`
- Optional agent identity and ERC-8004 prepare/link discovery

## Validation
- Bundled OpenAPI v4.2.0: 26 paths (24 paid + 2 free)
- Live origin discovery: 40 operations (38 paid method variants + 2 public)
- x402scan and MPPscan profiles verified

## Test plan
- [x] Local pay catalog validation
- [x] Live 402 probes on production origin
- [x] Greptile Review check green