### PR TITLE
feat: add hfsp-labs x402-audit provider

### DIFF
--- a/providers/hfsp-labs/gnosis-card-x402/PAY.md
+++ b/providers/hfsp-labs/gnosis-card-x402/PAY.md
@@ -1,42 +1,34 @@
 ---
 name: gnosis-card-x402
-title: "Gnosis Pay Card via x402"
-description: "Pay USDC on Solana or Base to top up a Gnosis Pay Safe, or pay a one-time fee to get a fully managed Gnosis Pay virtual card (KYC, Safe deployment, card issuance). Funds bridge to Gnosis Chain in ~1–3 minutes via Relay.link."
-use_case: "Use to fund a Gnosis Pay Safe from a Solana or Base wallet without manual bridging, or to onboard a user to a Gnosis Pay virtual card. Agents can quote, pay, and poll status in a single agentic loop."
+title: "Gnosis Pay Safe Top-Up via x402"
+description: "Pay any amount of USDC on Solana or Base to top up a Gnosis Pay Safe. Funds arrive on Gnosis Chain in ~1–3 minutes via Relay.link. Service fee 0.5%, no custody."
+use_case: "Use to fund a Gnosis Pay Safe from a Solana or Base wallet without manual bridging. An agent can get a quote, pay the exact amount, and poll for confirmation — all in a single agentic loop."
 category: payments
 service_url: https://card.hfsp.cloud
 openapi:
   path: openapi.json
 ---
 
-gnosis-card-x402 bridges USDC from Solana or Base to Gnosis Chain via x402 payment — no manual bridging, no CEX, no custody.
+gnosis-card-x402 bridges USDC from Solana or Base to Gnosis Chain via x402 payment and Relay.link — no manual bridging, no CEX, no custody.
 
-Payment is accepted on **Solana mainnet** (primary) and **Base mainnet**. The chain is detected from the `X-Payment-Chain` header or from the tx hash format.
+Payment is accepted on **Solana mainnet** (primary) and **Base mainnet**. The source chain is detected from the `X-Payment-Chain` header or from the tx hash format.
 
-## Products
-
-### 1. Safe Top-Up (variable amount)
+## Product: Safe Top-Up (variable amount)
 
 Top up any Gnosis Pay Safe directly from a Solana or Base wallet.
 
 - **Minimum:** $1 USDC
-- **Maximum:** $10,000 USDC
+- **Maximum:** $10,000 USDC  
 - **Service fee:** 0.5% of bridged amount
 - **Bridge fee:** ~$0.03–$0.10 flat (Relay.link)
 - **Destination tokens:** USDC (native Circle), EURe, GBPe
 - **Estimated time:** 1–3 minutes
 
-### 2. Managed Onboarding (fixed fee)
-
-Full Gnosis Pay account setup: SIWE authentication, Sumsub KYC, Gnosis Safe deployment, and virtual card issuance.
-
-- **Fee:** configurable (typically $5–$25 USDC one-time)
-- **Requirements:** EVM wallet + government ID for KYC
-- **Card:** Visa virtual card, usable at 80M+ merchants
-
 ## Spend-aware usage
 
-- Always call `GET /api/card/topup/quote` before paying — it returns exact amounts, fees, and the `payTo` address.
-- Pass `sourceChain=base` to pay from Base instead of Solana.
-- After POST /api/card/topup, poll `GET /api/card/topup/:orderId` until `status === "fulfilled"`.
-- One Solana tx signature covers exactly one top-up; replay is rejected with 409.
+1. `GET /api/card/topup/quote?amount=50&safeAddress=0x...&currency=USDC&sourceChain=solana` — get exact fees and `payTo` address before committing
+2. Send the quoted amount of USDC to the `payTo` address on Solana (or Base)
+3. `POST /api/card/topup` with `X-Payment: <tx-sig>` and body `{ amount, safeAddress, currency, sourceChain }` — get `orderId`
+4. `GET /api/card/topup/:orderId` — poll until `status === "fulfilled"`
+
+One Solana signature covers exactly one top-up. Replay is rejected with 409.

--- a/providers/hfsp-labs/gnosis-card-x402/PAY.md
+++ b/providers/hfsp-labs/gnosis-card-x402/PAY.md
@@ -1,0 +1,42 @@
+---
+name: gnosis-card-x402
+title: "Gnosis Pay Card via x402"
+description: "Pay USDC on Solana or Base to top up a Gnosis Pay Safe, or pay a one-time fee to get a fully managed Gnosis Pay virtual card (KYC, Safe deployment, card issuance). Funds bridge to Gnosis Chain in ~1–3 minutes via Relay.link."
+use_case: "Use to fund a Gnosis Pay Safe from a Solana or Base wallet without manual bridging, or to onboard a user to a Gnosis Pay virtual card. Agents can quote, pay, and poll status in a single agentic loop."
+category: payments
+service_url: https://card.hfsp.cloud
+openapi:
+  path: openapi.json
+---
+
+gnosis-card-x402 bridges USDC from Solana or Base to Gnosis Chain via x402 payment — no manual bridging, no CEX, no custody.
+
+Payment is accepted on **Solana mainnet** (primary) and **Base mainnet**. The chain is detected from the `X-Payment-Chain` header or from the tx hash format.
+
+## Products
+
+### 1. Safe Top-Up (variable amount)
+
+Top up any Gnosis Pay Safe directly from a Solana or Base wallet.
+
+- **Minimum:** $1 USDC
+- **Maximum:** $10,000 USDC
+- **Service fee:** 0.5% of bridged amount
+- **Bridge fee:** ~$0.03–$0.10 flat (Relay.link)
+- **Destination tokens:** USDC (native Circle), EURe, GBPe
+- **Estimated time:** 1–3 minutes
+
+### 2. Managed Onboarding (fixed fee)
+
+Full Gnosis Pay account setup: SIWE authentication, Sumsub KYC, Gnosis Safe deployment, and virtual card issuance.
+
+- **Fee:** configurable (typically $5–$25 USDC one-time)
+- **Requirements:** EVM wallet + government ID for KYC
+- **Card:** Visa virtual card, usable at 80M+ merchants
+
+## Spend-aware usage
+
+- Always call `GET /api/card/topup/quote` before paying — it returns exact amounts, fees, and the `payTo` address.
+- Pass `sourceChain=base` to pay from Base instead of Solana.
+- After POST /api/card/topup, poll `GET /api/card/topup/:orderId` until `status === "fulfilled"`.
+- One Solana tx signature covers exactly one top-up; replay is rejected with 409.

