### PR TITLE
feat: add Market Pulse provider (market intelligence via x402)

### DIFF
--- a/providers/cookerc21-dot/market-pulse/PAY.md
+++ b/providers/cookerc21-dot/market-pulse/PAY.md
@@ -1,0 +1,33 @@
+---
+name: market-pulse
+title: "Market Pulse"
+description: "Pay-per-call market intelligence for AI agents — stock quotes, gold futures, US indices, and commodity prices in real-time via yfinance. Pay USDC per request with x402, no subscription."
+use_case: "Use for live market data: SPY price quote, gold futures (GC=F), S&P 500 (^GSPC), NASDAQ, Dow, VIX, 10Y Treasury Yield, crude oil (CL=F), silver, and detailed stock data with PE ratio, market cap, 52-week range, and earnings dates."
+category: finance
+service_url: https://bestt.up.railway.app
+openapi:
+  path: openapi.json
+---
+
+# Market Pulse
+
+Real-time market data API for AI agents and developers. No API key, no subscription — just pay USDC per request via the x402 protocol.
+
+## Endpoints
+
+| Endpoint | Price | Description |
+|----------|-------|-------------|
+| `GET /api/market/quote?symbol=SPY` | $0.03 | Current price + change for any stock, ETF, future, or index |
+| `GET /api/market/gold` | $0.03 | Gold futures price + GLD ETF reference |
+| `GET /api/market/indices` | $0.05 | S&P 500, NASDAQ, Dow, Russell 2000, VIX, 10Y Yield |
+| `GET /api/market/commodities` | $0.05 | Gold, silver, crude oil, natural gas, copper, platinum, palladium |
+| `GET /api/market/stock?ticker=AAPL` | $0.05 | Detailed stock: PE, market cap, 52w range, earnings date |
+| `GET /api/market/summary` | $0.10 | Full macro: indices + gold + all commodities |
+
+## Data Sources
+
+Powered by yfinance (Yahoo Finance) — live prices for US equities, ETFs, futures, and indices.
+
+## Payment
+
+All paid endpoints return `402 Payment Required` with an x402 payment challenge. USDC accepted on **Base Sepolia** (eip155:84532) and **Solana Devnet** (solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1). See https://x402.org for client SDKs.

--- a/providers/cookerc21-dot/market-pulse/openapi.json
+++ b/providers/cookerc21-dot/market-pulse/openapi.json
@@ -1,0 +1,49 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Market Pulse",
+    "description": "Pay-per-call market intelligence API for AI agents",
+    "version": "1.0.0"
+  },
+  "servers": [{"url": "https://bestt.up.railway.app"}],
+  "paths": {
+    "/api/market/quote": {
+      "get": {
+        "summary": "Current price + change for any ticker",
+        "parameters": [{"name": "symbol", "in": "query", "schema": {"type": "string"}, "example": "SPY"}],
+        "responses": {"200": {"description": "Price data"}, "402": {"description": "Payment required"}}
+      }
+    },
+    "/api/market/gold": {
+      "get": {
+        "summary": "Gold futures + GLD ETF reference",
+        "responses": {"200": {"description": "Gold data"}, "402": {"description": "Payment required"}}
+      }
+    },
+    "/api/market/indices": {
+      "get": {
+        "summary": "Major US indices",
+        "responses": {"200": {"description": "Indices data"}, "402": {"description": "Payment required"}}
+      }
+    },
+    "/api/market/commodities": {
+      "get": {
+        "summary": "Major commodities",
+        "responses": {"200": {"description": "Commodity prices"}, "402": {"description": "Payment required"}}
+      }
+    },
+    "/api/market/stock": {
+      "get": {
+        "summary": "Detailed stock data",
+        "parameters": [{"name": "ticker", "in": "query", "schema": {"type": "string"}, "example": "AAPL"}],
+        "responses": {"200": {"description": "Stock details"}, "402": {"description": "Payment required"}}
+      }
+    },
+    "/api/market/summary": {
+      "get": {
+        "summary": "Full macro overview",
+        "responses": {"200": {"description": "Macro summary"}, "402": {"description": "Payment required"}}
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds [Market Pulse](https://bestt.up.railway.app) — a pay-per-call market intelligence API for AI agents via x402 protocol.

**Service URL:** https://bestt.up.railway.app

**Endpoints:**
- `GET /api/market/quote?symbol=SPY` — /usr/bin/bash.03 — Live price + change for any ticker
- `GET /api/market/gold` — /usr/bin/bash.03 — Gold futures + GLD ETF
- `GET /api/market/indices` — /usr/bin/bash.05 — S&P 500, NASDAQ, Dow, VIX, 10Y yield
- `GET /api/market/commodities` — /usr/bin/bash.05 — Gold, silver, crude, gas, copper, platinum, palladium
- `GET /api/market/stock?ticker=AAPL` — /usr/bin/bash.05 — Detailed stock data
- `GET /api/market/summary` — /usr/bin/bash.10 — Full macro overview

**Category:** finance

**Payment:** x402 USDC on Base Sepolia and Solana Devnet