### PR TITLE
feat: add hfsp/vpn-x402 — anonymous WireGuard VPN + ephemeral VPS on Solana

### DIFF
--- a/providers/hfsp/vpn-x402/PAY.md
+++ b/providers/hfsp/vpn-x402/PAY.md
@@ -80,7 +80,7 @@ POST /api/vps/hour
 → 402  { pay: { amount: 250000, mint: "EPjFWdd5...", payTo: "GdAWRcvr..." } }
 → (send 0.25 USDC on Solana mainnet)
 → POST /api/vps/hour  X-Solana-Tx: <signature>
-→ 200  { ip: "5.6.7.8", wireguardClientConf: "<base64>", expiresAt: "..." }
+→ 200  { ok: true, data: { ip: "5.6.7.8", wireguardClientConf: "<base64>" }, expiresAt: "..." }
 → ssh -i ~/.ssh/id_ed25519 root@5.6.7.8  (server ready in ~60s)
 ```
 

--- a/providers/hfsp/vpn-x402/PAY.md
+++ b/providers/hfsp/vpn-x402/PAY.md
@@ -1,0 +1,81 @@
+---
+name: vpn-x402
+title: "HFSP VPN x402"
+description: "Anonymous WireGuard VPN passes and ephemeral Ubuntu VPS servers. Pay USDC on Solana. No account, no logs, no identity. Servers auto-destroy at expiry."
+use_case: "Use for anonymous VPN tunnels, ephemeral compute, privacy-preserving network access, and burner VPS servers paid with Solana USDC."
+category: cloud
+service_url: https://vpn.hfsp.cloud
+openapi:
+  path: openapi.json
+---
+
+Pay-per-use anonymous VPN and ephemeral VPS infrastructure. A single POST returns a
+ready-to-use WireGuard config or SSH IP — no accounts, no identity, no logs.
+
+Payment is Solana mainnet USDC via the x402 protocol. Send the USDC transfer,
+then retry the original request with `X-Solana-Tx: <confirmed-signature>`. The
+server verifies on-chain via Helius and provisions immediately.
+
+## Endpoints at a glance
+
+| Path | Price | What you get |
+|------|-------|--------------|
+| `POST /api/vpn/hour`  | $0.20 USDC | WireGuard tunnel — 1 hour |
+| `POST /api/vpn/day`   | $0.79 USDC | WireGuard tunnel — 24 hours |
+| `POST /api/vpn/week`  | $2.99 USDC | WireGuard tunnel — 7 days |
+| `POST /api/vpn/month` | $7.99 USDC | WireGuard tunnel — 30 days |
+| `POST /api/vps/hour`  | $0.25 USDC | Ephemeral Ubuntu VPS — 1 hour |
+| `POST /api/vps/day`   | $0.79 USDC | Ephemeral Ubuntu VPS — 24 hours |
+| `POST /api/vps/week`  | $3.99 USDC | Ephemeral Ubuntu VPS — 7 days |
+
+## VPN flow
+
+Generate an X25519 WireGuard keypair client-side. Send the public key in the
+request body. The server provisions a WireGuard node, returns its public key and
+IP. Assemble the `.conf` locally — private key never leaves the client.
+
+```
+POST /api/vpn/week
+{ "region": "US_HIL", "clientWgPublicKey": "<base64 X25519>" }
+
+→ 402  { pay: { amount: 2990000, mint: "EPjFWdd5...", payTo: "GdAWRcvr..." } }
+→ (send 2.99 USDC on Solana mainnet)
+→ POST /api/vpn/week  X-Solana-Tx: <signature>
+→ 200  { ip: "1.2.3.4", serverWgPubKey: "<base64>", expiresAt: "..." }
+```
+
+## VPS flow
+
+Generate an Ed25519 SSH keypair client-side. Send only the public key. Server
+adds it to `authorized_keys` — operator never sees the private key.
+
+```
+POST /api/vps/hour
+{ "region": "SG_SIN", "sshPublicKey": "ssh-ed25519 AAAA..." }
+
+→ 402  { pay: { amount: 250000, mint: "EPjFWdd5...", payTo: "GdAWRcvr..." } }
+→ (send 0.25 USDC on Solana mainnet)
+→ POST /api/vps/hour  X-Solana-Tx: <signature>
+→ 200  { ip: "5.6.7.8", wireguardClientConf: "<base64>", expiresAt: "..." }
+→ ssh -i key.pem root@5.6.7.8  (server ready in ~60s)
+```
+
+## Regions
+
+`DE_NBG` (Nuremberg) · `FI_HEL` (Helsinki) · `US_HIL` (Hillsboro OR) · `SG_SIN` (Singapore)
+
+## Payment details
+
+- **Network:** Solana mainnet (`solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp`)
+- **Asset:** USDC (`EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`, 6 decimals)
+- **Recipient:** `GdAWRcvrVabFi6QtciGJNYsS8cykJkZTNZ3cFea6ywfY`
+- **Header:** `X-Solana-Tx: <confirmed transaction signature>`
+
+## Spend-aware usage
+
+- Each request is one USDC transfer — keep retries minimal. The tx signature is
+  single-use; a replay attempt returns 402 immediately.
+- For recurring usage, prefer `week` or `month` passes over many `hour` passes.
+- Use `GET /api/vps/regions` or `GET /api/vpn/regions` before provisioning to
+  verify the target region is listed — the set can change.
+- VPS servers take ~60 seconds to boot. Add a health-check loop before SSH.

--- a/providers/hfsp/vpn-x402/PAY.md
+++ b/providers/hfsp/vpn-x402/PAY.md
@@ -25,7 +25,7 @@ server verifies on-chain via Helius and provisions immediately.
 | `POST /api/vpn/week`  | $2.99 USDC | WireGuard tunnel — 7 days |
 | `POST /api/vpn/month` | $7.99 USDC | WireGuard tunnel — 30 days |
 | `POST /api/vps/hour`  | $0.25 USDC | Ephemeral Ubuntu VPS — 1 hour |
-| `POST /api/vps/day`   | $0.79 USDC | Ephemeral Ubuntu VPS — 24 hours |
+| `POST /api/vps/day`   | $0.99 USDC | Ephemeral Ubuntu VPS — 24 hours |
 | `POST /api/vps/week`  | $3.99 USDC | Ephemeral Ubuntu VPS — 7 days |
 
 ## VPN flow

--- a/providers/hfsp/vpn-x402/PAY.md
+++ b/providers/hfsp/vpn-x402/PAY.md
@@ -31,8 +31,9 @@ server verifies on-chain via Helius and provisions immediately.
 ## VPN flow
 
 Generate an X25519 WireGuard keypair client-side. Send the public key in the
-request body. The server provisions a WireGuard node, returns its public key and
-IP. Assemble the `.conf` locally — private key never leaves the client.
+request body. The server provisions a WireGuard node, returns its public key,
+IP, port, and your assigned tunnel IP. Assemble the `.conf` locally — your
+private key never leaves the client.
 
 ```
 POST /api/vpn/week