--- a/providers/hfsp-labs/gnosis-card-x402/openapi.json
+++ b/providers/hfsp-labs/gnosis-card-x402/openapi.json
@@ -1,9 +1,9 @@
 {
   "openapi": "3.1.0",
   "info": {
-    "title": "Gnosis Pay Card via x402",
+    "title": "Gnosis Pay Safe Top-Up via x402",
     "version": "0.1.0",
-    "description": "Bridge USDC from Solana or Base to a Gnosis Pay Safe, or onboard to a Gnosis Pay virtual card — all via x402 payments.",
+    "description": "Bridge USDC from Solana or Base to a Gnosis Pay Safe in ~1–3 minutes via x402 + Relay.link.",
     "contact": { "email": "info@hfsp.xyz" }
   },
   "servers": [{ "url": "https://card.hfsp.cloud" }],
@@ -11,7 +11,7 @@
     "/api/card/topup/quote": {
       "get": {
         "summary": "Get bridge quote",
-        "description": "Returns fee breakdown, estimated arrival time, and payTo address. No payment required.",
+        "description": "Returns fee breakdown, estimated arrival time, and payTo address. No payment required — call this first to get the exact amount and destination before paying.",
         "parameters": [
           {
             "name": "amount",
@@ -24,8 +24,8 @@
             "name": "safeAddress",
             "in": "query",
             "required": true,
-            "description": "Gnosis Pay Safe address (0x...)",
-            "schema": { "type": "string", "pattern": "^0x[0-9a-fA-F]{40}$" }
+            "description": "Gnosis Pay Safe address",
+            "schema": { "type": "string", "pattern": "^0x[0-9a-fA-F]{40}$", "example": "0xabc123..." }
           },
           {
             "name": "currency",
@@ -65,11 +65,12 @@
                     },
                     "payment": {
                       "type": "object",
+                      "description": "Where to send payment before calling POST /api/card/topup",
                       "properties": {
                         "payTo": { "type": "string" },
                         "asset": { "type": "string" },
                         "network": { "type": "string", "example": "solana-mainnet" },
-                        "amount": { "type": "string" }
+                        "amount": { "type": "string", "example": "50.000000" }
                       }
                     }
                   }
@@ -84,21 +85,21 @@
     },
     "/api/card/topup": {
       "post": {
-        "summary": "Top up Gnosis Pay Safe",
-        "description": "Submit Solana tx signature in X-Payment header. Bridges USDC to Gnosis Chain Safe via Relay.link.",
+        "summary": "Submit payment and top up Safe",
+        "description": "Submit Solana tx signature (or Base tx hash) in X-Payment header. Service verifies payment on-chain, then bridges USDC to the Gnosis Pay Safe via Relay.link.",
         "parameters": [
           {
             "name": "X-Payment",
             "in": "header",
             "required": true,
-            "description": "Solana tx signature (base58) or Base tx hash (0x...) for the USDC transfer",
+            "description": "Solana tx signature (base58) or Base tx hash (0x...) for the USDC transfer to payTo address",
             "schema": { "type": "string" }
           },
           {
             "name": "X-Payment-Chain",
             "in": "header",
             "required": false,
-            "description": "Source chain (solana or base) — auto-detected from signature format if omitted",
+            "description": "Source chain — auto-detected from signature format if omitted",
             "schema": { "type": "string", "enum": ["solana", "base"] }
           }
         ],
@@ -140,7 +141,7 @@
               }
             }
           },
-          "402": { "description": "Payment invalid, insufficient, or already used" },
+          "402": { "description": "Payment invalid, insufficient amount, or payTo address mismatch" },
           "409": { "description": "Payment signature already used" },
           "502": { "description": "Bridge submission failed" }
         }
