### PR TITLE
Add Sivut SEC crypto filings provider

### DIFF
--- a/providers/sivut/sec-crypto-filings/PAY.md
+++ b/providers/sivut/sec-crypto-filings/PAY.md
@@ -1,0 +1,27 @@
+---
+name: sec-crypto-filings
+title: "Sivut SEC Crypto Filings"
+description: "USDC-paid SEC EDGAR crypto filing radar for public-company bitcoin treasury, digital-asset, stablecoin, mining, blockchain, and crypto disclosure monitoring."
+use_case: "Use for fresh SEC filing due diligence, crypto treasury monitoring, public-company digital-asset disclosure checks, and analyst-ready filing provenance."
+category: finance
+service_url: https://pay.sivut.co
+version: "2026-06-10"
+openapi:
+  path: openapi.json
+---
+
+Sivut SEC Crypto Filings returns a buyer-ready package of current public
+SEC EDGAR filings that mention crypto, bitcoin, digital assets,
+stablecoins, mining, blockchain, or related treasury signals.
+
+The listed endpoint is x402-gated at $10 USDC on Solana mainnet and
+returns filing metadata, signal summaries, source URLs, snippets, source
+hashes, provenance, and integration notes.
+
+## Spend-Aware Usage
+
+- Use `limit=25` for the normal buyer pack and lower limits when testing.
+- Reuse `accession`, `source_hash`, and `primary_doc_url` values from the
+  response before paying for repeat checks.
+- Use the free sample endpoint at `https://pay.sivut.co/api/public-data/sec-crypto-filings/sample?limit=3`
+  to inspect freshness before making a paid call.

--- a/providers/sivut/sec-crypto-filings/openapi.json
+++ b/providers/sivut/sec-crypto-filings/openapi.json
@@ -1,0 +1,287 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Sivut SEC Crypto Filings",
+    "version": "2026-06-10",
+    "description": "USDC-paid SEC EDGAR crypto filing radar for public-company crypto, bitcoin treasury, digital-asset, stablecoin, mining, and blockchain disclosure monitoring.",
+    "contact": {
+      "name": "Sivut",
+      "email": "contact@sivut.co",
+      "url": "https://pay.sivut.co"
+    }
+  },
+  "servers": [
+    {
+      "url": "https://pay.sivut.co"
+    }
+  ],
+  "paths": {
+    "/api/solana/sec-crypto-filings/buyer-pack": {
+      "get": {
+        "operationId": "getSolanaSecCryptoFilingBuyerPack",
+        "summary": "Get a paid SEC crypto filing buyer pack",
+        "description": "Return a buyer-ready SEC EDGAR crypto filing package with current filings, signal and company summaries, provenance, source hashes, and integration notes. This endpoint requires x402 payment in USDC on Solana mainnet.",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of current filing records to include.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 50,
+              "default": 25
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paid SEC crypto filing buyer pack",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SecCryptoFilingBuyerPack"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required. Sign and retry with the PAYMENT-SIGNATURE header for the Solana mainnet USDC x402 challenge.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentRequired"
+                }
+              }
+            }
+          }
+        },
+        "x-agentcash-auth": {
+          "mode": "paid"
+        },
+        "x-payment-required": true,
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$10.00",
+          "settlementCurrency": "USDC",
+          "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+          "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+          "payTo": "4kRQGA5ciAXNSiDNo3nVQYRM5SSCCRwUw8boAV1xRPSM",
+          "paymentHeader": "PAYMENT-SIGNATURE"
+        },
+        "security": [
+          {
+            "x402": []
+          }
+        ]
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "x402": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "PAYMENT-SIGNATURE",
+        "description": "Base64-encoded x402 payment payload for the Solana mainnet USDC challenge."
+      }
+    },
+    "schemas": {
+      "PaymentRequired": {
+        "type": "object",
+        "required": [
+          "x402Version",
+          "resource",
+          "accepts",
+          "error"
+        ],
+        "properties": {
+          "x402Version": {
+            "type": "integer",
+            "const": 2
+          },
+          "resource": {
+            "type": "object",
+            "properties": {
+              "url": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "mimeType": {
+                "type": "string"
+              }
+            }
+          },
+          "accepts": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "scheme": {
+                  "type": "string",
+                  "const": "exact"
+                },
+                "network": {
+                  "type": "string",
+                  "const": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
+                },
+                "amount": {
+                  "type": "string",
+                  "const": "10000000"
+                },
+                "payTo": {
+                  "type": "string"
+                },
+                "asset": {
+                  "type": "string",
+                  "const": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+                }
+              },
+              "additionalProperties": true
+            }
+          },
+          "error": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": true
+      },
+      "SecCryptoFilingBuyerPack": {
+        "type": "object",
+        "required": [
+          "checkedAt",
+          "product",
+          "summary",
+          "integration",
+          "topFilings",
+          "filings"
+        ],
+        "properties": {
+          "checkedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "product": {
+            "type": "string",
+            "const": "public-sec-crypto-filing-buyer-pack"
+          },
+          "paidBy": {
+            "type": "string"
+          },
+          "payment": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "price": {
+            "type": "string"
+          },
+          "summary": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "integration": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "recommendedUseCases": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "caveats": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "sources": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "topFilings": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SecCryptoFiling"
+            }
+          },
+          "filings": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SecCryptoFiling"
+            }
+          }
+        },
+        "additionalProperties": true
+      },
+      "SecCryptoFiling": {
+        "type": "object",
+        "required": [
+          "company",
+          "form",
+          "filing_date",
+          "accession",
+          "signals",
+          "source_hash"
+        ],
+        "properties": {
+          "company": {
+            "type": "string"
+          },
+          "ticker": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "tickers": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "cik": {
+            "type": "string"
+          },
+          "form": {
+            "type": "string"
+          },
+          "filing_date": {
+            "type": "string"
+          },
+          "accession": {
+            "type": "string"
+          },
+          "primary_doc_url": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "signals": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "snippet": {
+            "type": "string"
+          },
+          "source_hash": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": true
+      }
+    }
+  }
+}

--- a/providers/sivut/sec-crypto-filings/openapi.json
+++ b/providers/sivut/sec-crypto-filings/openapi.json
@@ -209,12 +209,14 @@
             }
           },
           "topFilings": {
+            "description": "A compact subset of the highest-signal filings intended for quick analyst review.",
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/SecCryptoFiling"
             }
           },
           "filings": {
+            "description": "The full filing record list returned for the requested limit.",
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/SecCryptoFiling"
@@ -256,7 +258,8 @@
             "type": "string"
           },
           "filing_date": {
-            "type": "string"
+            "type": "string",
+            "format": "date"
           },
           "accession": {
             "type": "string"


### PR DESCRIPTION
Adds `sivut/sec-crypto-filings`, a Solana USDC x402-paid SEC EDGAR crypto filing radar buyer-pack endpoint.

Validation run locally:

```bash
npx --yes @solana/pay@latest catalog check providers/sivut/sec-crypto-filings/PAY.md -v
```

Result:

```text
providers/sivut/sec-crypto-filings OK
GET api/solana/sec-crypto-filings/buyer-pack OK 402 x402 USDC
Solana-compat verdict: PASS (1/1)
PAY.md check successful
```

Notes:
- OpenAPI is committed next to `PAY.md` per the current contribution guide.
- The listed endpoint is priced at $10 USDC on Solana mainnet and returns a buyer-ready SEC crypto filing package with provenance, summaries, source URLs, and source hashes.
- A free freshness sample is linked in `PAY.md` for pre-payment inspection.