@@ -41,7 +42,30 @@ POST /api/vpn/week
 → 402  { pay: { amount: 2990000, mint: "EPjFWdd5...", payTo: "GdAWRcvr..." } }
 → (send 2.99 USDC on Solana mainnet)
 → POST /api/vpn/week  X-Solana-Tx: <signature>
-→ 200  { ip: "1.2.3.4", serverWgPubKey: "<base64>", expiresAt: "..." }
+→ 200  {
+    data: {
+      ip: "1.2.3.4",           ← server public IP
+      serverWgPubKey: "<b64>", ← server WireGuard public key
+      wgPort: 51820,           ← WireGuard UDP port
+      clientTunnelIp: "10.8.0.2" ← your tunnel IP inside the VPN
+    },
+    expiresAt: "..."
+  }
+```
+
+Assemble the WireGuard config from the response fields:
+
+```ini
+[Interface]
+PrivateKey = <your X25519 private key>
+Address = 10.8.0.2/32        # clientTunnelIp from response
+DNS = 1.1.1.1
+
+[Peer]
+PublicKey = <serverWgPubKey>  # from response
+Endpoint = 1.2.3.4:51820     # ip:wgPort from response
+AllowedIPs = 0.0.0.0/0, ::/0
+PersistentKeepalive = 25
 ```
 
 ## VPS flow
@@ -57,7 +81,24 @@ POST /api/vps/hour
 → (send 0.25 USDC on Solana mainnet)
 → POST /api/vps/hour  X-Solana-Tx: <signature>
 → 200  { ip: "5.6.7.8", wireguardClientConf: "<base64>", expiresAt: "..." }
-→ ssh -i key.pem root@5.6.7.8  (server ready in ~60s)
+→ ssh -i ~/.ssh/id_ed25519 root@5.6.7.8  (server ready in ~60s)
+```
+
+`wireguardClientConf` is a base64-encoded config **template** for optional
+WireGuard VPN access to the VPS. The server public key and endpoint are
+pre-filled; you supply your own WireGuard keypair and register it as a peer
+via SSH:
+
+```bash
+# 1. Generate your WireGuard keypair
+wg genkey | tee wg-vps.key | wg pubkey > wg-vps.pub
+
+# 2. Register your public key on the VPS via SSH
+ssh root@5.6.7.8 "wg set wg0 peer $(cat wg-vps.pub) allowed-ips 10.9.0.2/32"
+
+# 3. Fill in the template (replace PrivateKey placeholder)
+base64 -d <<< "<wireguardClientConf>" | sed "s|<your-client-wireguard-private-key>|$(cat wg-vps.key)|" > wg-vps.conf
+wg-quick up ./wg-vps.conf
 ```
 
 ## Regions