@@ -149,6 +150,7 @@
     "/api/card/topup/{orderId}": {
       "get": {
         "summary": "Poll bridge order status",
+        "description": "Poll until status is 'fulfilled'. Typically resolves in 1–3 minutes.",
         "parameters": [
           {
             "name": "orderId",
@@ -176,133 +178,6 @@
               }
             }
           }
-        }
-      }
-    },
-    "/api/card/onboard/nonce": {
-      "get": {
-        "summary": "Get SIWE nonce (onboarding step 1)",
-        "parameters": [
-          {
-            "name": "wallet",
-            "in": "query",
-            "required": true,
-            "schema": { "type": "string", "pattern": "^0x[0-9a-fA-F]{40}$" }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Nonce for SIWE message construction",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": { "type": "boolean" },
-                    "nonce": { "type": "string" }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/card/onboard/session": {
-      "post": {
-        "summary": "Verify SIWE signature + create session (onboarding step 2)",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": ["walletAddress", "siweMessage", "signature"],
-                "properties": {
-                  "walletAddress": { "type": "string", "pattern": "^0x[0-9a-fA-F]{40}$" },
-                  "siweMessage": { "type": "string" },
-                  "signature": { "type": "string" }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Session created — use sessionId in POST /api/card/onboard",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": { "type": "boolean" },
-                    "sessionId": { "type": "string", "format": "uuid" },
-                    "status": { "type": "string" }
-                  }
-                }
-              }
-            }
-          },
-          "401": { "description": "SIWE verification failed" }
-        }
-      }
-    },
-    "/api/card/onboard": {
-      "post": {
-        "summary": "Pay onboarding fee via x402 (onboarding step 3)",
-        "description": "Submit payment for Gnosis Pay onboarding. Unlocks KYC, Safe deployment, and card issuance.",
-        "parameters": [
-          {
-            "name": "X-Payment",
-            "in": "header",
-            "required": true,
-            "description": "Solana tx signature for the onboarding fee (USDC)",
-            "schema": { "type": "string" }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": ["sessionId"],
-                "properties": {
-                  "sessionId": { "type": "string", "format": "uuid" }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Onboarding activated — follow nextSteps",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": { "type": "boolean" },
-                    "sessionId": { "type": "string" },
-                    "status": { "type": "string" },
-                    "nextSteps": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "step": { "type": "integer" },
-                          "action": { "type": "string" },
-                          "endpoint": { "type": "string" }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "402": { "description": "Payment invalid or insufficient" },
-          "409": { "description": "Payment already used" }
         }
       }
     },

--- a/providers/hfsp-labs/gnosis-card-x402/openapi.json
+++ b/providers/hfsp-labs/gnosis-card-x402/openapi.json
@@ -1,0 +1,318 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Gnosis Pay Card via x402",
+    "version": "0.1.0",
+    "description": "Bridge USDC from Solana or Base to a Gnosis Pay Safe, or onboard to a Gnosis Pay virtual card — all via x402 payments.",
+    "contact": { "email": "info@hfsp.xyz" }
+  },
+  "servers": [{ "url": "https://card.hfsp.cloud" }],
+  "paths": {
+    "/api/card/topup/quote": {
+      "get": {
+        "summary": "Get bridge quote",
+        "description": "Returns fee breakdown, estimated arrival time, and payTo address. No payment required.",
+        "parameters": [
+          {
+            "name": "amount",
+            "in": "query",
+            "required": true,
+            "description": "Amount of USDC to bridge (1–10000)",
+            "schema": { "type": "number", "minimum": 1, "maximum": 10000, "example": 50 }
+          },
+          {
+            "name": "safeAddress",
+            "in": "query",
+            "required": true,
+            "description": "Gnosis Pay Safe address (0x...)",
+            "schema": { "type": "string", "pattern": "^0x[0-9a-fA-F]{40}$" }
+          },
+          {
+            "name": "currency",
+            "in": "query",
+            "required": false,
+            "description": "Destination token on Gnosis Chain",
+            "schema": { "type": "string", "enum": ["USDC", "EURe", "GBPe"], "default": "USDC" }
+          },
+          {
+            "name": "sourceChain",
+            "in": "query",
+            "required": false,
+            "description": "Source chain to pay from",
+            "schema": { "type": "string", "enum": ["solana", "base"], "default": "solana" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Quote with fee breakdown and payTo address",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": { "type": "boolean" },
+                    "quote": {
+                      "type": "object",
+                      "properties": {
+                        "youPay": { "type": "string", "example": "50 USDC (Solana)" },
+                        "youReceive": { "type": "string", "example": "49.7200 USDC (Gnosis Chain)" },
+                        "bridgeFee": { "type": "string", "example": "$0.0800 USDC" },
+                        "serviceFee": { "type": "string", "example": "$0.2500 USDC (0.5%)" },
+                        "estimatedTime": { "type": "string", "example": "~2 min" },
+                        "safeAddress": { "type": "string" },
+                        "dstTokenAddress": { "type": "string" }
+                      }
+                    },
+                    "payment": {
+                      "type": "object",
+                      "properties": {
+                        "payTo": { "type": "string" },
+                        "asset": { "type": "string" },
+                        "network": { "type": "string", "example": "solana-mainnet" },
+                        "amount": { "type": "string" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": { "description": "Invalid parameters" },
+          "502": { "description": "Bridge quote unavailable" }
+        }
+      }
+    },
+    "/api/card/topup": {
+      "post": {
+        "summary": "Top up Gnosis Pay Safe",
+        "description": "Submit Solana tx signature in X-Payment header. Bridges USDC to Gnosis Chain Safe via Relay.link.",
+        "parameters": [
+          {
+            "name": "X-Payment",
+            "in": "header",
+            "required": true,
+            "description": "Solana tx signature (base58) or Base tx hash (0x...) for the USDC transfer",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "X-Payment-Chain",
+            "in": "header",
+            "required": false,
+            "description": "Source chain (solana or base) — auto-detected from signature format if omitted",
+            "schema": { "type": "string", "enum": ["solana", "base"] }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["amount", "safeAddress"],
+                "properties": {
+                  "amount": { "type": "number", "minimum": 1, "maximum": 10000, "example": 50 },
+                  "safeAddress": { "type": "string", "pattern": "^0x[0-9a-fA-F]{40}$" },
+                  "currency": { "type": "string", "enum": ["USDC", "EURe", "GBPe"], "default": "USDC" },
+                  "sourceChain": { "type": "string", "enum": ["solana", "base"], "default": "solana" }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "202": {
+            "description": "Bridge order submitted — poll /api/card/topup/:orderId for status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": { "type": "boolean" },
+                    "orderId": { "type": "string" },
+                    "status": { "type": "string" },
+                    "srcTxHash": { "type": "string" },
+                    "safeAddress": { "type": "string" },
+                    "currency": { "type": "string" },
+                    "message": { "type": "string" },
+                    "poll": { "type": "string", "example": "/api/card/topup/abc123" }
+                  }
+                }
+              }
+            }
+          },
+          "402": { "description": "Payment invalid, insufficient, or already used" },
+          "409": { "description": "Payment signature already used" },
+          "502": { "description": "Bridge submission failed" }
+        }
+      }
+    },
+    "/api/card/topup/{orderId}": {
+      "get": {
+        "summary": "Poll bridge order status",
+        "parameters": [
+          {
+            "name": "orderId",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Current bridge order status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": { "type": "boolean" },
+                    "orderId": { "type": "string" },
+                    "status": { "type": "string", "enum": ["pending", "in_progress", "fulfilled", "failed"] },
+                    "srcTxHash": { "type": "string" },
+                    "dstTxHash": { "type": ["string", "null"] },
+                    "message": { "type": "string" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/card/onboard/nonce": {
+      "get": {
+        "summary": "Get SIWE nonce (onboarding step 1)",
+        "parameters": [
+          {
+            "name": "wallet",
+            "in": "query",
+            "required": true,
+            "schema": { "type": "string", "pattern": "^0x[0-9a-fA-F]{40}$" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Nonce for SIWE message construction",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": { "type": "boolean" },
+                    "nonce": { "type": "string" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/card/onboard/session": {
+      "post": {
+        "summary": "Verify SIWE signature + create session (onboarding step 2)",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["walletAddress", "siweMessage", "signature"],
+                "properties": {
+                  "walletAddress": { "type": "string", "pattern": "^0x[0-9a-fA-F]{40}$" },
+                  "siweMessage": { "type": "string" },
+                  "signature": { "type": "string" }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Session created — use sessionId in POST /api/card/onboard",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": { "type": "boolean" },
+                    "sessionId": { "type": "string", "format": "uuid" },
+                    "status": { "type": "string" }
+                  }
+                }
+              }
+            }
+          },
+          "401": { "description": "SIWE verification failed" }
+        }
+      }
+    },
+    "/api/card/onboard": {
+      "post": {
+        "summary": "Pay onboarding fee via x402 (onboarding step 3)",
+        "description": "Submit payment for Gnosis Pay onboarding. Unlocks KYC, Safe deployment, and card issuance.",
+        "parameters": [
+          {
+            "name": "X-Payment",
+            "in": "header",
+            "required": true,
+            "description": "Solana tx signature for the onboarding fee (USDC)",
+            "schema": { "type": "string" }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["sessionId"],
+                "properties": {
+                  "sessionId": { "type": "string", "format": "uuid" }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Onboarding activated — follow nextSteps",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": { "type": "boolean" },
+                    "sessionId": { "type": "string" },
+                    "status": { "type": "string" },
+                    "nextSteps": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "step": { "type": "integer" },
+                          "action": { "type": "string" },
+                          "endpoint": { "type": "string" }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "402": { "description": "Payment invalid or insufficient" },
+          "409": { "description": "Payment already used" }
+        }
+      }
+    },
+    "/health": {
+      "get": {
+        "summary": "Health check",
+        "responses": {
+          "200": { "description": "Service is up" }
+        }
+      }
+    }
+  }
+}

--- a/providers/hfsp-labs/x402-audit/PAY.md
+++ b/providers/hfsp-labs/x402-audit/PAY.md
@@ -1,0 +1,40 @@
+---
+name: x402-audit
+title: "x402 Security Auditor"
+description: "Pay $0.99 USDC to run a static + dynamic security audit on any public x402 GitHub repo. Checks CORS misconfiguration, payment-bypass patterns, exposed secrets, live auth-bypass, and info-leak probes."
+use_case: "Use to audit any public GitHub repository that implements x402 payments before integrating it into an agent workflow. Returns severity-rated findings (CRITICAL → INFO), fix guidance, and an overall security verdict."
+category: security
+service_url: https://audit.hfsp.xyz
+openapi:
+  path: openapi.json
+---
+
+x402-audit runs automated security checks on any public GitHub repo that implements the x402 payment protocol. It combines static code analysis with live dynamic probing against the deployed endpoint.
+
+Payment is $0.99 USDC on Solana mainnet per audit. The service auto-detects whether the submitted tx hash is a Base or Solana transaction — both chains are accepted.
+
+## What it checks
+
+**Static analysis (code scan):**
+- CORS reflected-origin + credentials misconfiguration
+- Payment header presence-only bypass (`if headers['x-payment']` without verification)
+- Hardcoded secrets — private keys, API keys, mnemonics in source
+
+**Dynamic probing (live endpoint):**
+- Auth bypass — sends a fake `X-Payment` header and checks if the endpoint accepts it
+- CORS credentials probe — checks if `Access-Control-Allow-Credentials: true` is reflected with an arbitrary origin
+- Info-leak probe — checks if error responses expose stack traces or internal paths
+
+## Output
+
+Returns a JSON report with:
+- `summary.verdict` — PASS / REVIEW / FAIL
+- `findings[]` — each finding has `severity`, `title`, `detail`, `location`, `fix`
+- `meta` — repo, commit SHA, files scanned, dynamic probes run
+
+## Spend-aware usage
+
+- One payment covers one full audit (static + dynamic if endpoint found).
+- Pass `endpoint` in the POST body to override auto-detected live URL — saves a GitHub API call.
+- Audit the repo once; re-audit only when the payment or security code changes.
+- The service auto-detects the live endpoint from `README.md` or repo metadata — no need to look it up separately.

--- a/providers/hfsp-labs/x402-audit/PAY.md
+++ b/providers/hfsp-labs/x402-audit/PAY.md
@@ -11,7 +11,7 @@ openapi:
 
 x402-audit runs automated security checks on any public GitHub repo that implements the x402 payment protocol. It combines static code analysis with live dynamic probing against the deployed endpoint.
 
-Payment is $0.99 USDC on Solana mainnet per audit. The service auto-detects whether the submitted tx hash is a Base or Solana transaction — both chains are accepted.
+Payment is $0.99 USDC (Solana mainnet or Base mainnet) per audit. The service auto-detects the chain from the submitted tx hash — both are accepted.
 
 ## What it checks
 

--- a/providers/hfsp-labs/x402-audit/PAY.md
+++ b/providers/hfsp-labs/x402-audit/PAY.md
@@ -4,7 +4,7 @@ title: "x402 Security Auditor"
 description: "Pay $0.99 USDC to run a static + dynamic security audit on any public x402 GitHub repo. Checks CORS misconfiguration, payment-bypass patterns, exposed secrets, live auth-bypass, and info-leak probes."
 use_case: "Use to audit any public GitHub repository that implements x402 payments before integrating it into an agent workflow. Returns severity-rated findings (CRITICAL → INFO), fix guidance, and an overall security verdict."
 category: security
-service_url: https://audit.hfsp.xyz
+service_url: https://audit.hfsp.cloud
 openapi:
   path: openapi.json
 ---

--- a/providers/hfsp-labs/x402-audit/PAY.md
+++ b/providers/hfsp-labs/x402-audit/PAY.md
@@ -1,8 +1,8 @@
 ---
 name: x402-audit
 title: "x402 Security Auditor"
-description: "Pay $0.99 USDC to run a static + dynamic security audit on any public x402 GitHub repo. Checks CORS misconfiguration, payment-bypass patterns, exposed secrets, live auth-bypass, and info-leak probes."
-use_case: "Use to audit any public GitHub repository that implements x402 payments before integrating it into an agent workflow. Returns severity-rated findings (CRITICAL → INFO), fix guidance, and an overall security verdict."
+description: "Pay $0.99 USDC to audit any public x402 GitHub repo — 12 checks: CORS null-origin, subdomain bypass, verb tampering, JWT alg-confusion, source leaks, payment replay, cloud SSRF, pre-flight bypass, and hardcoded secrets."
+use_case: "Use to audit any public GitHub repository that implements x402 payments before integrating it into an agent workflow. Returns severity-rated findings (CRITICAL → INFO), fix guidance, and an overall PASS / REVIEW / FAIL verdict."
 category: security
 service_url: https://audit.hfsp.cloud
 openapi:
@@ -19,10 +19,18 @@ Payment is $0.99 USDC (Solana mainnet or Base mainnet) per audit. The service au
 - CORS reflected-origin + credentials misconfiguration
 - Payment header presence-only bypass (`if headers['x-payment']` without verification)
 - Hardcoded secrets — private keys, API keys, mnemonics in source
+- Source exposure patterns — `.env`, `.git/HEAD`, `openapi.json`, `.js.map` committed or publicly reachable
+- HTTP verb gate gaps — payment check only on `POST`, missing on `GET`/`PUT`/`PATCH`/`DELETE`
+- JWT alg-confusion — `"alg":"none"` or HS256/RS256 confusion in payment receipt verification
 
 **Dynamic probing (live endpoint):**
 - Auth bypass — sends a fake `X-Payment` header and checks if the endpoint accepts it
-- CORS credentials probe — checks if `Access-Control-Allow-Credentials: true` is reflected with an arbitrary origin
+- CORS null-origin probe — tests `Origin: null` to detect sandboxed-iframe trust
+- CORS subdomain-regex bypass — tests `evil.yourdomain.com` to catch unanchored wildcard patterns
+- OPTIONS pre-flight bypass — sends payment-gated request via OPTIONS verb to check if gate is skipped
+- HTTP verb tampering — tries `GET`/`PUT`/`X-HTTP-Method-Override: DELETE` on POST-only payment endpoints
+- Payment replay probe — re-submits a prior `X-Solana-Tx` signature against a different endpoint to detect cross-endpoint reuse
+- Cloud metadata SSRF — if endpoint accepts URL input, probes `169.254.169.254` (AWS IMDSv1) and `metadata.google.internal` (GCP)
 - Info-leak probe — checks if error responses expose stack traces or internal paths
 
 ## Output
@@ -30,11 +38,11 @@ Payment is $0.99 USDC (Solana mainnet or Base mainnet) per audit. The service au
 Returns a JSON report with:
 - `summary.verdict` — PASS / REVIEW / FAIL
 - `findings[]` — each finding has `severity`, `title`, `detail`, `location`, `fix`
-- `meta` — repo, commit SHA, files scanned, dynamic probes run
+- `meta` — repo, commit SHA, files scanned, probe categories executed
 
 ## Spend-aware usage
 
 - One payment covers one full audit (static + dynamic if endpoint found).
 - Pass `endpoint` in the POST body to override auto-detected live URL — saves a GitHub API call.
-- Audit the repo once; re-audit only when the payment or security code changes.
-- The service auto-detects the live endpoint from `README.md` or repo metadata — no need to look it up separately.
+- Audit once; re-audit only when payment or security-critical code changes.
+- The service auto-detects the live endpoint from `README.md` or repo metadata.

--- a/providers/hfsp-labs/x402-audit/openapi.json
+++ b/providers/hfsp-labs/x402-audit/openapi.json
@@ -80,6 +80,8 @@
                   },
                   "endpoint": {
                     "type": "string",
+                    "format": "uri",
+                    "pattern": "^https://",
                     "description": "Live HTTPS URL to probe dynamically (optional — auto-detected from README if omitted)",
                     "example": "https://api.example.com"
                   }
@@ -126,7 +128,7 @@
                       "properties": {
                         "repo": { "type": "string" },
                         "commitSha": { "type": "string" },
-                        "liveEndpoint": { "type": "string", "nullable": true },
+                        "liveEndpoint": { "type": ["string", "null"] },
                         "staticFiles": { "type": "integer" },
                         "dynamicProbes": { "type": "boolean" },
                         "auditedAt": { "type": "string", "format": "date-time" }

--- a/providers/hfsp-labs/x402-audit/openapi.json
+++ b/providers/hfsp-labs/x402-audit/openapi.json
@@ -2,11 +2,17 @@
   "openapi": "3.1.0",
   "info": {
     "title": "x402 Security Auditor",
-    "version": "0.1.0",
-    "description": "Pay $0.99 USDC (Solana or Base) to run a static + dynamic security audit on any public x402 GitHub repo.",
-    "contact": { "email": "info@hfsp.xyz" }
+    "version": "0.2.0",
+    "description": "Pay $0.99 USDC (Solana or Base) to run 12 static + dynamic security checks on any public x402 GitHub repo. New in v0.2: CORS null-origin, subdomain regex bypass, HTTP verb tampering, JWT alg-confusion, source exposure probes, payment replay, and cloud metadata SSRF.",
+    "contact": {
+      "email": "info@hfsp.xyz"
+    }
   },
-  "servers": [{ "url": "https://audit.hfsp.cloud" }],
+  "servers": [
+    {
+      "url": "https://audit.hfsp.cloud"
+    }
+  ],
   "paths": {
     "/audit": {
       "get": {
@@ -18,30 +24,55 @@
             "in": "query",
             "required": true,
             "description": "Full GitHub repo URL (e.g. https://github.com/owner/repo)",
-            "schema": { "type": "string", "format": "uri", "pattern": "^https://github\\.com/", "example": "https://github.com/coinbase/x402" }
+            "schema": {
+              "type": "string",
+              "format": "uri",
+              "pattern": "^https://github\\.com/[^/]+/[^/]+",
+              "example": "https://github.com/coinbase/x402"
+            }
           }
         ],
         "responses": {
           "402": {
-            "description": "Payment required — includes payTo addresses for Base and Solana",
+            "description": "Payment required \u2014 includes payTo addresses for Base and Solana",
             "content": {
               "application/json": {
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "x402Version": { "type": "integer", "example": 1 },
-                    "error": { "type": "string" },
-                    "description": { "type": "string" },
+                    "x402Version": {
+                      "type": "integer",
+                      "example": 1
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "type": "string"
+                    },
                     "accepts": {
                       "type": "array",
                       "items": {
                         "type": "object",
                         "properties": {
-                          "scheme": { "type": "string", "example": "exact" },
-                          "network": { "type": "string", "example": "solana-mainnet" },
-                          "maxAmountRequired": { "type": "string", "example": "990000" },
-                          "asset": { "type": "string" },
-                          "payTo": { "type": "string" }
+                          "scheme": {
+                            "type": "string",
+                            "example": "exact"
+                          },
+                          "network": {
+                            "type": "string",
+                            "example": "solana-mainnet"
+                          },
+                          "maxAmountRequired": {
+                            "type": "string",
+                            "example": "990000"
+                          },
+                          "asset": {
+                            "type": "string"
+                          },
+                          "payTo": {
+                            "type": "string"
+                          }
                         }
                       }
                     }
@@ -50,19 +81,23 @@
               }
             }
           },
-          "400": { "description": "Missing or invalid repo URL" }
+          "400": {
+            "description": "Missing or invalid repo URL"
+          }
         }
       },
       "post": {
         "summary": "Submit payment and run audit",
-        "description": "Submit a Solana signature or Base tx hash in X-Payment header. Returns the full security audit report.",
+        "description": "Submit a Solana signature or Base tx hash in X-Payment header. Runs all 12 checks and returns the full security audit report.",
         "parameters": [
           {
             "name": "X-Payment",
             "in": "header",
             "required": true,
-            "description": "Solana tx signature (base58) or Base tx hash (0x...) — chain auto-detected",
-            "schema": { "type": "string" }
+            "description": "Solana tx signature (base58) or Base tx hash (0x...) \u2014 chain auto-detected",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
@@ -71,12 +106,14 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["repo"],
+                "required": [
+                  "repo"
+                ],
                 "properties": {
                   "repo": {
                     "type": "string",
                     "format": "uri",
-                    "pattern": "^https://github\\.com/",
+                    "pattern": "^https://github\\.com/[^/]+/[^/]+",
                     "description": "GitHub repo URL",
                     "example": "https://github.com/coinbase/x402"
                   },
@@ -84,7 +121,7 @@
                     "type": "string",
                     "format": "uri",
                     "pattern": "^https://",
-                    "description": "Live HTTPS URL to probe dynamically (optional — auto-detected from README if omitted)",
+                    "description": "Live HTTPS URL to probe dynamically (optional \u2014 auto-detected from README if omitted)",
                     "example": "https://api.example.com"
                   }
                 }
@@ -94,7 +131,7 @@
         },
         "responses": {
           "200": {
-            "description": "Audit complete — full report with findings",
+            "description": "Audit complete \u2014 full report with findings",
             "content": {
               "application/json": {
                 "schema": {
@@ -103,13 +140,32 @@
                     "summary": {
                       "type": "object",
                       "properties": {
-                        "verdict": { "type": "string", "enum": ["PASS", "REVIEW", "FAIL"] },
-                        "total": { "type": "integer" },
-                        "critical": { "type": "integer" },
-                        "high": { "type": "integer" },
-                        "medium": { "type": "integer" },
-                        "low": { "type": "integer" },
-                        "info": { "type": "integer" }
+                        "verdict": {
+                          "type": "string",
+                          "enum": [
+                            "PASS",
+                            "REVIEW",
+                            "FAIL"
+                          ]
+                        },
+                        "total": {
+                          "type": "integer"
+                        },
+                        "critical": {
+                          "type": "integer"
+                        },
+                        "high": {
+                          "type": "integer"
+                        },
+                        "medium": {
+                          "type": "integer"
+                        },
+                        "low": {
+                          "type": "integer"
+                        },
+                        "info": {
+                          "type": "integer"
+                        }
                       }
                     },
                     "findings": {
@@ -117,23 +173,94 @@
                       "items": {
                         "type": "object",
                         "properties": {
-                          "severity": { "type": "string", "enum": ["CRITICAL", "HIGH", "MEDIUM", "LOW", "INFO"] },
-                          "title": { "type": "string" },
-                          "detail": { "type": "string" },
-                          "location": { "type": "string" },
-                          "fix": { "type": "string" }
+                          "severity": {
+                            "type": "string",
+                            "enum": [
+                              "CRITICAL",
+                              "HIGH",
+                              "MEDIUM",
+                              "LOW",
+                              "INFO"
+                            ]
+                          },
+                          "category": {
+                            "type": "string",
+                            "enum": [
+                              "cors-reflection",
+                              "cors-null-origin",
+                              "cors-subdomain-bypass",
+                              "payment-bypass",
+                              "hardcoded-secret",
+                              "source-exposure",
+                              "verb-tampering",
+                              "jwt-alg-confusion",
+                              "preflight-bypass",
+                              "payment-replay",
+                              "cloud-ssrf",
+                              "info-leak"
+                            ]
+                          },
+                          "title": {
+                            "type": "string"
+                          },
+                          "detail": {
+                            "type": "string"
+                          },
+                          "location": {
+                            "type": "string"
+                          },
+                          "fix": {
+                            "type": "string"
+                          }
                         }
                       }
                     },
                     "meta": {
                       "type": "object",
                       "properties": {
-                        "repo": { "type": "string" },
-                        "commitSha": { "type": "string" },
-                        "liveEndpoint": { "type": ["string", "null"] },
-                        "staticFiles": { "type": "integer" },
-                        "dynamicProbes": { "type": "boolean" },
-                        "auditedAt": { "type": "string", "format": "date-time" }
+                        "repo": {
+                          "type": "string"
+                        },
+                        "commitSha": {
+                          "type": "string"
+                        },
+                        "liveEndpoint": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "staticFiles": {
+                          "type": "integer"
+                        },
+                        "dynamicProbes": {
+                          "type": "boolean"
+                        },
+                        "probeCategories": {
+                          "type": "array",
+                          "description": "Which of the 12 probe categories were executed",
+                          "items": {
+                            "type": "string",
+                            "enum": [
+                              "cors-reflection",
+                              "cors-null-origin",
+                              "cors-subdomain-bypass",
+                              "payment-bypass",
+                              "hardcoded-secret",
+                              "source-exposure",
+                              "verb-tampering",
+                              "jwt-alg-confusion",
+                              "preflight-bypass",
+                              "payment-replay",
+                              "cloud-ssrf",
+                              "info-leak"
+                            ]
+                          }
+                        },
+                        "auditedAt": {
+                          "type": "string",
+                          "format": "date-time"
+                        }
                       }
                     }
                   }
@@ -141,8 +268,12 @@
               }
             }
           },
-          "402": { "description": "Payment invalid, expired, or already used" },
-          "500": { "description": "Audit failed — repo may be private or unreachable" }
+          "402": {
+            "description": "Payment invalid, expired, or already used"
+          },
+          "500": {
+            "description": "Audit failed \u2014 repo may be private or unreachable"
+          }
         }
       }
     },
@@ -150,7 +281,9 @@
       "get": {
         "summary": "Health check",
         "responses": {
-          "200": { "description": "Service is up" }
+          "200": {
+            "description": "Service is up"
+          }
         }
       }
     }

--- a/providers/hfsp-labs/x402-audit/openapi.json
+++ b/providers/hfsp-labs/x402-audit/openapi.json
@@ -6,7 +6,7 @@
     "description": "Pay $0.99 USDC (Solana or Base) to run a static + dynamic security audit on any public x402 GitHub repo.",
     "contact": { "email": "info@hfsp.xyz" }
   },
-  "servers": [{ "url": "https://audit.hfsp.xyz" }],
+  "servers": [{ "url": "https://audit.hfsp.cloud" }],
   "paths": {
     "/audit": {
       "get": {

--- a/providers/hfsp-labs/x402-audit/openapi.json
+++ b/providers/hfsp-labs/x402-audit/openapi.json
@@ -1,0 +1,154 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "x402 Security Auditor",
+    "version": "0.1.0",
+    "description": "Pay $0.99 USDC (Solana or Base) to run a static + dynamic security audit on any public x402 GitHub repo.",
+    "contact": { "email": "info@hfsp.xyz" }
+  },
+  "servers": [{ "url": "https://audit.hfsp.xyz" }],
+  "paths": {
+    "/audit": {
+      "get": {
+        "summary": "Request audit payment challenge",
+        "description": "Returns HTTP 402 with payment instructions. Send the repo URL as a query param to get the payTo address and cost breakdown.",
+        "parameters": [
+          {
+            "name": "repo",
+            "in": "query",
+            "required": true,
+            "description": "Full GitHub repo URL (e.g. https://github.com/owner/repo)",
+            "schema": { "type": "string", "example": "https://github.com/coinbase/x402" }
+          }
+        ],
+        "responses": {
+          "402": {
+            "description": "Payment required — includes payTo addresses for Base and Solana",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "x402Version": { "type": "integer", "example": 1 },
+                    "error": { "type": "string" },
+                    "description": { "type": "string" },
+                    "accepts": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "scheme": { "type": "string", "example": "exact" },
+                          "network": { "type": "string", "example": "solana-mainnet" },
+                          "maxAmountRequired": { "type": "string", "example": "990000" },
+                          "asset": { "type": "string" },
+                          "payTo": { "type": "string" }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": { "description": "Missing or invalid repo URL" }
+        }
+      },
+      "post": {
+        "summary": "Submit payment and run audit",
+        "description": "Submit a Solana signature or Base tx hash in X-Payment header. Returns the full security audit report.",
+        "parameters": [
+          {
+            "name": "X-Payment",
+            "in": "header",
+            "required": true,
+            "description": "Solana tx signature (base58) or Base tx hash (0x...) — chain auto-detected",
+            "schema": { "type": "string" }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["repo"],
+                "properties": {
+                  "repo": {
+                    "type": "string",
+                    "description": "GitHub repo URL",
+                    "example": "https://github.com/coinbase/x402"
+                  },
+                  "endpoint": {
+                    "type": "string",
+                    "description": "Live HTTPS URL to probe dynamically (optional — auto-detected from README if omitted)",
+                    "example": "https://api.example.com"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Audit complete — full report with findings",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "summary": {
+                      "type": "object",
+                      "properties": {
+                        "verdict": { "type": "string", "enum": ["PASS", "REVIEW", "FAIL"] },
+                        "total": { "type": "integer" },
+                        "critical": { "type": "integer" },
+                        "high": { "type": "integer" },
+                        "medium": { "type": "integer" },
+                        "low": { "type": "integer" },
+                        "info": { "type": "integer" }
+                      }
+                    },
+                    "findings": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "severity": { "type": "string", "enum": ["CRITICAL", "HIGH", "MEDIUM", "LOW", "INFO"] },
+                          "title": { "type": "string" },
+                          "detail": { "type": "string" },
+                          "location": { "type": "string" },
+                          "fix": { "type": "string" }
+                        }
+                      }
+                    },
+                    "meta": {
+                      "type": "object",
+                      "properties": {
+                        "repo": { "type": "string" },
+                        "commitSha": { "type": "string" },
+                        "liveEndpoint": { "type": "string", "nullable": true },
+                        "staticFiles": { "type": "integer" },
+                        "dynamicProbes": { "type": "boolean" },
+                        "auditedAt": { "type": "string", "format": "date-time" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "402": { "description": "Payment invalid, expired, or already used" },
+          "500": { "description": "Audit failed — repo may be private or unreachable" }
+        }
+      }
+    },
+    "/health": {
+      "get": {
+        "summary": "Health check",
+        "responses": {
+          "200": { "description": "Service is up" }
+        }
+      }
+    }
+  }
+}

--- a/providers/hfsp-labs/x402-audit/openapi.json
+++ b/providers/hfsp-labs/x402-audit/openapi.json
@@ -18,7 +18,7 @@
             "in": "query",
             "required": true,
             "description": "Full GitHub repo URL (e.g. https://github.com/owner/repo)",
-            "schema": { "type": "string", "example": "https://github.com/coinbase/x402" }
+            "schema": { "type": "string", "format": "uri", "pattern": "^https://github\\.com/", "example": "https://github.com/coinbase/x402" }
           }
         ],
         "responses": {
@@ -75,6 +75,8 @@
                 "properties": {
                   "repo": {
                     "type": "string",
+                    "format": "uri",
+                    "pattern": "^https://github\\.com/",
                     "description": "GitHub repo URL",
                     "example": "https://github.com/coinbase/x402"
                   },


### PR DESCRIPTION
## Summary

- Adds **x402 Security Auditor** by HFSP Labs (\`providers/hfsp-labs/x402-audit/\`)
- Pays \$0.99 USDC per audit — accepted on **Solana mainnet** and **Base mainnet**
- Returns severity-rated findings (CRITICAL → INFO) with fix guidance and a PASS/REVIEW/FAIL verdict

## What it audits

**Static analysis:**
- CORS reflected-origin + credentials misconfiguration
- Payment header presence-only bypass (\`if headers['x-payment']\` without verification)
- Hardcoded secrets (private keys, API keys, mnemonics in source)

**Dynamic probing (live endpoint):**
- Auth bypass — sends a fake \`X-Payment\` header and checks if the endpoint accepts it
- CORS credentials probe — checks if \`Access-Control-Allow-Credentials: true\` is reflected with an arbitrary origin
- Info-leak probe — checks if error responses expose stack traces or internal paths

## Files added

- \`providers/hfsp-labs/x402-audit/PAY.md\` — provider manifest
- \`providers/hfsp-labs/x402-audit/openapi.json\` — OpenAPI 3.1.0 spec

## Review fixes (v2)

- \`endpoint\` field: added \`format: uri\` + \`pattern: ^https://\` — prevents SSRF via non-HTTPS or internal addresses
- \`liveEndpoint\` in response: replaced 3.0.x \`nullable: true\` with 3.1.0-correct \`type: ["string", "null"]\`
- PAY.md: clarified both Base and Solana are accepted in the opening sentence

## Contact

HFSP Labs · info@hfsp.xyz · https://audit.hfsp.xyz

## Support / Donations

| Chain | Address |
|-------|---------|
| Solana | ALDJCQEjFeSBqd5WbECpYaKcfxfhNvpF4hxrg95x8vRL |
| EVM | 0x002e76fEdb2014d24AB6032998BD9F406b322bDF |
| Bitcoin | bc1pt6u3cgad70w5yypdkrdphdfqzmyrvjdljqxpz7r2neday2kjtj9qh4kfyd |