### PR TITLE
feat: add hfsp-store — gift cards, top-ups & eSIMs via x402 (Solana USDC)

### DIFF
--- a/providers/hfsp/hfsp-store/PAY.md
+++ b/providers/hfsp/hfsp-store/PAY.md
@@ -1,0 +1,59 @@
+---
+name: hfsp-store
+title: "HFSP Store"
+description: "Buy gift cards, mobile top-ups, and eSIMs from 10,500+ brands in 180+ countries. Pay USDC on Solana. No account required. Powered by Cryptorefills."
+use_case: "Use for purchasing gift cards (Amazon, Google Play, Steam, iTunes, etc.), mobile top-ups, and eSIM data plans with Solana USDC. Browse brands by country, get a live price quote, then pay and receive the code instantly."
+category: shopping
+service_url: https://store.hfsp.cloud
+openapi:
+  path: openapi.json
+---
+
+Pay-per-purchase gift cards, mobile top-ups, and eSIMs for AI agents. One POST
+returns a voucher code or top-up confirmation — no accounts, no API keys.
+
+Payment is Solana mainnet USDC via the x402 protocol. The store returns a 402
+with the exact USDC amount (Cryptorefills base price + 2.5% commission). Send
+the payment, retry with `X-Solana-Tx: <confirmed-signature>`, receive the code.
+
+## Flow
+
+```
+GET /api/brands?country_code=us
+→ 200  [{ "brand_name": "Amazon.com", ... }, ...]
+
+GET /api/catalog?country_code=us&brand_name=Amazon.com
+→ 200  [{ "product_id": "...", "price_usdc": 10.25, ... }, ...]
+
+POST /api/orders
+{ "email": "agent@example.com", "items": [{ "product_id": "..." }] }
+
+→ 402  { pay: { amount: 10512820, amountUsd: "10.51", payTo: "FEuTe..." } }
+→ (send USDC on Solana mainnet)
+→ POST /api/orders  X-Solana-Tx: <signature>
+→ 200  { data: { order_id: "...", deliveries: [{ voucher_code: "XXXX-YYYY" }] } }
+```
+
+For async orders, poll `GET /api/orders/{id}` until `status: completed`.
+
+## Catalog coverage
+
+- **Gift cards:** Amazon, Google Play, Steam, iTunes, Netflix, Xbox, PlayStation, and thousands more
+- **Mobile top-ups:** Prepaid recharges in 180+ countries
+- **eSIMs:** Data plans for travel
+
+## Payment details
+
+- **Network:** Solana mainnet (`solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp`)
+- **Asset:** USDC (`EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`, 6 decimals)
+- **Recipient:** `FEuTewmn9RdwexQnhvkCq7VaXfpnQL9qsYrTrCgTtk5e`
+- **Header:** `X-Solana-Tx: <confirmed transaction signature>`
+
+## Spend-aware usage
+
+- Call `GET /api/brands` first to confirm brand availability in the target country before placing an order.
+- Call `GET /api/catalog` to get the exact `product_id` and see if the product has a fixed price or accepts a `product_value` range.
+- The 402 response includes `pay.amountUsd` — confirm this matches expectations before sending USDC.
+- Each transaction signature is single-use; a replay returns 402 immediately.
+- For range products (mobile top-ups), pass `product_value` in the order body.
+- If `status: processing` is returned, poll `GET /api/orders/{id}` — most orders complete within 30 seconds.