--- a/providers/hfsp/vpn-x402/openapi.json
+++ b/providers/hfsp/vpn-x402/openapi.json
@@ -1,0 +1,312 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "HFSP VPN x402",
+    "description": "Anonymous WireGuard VPN passes and ephemeral Ubuntu VPS servers. Pay USDC on Solana. No account, no logs, no identity. Servers auto-destroy at expiry.",
+    "version": "2.0.0",
+    "contact": {
+      "name": "HFSP",
+      "url": "https://hfsp.xyz",
+      "email": "info@hfsp.xyz"
+    }
+  },
+  "servers": [
+    { "url": "https://vpn.hfsp.cloud" }
+  ],
+  "x-x402": {
+    "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+    "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+    "recipient": "GdAWRcvrVabFi6QtciGJNYsS8cykJkZTNZ3cFea6ywfY",
+    "paymentHeader": "X-Solana-Tx",
+    "discovery": "/.well-known/x402.json"
+  },
+  "components": {
+    "schemas": {
+      "Region": {
+        "type": "string",
+        "enum": ["DE_NBG", "FI_HEL", "US_HIL", "SG_SIN"],
+        "description": "DE_NBG=Nuremberg Germany, FI_HEL=Helsinki Finland, US_HIL=Hillsboro Oregon USA, SG_SIN=Singapore"
+      },
+      "PaymentRequired": {
+        "type": "object",
+        "properties": {
+          "ok":    { "type": "boolean", "example": false },
+          "error": { "type": "string",  "example": "Payment required" },
+          "pay": {
+            "type": "object",
+            "properties": {
+              "amount":    { "type": "integer", "description": "Atomic USDC units (6 decimals)", "example": 2990000 },
+              "amountUsd": { "type": "string",  "example": "2.9900" },
+              "mint":      { "type": "string",  "example": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v" },
+              "payTo":     { "type": "string",  "example": "GdAWRcvrVabFi6QtciGJNYsS8cykJkZTNZ3cFea6ywfY" },
+              "network":   { "type": "string",  "example": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp" },
+              "description":{ "type": "string" }
+            }
+          },
+          "instructions": {
+            "type": "string",
+            "example": "Send Solana mainnet USDC, then retry with X-Solana-Tx: <signature>"
+          }
+        }
+      },
+      "ApiError": {
+        "type": "object",
+        "properties": {
+          "ok":     { "type": "boolean", "example": false },
+          "code":   { "type": "string" },
+          "error":  { "type": "string" },
+          "detail": { "type": "string" }
+        }
+      }
+    }
+  },
+  "paths": {
+    "/.well-known/x402.json": {
+      "get": {
+        "summary": "Service discovery manifest",
+        "operationId": "getDiscovery",
+        "description": "Returns the x402 discovery manifest listing all endpoints, prices, and supported networks.",
+        "responses": {
+          "200": {
+            "description": "Discovery manifest",
+            "content": {
+              "application/json": {
+                "schema": { "type": "object" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/vpn/regions": {
+      "get": {
+        "summary": "List available VPN regions",
+        "operationId": "listVpnRegions",
+        "responses": {
+          "200": {
+            "description": "Available regions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok":      { "type": "boolean" },
+                    "regions": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id":        { "$ref": "#/components/schemas/Region" },
+                          "city":      { "type": "string" },
+                          "continent": { "type": "string" }
+                        }
+                      }
+                    },
+                    "default": { "$ref": "#/components/schemas/Region" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/vpn/hour": {
+      "post": {
+        "summary": "Buy a 1-hour WireGuard VPN pass — $0.20 USDC",
+        "operationId": "vpnHour",
+        "x-x402-amount": "200000",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["clientWgPublicKey"],
+                "properties": {
+                  "region":            { "$ref": "#/components/schemas/Region", "default": "DE_NBG" },
+                  "clientWgPublicKey": { "type": "string", "description": "Base64-encoded X25519 WireGuard public key, generated client-side." }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          { "in": "header", "name": "X-Solana-Tx", "required": false, "schema": { "type": "string" }, "description": "Confirmed Solana transaction signature proving USDC payment." }
+        ],
+        "responses": {
+          "200": {
+            "description": "VPN provisioned",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok":    { "type": "boolean", "example": true },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ip":            { "type": "string", "example": "1.2.3.4" },
+                        "serverWgPubKey":{ "type": "string", "description": "Base64 X25519 server public key — use to build WireGuard [Peer] section." }
+                      }
+                    },
+                    "expiresAt": { "type": "string", "format": "date-time" }
+                  }
+                }
+              }
+            }
+          },
+          "402": { "description": "Payment required", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/PaymentRequired" } } } }
+        }
+      }
+    },
+    "/api/vpn/day": {
+      "post": {
+        "summary": "Buy a 24-hour WireGuard VPN pass — $0.79 USDC",
+        "operationId": "vpnDay",
+        "x-x402-amount": "790000",
+        "requestBody": { "$ref": "#/paths/~1api~1vpn~1hour/post/requestBody" },
+        "parameters": [ { "in": "header", "name": "X-Solana-Tx", "required": false, "schema": { "type": "string" } } ],
+        "responses": {
+          "200": { "$ref": "#/paths/~1api~1vpn~1hour/post/responses/200" },
+          "402": { "$ref": "#/paths/~1api~1vpn~1hour/post/responses/402" }
+        }
+      }
+    },
+    "/api/vpn/week": {
+      "post": {
+        "summary": "Buy a 7-day WireGuard VPN pass — $2.99 USDC",
+        "operationId": "vpnWeek",
+        "x-x402-amount": "2990000",
+        "requestBody": { "$ref": "#/paths/~1api~1vpn~1hour/post/requestBody" },
+        "parameters": [ { "in": "header", "name": "X-Solana-Tx", "required": false, "schema": { "type": "string" } } ],
+        "responses": {
+          "200": { "$ref": "#/paths/~1api~1vpn~1hour/post/responses/200" },
+          "402": { "$ref": "#/paths/~1api~1vpn~1hour/post/responses/402" }
+        }
+      }
+    },
+    "/api/vpn/month": {
+      "post": {
+        "summary": "Buy a 30-day WireGuard VPN pass — $7.99 USDC",
+        "operationId": "vpnMonth",
+        "x-x402-amount": "7990000",
+        "requestBody": { "$ref": "#/paths/~1api~1vpn~1hour/post/requestBody" },
+        "parameters": [ { "in": "header", "name": "X-Solana-Tx", "required": false, "schema": { "type": "string" } } ],
+        "responses": {
+          "200": { "$ref": "#/paths/~1api~1vpn~1hour/post/responses/200" },
+          "402": { "$ref": "#/paths/~1api~1vpn~1hour/post/responses/402" }
+        }
+      }
+    },
+    "/api/vps/regions": {
+      "get": {
+        "summary": "List available VPS regions",
+        "operationId": "listVpsRegions",
+        "responses": {
+          "200": {
+            "description": "Available regions with geo info",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok":      { "type": "boolean" },
+                    "regions": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id":        { "$ref": "#/components/schemas/Region" },
+                          "city":      { "type": "string" },
+                          "continent": { "type": "string" }
+                        }
+                      }
+                    },
+                    "default": { "$ref": "#/components/schemas/Region" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/vps/hour": {
+      "post": {
+        "summary": "Provision a 1-hour ephemeral Ubuntu VPS — $0.25 USDC",
+        "operationId": "vpsHour",
+        "x-x402-amount": "250000",
+        "description": "Returns the server IP and a base64 WireGuard client config template. Server is SSH-accessible ~60s after provisioning. Private key never leaves the client.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["sshPublicKey"],
+                "properties": {
+                  "region":       { "$ref": "#/components/schemas/Region", "default": "DE_NBG" },
+                  "sshPublicKey": { "type": "string", "description": "OpenSSH Ed25519 public key (ssh-ed25519 AAAA...). Generate client-side — private key never sent." }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          { "in": "header", "name": "X-Solana-Tx", "required": false, "schema": { "type": "string" }, "description": "Confirmed Solana transaction signature proving USDC payment." }
+        ],
+        "responses": {
+          "200": {
+            "description": "VPS provisioned",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok":    { "type": "boolean", "example": true },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ip":                  { "type": "string", "example": "5.6.7.8", "description": "Use: ssh -i key.pem root@<ip>" },
+                        "wireguardClientConf": { "type": "string", "description": "Base64-encoded WireGuard client config template for optional VPN access to the VPS." }
+                      }
+                    },
+                    "expiresAt": { "type": "string", "format": "date-time", "description": "Server is destroyed at this time." }
+                  }
+                }
+              }
+            }
+          },
+          "402": { "description": "Payment required", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/PaymentRequired" } } } }
+        }
+      }
+    },
+    "/api/vps/day": {
+      "post": {
+        "summary": "Provision a 24-hour ephemeral Ubuntu VPS — $0.99 USDC",
+          "operationId": "vpsDay",
+          "x-x402-amount": "990000",
+        "requestBody": { "$ref": "#/paths/~1api~1vps~1hour/post/requestBody" },
+        "parameters": [ { "in": "header", "name": "X-Solana-Tx", "required": false, "schema": { "type": "string" } } ],
+        "responses": {
+          "200": { "$ref": "#/paths/~1api~1vps~1hour/post/responses/200" },
+          "402": { "$ref": "#/paths/~1api~1vps~1hour/post/responses/402" }
+        }
+      }
+    },
+    "/api/vps/week": {
+      "post": {
+        "summary": "Provision a 7-day ephemeral Ubuntu VPS — $3.99 USDC",
+        "operationId": "vpsWeek",
+        "x-x402-amount": "3990000",
+        "requestBody": { "$ref": "#/paths/~1api~1vps~1hour/post/requestBody" },
+        "parameters": [ { "in": "header", "name": "X-Solana-Tx", "required": false, "schema": { "type": "string" } } ],
+        "responses": {
+          "200": { "$ref": "#/paths/~1api~1vps~1hour/post/responses/200" },
+          "402": { "$ref": "#/paths/~1api~1vps~1hour/post/responses/402" }
+        }
+      }
+    }
+  }
+}

--- a/providers/hfsp/vpn-x402/openapi.json
+++ b/providers/hfsp/vpn-x402/openapi.json
@@ -146,8 +146,10 @@
                     "data": {
                       "type": "object",
                       "properties": {
-                        "ip":            { "type": "string", "example": "1.2.3.4" },
-                        "serverWgPubKey":{ "type": "string", "description": "Base64 X25519 server public key — use to build WireGuard [Peer] section." }
+                        "ip":             { "type": "string", "example": "1.2.3.4", "description": "Server public IP — use as Endpoint host in WireGuard [Peer]." },
+                        "serverWgPubKey": { "type": "string", "description": "Server X25519 public key — use as PublicKey in WireGuard [Peer]." },
+                        "wgPort":         { "type": "integer", "example": 51820, "description": "WireGuard UDP port — use as Endpoint port in WireGuard [Peer]." },
+                        "clientTunnelIp": { "type": "string", "example": "10.8.0.2", "description": "Your assigned tunnel IP — use as Address in WireGuard [Interface]." }
                       }
                     },
                     "expiresAt": { "type": "string", "format": "date-time" }
@@ -269,7 +271,7 @@
                       "type": "object",
                       "properties": {
                         "ip":                  { "type": "string", "example": "5.6.7.8", "description": "Use: ssh -i key.pem root@<ip>" },
-                        "wireguardClientConf": { "type": "string", "description": "Base64-encoded WireGuard client config template for optional VPN access to the VPS." }
+                        "wireguardClientConf": { "type": "string", "description": "Base64-encoded WireGuard config template. Contains the server public key and endpoint pre-filled. You must: (1) generate your own WireGuard keypair, (2) replace the PrivateKey placeholder, (3) SSH into the VPS and add your public key as a peer with `wg set wg0 peer <your-pubkey> allowed-ips 10.9.0.2/32`." }
                       }
                     },
                     "expiresAt": { "type": "string", "format": "date-time", "description": "Server is destroyed at this time." }