--- a/providers/hfsp/hfsp-store/openapi.json
+++ b/providers/hfsp/hfsp-store/openapi.json
@@ -140,7 +140,10 @@
                                                 "type": "string"
                                             },
                                             "price_usdc": {
-                                                "type": "number",
+                                                "type": [
+                                                    "number",
+                                                    "null"
+                                                ],
                                                 "description": "Fixed price in USD (USDC). Null for range products."
                                             },
                                             "is_range": {
@@ -149,11 +152,11 @@
                                             },
                                             "min_value": {
                                                 "type": "number",
-                                                "description": "Minimum value (USD) for range products"
+                                                "description": "Minimum value in the product's local currency for range products"
                                             },
                                             "max_value": {
                                                 "type": "number",
-                                                "description": "Maximum value (USD) for range products"
+                                                "description": "Maximum value in the product's local currency for range products"
                                             },
                                             "currency": {
                                                 "type": "string",
@@ -226,7 +229,7 @@
                                                 },
                                                 "product_value": {
                                                     "type": "number",
-                                                    "description": "Amount in local currency for range products"
+                                                    "description": "Amount in the product's local currency for range products; must fall between min_value and max_value from /api/catalog"
                                                 },
                                                 "beneficiary_account": {
                                                     "type": "string",

--- a/providers/hfsp/hfsp-store/openapi.json
+++ b/providers/hfsp/hfsp-store/openapi.json
@@ -1,0 +1,336 @@
+{
+    "openapi": "3.1.0",
+    "info": {
+        "title": "HFSP Store x402 (Solana)",
+        "version": "1.0.0",
+        "description": "Gift cards, mobile top-ups, and eSIMs for AI agents. 10,500+ brands, 180+ countries. Powered by Cryptorefills. Pay USDC on Solana mainnet via x402 v2. No account, no API key. Commission: 2.5% added to Cryptorefills catalog price. Flow: 1) GET /api/brands or /api/catalog to discover products. 2) POST /api/orders \u2192 402 with pay.amount and pay.payTo. 3) Send Solana mainnet USDC to pay.payTo (mint: EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v). 4) Wait for confirmation, retry POST with X-Solana-Tx: <signature>. 5) Receive gift card code in 200 response. 6) Poll GET /api/orders/{id} until status=completed if delivery is async.",
+        "contact": {
+            "email": "info@hfsp.xyz",
+            "url": "https://hfsp.xyz"
+        }
+    },
+    "x-discovery": {
+        "ownershipProofs": []
+    },
+    "servers": [
+        {
+            "url": "https://store.hfsp.cloud"
+        }
+    ],
+    "tags": [
+        {
+            "name": "Catalog",
+            "description": "Browse brands and products (free, no payment)"
+        },
+        {
+            "name": "Orders",
+            "description": "Place and track orders (x402 payment required)"
+        }
+    ],
+    "paths": {
+        "/api/brands": {
+            "get": {
+                "operationId": "get-brands",
+                "summary": "List available brands for a country",
+                "tags": [
+                    "Catalog"
+                ],
+                "parameters": [
+                    {
+                        "name": "country_code",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "example": "us"
+                        },
+                        "description": "Lowercase ISO 3166-1 Alpha-2 country code (e.g. us, gb, de)"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Array of brand objects",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/catalog": {
+            "get": {
+                "operationId": "get-catalog",
+                "summary": "List products for a brand",
+                "tags": [
+                    "Catalog"
+                ],
+                "parameters": [
+                    {
+                        "name": "country_code",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "example": "us"
+                        }
+                    },
+                    {
+                        "name": "brand_name",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "example": "Amazon.com"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Array of products with product_id, price_usdc, is_range, etc.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/orders": {
+            "post": {
+                "operationId": "create-order",
+                "summary": "Buy a gift card, top-up, or eSIM",
+                "tags": [
+                    "Orders"
+                ],
+                "x-payment-info": {
+                    "price": {
+                        "mode": "dynamic",
+                        "currency": "USD",
+                        "note": "Price determined by product. Check pay.amountUsd in 402 response."
+                    },
+                    "protocols": [
+                        {
+                            "x402": {
+                                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                                "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                                "payTo": "FEuTewmn9RdwexQnhvkCq7VaXfpnQL9qsYrTrCgTtk5e",
+                                "header": "X-Solana-Tx",
+                                "note": "Send confirmed Solana mainnet USDC, retry with X-Solana-Tx: <signature>"
+                            }
+                        }
+                    ]
+                },
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "email",
+                                    "items"
+                                ],
+                                "properties": {
+                                    "email": {
+                                        "type": "string",
+                                        "format": "email",
+                                        "description": "Delivery email for the gift card / top-up"
+                                    },
+                                    "items": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object",
+                                            "required": [
+                                                "product_id"
+                                            ],
+                                            "properties": {
+                                                "product_id": {
+                                                    "type": "string",
+                                                    "description": "Product ID from /api/catalog"
+                                                },
+                                                "product_value": {
+                                                    "type": "number",
+                                                    "description": "Amount in local currency for range products"
+                                                },
+                                                "beneficiary_account": {
+                                                    "type": "string",
+                                                    "description": "Delivery email or account (if different from order email)"
+                                                }
+                                            }
+                                        },
+                                        "minItems": 1,
+                                        "maxItems": 10
+                                    },
+                                    "callback_url": {
+                                        "type": "string",
+                                        "format": "uri",
+                                        "description": "Optional webhook for delivery notification"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Order placed. May include immediate gift card delivery or order_id for polling.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "ok": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "data": {
+                                            "type": "object",
+                                            "properties": {
+                                                "order_id": {
+                                                    "type": "string"
+                                                },
+                                                "status": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "processing",
+                                                        "completed",
+                                                        "failed"
+                                                    ]
+                                                },
+                                                "estimated_delivery_seconds": {
+                                                    "type": "integer"
+                                                },
+                                                "poll_url": {
+                                                    "type": "string"
+                                                },
+                                                "deliveries": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "voucher_code": {
+                                                                "type": "string"
+                                                            },
+                                                            "pin": {
+                                                                "type": "string"
+                                                            },
+                                                            "url": {
+                                                                "type": "string"
+                                                            },
+                                                            "brand_name": {
+                                                                "type": "string"
+                                                            },
+                                                            "product_name": {
+                                                                "type": "string"
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "402": {
+                        "description": "Payment Required \u2014 x402 v2 challenge. PAYMENT-REQUIRED header contains base64(JSON). Pay USDC on Solana, retry with X-Solana-Tx.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "x402Version": {
+                                            "type": "integer",
+                                            "example": 2
+                                        },
+                                        "accepts": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object"
+                                            }
+                                        },
+                                        "resource": {
+                                            "type": "object"
+                                        },
+                                        "pay": {
+                                            "type": "object",
+                                            "properties": {
+                                                "amount": {
+                                                    "type": "integer",
+                                                    "description": "Atomic USDC units (6 decimals)"
+                                                },
+                                                "amountUsd": {
+                                                    "type": "string",
+                                                    "description": "Human-readable USD amount"
+                                                },
+                                                "crAmount": {
+                                                    "type": "integer",
+                                                    "description": "Cryptorefills base price (atomic)"
+                                                },
+                                                "crAmountUsd": {
+                                                    "type": "string",
+                                                    "description": "Cryptorefills base price (USD)"
+                                                },
+                                                "commissionUsd": {
+                                                    "type": "string",
+                                                    "description": "HFSP Store commission (USD)"
+                                                },
+                                                "payTo": {
+                                                    "type": "string",
+                                                    "description": "Solana wallet to send USDC to"
+                                                },
+                                                "instructions": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/orders/{id}": {
+            "get": {
+                "operationId": "get-order",
+                "summary": "Poll order status and retrieve gift card when ready",
+                "tags": [
+                    "Orders"
+                ],
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "order_id from POST /api/orders response"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Order status and deliveries if completed",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/providers/hfsp/hfsp-store/openapi.json
+++ b/providers/hfsp/hfsp-store/openapi.json
@@ -213,6 +213,7 @@
                                     },
                                     "items": {
                                         "type": "array",
+                                        "description": "Line items to purchase in this order (1-10). Each item needs a product_id from /api/catalog; range products (is_range=true) also require product_value.",
                                         "items": {
                                             "type": "object",
                                             "required": [

--- a/providers/hfsp/hfsp-store/openapi.json
+++ b/providers/hfsp/hfsp-store/openapi.json
@@ -9,14 +9,26 @@
             "url": "https://hfsp.xyz"
         }
     },
-    "x-discovery": {
-        "ownershipProofs": []
-    },
     "servers": [
         {
             "url": "https://store.hfsp.cloud"
         }
     ],
+    "security": [
+        {
+            "x402": []
+        }
+    ],
+    "components": {
+        "securitySchemes": {
+            "x402": {
+                "type": "apiKey",
+                "in": "header",
+                "name": "X-Solana-Tx",
+                "description": "x402 v2 payment. Send confirmed Solana mainnet USDC to the address in the 402 response, then retry with X-Solana-Tx: <signature>."
+            }
+        }
+    },
     "tags": [
         {
             "name": "Catalog",
@@ -35,6 +47,7 @@
                 "tags": [
                     "Catalog"
                 ],
+                "security": [],
                 "parameters": [
                     {
                         "name": "country_code",
@@ -53,7 +66,24 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "type": "array"
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "brand_name": {
+                                                "type": "string",
+                                                "description": "Brand display name, use as brand_name in /api/catalog"
+                                            },
+                                            "country_code": {
+                                                "type": "string",
+                                                "description": "ISO 3166-1 Alpha-2 country code"
+                                            },
+                                            "category": {
+                                                "type": "string",
+                                                "description": "Brand category (e.g. gaming, shopping, telecom)"
+                                            }
+                                        }
+                                    }
                                 }
                             }
                         }
@@ -68,6 +98,7 @@
                 "tags": [
                     "Catalog"
                 ],
+                "security": [],
                 "parameters": [
                     {
                         "name": "country_code",
@@ -94,7 +125,45 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "type": "array"
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "product_id": {
+                                                "type": "string",
+                                                "description": "Use this value in POST /api/orders items[].product_id"
+                                            },
+                                            "brand_name": {
+                                                "type": "string"
+                                            },
+                                            "product_name": {
+                                                "type": "string"
+                                            },
+                                            "price_usdc": {
+                                                "type": "number",
+                                                "description": "Fixed price in USD (USDC). Null for range products."
+                                            },
+                                            "is_range": {
+                                                "type": "boolean",
+                                                "description": "If true, pass product_value in the order body"
+                                            },
+                                            "min_value": {
+                                                "type": "number",
+                                                "description": "Minimum value (USD) for range products"
+                                            },
+                                            "max_value": {
+                                                "type": "number",
+                                                "description": "Maximum value (USD) for range products"
+                                            },
+                                            "currency": {
+                                                "type": "string",
+                                                "description": "Local currency code for range products"
+                                            },
+                                            "country_code": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
                                 }
                             }
                         }
@@ -120,9 +189,8 @@
                             "x402": {
                                 "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
                                 "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
-                                "payTo": "FEuTewmn9RdwexQnhvkCq7VaXfpnQL9qsYrTrCgTtk5e",
                                 "header": "X-Solana-Tx",
-                                "note": "Send confirmed Solana mainnet USDC, retry with X-Solana-Tx: <signature>"
+                                "note": "Send confirmed Solana mainnet USDC to the payTo address in the 402 response body, then retry with X-Solana-Tx: <signature>."
                             }
                         }
                     ]
@@ -307,6 +375,7 @@
                 "tags": [
                     "Orders"
                 ],
+                "security": [],
                 "parameters": [
                     {
                         "name": "id",
@@ -324,10 +393,57 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "type": "object"
+                                    "type": "object",
+                                    "properties": {
+                                        "ok": {
+                                            "type": "boolean"
+                                        },
+                                        "data": {
+                                            "type": "object",
+                                            "properties": {
+                                                "order_id": {
+                                                    "type": "string"
+                                                },
+                                                "status": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "processing",
+                                                        "completed",
+                                                        "failed"
+                                                    ]
+                                                },
+                                                "deliveries": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "voucher_code": {
+                                                                "type": "string"
+                                                            },
+                                                            "pin": {
+                                                                "type": "string"
+                                                            },
+                                                            "url": {
+                                                                "type": "string"
+                                                            },
+                                                            "brand_name": {
+                                                                "type": "string"
+                                                            },
+                                                            "product_name": {
+                                                                "type": "string"
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
                                 }
                             }
                         }
+                    },
+                    "404": {
+                        "description": "Order not found"
                     }
                 }
             }

--- a/providers/hfsp/hfsp-store/openapi.json
+++ b/providers/hfsp/hfsp-store/openapi.json
@@ -262,7 +262,8 @@
                                             "type": "object",
                                             "properties": {
                                                 "order_id": {
-                                                    "type": "string"
+                                                    "type": "string",
+                                                    "description": "Cryptorefills-issued UUID v4. Treat as a bearer token \u2014 anyone with this ID can poll the order and retrieve voucher codes. Store securely."
                                                 },
                                                 "status": {
                                                     "type": "string",
@@ -384,7 +385,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "order_id from POST /api/orders response"
+                        "description": "order_id from POST /api/orders response. This is a Cryptorefills UUID v4 that acts as a bearer token \u2014 keep it private."
                     }
                 ],
                 "responses": {


### PR DESCRIPTION
## Provider: HFSP Store

Gift cards, mobile top-ups, and eSIMs from 10,500+ brands in 180+ countries — paid with Solana USDC via x402.

**Service URL:** https://store.hfsp.cloud
**OpenAPI:** https://store.hfsp.cloud/openapi.json
**x402 manifest:** https://store.hfsp.cloud/.well-known/x402

## What agents can buy

- Gift cards (Amazon, Google Play, Steam, iTunes, Netflix, Xbox, PlayStation, and thousands more)
- Mobile top-ups (prepaid recharges in 180+ countries)
- eSIMs (data plans for travel)

## Payment

- Network: Solana mainnet
- Asset: USDC (6 decimals)
- Protocol: x402 v2 — send USDC, retry with `X-Solana-Tx: <signature>`
- Price: Cryptorefills catalog price + 2.5% commission (dynamic per product, quoted in 402 response)

## Flow

1. `GET /api/brands?country_code=us` — browse available brands
2. `GET /api/catalog?country_code=us&brand_name=Amazon.com` — list products with prices
3. `POST /api/orders` → 402 with exact USDC amount
4. Send USDC on Solana mainnet, retry with `X-Solana-Tx`
5. Receive voucher code in 200 response