--- a/providers/hfsp/vpn-x402/openapi.json
+++ b/providers/hfsp/vpn-x402/openapi.json
@@ -63,7 +63,7 @@
   "paths": {
     "/.well-known/x402.json": {
       "get": {
-        "summary": "Service discovery manifest",
+        "summary": "Fetch service discovery manifest",
         "operationId": "getDiscovery",
         "description": "Returns the x402 discovery manifest listing all endpoints, prices, and supported networks.",
         "responses": {
@@ -113,7 +113,7 @@
     },
     "/api/vpn/hour": {
       "post": {
-        "summary": "Buy a 1-hour WireGuard VPN pass — $0.20 USDC",
+        "summary": "Buy a 1-hour WireGuard VPN pass - $0.20 USDC",
         "operationId": "vpnHour",
         "x-x402-amount": "200000",
         "requestBody": {
@@ -164,11 +164,11 @@
     },
     "/api/vpn/day": {
       "post": {
-        "summary": "Buy a 24-hour WireGuard VPN pass — $0.79 USDC",
+        "summary": "Buy a 24-hour WireGuard VPN pass - $0.79 USDC",
         "operationId": "vpnDay",
         "x-x402-amount": "790000",
         "requestBody": { "$ref": "#/paths/~1api~1vpn~1hour/post/requestBody" },
-        "parameters": [ { "in": "header", "name": "X-Solana-Tx", "required": false, "schema": { "type": "string" } } ],
+        "parameters": [ { "in": "header", "name": "X-Solana-Tx", "required": false, "schema": { "type": "string" }, "description": "Confirmed Solana transaction signature proving USDC payment." } ],
         "responses": {
           "200": { "$ref": "#/paths/~1api~1vpn~1hour/post/responses/200" },
           "402": { "$ref": "#/paths/~1api~1vpn~1hour/post/responses/402" }
@@ -177,11 +177,11 @@
     },
     "/api/vpn/week": {
       "post": {
-        "summary": "Buy a 7-day WireGuard VPN pass — $2.99 USDC",
+        "summary": "Buy a 7-day WireGuard VPN pass - $2.99 USDC",
         "operationId": "vpnWeek",
         "x-x402-amount": "2990000",
         "requestBody": { "$ref": "#/paths/~1api~1vpn~1hour/post/requestBody" },
-        "parameters": [ { "in": "header", "name": "X-Solana-Tx", "required": false, "schema": { "type": "string" } } ],
+        "parameters": [ { "in": "header", "name": "X-Solana-Tx", "required": false, "schema": { "type": "string" }, "description": "Confirmed Solana transaction signature proving USDC payment." } ],
         "responses": {
           "200": { "$ref": "#/paths/~1api~1vpn~1hour/post/responses/200" },
           "402": { "$ref": "#/paths/~1api~1vpn~1hour/post/responses/402" }
@@ -190,11 +190,11 @@
     },
     "/api/vpn/month": {
       "post": {
-        "summary": "Buy a 30-day WireGuard VPN pass — $7.99 USDC",
+        "summary": "Buy a 30-day WireGuard VPN pass - $7.99 USDC",
         "operationId": "vpnMonth",
         "x-x402-amount": "7990000",
         "requestBody": { "$ref": "#/paths/~1api~1vpn~1hour/post/requestBody" },
-        "parameters": [ { "in": "header", "name": "X-Solana-Tx", "required": false, "schema": { "type": "string" } } ],
+        "parameters": [ { "in": "header", "name": "X-Solana-Tx", "required": false, "schema": { "type": "string" }, "description": "Confirmed Solana transaction signature proving USDC payment." } ],
         "responses": {
           "200": { "$ref": "#/paths/~1api~1vpn~1hour/post/responses/200" },
           "402": { "$ref": "#/paths/~1api~1vpn~1hour/post/responses/402" }
@@ -236,7 +236,7 @@
     },
     "/api/vps/hour": {
       "post": {
-        "summary": "Provision a 1-hour ephemeral Ubuntu VPS — $0.25 USDC",
+        "summary": "Provision a 1-hour ephemeral Ubuntu VPS - $0.25 USDC",
         "operationId": "vpsHour",
         "x-x402-amount": "250000",
         "description": "Returns the server IP and a base64 WireGuard client config template. Server is SSH-accessible ~60s after provisioning. Private key never leaves the client.",
@@ -286,11 +286,11 @@
     },
     "/api/vps/day": {
       "post": {
-        "summary": "Provision a 24-hour ephemeral Ubuntu VPS — $0.99 USDC",
-          "operationId": "vpsDay",
-          "x-x402-amount": "990000",
+        "summary": "Provision a 24-hour ephemeral Ubuntu VPS - $0.99 USDC",
+        "operationId": "vpsDay",
+        "x-x402-amount": "990000",
         "requestBody": { "$ref": "#/paths/~1api~1vps~1hour/post/requestBody" },
-        "parameters": [ { "in": "header", "name": "X-Solana-Tx", "required": false, "schema": { "type": "string" } } ],
+        "parameters": [ { "in": "header", "name": "X-Solana-Tx", "required": false, "schema": { "type": "string" }, "description": "Confirmed Solana transaction signature proving USDC payment." } ],
         "responses": {
           "200": { "$ref": "#/paths/~1api~1vps~1hour/post/responses/200" },
           "402": { "$ref": "#/paths/~1api~1vps~1hour/post/responses/402" }
@@ -299,11 +299,11 @@
     },
     "/api/vps/week": {
       "post": {
-        "summary": "Provision a 7-day ephemeral Ubuntu VPS — $3.99 USDC",
+        "summary": "Provision a 7-day ephemeral Ubuntu VPS - $3.99 USDC",
         "operationId": "vpsWeek",
         "x-x402-amount": "3990000",
         "requestBody": { "$ref": "#/paths/~1api~1vps~1hour/post/requestBody" },
-        "parameters": [ { "in": "header", "name": "X-Solana-Tx", "required": false, "schema": { "type": "string" } } ],
+        "parameters": [ { "in": "header", "name": "X-Solana-Tx", "required": false, "schema": { "type": "string" }, "description": "Confirmed Solana transaction signature proving USDC payment." } ],
         "responses": {
           "200": { "$ref": "#/paths/~1api~1vps~1hour/post/responses/200" },
           "402": { "$ref": "#/paths/~1api~1vps~1hour/post/responses/402" }


### PR DESCRIPTION
## Summary

Adds **HFSP VPN x402** to the pay-skills catalog — anonymous WireGuard VPN passes and ephemeral Ubuntu VPS servers, payable with Solana USDC via the x402 protocol.

- **FQN:** `hfsp/vpn-x402`
- **Service URL:** https://vpn.hfsp.cloud
- **Category:** `cloud`
- **Network:** Solana mainnet (`solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp`)
- **Asset:** USDC (`EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`, 6 decimals)
- **Recipient:** `GdAWRcvrVabFi6QtciGJNYsS8cykJkZTNZ3cFea6ywfY`

## Endpoints

| Path | Price | Duration |
|------|-------|----------|
| `POST /api/vpn/hour`  | $0.20 USDC | WireGuard VPN 1h |
| `POST /api/vpn/day`   | $0.79 USDC | WireGuard VPN 24h |
| `POST /api/vpn/week`  | $2.99 USDC | WireGuard VPN 7d |
| `POST /api/vpn/month` | $7.99 USDC | WireGuard VPN 30d |
| `POST /api/vps/hour`  | $0.25 USDC | Ephemeral Ubuntu VPS 1h |
| `POST /api/vps/day`   | $0.79 USDC | Ephemeral Ubuntu VPS 24h |
| `POST /api/vps/week`  | $3.99 USDC | Ephemeral Ubuntu VPS 7d |

## Payment flow

```
1. POST /api/vpn/week  { region, clientWgPublicKey }
2. ← 402  { pay: { amount, mint, payTo, network } }
3. Send USDC on Solana mainnet
4. POST /api/vpn/week  X-Solana-Tx: <confirmed-sig>
5. ← 200  { ip, serverWgPubKey, expiresAt }
```

## Privacy model

- VPN: SSH port fully closed — zero operator access
- VPS: only client-generated SSH public key in `authorized_keys` — operator never sees private key
- No logs of IPs, payment amounts, or provisioning details
- Servers auto-destroyed at `expiresAt` by cron

## Regions

`DE_NBG` · `FI_HEL` · `US_HIL` · `SG_SIN`

## Discovery

- `GET https://vpn.hfsp.cloud/.well-known/x402.json`
- `GET https://vpn.hfsp.cloud/openapi.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)