### PR TITLE
feat: add scry/wallet-intel provider

### DIFF
--- a/providers/scry/wallet-intel/PAY.md
+++ b/providers/scry/wallet-intel/PAY.md
@@ -1,0 +1,88 @@
+---
+name: wallet-intel
+title: "Scry Wallet Intelligence"
+description: "Solana wallet-intelligence and forensic evidence API for agents: wallet screening, counterparty graphs, funding lineage, bundler and private-routing checks, transfer history, PnL context, Pump.fun cohorts, mint risk, and priority fees."
+use_case: "Use for Solana wallet due diligence, transfer and transaction review, counterparty or cluster analysis, funding-source tracing, bundler detection, Pump.fun launch screening, mint-risk preflight, watchlists, and wallet monitoring."
+category: finance
+service_url: https://scry.solanahub.de
+openapi:
+  path: openapi.json
+---
+
+Scry Wallet Intelligence exposes 17 x402-paid Solana evidence products from a
+$0.001 wallet quick-flag through a $0.30 Pump.fun launch dossier. It covers
+single-wallet screening, pairwise connection evidence, counterparty and cluster
+context, funding lineage, bundler or private-routing hints, transfers, PnL
+context, watchlists, mint risk, wallet cohorts, and priority-fee estimates.
+
+Responses are evidence-only: they include coverage, confidence, freshness,
+field provenance, methodology, and spend guidance without returning a trading
+recommendation or risk verdict. Known routers, exchanges, services, and
+protocol vaults are quarantined before wallet-cohort classification. No API
+keys or subscriptions are required. The payment challenge supports Solana USDC
+and a Base USDC fallback.
+
+## Choose the smallest sufficient product
+
+| Need | Start with | Price |
+|---|---|---:|
+| One-wallet triage | `GET /x402/wallet/{address}/quick-flag` | $0.001 |
+| Canonical wallet PnL evidence | `GET /x402/wallet/{address}/pnl` | $0.002 |
+| Current Solana priority-fee estimate | `GET /x402/network/priority-fees-live` | $0.005 |
+| Bundler or private-routing evidence | `GET /x402/wallet/{address}/bundler-check` | $0.01 |
+| Funding source or upstream-funder trace | `GET /x402/wallet/{address}/lineage` | $0.03 |
+| One-mint evidence preflight | `GET /x402/mint/{mint}/risk` | $0.03 |
+| Product-routing brief for an agent | `GET /x402/solana/agent-intel-brief` | $0.03 |
+| Evidence connecting two known wallets | `GET /x402/wallet/connection` | $0.04 |
+| One-wallet forensic dossier | `GET /x402/wallet/{address}/forensics` | $0.05 |
+| Launch-window coordination evidence | `GET /x402/wallet/{address}/launch-window-cluster` | $0.05 |
+| Up to 25 monitored wallets | `GET /x402/wallet/watchlist-snapshot` | $0.05 |
+| Pump.fun wallet-cohort evidence | `GET /x402/solana/pumpfun-risk-protection` | $0.05 |
+| Daily wallet shortlist | `GET /x402/solana/hot-wallets/daily` | $0.10 |
+| Recent transfer evidence | `GET /x402/wallet/{address}/transfer-tape` | $0.15 |
+| Broad one-wallet context bundle | `GET /x402/wallet/{address}/full-context-pro` | $0.18 |
+| Weekly persistent-wallet shortlist | `GET /x402/solana/persistent-wallets/weekly` | $0.20 |
+| Composite Pump.fun launch dossier | `GET /x402/pumpfun/launch-dossier` | $0.30 |
+
+## Where Scry fits
+
+Use Scry when the task is Solana wallet evidence: funding lineage, pairwise or
+cluster relationships, bundler/private-routing traces, launch-window context,
+transfer review, or a provenance-aware wallet dossier. Use a broad market-data
+provider instead when the task is primarily spot price, OHLCV, generic token
+metadata, or cross-chain market coverage.
+
+Every Scry product exposes what was checked, what is missing, how fresh the
+evidence is, and why a deeper call may or may not be justified. A partial result
+is reported as partial; a higher price never implies evidence that is not
+available.
+
+## Performance and payment contract
+
+- The current release gate requires local indexed product responses within
+  500 ms, every public unpaid 402 challenge within 1,000 ms, and public 402 p95
+  within 750 ms from the release probe location.
+- Pay.sh and Coinbase Bazaar both resolve to `https://scry.solanahub.de`; there
+  is no Pay.sh proxy in the paid request path.
+- DB-backed products are optimized for indexed or cached evidence. Explicit
+  live-upstream products can take longer after payment; clients should honor
+  the route-specific timeout and response freshness fields.
+- Validation can stop at the unpaid 402 challenge. Never sign or settle a
+  payment merely to test catalog compatibility.
+
+## Spend-aware usage
+
+- Read `GET /x402/freshness-sla.json` and `GET /x402/products.json` for free
+  before paying. They expose freshness, coverage gates, product fit, prices,
+  and request commands.
+- Start one-wallet triage with
+  `GET /x402/wallet/{address}/quick-flag` ($0.001). Escalate only when the
+  returned evidence gap requires lineage, bundler, forensics, transfer, or
+  full-context evidence.
+- Use `GET /x402/wallet/connection` ($0.04) for a specific wallet pair instead
+  of buying two broad dossiers merely to test whether the pair is connected.
+- Use cohort endpoints only for shortlist or monitoring questions. They do not
+  replace a single-wallet dossier or prove that every cohort member is related.
+- Reuse wallet and mint identifiers across calls. If coverage is partial,
+  inspect the returned provenance and freshness before buying a higher tier;
+  a higher price does not imply new underlying coverage.

--- a/providers/scry/wallet-intel/openapi.json
+++ b/providers/scry/wallet-intel/openapi.json
@@ -1,0 +1,4542 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Scry Wallet Intelligence",
+    "version": "0.1.0",
+    "summary": "Pay-per-request Solana wallet intelligence and forensic evidence for agents.",
+    "description": "Evidence-only Solana wallet screening, counterparty graphs, funding lineage, bundler checks, transfers, PnL context, Pump.fun cohorts, mint risk, watchlists, and priority fees.",
+    "x-logo": {
+      "url": "https://scry.solanahub.de/x402/assets/scry-wallet-intelligence-512.png",
+      "altText": "Scry Wallet Intelligence"
+    },
+    "contact": {
+      "name": "Scry Wallet Intelligence",
+      "url": "https://solanahub.de/en/scry/"
+    },
+    "x-guidance": "Start with GET /x402/wallet/{address}/quick-flag ($0.001) for the cheapest coverage and evidence check. Escalate only the dimensions the task needs: PnL ($0.002), live priority fees ($0.005), bundler evidence ($0.01), funding lineage ($0.03), pairwise wallet connections ($0.04), or a forensic dossier ($0.05). Use launch-window-cluster for launch-cohort evidence and full-context-pro only when the combined evidence surface is worth the higher spend. Read coverage_status, confidence, freshness timestamps, field provenance, and methodology before applying caller-owned policy; absent evidence and partial coverage are not negative findings. No API key or subscription is required. Call a paid endpoint without X-PAYMENT to receive the x402 challenge, pay the declared USDC amount, then retry the identical request.",
+    "x-provider": "Scry",
+    "x-contract-source": "https://scry.solanahub.de/openapi.json"
+  },
+  "externalDocs": {
+    "description": "Scry product overview and live discovery",
+    "url": "https://solanahub.de/en/scry/"
+  },
+  "servers": [
+    {
+      "url": "https://scry.solanahub.de"
+    }
+  ],
+  "paths": {
+    "/x402/solana/hot-wallets/daily": {
+      "get": {
+        "tags": [
+          "x402-paid",
+          "solana",
+          "daily-hot-wallets",
+          "cohort",
+          "wallet-intelligence",
+          "x402-data-broker",
+          "solana-x402-data-marketplace",
+          "agent-product"
+        ],
+        "summary": "List notable Solana wallets for daily review",
+        "description": "Low-cost daily Solana notable-wallet cohort for autonomous agents. Returns today's ranked cohort shortlist, pre-filtered against known routers, exchanges, services, and vaults. Each wallet includes source-rank context, Scry coverage gaps, cluster tags, missing dimensions, and a credit-aware depth-call plan before single-wallet forensics. Use for daily discovery and routing. Not for one-wallet transaction rows; use Wallet Transfer Tape for that object. No API keys, no subscriptions; x402 exact payment per request.\n\nPrice: $0.10. Requires x402 exact payment.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Paid intelligence response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "product",
+                    "wallet_count",
+                    "wallets",
+                    "evidence_pack",
+                    "agent_decision_support",
+                    "spend_rationale",
+                    "methodology"
+                  ],
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "success",
+                        "partial",
+                        "error"
+                      ]
+                    },
+                    "product": {
+                      "type": "string",
+                      "const": "scry_daily_hot_wallets"
+                    },
+                    "as_of": {
+                      "type": "string"
+                    },
+                    "sources": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "confidence_score": {
+                      "type": "number",
+                      "minimum": 0,
+                      "maximum": 1
+                    },
+                    "generated_at": {
+                      "type": "string"
+                    },
+                    "wallet_count": {
+                      "type": "number"
+                    },
+                    "buyer_job": {
+                      "type": "string"
+                    },
+                    "wallets": {
+                      "type": "array",
+                      "items": {
+                        "type": "object"
+                      }
+                    },
+                    "source_reports": {
+                      "type": "object"
+                    },
+                    "evidence_pack": {
+                      "type": "object"
+                    },
+                    "caveat": {
+                      "type": "string"
+                    },
+                    "agent_decision_support": {
+                      "type": "object",
+                      "properties": {
+                        "posture": {
+                          "type": "string",
+                          "const": "evidence_only"
+                        },
+                        "confidence": {
+                          "type": "string",
+                          "enum": [
+                            "LOW",
+                            "MID",
+                            "HIGH",
+                            "UNKNOWN"
+                          ]
+                        },
+                        "evidence_summary": {
+                          "type": "string"
+                        },
+                        "decision_options": {
+                          "type": "array",
+                          "items": {
+                            "type": "object"
+                          }
+                        },
+                        "escalation_triggers": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "spend_rationale": {
+                      "type": "object",
+                      "properties": {
+                        "why_this_cost_is_worth_it": {
+                          "type": "string"
+                        },
+                        "cheaper_alternative": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "more_complete_alternative": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "explicit_delta_over_daily_plus_weekly": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "methodology": {
+                      "type": "string",
+                      "const": "scry_agent_product_daily_hot_wallets_v1"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid address or mint"
+          },
+          "402": {
+            "description": "X-PAYMENT header required"
+          }
+        },
+        "x-scry-price": "$0.10",
+        "x-scry-cache-ttl-seconds": 900,
+        "x-marketplace-alias": false,
+        "operationId": "list_solana_hot_wallets_daily",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.100000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        }
+      }
+    },
+    "/x402/solana/persistent-wallets/weekly": {
+      "get": {
+        "tags": [
+          "x402-paid",
+          "solana",
+          "weekly-persistent-wallets",
+          "cohort-7d",
+          "wallet-intelligence",
+          "x402-data-broker",
+          "solana-x402-data-marketplace",
+          "agent-product"
+        ],
+        "summary": "List persistent Solana wallets for weekly review",
+        "description": "Low-cost weekly persistence cohort for agents that need lower-noise recurring wallets before deeper wallet forensics. Includes daily-overlap context, Scry coverage gaps, missing dimensions, and a deeper analysis ladder for caller-defined monitoring and research workflows. No API keys, no subscriptions; x402 exact payment per request.\n\nPrice: $0.20. Requires x402 exact payment.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Paid intelligence response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "product",
+                    "wallet_count",
+                    "wallets",
+                    "evidence_pack",
+                    "agent_decision_support",
+                    "spend_rationale",
+                    "methodology"
+                  ],
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "success",
+                        "partial",
+                        "error"
+                      ]
+                    },
+                    "product": {
+                      "type": "string",
+                      "const": "scry_weekly_persistent_wallets"
+                    },
+                    "as_of": {
+                      "type": "string"
+                    },
+                    "sources": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "confidence_score": {
+                      "type": "number",
+                      "minimum": 0,
+                      "maximum": 1
+                    },
+                    "generated_at": {
+                      "type": "string"
+                    },
+                    "wallet_count": {
+                      "type": "number"
+                    },
+                    "buyer_job": {
+                      "type": "string"
+                    },
+                    "wallets": {
+                      "type": "array",
+                      "items": {
+                        "type": "object"
+                      }
+                    },
+                    "source_reports": {
+                      "type": "object"
+                    },
+                    "evidence_pack": {
+                      "type": "object"
+                    },
+                    "caveat": {
+                      "type": "string"
+                    },
+                    "agent_decision_support": {
+                      "type": "object",
+                      "properties": {
+                        "posture": {
+                          "type": "string",
+                          "const": "evidence_only"
+                        },
+                        "confidence": {
+                          "type": "string",
+                          "enum": [
+                            "LOW",
+                            "MID",
+                            "HIGH",
+                            "UNKNOWN"
+                          ]
+                        },
+                        "evidence_summary": {
+                          "type": "string"
+                        },
+                        "decision_options": {
+                          "type": "array",
+                          "items": {
+                            "type": "object"
+                          }
+                        },
+                        "escalation_triggers": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "spend_rationale": {
+                      "type": "object",
+                      "properties": {
+                        "why_this_cost_is_worth_it": {
+                          "type": "string"
+                        },
+                        "cheaper_alternative": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "more_complete_alternative": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "explicit_delta_over_daily_plus_weekly": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "methodology": {
+                      "type": "string",
+                      "const": "scry_agent_product_weekly_persistent_wallets_v1"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid address or mint"
+          },
+          "402": {
+            "description": "X-PAYMENT header required"
+          }
+        },
+        "x-scry-price": "$0.20",
+        "x-scry-cache-ttl-seconds": 3600,
+        "x-marketplace-alias": false,
+        "operationId": "list_solana_persistent_wallets_weekly",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.200000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        }
+      }
+    },
+    "/x402/solana/pumpfun-risk-protection": {
+      "get": {
+        "tags": [
+          "x402-paid",
+          "solana",
+          "pumpfun-risk-protection-api",
+          "pumpfun-risk-protection",
+          "pumpfun-risk-wallets",
+          "pumpfun-rugger-detection",
+          "pumpfun-rugger-wallet-detection",
+          "serial-deployer-wallets",
+          "pumpfun-serial-deployer-wallets",
+          "consumer-protection",
+          "rug-pattern-wallets",
+          "rugger-pattern-wallets",
+          "wallet-intelligence",
+          "x402-data-broker",
+          "solana-x402-data-marketplace",
+          "agent-product"
+        ],
+        "summary": "Fetch Pump.fun wallet-cohort risk evidence",
+        "description": "Low-cost Pump.fun wallet-cohort screen for agents that need rugger-pattern, serial-deployer, service-router, and suspicious-activity context before deeper review. Returns identity, activity, coverage, and sample evidence for wallet cohorts and deployer sets. Use for cohorts, not one mint, one launch, or one wallet. Evidence only; no verdict. No API keys, no subscriptions; x402 exact payment per request. Search aliases: pumpfun risk protection solana; pumpfun rugger wallet detection; pumpfun serial deployer wallet api; pump.fun rugger wallet detection; pump.fun serial deployer wallets; pumpfun risk wallet cohort; pumpfun wallet cohort risk screen; pumpfun deployer risk screen. Primary object: low cost pumpfun wallet cohort screen.\n\nPrice: $0.05. Requires x402 exact payment.",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "number",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 50
+            },
+            "description": "Maximum number of cohort rows to return, from 1 through 100.",
+            "example": 25
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paid intelligence response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "product",
+                    "wallet_count",
+                    "wallets",
+                    "data_quality",
+                    "evidence_pack",
+                    "agent_decision_support",
+                    "spend_rationale",
+                    "methodology"
+                  ],
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "success",
+                        "partial",
+                        "error"
+                      ]
+                    },
+                    "product": {
+                      "type": "string",
+                      "const": "scry_pumpfun_risk_protection"
+                    },
+                    "as_of": {
+                      "type": "string"
+                    },
+                    "sources": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "confidence_score": {
+                      "type": "number",
+                      "minimum": 0,
+                      "maximum": 1
+                    },
+                    "generated_at": {
+                      "type": "string"
+                    },
+                    "wallet_count": {
+                      "type": "number"
+                    },
+                    "cohort_summary": {
+                      "type": "object"
+                    },
+                    "data_quality": {
+                      "type": "object",
+                      "description": "Product-level freshness, onchain enrichment, and risk-coverage attestation."
+                    },
+                    "buyer_job": {
+                      "type": "string"
+                    },
+                    "wallets": {
+                      "type": "array",
+                      "items": {
+                        "type": "object"
+                      }
+                    },
+                    "evidence_pack": {
+                      "type": "object"
+                    },
+                    "caveat": {
+                      "type": "string"
+                    },
+                    "agent_decision_support": {
+                      "type": "object",
+                      "properties": {
+                        "posture": {
+                          "type": "string",
+                          "const": "evidence_only"
+                        },
+                        "confidence": {
+                          "type": "string",
+                          "enum": [
+                            "LOW",
+                            "MID",
+                            "HIGH",
+                            "UNKNOWN"
+                          ]
+                        },
+                        "evidence_summary": {
+                          "type": "string"
+                        },
+                        "decision_options": {
+                          "type": "array",
+                          "items": {
+                            "type": "object"
+                          }
+                        },
+                        "escalation_triggers": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "spend_rationale": {
+                      "type": "object",
+                      "properties": {
+                        "why_this_cost_is_worth_it": {
+                          "type": "string"
+                        },
+                        "cheaper_alternative": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "more_complete_alternative": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "explicit_delta_over_daily_plus_weekly": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "methodology": {
+                      "type": "string",
+                      "const": "scry_agent_product_pumpfun_risk_protection_v1"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid address or mint"
+          },
+          "402": {
+            "description": "X-PAYMENT header required"
+          }
+        },
+        "x-scry-price": "$0.05",
+        "x-scry-cache-ttl-seconds": 1800,
+        "x-marketplace-alias": false,
+        "operationId": "get_pumpfun_wallet_cohort_risk",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.050000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        }
+      }
+    },
+    "/x402/solana/agent-intel-brief": {
+      "get": {
+        "tags": [
+          "x402-paid",
+          "solana",
+          "agent-intel-brief",
+          "agent-orchestrator-solana-wallet-intelligence",
+          "orchestrator-wallet-intelligence",
+          "solana-agent-wallet-intelligence",
+          "solana-spend-router",
+          "orchestrator-agent",
+          "agent-spend-routing",
+          "product-ladder-routing",
+          "onchain-call-plan",
+          "wallet-triage",
+          "solana-agent-brief",
+          "agent-operations-brief",
+          "cohort-brief",
+          "daily-weekly-wallet-brief",
+          "refresh-queue",
+          "wallet-refresh-plan",
+          "scry-agent-intel",
+          "x402-data-broker",
+          "solana-x402-data-marketplace",
+          "wallet-intelligence",
+          "onchain-plan",
+          "agent-product"
+        ],
+        "summary": "Fetch a Solana wallet-intelligence routing brief",
+        "description": "Agent orchestrator Solana wallet intelligence brief and low-cost spend-router for autonomous agents deciding which Scry endpoint or onchain depth workflow to request next. Combines 24h/7d wallet context, DB freshness, refresh queue, coverage gaps, product-ladder routing, and next evidence depth in one response. Use when the object is an agent workflow. Not a single-wallet bundler/private-routing check. No API keys, no subscriptions; x402 exact payment per request. Search aliases: agent orchestrator solana wallet intelligence; which scry endpoint should my agent select; solana agent spend router; agent orchestrator solana wallet intelligence api; which scry endpoint should my agent request next; low cost solana agent wallet intelligence router; scry agent orchestrator spend router; solana wallet intelligence spend router. Primary object: agent spend router.\n\nPrice: $0.03. Requires x402 exact payment.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Paid intelligence response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "product",
+                    "service_objective",
+                    "brief",
+                    "evidence_pack",
+                    "agent_decision_support",
+                    "spend_rationale",
+                    "methodology"
+                  ],
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "success",
+                        "partial",
+                        "error"
+                      ]
+                    },
+                    "product": {
+                      "type": "string",
+                      "const": "scry_agent_intel_brief"
+                    },
+                    "as_of": {
+                      "type": "string"
+                    },
+                    "sources": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "confidence_score": {
+                      "type": "number",
+                      "minimum": 0,
+                      "maximum": 1
+                    },
+                    "generated_at": {
+                      "type": "string"
+                    },
+                    "service_objective": {
+                      "type": "string"
+                    },
+                    "brief": {
+                      "type": "object"
+                    },
+                    "evidence_pack": {
+                      "type": "object"
+                    },
+                    "product_ladder": {
+                      "type": "array",
+                      "items": {
+                        "type": "object"
+                      }
+                    },
+                    "caveat": {
+                      "type": "string"
+                    },
+                    "agent_decision_support": {
+                      "type": "object",
+                      "properties": {
+                        "posture": {
+                          "type": "string",
+                          "const": "evidence_only"
+                        },
+                        "confidence": {
+                          "type": "string",
+                          "enum": [
+                            "LOW",
+                            "MID",
+                            "HIGH",
+                            "UNKNOWN"
+                          ]
+                        },
+                        "evidence_summary": {
+                          "type": "string"
+                        },
+                        "decision_options": {
+                          "type": "array",
+                          "items": {
+                            "type": "object"
+                          }
+                        },
+                        "escalation_triggers": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "spend_rationale": {
+                      "type": "object",
+                      "properties": {
+                        "why_this_cost_is_worth_it": {
+                          "type": "string"
+                        },
+                        "cheaper_alternative": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "more_complete_alternative": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "explicit_delta_over_daily_plus_weekly": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "methodology": {
+                      "type": "string",
+                      "const": "scry_agent_product_intel_brief_v1"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid address or mint"
+          },
+          "402": {
+            "description": "X-PAYMENT header required"
+          }
+        },
+        "x-scry-price": "$0.03",
+        "x-scry-cache-ttl-seconds": 900,
+        "x-marketplace-alias": false,
+        "operationId": "get_solana_agent_intel_brief",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.030000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        }
+      }
+    },
+    "/x402/wallet/{address}/quick-flag": {
+      "get": {
+        "tags": [
+          "x402-paid",
+          "solana",
+          "wallet-quick-flag",
+          "sub-cent-prefilter",
+          "wallet-prefilter",
+          "bulk-wallet-screen",
+          "identity-quarantine",
+          "transfer-freshness",
+          "private-routing",
+          "low-cost-agent-sku",
+          "x402-data-broker",
+          "solana-x402-data-marketplace"
+        ],
+        "summary": "Fetch quick evidence flags for a Solana wallet",
+        "description": "A $0.001 x402 call — the lowest-price endpoint in this catalog and a practical first target to test a real USDC micropayment end-to-end. Returns service-quarantine status, bundler-routing hint, known identity, coverage status, cached transfer freshness, and stale-vs-DB marker for any Solana wallet. Built for agents bulk-screening before paying for deeper wallet evidence, and for x402 clients that want a working sub-cent settlement test against a live API. No API keys, no subscriptions; x402 exact payment per request.\n\nPrice: $0.001. Requires x402 exact payment.",
+        "parameters": [
+          {
+            "name": "address",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Solana wallet address"
+            },
+            "example": "DR5vSR5xCTqaejVymJuKRbXg7gztniaJ7hH8148C4q9F"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paid intelligence response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "status",
+                    "product",
+                    "address",
+                    "in_db",
+                    "supported",
+                    "quick_flags",
+                    "coverage",
+                    "evidence_pack",
+                    "evidence_pathways",
+                    "agent_decision_support",
+                    "spend_rationale",
+                    "methodology"
+                  ],
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "success",
+                        "partial",
+                        "error"
+                      ]
+                    },
+                    "product": {
+                      "type": "string",
+                      "const": "scry_wallet_quick_flag"
+                    },
+                    "as_of": {
+                      "type": "string"
+                    },
+                    "sources": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "confidence_score": {
+                      "type": "number",
+                      "minimum": 0,
+                      "maximum": 1
+                    },
+                    "address": {
+                      "type": "string"
+                    },
+                    "in_db": {
+                      "type": "boolean"
+                    },
+                    "supported": {
+                      "type": "boolean"
+                    },
+                    "quick_flags": {
+                      "type": "object"
+                    },
+                    "coverage": {
+                      "type": "object"
+                    },
+                    "caveat": {
+                      "type": "string"
+                    },
+                    "evidence_pack": {
+                      "type": "object"
+                    },
+                    "evidence_pathways": {
+                      "type": "object",
+                      "properties": {
+                        "contract": {
+                          "type": "string",
+                          "const": "scry_evidence_pathways_v1"
+                        },
+                        "posture": {
+                          "type": "string",
+                          "const": "caller_selects"
+                        },
+                        "current_product": {
+                          "type": "string"
+                        },
+                        "next_steps": {
+                          "type": "array",
+                          "items": {
+                            "type": "object"
+                          }
+                        }
+                      }
+                    },
+                    "agent_decision_support": {
+                      "type": "object",
+                      "properties": {
+                        "posture": {
+                          "type": "string",
+                          "const": "evidence_only"
+                        },
+                        "confidence": {
+                          "type": "string",
+                          "enum": [
+                            "LOW",
+                            "MID",
+                            "HIGH",
+                            "UNKNOWN"
+                          ]
+                        },
+                        "evidence_summary": {
+                          "type": "string"
+                        },
+                        "decision_options": {
+                          "type": "array",
+                          "items": {
+                            "type": "object"
+                          }
+                        },
+                        "escalation_triggers": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "spend_rationale": {
+                      "type": "object",
+                      "properties": {
+                        "why_this_cost_is_worth_it": {
+                          "type": "string"
+                        },
+                        "cheaper_alternative": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "more_complete_alternative": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "explicit_delta_over_daily_plus_weekly": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "methodology": {
+                      "type": "string",
+                      "const": "scry_wallet_quick_flag_v1"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid address or mint"
+          },
+          "402": {
+            "description": "X-PAYMENT header required"
+          }
+        },
+        "x-scry-price": "$0.001",
+        "x-scry-cache-ttl-seconds": 120,
+        "x-marketplace-alias": false,
+        "operationId": "get_wallet_quick_flag",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        }
+      }
+    },
+    "/x402/wallet/{address}/pnl": {
+      "get": {
+        "tags": [
+          "x402-paid",
+          "solana",
+          "wallet-pnl",
+          "canonical-pnl",
+          "pre-post-balances",
+          "no-estimated-pnl",
+          "validator-native-balance-delta",
+          "profit-and-loss",
+          "wallet-profit",
+          "low-cost-agent-sku",
+          "x402-data-broker",
+          "solana-x402-data-marketplace"
+        ],
+        "summary": "Fetch canonical SOL PnL evidence for a wallet",
+        "description": "Per-transaction SOL PnL for one Solana wallet from validator pre/postBalances — never estimated or price-derived (that data source is verified to the lamport). Returns an explicit null + reason when the number is not computable, the wallet is multi-asset, or a large PnL sits on a now-empty wallet (withheld as unverifiable pending the chain-anchored recompute — equally a real winner who withdrew or a flow artifact, NOT judged fake). NOTE: whole-lifetime chain-anchored verification is being hardened — the served number is currently internal-consistency-checked, NOT yet certified against the on-chain lifetime balance delta (sol_pnl_chain_anchored=false). Includes trade count, classification, coverage, and freshness. No API keys, no subscriptions; x402 exact payment per request.\n\nPrice: $0.002. Requires x402 exact payment.",
+        "parameters": [
+          {
+            "name": "address",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Solana wallet address"
+            },
+            "example": "DR5vSR5xCTqaejVymJuKRbXg7gztniaJ7hH8148C4q9F"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paid intelligence response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "status",
+                    "product",
+                    "address",
+                    "in_db",
+                    "supported",
+                    "pnl",
+                    "coverage",
+                    "evidence_pack",
+                    "agent_decision_support",
+                    "spend_rationale",
+                    "methodology"
+                  ],
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "success",
+                        "partial",
+                        "error"
+                      ]
+                    },
+                    "product": {
+                      "type": "string",
+                      "const": "scry_wallet_pnl"
+                    },
+                    "as_of": {
+                      "type": "string"
+                    },
+                    "sources": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "confidence_score": {
+                      "type": "number",
+                      "minimum": 0,
+                      "maximum": 1
+                    },
+                    "address": {
+                      "type": "string"
+                    },
+                    "in_db": {
+                      "type": "boolean"
+                    },
+                    "supported": {
+                      "type": "boolean"
+                    },
+                    "pnl": {
+                      "type": [
+                        "object",
+                        "null"
+                      ]
+                    },
+                    "coverage": {
+                      "type": "object"
+                    },
+                    "caveat": {
+                      "type": "string"
+                    },
+                    "evidence_pack": {
+                      "type": "object"
+                    },
+                    "agent_decision_support": {
+                      "type": "object",
+                      "properties": {
+                        "posture": {
+                          "type": "string",
+                          "const": "evidence_only"
+                        },
+                        "confidence": {
+                          "type": "string",
+                          "enum": [
+                            "LOW",
+                            "MID",
+                            "HIGH",
+                            "UNKNOWN"
+                          ]
+                        },
+                        "evidence_summary": {
+                          "type": "string"
+                        },
+                        "decision_options": {
+                          "type": "array",
+                          "items": {
+                            "type": "object"
+                          }
+                        },
+                        "escalation_triggers": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "spend_rationale": {
+                      "type": "object",
+                      "properties": {
+                        "why_this_cost_is_worth_it": {
+                          "type": "string"
+                        },
+                        "cheaper_alternative": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "more_complete_alternative": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "explicit_delta_over_daily_plus_weekly": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "methodology": {
+                      "type": "string",
+                      "const": "scry_wallet_pnl_v1"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid address or mint"
+          },
+          "402": {
+            "description": "X-PAYMENT header required"
+          }
+        },
+        "x-scry-price": "$0.002",
+        "x-scry-cache-ttl-seconds": 300,
+        "x-marketplace-alias": false,
+        "operationId": "get_wallet_pnl",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.002000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        }
+      }
+    },
+    "/x402/wallet/{address}/bundler-check": {
+      "get": {
+        "tags": [
+          "x402-paid",
+          "solana",
+          "wallet-intelligence",
+          "bundler-detection",
+          "jito",
+          "nozomi",
+          "bloxroute",
+          "private-routing-wallet",
+          "memecoin",
+          "x402-data-broker",
+          "solana-x402-data-marketplace"
+        ],
+        "summary": "Check a Solana wallet for bundler routing evidence",
+        "description": "Is this Solana wallet a bundler? Single-wallet bundler and private-routing evidence check. Detects whether one wallet routes through Jito, Nozomi, BloXroute, ZeroSlot, BlockRazor, NextBlock, Astralane, or onchain Sender. Returns routing-pattern evidence, tip-stack counts, service-quarantine status, and coverage warnings before deeper wallet forensics. Not an agent orchestrator brief. No API keys, no subscriptions; x402 exact payment per request. Search aliases: solana wallet private routing detection; solana wallet bundler detection api; x402 solana bundler check; one cent solana wallet bundler check; low cost solana private routing evidence; jito tip service wallet evidence; solana wallet jito nozomi bloxroute check; solana jito wallet check. Primary object: low cost single wallet precheck.\n\nPrice: $0.01. Requires x402 exact payment.",
+        "parameters": [
+          {
+            "name": "address",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Solana wallet address"
+            },
+            "example": "DR5vSR5xCTqaejVymJuKRbXg7gztniaJ7hH8148C4q9F"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paid intelligence response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "product",
+                    "address",
+                    "in_db",
+                    "supported",
+                    "risk",
+                    "confidence",
+                    "coverage",
+                    "evidence_pack",
+                    "agent_decision_support",
+                    "spend_rationale",
+                    "methodology"
+                  ],
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "success",
+                        "partial",
+                        "error"
+                      ]
+                    },
+                    "product": {
+                      "type": "string",
+                      "const": "scry_wallet_bundler_check"
+                    },
+                    "as_of": {
+                      "type": "string",
+                      "description": "Response evidence timestamp."
+                    },
+                    "sources": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "description": "Named data sources used in this response."
+                    },
+                    "confidence_score": {
+                      "type": "number",
+                      "minimum": 0,
+                      "maximum": 1
+                    },
+                    "address": {
+                      "type": "string",
+                      "description": "Queried Solana wallet address."
+                    },
+                    "in_db": {
+                      "type": "boolean",
+                      "description": "Whether this wallet is currently in Scry coverage."
+                    },
+                    "supported": {
+                      "type": "boolean",
+                      "description": "False for known infrastructure/CEX/system wallets."
+                    },
+                    "risk": {
+                      "type": "string",
+                      "enum": [
+                        "LOW",
+                        "MID",
+                        "HIGH",
+                        "UNKNOWN"
+                      ]
+                    },
+                    "confidence": {
+                      "type": "string",
+                      "enum": [
+                        "LOW",
+                        "MID",
+                        "HIGH",
+                        "UNKNOWN"
+                      ]
+                    },
+                    "pattern": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Bundler usage class, when available."
+                    },
+                    "bundler_pattern": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Deprecated compatibility alias for pattern."
+                    },
+                    "primary_service": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Primary observed service, or multi."
+                    },
+                    "services_observed": {
+                      "type": "object",
+                      "description": "Observed bundler/tip-service counts by provider."
+                    },
+                    "tip_total_sol": {
+                      "type": [
+                        "number",
+                        "null"
+                      ],
+                      "description": "Sanitized total SOL sent to known tip addresses."
+                    },
+                    "sample_size": {
+                      "type": "object",
+                      "properties": {
+                        "txs_scanned": {
+                          "type": [
+                            "number",
+                            "null"
+                          ]
+                        },
+                        "services_observed_total": {
+                          "type": [
+                            "number",
+                            "null"
+                          ]
+                        },
+                        "tips_observed_total": {
+                          "type": [
+                            "number",
+                            "null"
+                          ]
+                        }
+                      }
+                    },
+                    "bundler_evidence_scope": {
+                      "type": "object",
+                      "description": "Scan-specific completeness and confidence boundary, independent of unrelated holdings or trading coverage."
+                    },
+                    "coverage": {
+                      "type": "object",
+                      "description": "Coverage warnings and checked sources."
+                    },
+                    "profile": {
+                      "type": "object",
+                      "description": "Sanitized wallet trading/context profile."
+                    },
+                    "trade_context": {
+                      "type": "object",
+                      "description": "High-level wallet trade context."
+                    },
+                    "explanation": {
+                      "type": "string"
+                    },
+                    "caveat": {
+                      "type": "string"
+                    },
+                    "evidence_pack": {
+                      "type": "object",
+                      "description": "Machine-readable evidence contract for caller-defined policies."
+                    },
+                    "agent_decision_support": {
+                      "type": "object",
+                      "properties": {
+                        "posture": {
+                          "type": "string",
+                          "const": "evidence_only"
+                        },
+                        "confidence": {
+                          "type": "string",
+                          "enum": [
+                            "LOW",
+                            "MID",
+                            "HIGH",
+                            "UNKNOWN"
+                          ]
+                        },
+                        "evidence_summary": {
+                          "type": "string"
+                        },
+                        "decision_options": {
+                          "type": "array",
+                          "items": {
+                            "type": "object"
+                          }
+                        },
+                        "escalation_triggers": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "spend_rationale": {
+                      "type": "object",
+                      "properties": {
+                        "why_this_cost_is_worth_it": {
+                          "type": "string"
+                        },
+                        "cheaper_alternative": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "more_complete_alternative": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "explicit_delta_over_daily_plus_weekly": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "methodology": {
+                      "type": "string",
+                      "const": "sentinel_x402_bundler_check_v1"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid address or mint"
+          },
+          "402": {
+            "description": "X-PAYMENT header required"
+          }
+        },
+        "x-scry-price": "$0.01",
+        "x-scry-cache-ttl-seconds": 14400,
+        "x-marketplace-alias": false,
+        "operationId": "get_wallet_bundler_evidence",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.010000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        }
+      }
+    },
+    "/x402/wallet/{address}/forensics": {
+      "get": {
+        "tags": [
+          "x402-paid",
+          "solana",
+          "wallet-forensics",
+          "wallet-evidence-dossier",
+          "wallet-evidence-dossier-api",
+          "solana-wallet-evidence-dossier",
+          "solana-wallet-evidence-dossier-api",
+          "full-wallet-dossier",
+          "wallet-intelligence",
+          "kol-identity",
+          "x-handle",
+          "twitter-handle",
+          "wallet-to-twitter",
+          "social-identity",
+          "onchain-identity-context",
+          "onchain-deep-tx-evidence",
+          "gettransactionsforaddress",
+          "kol-lookup",
+          "funding-lineage",
+          "sol-flow",
+          "coordination-peers",
+          "rug-evidence",
+          "sniper-risk-context",
+          "manipulation-window-context",
+          "mev-risk-context",
+          "verdict-free",
+          "launch-window-context",
+          "memecoin",
+          "wallet-research",
+          "x402-data-broker",
+          "solana-x402-data-marketplace"
+        ],
+        "summary": "Fetch a forensic evidence dossier for a Solana wallet",
+        "description": "What is the on-chain forensic profile of this Solana wallet? Single-wallet evidence dossier API for agents that need one wallet in depth. Returns identity and X/Twitter-handle hints when available, service/router/exchange quarantine, funding-source lineage, cached transaction evidence, SOL-flow graph, coordination peers, cluster membership, rug-evidence flags, sniper/MEV/bundler pattern context, current activity, holdings snapshot when covered, coverage confidence, and source freshness timestamps. Use when the object is one Solana wallet. Not for token-launch dossiers, daily wallet cohorts, or transfer-only tapes. Evidence context only; caller owns policy decisions. No API keys or subscriptions; x402 exact payment per request. Search aliases: solana wallet evidence dossier; solana wallet to twitter handle; solana wallet to twitter handle reverse lookup; solana wallet evidence dossier api; full solana wallet evidence dossier; one wallet solana evidence dossier; solana wallet forensic dossier; solana wallet x handle lookup api. Primary object: single wallet dossier.\n\nPrice: $0.05. Requires x402 exact payment.",
+        "parameters": [
+          {
+            "name": "address",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Solana wallet address"
+            },
+            "example": "DR5vSR5xCTqaejVymJuKRbXg7gztniaJ7hH8148C4q9F"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paid intelligence response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "product",
+                    "address",
+                    "in_db",
+                    "supported",
+                    "risk_summary",
+                    "coverage",
+                    "evidence_pack",
+                    "agent_decision_support",
+                    "spend_rationale",
+                    "methodology"
+                  ],
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "success",
+                        "partial",
+                        "error"
+                      ]
+                    },
+                    "product": {
+                      "type": "string",
+                      "const": "scry_wallet_forensics"
+                    },
+                    "as_of": {
+                      "type": "string",
+                      "description": "Response evidence timestamp."
+                    },
+                    "sources": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "description": "Named data sources used in this response."
+                    },
+                    "confidence_score": {
+                      "type": "number",
+                      "minimum": 0,
+                      "maximum": 1
+                    },
+                    "address": {
+                      "type": "string",
+                      "description": "Queried Solana wallet address."
+                    },
+                    "in_db": {
+                      "type": "boolean",
+                      "description": "Whether this wallet is currently in Scry coverage."
+                    },
+                    "supported": {
+                      "type": "boolean",
+                      "description": "False for known infrastructure/CEX/system wallets."
+                    },
+                    "identity": {
+                      "type": "object",
+                      "description": "Known labels, handles, or entity hints when available."
+                    },
+                    "trading_profile": {
+                      "type": "object",
+                      "description": "Canonical wallet trading profile, including PnL/classification/sample size when available."
+                    },
+                    "bundler": {
+                      "type": "object",
+                      "description": "Bundler/tip-service pattern summary."
+                    },
+                    "activity": {
+                      "type": "object",
+                      "description": "Recent wallet balance and transaction-success fingerprint."
+                    },
+                    "holdings_snapshot": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "description": "Latest holdings snapshot. Exact counts are returned only when snapshot_completeness=complete; bounded scans expose token_count_lower_bound instead.",
+                      "properties": {
+                        "captured_at": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "snapshot_freshness": {
+                          "type": "object",
+                          "properties": {
+                            "observed_at": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "age_seconds": {
+                              "type": [
+                                "integer",
+                                "null"
+                              ],
+                              "minimum": 0
+                            },
+                            "tier": {
+                              "type": "string",
+                              "enum": [
+                                "fresh",
+                                "standard",
+                                "stale",
+                                "unknown"
+                              ]
+                            },
+                            "stale_gt_30d": {
+                              "type": [
+                                "boolean",
+                                "null"
+                              ]
+                            }
+                          }
+                        },
+                        "snapshot_completeness": {
+                          "type": "string",
+                          "enum": [
+                            "complete",
+                            "bounded_lower_bound",
+                            "unverified"
+                          ]
+                        },
+                        "total_value_usd": {
+                          "type": [
+                            "number",
+                            "null"
+                          ]
+                        },
+                        "native_balance_sol": {
+                          "type": [
+                            "number",
+                            "null"
+                          ]
+                        },
+                        "token_count": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ],
+                          "minimum": 0,
+                          "description": "Exact token count; null unless snapshot_completeness=complete."
+                        },
+                        "token_count_lower_bound": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ],
+                          "minimum": 0,
+                          "description": "Observed lower bound; populated only for a bounded lower-bound scan."
+                        },
+                        "token_count_is_lower_bound": {
+                          "type": "boolean"
+                        },
+                        "tokens": {
+                          "type": "array",
+                          "items": {
+                            "type": "object"
+                          }
+                        },
+                        "tokens_truncated": {
+                          "type": "boolean"
+                        },
+                        "token_preview_limit": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ],
+                          "minimum": 0
+                        },
+                        "tokens_omitted_count": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ],
+                          "minimum": 0
+                        },
+                        "field_coverage": {
+                          "type": "object"
+                        },
+                        "active_mint_inventory": {
+                          "type": "object"
+                        },
+                        "warnings": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "source": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      }
+                    },
+                    "sol_flows": {
+                      "type": "object",
+                      "description": "Native SOL top destinations and funding sources."
+                    },
+                    "deep_tx_evidence": {
+                      "type": "object",
+                      "description": "Cached onchain onchain-transaction-read transaction evidence summary. Raw transactions are not returned; this is forensic context for caller-defined policies."
+                    },
+                    "sniper_risk_context": {
+                      "type": "object",
+                      "description": "Sniper/MEV/bundler cohort context exposed as risk-pattern evidence only. Stage-1 forward-return testing did not support execution use."
+                    },
+                    "clusters": {
+                      "type": "array",
+                      "description": "Cluster memberships and related wallet context."
+                    },
+                    "coordination_peers": {
+                      "type": "array",
+                      "description": "Wallets with joint-trigger or coordinated activity behavior."
+                    },
+                    "funding_trace": {
+                      "type": "array",
+                      "description": "Funding lineage edges known to Scry."
+                    },
+                    "red_flags": {
+                      "type": "object",
+                      "description": "Structured advisory flags."
+                    },
+                    "risk_summary": {
+                      "type": "object",
+                      "properties": {
+                        "level": {
+                          "type": "string",
+                          "enum": [
+                            "LOW",
+                            "MID",
+                            "HIGH",
+                            "UNKNOWN"
+                          ]
+                        },
+                        "confidence": {
+                          "type": "string",
+                          "enum": [
+                            "LOW",
+                            "MID",
+                            "HIGH",
+                            "UNKNOWN"
+                          ]
+                        },
+                        "explanation": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "coverage": {
+                      "type": "object",
+                      "properties": {
+                        "coverage_status": {
+                          "type": "string",
+                          "enum": [
+                            "deep",
+                            "medium",
+                            "shallow",
+                            "unavailable"
+                          ]
+                        },
+                        "confidence": {
+                          "type": "number"
+                        },
+                        "last_scanned_at": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "missing_fields": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "warnings": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "source_updated_at": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Latest source update timestamp."
+                    },
+                    "caveat": {
+                      "type": "string"
+                    },
+                    "evidence_pack": {
+                      "type": "object",
+                      "description": "Machine-readable evidence contract for caller-defined policies."
+                    },
+                    "agent_decision_support": {
+                      "type": "object",
+                      "properties": {
+                        "posture": {
+                          "type": "string",
+                          "const": "evidence_only"
+                        },
+                        "confidence": {
+                          "type": "string",
+                          "enum": [
+                            "LOW",
+                            "MID",
+                            "HIGH",
+                            "UNKNOWN"
+                          ]
+                        },
+                        "evidence_summary": {
+                          "type": "string"
+                        },
+                        "decision_options": {
+                          "type": "array",
+                          "items": {
+                            "type": "object"
+                          }
+                        },
+                        "escalation_triggers": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "spend_rationale": {
+                      "type": "object",
+                      "properties": {
+                        "why_this_cost_is_worth_it": {
+                          "type": "string"
+                        },
+                        "cheaper_alternative": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "more_complete_alternative": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "explicit_delta_over_daily_plus_weekly": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "methodology": {
+                      "type": "string",
+                      "const": "sentinel_x402_wallet_forensics_v1"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid address or mint"
+          },
+          "402": {
+            "description": "X-PAYMENT header required"
+          }
+        },
+        "x-scry-price": "$0.05",
+        "x-scry-cache-ttl-seconds": 3600,
+        "x-marketplace-alias": false,
+        "operationId": "get_wallet_forensics",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.050000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        }
+      }
+    },
+    "/x402/wallet/{address}/lineage": {
+      "get": {
+        "tags": [
+          "x402-paid",
+          "solana",
+          "solana-funding-lineage-api",
+          "funding-lineage",
+          "funding-lineage-api",
+          "upstream-funder",
+          "funder-lookup",
+          "wallet-provenance",
+          "wallet-forensics",
+          "wallet-intelligence",
+          "source-of-funds",
+          "counterparty-review",
+          "x402-data-broker",
+          "solana-x402-data-marketplace"
+        ],
+        "summary": "Trace funding lineage for a Solana wallet",
+        "description": "Who funded this Solana wallet, and where did its funds come from? Cache-first funding-lineage evidence API returns known upstream funders, hop depth, source freshness, identity hints, loop detection, and coverage/confidence without forcing a live onchain refresh per request. Built for wallet provenance, source-of-funds review, counterparty review, risk triage, and paid Globe wallet dossiers. No API keys, no subscriptions; x402 exact payment per request. Search aliases: wallet source of funds solana api; solana funding lineage api; who funded this solana wallet; solana wallet funding lineage api; solana wallet lineage api; solana source of funds api; solana wallet provenance api; wallet funder lookup solana. Primary object: single wallet source of funds.\n\nPrice: $0.03. Requires x402 exact payment.",
+        "parameters": [
+          {
+            "name": "address",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Solana wallet address"
+            },
+            "example": "DR5vSR5xCTqaejVymJuKRbXg7gztniaJ7hH8148C4q9F"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paid intelligence response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "product",
+                    "address",
+                    "lineage_available",
+                    "lineage",
+                    "coverage",
+                    "evidence_pack",
+                    "agent_decision_support",
+                    "spend_rationale",
+                    "methodology"
+                  ],
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "success",
+                        "partial",
+                        "error"
+                      ]
+                    },
+                    "product": {
+                      "type": "string",
+                      "const": "scry_wallet_lineage"
+                    },
+                    "address": {
+                      "type": "string"
+                    },
+                    "in_db": {
+                      "type": "boolean"
+                    },
+                    "supported": {
+                      "type": "boolean"
+                    },
+                    "lineage_available": {
+                      "type": "boolean"
+                    },
+                    "lineage": {
+                      "type": "array",
+                      "items": {
+                        "type": "object"
+                      }
+                    },
+                    "evidence_contract_version": {
+                      "type": "string",
+                      "const": "scry_lineage_edge_evidence_v2"
+                    },
+                    "depth_reached": {
+                      "type": "number"
+                    },
+                    "terminal_funder": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "loop_detected": {
+                      "type": "boolean"
+                    },
+                    "wallet": {
+                      "type": [
+                        "object",
+                        "null"
+                      ]
+                    },
+                    "coverage": {
+                      "type": "object"
+                    },
+                    "source_updated_at": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "caveat": {
+                      "type": "string"
+                    },
+                    "evidence_pack": {
+                      "type": "object"
+                    },
+                    "agent_decision_support": {
+                      "type": "object",
+                      "properties": {
+                        "posture": {
+                          "type": "string",
+                          "const": "evidence_only"
+                        },
+                        "confidence": {
+                          "type": "string",
+                          "enum": [
+                            "LOW",
+                            "MID",
+                            "HIGH",
+                            "UNKNOWN"
+                          ]
+                        },
+                        "evidence_summary": {
+                          "type": "string"
+                        },
+                        "decision_options": {
+                          "type": "array",
+                          "items": {
+                            "type": "object"
+                          }
+                        },
+                        "escalation_triggers": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "spend_rationale": {
+                      "type": "object",
+                      "properties": {
+                        "why_this_cost_is_worth_it": {
+                          "type": "string"
+                        },
+                        "cheaper_alternative": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "more_complete_alternative": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "explicit_delta_over_daily_plus_weekly": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "methodology": {
+                      "type": "string",
+                      "const": "scry_wallet_lineage_cache_v1"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid address or mint"
+          },
+          "402": {
+            "description": "X-PAYMENT header required"
+          }
+        },
+        "x-scry-price": "$0.03",
+        "x-scry-cache-ttl-seconds": 3600,
+        "x-marketplace-alias": false,
+        "operationId": "get_wallet_funding_lineage",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.030000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        }
+      }
+    },
+    "/x402/wallet/connection": {
+      "get": {
+        "tags": [
+          "x402-paid",
+          "solana",
+          "wallet-connection",
+          "wallet-pair-evidence",
+          "wallet-link-check",
+          "are-wallets-connected",
+          "wallet-relationship-api",
+          "shared-funder",
+          "funding-lineage",
+          "shared-counterparties",
+          "common-counterparty",
+          "graph-community",
+          "cluster-co-membership",
+          "token-overlap",
+          "sybil-evidence-context",
+          "airdrop-farming-context",
+          "wallet-graph",
+          "verdict-free",
+          "coverage-aware",
+          "x402-data-broker",
+          "solana-x402-data-marketplace"
+        ],
+        "summary": "Check evidence connecting two Solana wallets",
+        "description": "Are these two Solana wallets connected on-chain? Pairwise wallet connection evidence API for agents that need to know whether two specific wallets are linked. Takes two wallet addresses and returns typed evidence blocks: direct transfer and swap-counterparty edges between the pair with direction and observed volume, funding-lineage comparison with terminal-funder match, shared transfer counterparties ranked by observed SOL volume with infrastructure flags, graph-community co-membership from network clustering, and traded-token overlap with Jaccard score. Every block carries its own computed_at timestamp and coverage status; wallets outside the covered transfer universe return explicit nulls instead of fabricated negatives. Use when the object is a PAIR of wallets. Not for single-wallet dossiers, token-launch analysis, or bulk cohort scans. Evidence context only; caller owns interpretation and policy decisions. No API keys or subscriptions; x402 exact payment per request.\n\nPrice: $0.04. Requires x402 exact payment.",
+        "parameters": [
+          {
+            "name": "a",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "First Solana wallet address of the pair"
+            },
+            "example": "DR5vSR5xCTqaejVymJuKRbXg7gztniaJ7hH8148C4q9F"
+          },
+          {
+            "name": "b",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Second Solana wallet address of the pair (must differ from `a`)"
+            },
+            "example": "Dzc54GPaA59RXdQ7Q4auqHxJkD2w1AmsPKfgL9vTQbnt"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paid intelligence response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "product",
+                    "pair",
+                    "connection_found",
+                    "evidence",
+                    "coverage",
+                    "evidence_pack",
+                    "agent_decision_support",
+                    "spend_rationale",
+                    "methodology"
+                  ],
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "success",
+                        "partial",
+                        "error"
+                      ]
+                    },
+                    "product": {
+                      "type": "string",
+                      "const": "scry_wallet_connection"
+                    },
+                    "as_of": {
+                      "type": "string",
+                      "description": "Response evidence timestamp derived from source data, never fabricated."
+                    },
+                    "sources": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "confidence_score": {
+                      "type": "number",
+                      "minimum": 0,
+                      "maximum": 1
+                    },
+                    "pair": {
+                      "type": "object",
+                      "properties": {
+                        "a": {
+                          "type": "string"
+                        },
+                        "b": {
+                          "type": "string"
+                        }
+                      },
+                      "description": "Echoed wallet pair, lexicographically normalized; direction fields refer to this order."
+                    },
+                    "pair_order": {
+                      "type": "string",
+                      "const": "lexicographic_normalized"
+                    },
+                    "in_db": {
+                      "type": "object",
+                      "description": "Per-wallet index membership."
+                    },
+                    "supported": {
+                      "type": "boolean"
+                    },
+                    "connection_found": {
+                      "type": "boolean",
+                      "description": "True when at least one evidence block carries a positive signal (edge count > 0, funder match, community match, shared counterparties, or token overlap). False with full coverage is an honest 'no connection in evidence'."
+                    },
+                    "evidence": {
+                      "type": "object",
+                      "properties": {
+                        "direct_edges": {
+                          "type": "object",
+                          "description": "Direct graph edges between the pair with direction, weight, and detected_at."
+                        },
+                        "shared_terminal_funder": {
+                          "type": "object",
+                          "description": "Funding-lineage comparison with terminal-funder match and per-side depth."
+                        },
+                        "shared_counterparties": {
+                          "type": "object",
+                          "description": "Transfer counterparties observed on both sides, ranked by observed SOL volume, with is_infrastructure flags."
+                        },
+                        "same_community": {
+                          "type": "object",
+                          "description": "Graph-community co-membership from network clustering with community id, size, and staleness flag."
+                        },
+                        "token_overlap": {
+                          "type": "object",
+                          "description": "Traded-token overlap with per-side counts, shared mints, and Jaccard score."
+                        }
+                      },
+                      "description": "Typed evidence blocks; each carries its own computed_at and coverage_status (covered | partial | not_covered)."
+                    },
+                    "coverage": {
+                      "type": "object",
+                      "description": "Merged pair coverage plus per-wallet coverage gates."
+                    },
+                    "source_updated_at": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "caveat": {
+                      "type": "string"
+                    },
+                    "evidence_pack": {
+                      "type": "object"
+                    },
+                    "agent_decision_support": {
+                      "type": "object",
+                      "properties": {
+                        "posture": {
+                          "type": "string",
+                          "const": "evidence_only"
+                        },
+                        "confidence": {
+                          "type": "string",
+                          "enum": [
+                            "LOW",
+                            "MID",
+                            "HIGH",
+                            "UNKNOWN"
+                          ]
+                        },
+                        "evidence_summary": {
+                          "type": "string"
+                        },
+                        "decision_options": {
+                          "type": "array",
+                          "items": {
+                            "type": "object"
+                          }
+                        },
+                        "escalation_triggers": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "spend_rationale": {
+                      "type": "object",
+                      "properties": {
+                        "why_this_cost_is_worth_it": {
+                          "type": "string"
+                        },
+                        "cheaper_alternative": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "more_complete_alternative": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "explicit_delta_over_daily_plus_weekly": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "methodology": {
+                      "type": "string",
+                      "const": "scry_wallet_connection_pair_v1"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid address or mint"
+          },
+          "402": {
+            "description": "X-PAYMENT header required"
+          }
+        },
+        "x-scry-price": "$0.04",
+        "x-scry-cache-ttl-seconds": 3600,
+        "x-marketplace-alias": false,
+        "operationId": "get_wallet_connection",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.040000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        }
+      }
+    },
+    "/x402/wallet/{address}/transfer-tape": {
+      "get": {
+        "tags": [
+          "x402-paid",
+          "solana",
+          "wallet-transfer-tape",
+          "fresh-solana-wallet-transfers",
+          "fresh-wallet-transfers",
+          "single-wallet-transfers",
+          "wallet-transfers",
+          "onchain-wallet-transfers",
+          "transfer-reconciliation",
+          "wallet-activity",
+          "fresh-wallet-activity",
+          "today-wallet-activity",
+          "counterparty-graph",
+          "edge-gap",
+          "pnl-reconciliation-input",
+          "x402-data-broker",
+          "solana-x402-data-marketplace"
+        ],
+        "summary": "List recent transfers for a Solana wallet",
+        "description": "Fresh Solana wallet transfers for one wallet. Returns one-wallet transfer rows as the live evidence tape: deduplicated activity, exact organization/service counterparty context across the cached history, in/out direction counts, mints touched, local edge-gap reconciliation, and freshness timestamps. Use for one wallet's latest transfer evidence before deeper forensics or graph refresh. Not a daily hot-wallet cohort and not a ranked wallet shortlist. No API keys, no subscriptions; x402 exact payment per request. Search aliases: fresh solana wallet transfers; wallet activity feed solana; solana wallet transfer tape; fresh solana wallet transfers x402; what happened to this wallet today; solana wallet transfer tape x402; solana wallet transfers api; solana wallet transfer history x402. Primary object: single wallet fresh activity.\n\nPrice: $0.15. Requires x402 exact payment.",
+        "parameters": [
+          {
+            "name": "address",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Solana wallet address"
+            },
+            "example": "DR5vSR5xCTqaejVymJuKRbXg7gztniaJ7hH8148C4q9F"
+          },
+          {
+            "name": "since_slot",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Optional exclusive Solana slot cursor. Returns only cached transfer rows with slot > since_slot."
+            },
+            "example": 350000000
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paid intelligence response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "status",
+                    "product",
+                    "address",
+                    "supported",
+                    "transfer_tape",
+                    "reconciliation",
+                    "coverage",
+                    "evidence_pack",
+                    "agent_decision_support",
+                    "spend_rationale",
+                    "methodology"
+                  ],
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "success",
+                        "partial",
+                        "error"
+                      ]
+                    },
+                    "product": {
+                      "type": "string",
+                      "const": "scry_wallet_transfer_tape"
+                    },
+                    "as_of": {
+                      "type": "string",
+                      "description": "Response evidence timestamp."
+                    },
+                    "sources": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "confidence_score": {
+                      "type": "number",
+                      "minimum": 0,
+                      "maximum": 1
+                    },
+                    "address": {
+                      "type": "string"
+                    },
+                    "in_db": {
+                      "type": "boolean"
+                    },
+                    "supported": {
+                      "type": "boolean"
+                    },
+                    "wallet": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "description": "Indexed wallet context when available."
+                    },
+                    "transfer_tape": {
+                      "type": "object",
+                      "description": "Normalized transfer rows and aggregate counts after direct onchain freshen-on-request.",
+                      "properties": {
+                        "row_count": {
+                          "type": "number"
+                        },
+                        "signature_count": {
+                          "type": "number"
+                        },
+                        "latest_observed_at": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "latest_fetched_at": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "direction_counts": {
+                          "type": "object"
+                        },
+                        "distinct_counterparty_count": {
+                          "type": "number"
+                        },
+                        "counterparties_missing_from_local_edges": {
+                          "type": "number"
+                        },
+                        "edge_gap_ratio": {
+                          "type": [
+                            "number",
+                            "null"
+                          ]
+                        },
+                        "distinct_mint_count": {
+                          "type": "number"
+                        },
+                        "organization_context": {
+                          "type": "object",
+                          "description": "Exact-address organization/service matches across all cached transfer rows. History completeness is explicit and may be bounded."
+                        },
+                        "rows": {
+                          "type": "array",
+                          "items": {
+                            "type": "object"
+                          }
+                        }
+                      }
+                    },
+                    "activity_delta": {
+                      "type": "object",
+                      "description": "Slot cursor receipt for incremental polling, including explicit gap/completeness semantics."
+                    },
+                    "reconciliation": {
+                      "type": "object",
+                      "description": "Comparison between cached transfer rows and Scry's current local graph/freshness fields."
+                    },
+                    "onchain_live_refresh": {
+                      "type": "object",
+                      "description": "Direct onchain onchain-transfer-read refresh metadata for this response when on-demand freshening is enabled."
+                    },
+                    "coverage": {
+                      "type": "object",
+                      "properties": {
+                        "coverage_status": {
+                          "type": "string",
+                          "enum": [
+                            "deep",
+                            "medium",
+                            "shallow",
+                            "unavailable"
+                          ]
+                        },
+                        "confidence": {
+                          "type": "number"
+                        },
+                        "last_refreshed_at": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "missing_fields": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "warnings": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "source_updated_at": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "caveat": {
+                      "type": "string"
+                    },
+                    "evidence_pack": {
+                      "type": "object"
+                    },
+                    "agent_decision_support": {
+                      "type": "object",
+                      "properties": {
+                        "posture": {
+                          "type": "string",
+                          "const": "evidence_only"
+                        },
+                        "confidence": {
+                          "type": "string",
+                          "enum": [
+                            "LOW",
+                            "MID",
+                            "HIGH",
+                            "UNKNOWN"
+                          ]
+                        },
+                        "evidence_summary": {
+                          "type": "string"
+                        },
+                        "decision_options": {
+                          "type": "array",
+                          "items": {
+                            "type": "object"
+                          }
+                        },
+                        "escalation_triggers": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "spend_rationale": {
+                      "type": "object",
+                      "properties": {
+                        "why_this_cost_is_worth_it": {
+                          "type": "string"
+                        },
+                        "cheaper_alternative": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "more_complete_alternative": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "explicit_delta_over_daily_plus_weekly": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "methodology": {
+                      "type": "string",
+                      "const": "scry_wallet_transfer_tape_v1"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid address or mint"
+          },
+          "402": {
+            "description": "X-PAYMENT header required"
+          }
+        },
+        "x-scry-price": "$0.15",
+        "x-scry-cache-ttl-seconds": 0,
+        "x-marketplace-alias": false,
+        "operationId": "get_wallet_transfer_tape",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.150000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        }
+      }
+    },
+    "/x402/wallet/{address}/launch-window-cluster": {
+      "get": {
+        "tags": [
+          "x402-paid",
+          "solana",
+          "launch-window-cluster",
+          "wallet-relationship-evidence",
+          "counterparty-cluster",
+          "repeat-cluster-patterns",
+          "private-routing",
+          "bundler-detection",
+          "wallet-relationship-graph",
+          "counterparty-graph",
+          "cohort-wallets",
+          "memecoin",
+          "x402-data-broker",
+          "solana-x402-data-marketplace"
+        ],
+        "summary": "Fetch launch-window cluster evidence for a wallet",
+        "description": "Did this wallet trade inside the token launch window together with related wallets? Returns relationship evidence for one Solana wallet in a launch/high-activity context: its chain-normalized transfer counterparties, private-routing and bundler context, repeat-cluster patterns, identity tags when indexed, and local edge-gap reconciliation. NOTE: this is the wallet's counterparty + cluster evidence, NOT a verified same-block co-execution set. Evidence layer only; no verdict or action instruction. No API keys, no subscriptions; x402 exact payment per request.\n\nPrice: $0.05. Requires x402 exact payment.",
+        "parameters": [
+          {
+            "name": "address",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Solana wallet address"
+            },
+            "example": "DR5vSR5xCTqaejVymJuKRbXg7gztniaJ7hH8148C4q9F"
+          },
+          {
+            "name": "since_slot",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Optional exclusive Solana slot cursor. Adds a bounded what-changed-since receipt without server-side state."
+            },
+            "example": 350000000
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paid intelligence response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "status",
+                    "product",
+                    "address",
+                    "supported",
+                    "execution_window",
+                    "monitoring_delta",
+                    "private_routing_context",
+                    "relationship_cluster",
+                    "coverage",
+                    "paid_subject_coverage_sla",
+                    "evidence_pack",
+                    "evidence_pathways",
+                    "agent_decision_support",
+                    "spend_rationale",
+                    "methodology"
+                  ],
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "success",
+                        "partial",
+                        "error"
+                      ]
+                    },
+                    "product": {
+                      "type": "string",
+                      "const": "scry_launch_window_cluster"
+                    },
+                    "as_of": {
+                      "type": "string"
+                    },
+                    "sources": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "confidence_score": {
+                      "type": "number",
+                      "minimum": 0,
+                      "maximum": 1
+                    },
+                    "address": {
+                      "type": "string"
+                    },
+                    "in_db": {
+                      "type": "boolean"
+                    },
+                    "supported": {
+                      "type": "boolean"
+                    },
+                    "wallet": {
+                      "type": [
+                        "object",
+                        "null"
+                      ]
+                    },
+                    "execution_window": {
+                      "type": "object"
+                    },
+                    "monitoring_delta": {
+                      "type": "object",
+                      "required": [
+                        "contract",
+                        "mode",
+                        "change_status",
+                        "requested_since_slot",
+                        "observed_window",
+                        "changes",
+                        "continuation",
+                        "caveat"
+                      ],
+                      "properties": {
+                        "contract": {
+                          "type": "string",
+                          "const": "scry_monitoring_delta_v1"
+                        },
+                        "mode": {
+                          "type": "string",
+                          "enum": [
+                            "baseline",
+                            "delta"
+                          ]
+                        },
+                        "change_status": {
+                          "type": "string",
+                          "enum": [
+                            "baseline",
+                            "changed",
+                            "no_change",
+                            "no_change_within_bounded_window"
+                          ]
+                        },
+                        "requested_since_slot": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ],
+                          "minimum": 0
+                        },
+                        "observed_window": {
+                          "type": "object"
+                        },
+                        "changes": {
+                          "type": "object"
+                        },
+                        "continuation": {
+                          "type": "object"
+                        },
+                        "caveat": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "onchain_live_refresh": {
+                      "type": "object",
+                      "description": "Direct onchain onchain-transfer-read refresh metadata for this response when on-demand freshening is enabled."
+                    },
+                    "private_routing_context": {
+                      "type": "object"
+                    },
+                    "relationship_cluster": {
+                      "type": "object",
+                      "description": "Counterparty/edge context including exact-address organization and service matches over the cached history with explicit completeness."
+                    },
+                    "coverage": {
+                      "type": "object"
+                    },
+                    "paid_subject_coverage_sla": {
+                      "type": "object",
+                      "required": [
+                        "contract",
+                        "subject_type",
+                        "minimum_coverage_status",
+                        "observed_coverage_status",
+                        "status",
+                        "response_status",
+                        "requires_deepening",
+                        "deepening_trigger",
+                        "measurement_stage",
+                        "reason_codes"
+                      ],
+                      "properties": {
+                        "contract": {
+                          "type": "string",
+                          "const": "scry_paid_subject_coverage_sla_v1"
+                        },
+                        "subject_type": {
+                          "type": "string",
+                          "const": "wallet"
+                        },
+                        "minimum_coverage_status": {
+                          "type": "string",
+                          "const": "medium"
+                        },
+                        "observed_coverage_status": {
+                          "type": "string",
+                          "enum": [
+                            "deep",
+                            "medium",
+                            "shallow",
+                            "unavailable"
+                          ]
+                        },
+                        "status": {
+                          "type": "string",
+                          "enum": [
+                            "met",
+                            "not_met"
+                          ]
+                        },
+                        "response_status": {
+                          "type": "string",
+                          "enum": [
+                            "success",
+                            "partial"
+                          ]
+                        },
+                        "requires_deepening": {
+                          "type": "boolean"
+                        },
+                        "deepening_trigger": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "enum": [
+                            "successful_settlement",
+                            null
+                          ]
+                        },
+                        "measurement_stage": {
+                          "type": "string",
+                          "const": "response_before_settlement"
+                        },
+                        "reason_codes": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "evidence_pack": {
+                      "type": "object"
+                    },
+                    "evidence_pathways": {
+                      "type": "object",
+                      "properties": {
+                        "contract": {
+                          "type": "string",
+                          "const": "scry_evidence_pathways_v1"
+                        },
+                        "posture": {
+                          "type": "string",
+                          "const": "caller_selects"
+                        },
+                        "current_product": {
+                          "type": "string"
+                        },
+                        "next_steps": {
+                          "type": "array",
+                          "items": {
+                            "type": "object"
+                          }
+                        }
+                      }
+                    },
+                    "agent_decision_support": {
+                      "type": "object",
+                      "properties": {
+                        "posture": {
+                          "type": "string",
+                          "const": "evidence_only"
+                        },
+                        "confidence": {
+                          "type": "string",
+                          "enum": [
+                            "LOW",
+                            "MID",
+                            "HIGH",
+                            "UNKNOWN"
+                          ]
+                        },
+                        "evidence_summary": {
+                          "type": "string"
+                        },
+                        "decision_options": {
+                          "type": "array",
+                          "items": {
+                            "type": "object"
+                          }
+                        },
+                        "escalation_triggers": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "spend_rationale": {
+                      "type": "object",
+                      "properties": {
+                        "why_this_cost_is_worth_it": {
+                          "type": "string"
+                        },
+                        "cheaper_alternative": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "more_complete_alternative": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "explicit_delta_over_daily_plus_weekly": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "methodology": {
+                      "type": "string",
+                      "const": "scry_launch_window_cluster_v1"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid address or mint"
+          },
+          "402": {
+            "description": "X-PAYMENT header required"
+          }
+        },
+        "x-scry-price": "$0.05",
+        "x-scry-cache-ttl-seconds": 0,
+        "x-marketplace-alias": false,
+        "operationId": "get_wallet_launch_window_cluster",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.050000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        }
+      }
+    },
+    "/x402/wallet/{address}/full-context-pro": {
+      "get": {
+        "tags": [
+          "x402-paid",
+          "edge-gap-reconciliation",
+          "coverage-gap",
+          "missing-counterparties",
+          "what-single-lookup-misses",
+          "solana",
+          "wallet-full-context",
+          "cross-context-wallet",
+          "wallet-defi-context",
+          "wallet-context-bundle",
+          "wallet-forensics",
+          "wallet-transfer-tape",
+          "launch-window-cluster",
+          "onchain-wallet-transfers",
+          "identity-quarantine",
+          "counterparty-graph",
+          "edge-gap",
+          "x402-data-broker",
+          "solana-x402-data-marketplace"
+        ],
+        "summary": "Fetch full forensic context for a Solana wallet",
+        "description": "Edge-gap reconciliation first: measures how many of a Solana wallet's real transfer counterparties are missing from any single-call view (edge_gap_ratio, missing_local_edge_count) — the coverage gap a one-shot onchain/RPC lookup leaves behind — then fuses Scry wallet forensics, multi-hop funding lineage, launch-window relationship evidence, identity quarantine, KOL X-handle when available, and coverage/provenance/freshness timestamps into one composite response. Neutral evidence only, no verdicts; built for research, monitoring, and orchestrator agents that need to see what a single lookup would miss before caller-owned policy decisions. No API keys, no subscriptions; x402 exact payment per request.\n\nPrice: $0.18. Requires x402 exact payment.",
+        "parameters": [
+          {
+            "name": "address",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Solana wallet address"
+            },
+            "example": "DR5vSR5xCTqaejVymJuKRbXg7gztniaJ7hH8148C4q9F"
+          },
+          {
+            "name": "since_slot",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Optional exclusive Solana slot cursor. Adds a bounded what-changed-since receipt without server-side state."
+            },
+            "example": 350000000
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paid intelligence response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "status",
+                    "product",
+                    "address",
+                    "supported",
+                    "context_summary",
+                    "forensics",
+                    "transfer_tape",
+                    "monitoring_delta",
+                    "funding_lineage",
+                    "launch_window_cluster",
+                    "coverage",
+                    "delivery_quality",
+                    "paid_subject_coverage_sla",
+                    "verification_receipts",
+                    "evidence_pack",
+                    "evidence_pathways",
+                    "agent_decision_support",
+                    "spend_rationale",
+                    "methodology"
+                  ],
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "success",
+                        "partial",
+                        "error"
+                      ]
+                    },
+                    "product": {
+                      "type": "string",
+                      "const": "scry_wallet_full_context_pro"
+                    },
+                    "as_of": {
+                      "type": "string"
+                    },
+                    "sources": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "confidence_score": {
+                      "type": "number",
+                      "minimum": 0,
+                      "maximum": 1
+                    },
+                    "address": {
+                      "type": "string"
+                    },
+                    "supported": {
+                      "type": "boolean"
+                    },
+                    "context_summary": {
+                      "type": "object"
+                    },
+                    "forensics": {
+                      "type": "object"
+                    },
+                    "transfer_tape": {
+                      "type": "object"
+                    },
+                    "monitoring_delta": {
+                      "type": "object",
+                      "required": [
+                        "contract",
+                        "mode",
+                        "change_status",
+                        "requested_since_slot",
+                        "observed_window",
+                        "changes",
+                        "continuation",
+                        "caveat"
+                      ],
+                      "properties": {
+                        "contract": {
+                          "type": "string",
+                          "const": "scry_monitoring_delta_v1"
+                        },
+                        "mode": {
+                          "type": "string",
+                          "enum": [
+                            "baseline",
+                            "delta"
+                          ]
+                        },
+                        "change_status": {
+                          "type": "string",
+                          "enum": [
+                            "baseline",
+                            "changed",
+                            "no_change",
+                            "no_change_within_bounded_window"
+                          ]
+                        },
+                        "requested_since_slot": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ],
+                          "minimum": 0
+                        },
+                        "observed_window": {
+                          "type": "object"
+                        },
+                        "changes": {
+                          "type": "object"
+                        },
+                        "continuation": {
+                          "type": "object"
+                        },
+                        "caveat": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "funding_lineage": {
+                      "type": "object"
+                    },
+                    "launch_window_cluster": {
+                      "type": "object"
+                    },
+                    "coverage": {
+                      "type": "object"
+                    },
+                    "delivery_quality": {
+                      "type": "object",
+                      "required": [
+                        "status",
+                        "contract",
+                        "minimum_coverage_status",
+                        "requires_deepening",
+                        "reason_codes"
+                      ],
+                      "properties": {
+                        "status": {
+                          "type": "string",
+                          "enum": [
+                            "success",
+                            "partial"
+                          ]
+                        },
+                        "contract": {
+                          "type": "string",
+                          "const": "scry_full_context_delivery_quality_v1"
+                        },
+                        "minimum_coverage_status": {
+                          "type": "string",
+                          "const": "medium"
+                        },
+                        "requires_deepening": {
+                          "type": "boolean"
+                        },
+                        "reason_codes": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "paid_subject_coverage_sla": {
+                      "type": "object",
+                      "required": [
+                        "contract",
+                        "subject_type",
+                        "minimum_coverage_status",
+                        "observed_coverage_status",
+                        "status",
+                        "response_status",
+                        "requires_deepening",
+                        "deepening_trigger",
+                        "measurement_stage",
+                        "reason_codes"
+                      ],
+                      "properties": {
+                        "contract": {
+                          "type": "string",
+                          "const": "scry_paid_subject_coverage_sla_v1"
+                        },
+                        "subject_type": {
+                          "type": "string",
+                          "const": "wallet"
+                        },
+                        "minimum_coverage_status": {
+                          "type": "string",
+                          "const": "medium"
+                        },
+                        "observed_coverage_status": {
+                          "type": "string",
+                          "enum": [
+                            "deep",
+                            "medium",
+                            "shallow",
+                            "unavailable"
+                          ]
+                        },
+                        "status": {
+                          "type": "string",
+                          "enum": [
+                            "met",
+                            "not_met"
+                          ]
+                        },
+                        "response_status": {
+                          "type": "string",
+                          "enum": [
+                            "success",
+                            "partial"
+                          ]
+                        },
+                        "requires_deepening": {
+                          "type": "boolean"
+                        },
+                        "deepening_trigger": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "enum": [
+                            "successful_settlement",
+                            null
+                          ]
+                        },
+                        "measurement_stage": {
+                          "type": "string",
+                          "const": "response_before_settlement"
+                        },
+                        "reason_codes": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "verification_receipts": {
+                      "type": "object"
+                    },
+                    "caveat": {
+                      "type": "string"
+                    },
+                    "evidence_pack": {
+                      "type": "object"
+                    },
+                    "evidence_pathways": {
+                      "type": "object",
+                      "properties": {
+                        "contract": {
+                          "type": "string",
+                          "const": "scry_evidence_pathways_v1"
+                        },
+                        "posture": {
+                          "type": "string",
+                          "const": "caller_selects"
+                        },
+                        "current_product": {
+                          "type": "string"
+                        },
+                        "next_steps": {
+                          "type": "array",
+                          "items": {
+                            "type": "object"
+                          }
+                        }
+                      }
+                    },
+                    "agent_decision_support": {
+                      "type": "object",
+                      "properties": {
+                        "posture": {
+                          "type": "string",
+                          "const": "evidence_only"
+                        },
+                        "confidence": {
+                          "type": "string",
+                          "enum": [
+                            "LOW",
+                            "MID",
+                            "HIGH",
+                            "UNKNOWN"
+                          ]
+                        },
+                        "evidence_summary": {
+                          "type": "string"
+                        },
+                        "decision_options": {
+                          "type": "array",
+                          "items": {
+                            "type": "object"
+                          }
+                        },
+                        "escalation_triggers": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "spend_rationale": {
+                      "type": "object",
+                      "properties": {
+                        "why_this_cost_is_worth_it": {
+                          "type": "string"
+                        },
+                        "cheaper_alternative": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "more_complete_alternative": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "explicit_delta_over_daily_plus_weekly": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "methodology": {
+                      "type": "string",
+                      "const": "scry_wallet_full_context_pro_v1"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid address or mint"
+          },
+          "402": {
+            "description": "X-PAYMENT header required"
+          }
+        },
+        "x-scry-price": "$0.18",
+        "x-scry-cache-ttl-seconds": 0,
+        "x-marketplace-alias": false,
+        "operationId": "get_wallet_full_context",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.180000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        }
+      }
+    },
+    "/x402/network/priority-fees-live": {
+      "get": {
+        "tags": [
+          "x402-paid",
+          "solana",
+          "priority-fees",
+          "priority-fee-estimate",
+          "onchain-priority-fee-api",
+          "transaction-fees",
+          "compute-budget",
+          "jupiter",
+          "raydium",
+          "network-fees",
+          "x402-data-broker",
+          "solana-x402-data-marketplace"
+        ],
+        "summary": "Fetch live Solana priority-fee estimates",
+        "description": "Return live Solana priority-fee estimates from onchain for global, Jupiter, Raydium, or caller-supplied account keys. Includes all fee levels in micro-lamports per compute unit, freshness, coverage, and caller-policy caveats for transaction-building agents that need a low-cost execution-cost snapshot before submit or simulation. No API keys, no subscriptions; x402 exact payment per request.\n\nPrice: $0.005. Requires x402 exact payment.",
+        "parameters": [
+          {
+            "name": "preset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Optional preset: global, jupiter_swap, or raydium_amm. Defaults to global."
+            },
+            "example": "global"
+          },
+          {
+            "name": "account_keys",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Optional comma-separated Solana account keys. Overrides preset when provided."
+            },
+            "example": "11111111111111111111111111111111"
+          },
+          {
+            "name": "lookback_slots",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "number",
+              "description": "Optional lookback slots for onchain estimate. Clamped to 1-150. Defaults to 50."
+            },
+            "example": 50
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paid intelligence response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "status",
+                    "product",
+                    "preset",
+                    "supported",
+                    "estimate",
+                    "coverage",
+                    "evidence_pack",
+                    "agent_decision_support",
+                    "spend_rationale",
+                    "methodology"
+                  ],
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "success",
+                        "partial",
+                        "error"
+                      ]
+                    },
+                    "product": {
+                      "type": "string",
+                      "const": "scry_priority_fees_live"
+                    },
+                    "as_of": {
+                      "type": "string"
+                    },
+                    "sources": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "confidence_score": {
+                      "type": "number",
+                      "minimum": 0,
+                      "maximum": 1
+                    },
+                    "preset": {
+                      "type": "string"
+                    },
+                    "preset_label": {
+                      "type": "string"
+                    },
+                    "account_keys": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "lookback_slots": {
+                      "type": "number"
+                    },
+                    "supported": {
+                      "type": "boolean"
+                    },
+                    "estimate": {
+                      "type": "object",
+                      "properties": {
+                        "priority_fee_estimate_micro_lamports": {
+                          "type": [
+                            "number",
+                            "null"
+                          ]
+                        },
+                        "recommended_micro_lamports": {
+                          "type": [
+                            "number",
+                            "null"
+                          ]
+                        },
+                        "priority_fee_levels_micro_lamports": {
+                          "type": "object"
+                        },
+                        "unit": {
+                          "type": "string",
+                          "const": "micro_lamports_per_compute_unit"
+                        }
+                      }
+                    },
+                    "coverage": {
+                      "type": "object"
+                    },
+                    "evidence_pack": {
+                      "type": "object"
+                    },
+                    "agent_decision_support": {
+                      "type": "object",
+                      "properties": {
+                        "posture": {
+                          "type": "string",
+                          "const": "evidence_only"
+                        },
+                        "confidence": {
+                          "type": "string",
+                          "enum": [
+                            "LOW",
+                            "MID",
+                            "HIGH",
+                            "UNKNOWN"
+                          ]
+                        },
+                        "evidence_summary": {
+                          "type": "string"
+                        },
+                        "decision_options": {
+                          "type": "array",
+                          "items": {
+                            "type": "object"
+                          }
+                        },
+                        "escalation_triggers": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "spend_rationale": {
+                      "type": "object",
+                      "properties": {
+                        "why_this_cost_is_worth_it": {
+                          "type": "string"
+                        },
+                        "cheaper_alternative": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "more_complete_alternative": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "explicit_delta_over_daily_plus_weekly": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "caveat": {
+                      "type": "string"
+                    },
+                    "methodology": {
+                      "type": "string",
+                      "const": "scry_priority_fees_live_v1"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid address or mint"
+          },
+          "402": {
+            "description": "X-PAYMENT header required"
+          }
+        },
+        "x-scry-price": "$0.005",
+        "x-scry-cache-ttl-seconds": 20,
+        "x-marketplace-alias": false,
+        "operationId": "get_solana_priority_fees_live",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.005000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        }
+      }
+    },
+    "/x402/wallet/watchlist-snapshot": {
+      "get": {
+        "tags": [
+          "x402-paid",
+          "solana",
+          "watchlist-snapshot",
+          "wallet-watchlist",
+          "wallet-watchlist-snapshot",
+          "cached-polling-snapshot",
+          "polling-alerts",
+          "paid-pull-monitoring",
+          "onchain-wallet-transfers",
+          "transfer-freshness",
+          "wallet-activity",
+          "counterparty-graph",
+          "edge-gap",
+          "recurring-agent-monitoring",
+          "x402-data-broker",
+          "solana-x402-data-marketplace"
+        ],
+        "summary": "Fetch transfer evidence for a wallet watchlist",
+        "description": "Multi-wallet (up to 25) cached transfer-evidence snapshot via paid pull: no webhook subscription, no callback URL, no delivery infrastructure. Scry summarizes cached chain-normalized transfer-freshness timestamps, local edge-gap evidence, coverage status, and drill-down routes so autonomous agents can poll a watchlist. NOTE: serves indexed/cached evidence with per-wallet freshness stamps — it is NOT a live or streaming feed. No API keys, no subscriptions; x402 exact payment per request.\n\nPrice: $0.05. Requires x402 exact payment.",
+        "parameters": [
+          {
+            "name": "addresses",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Comma-separated Solana wallet addresses. Maximum 25 addresses per paid snapshot."
+            },
+            "example": "DR5vSR5xCTqaejVymJuKRbXg7gztniaJ7hH8148C4q9F,Dzc54GPaA59RXdQ7Q4auqHxJkD2w1AmsPKfgL9vTQbnt"
+          },
+          {
+            "name": "since_slot",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Optional exclusive Solana slot cursor applied to every watchlist wallet."
+            },
+            "example": 350000000
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paid intelligence response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "status",
+                    "product",
+                    "requested_count",
+                    "watchlist_count",
+                    "wallets",
+                    "aggregate",
+                    "coverage",
+                    "evidence_pack",
+                    "agent_decision_support",
+                    "spend_rationale",
+                    "methodology"
+                  ],
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "success",
+                        "partial",
+                        "error"
+                      ]
+                    },
+                    "product": {
+                      "type": "string",
+                      "const": "scry_watchlist_snapshot"
+                    },
+                    "as_of": {
+                      "type": "string"
+                    },
+                    "sources": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "confidence_score": {
+                      "type": "number",
+                      "minimum": 0,
+                      "maximum": 1
+                    },
+                    "requested_count": {
+                      "type": "number"
+                    },
+                    "watchlist_count": {
+                      "type": "number"
+                    },
+                    "invalid_addresses": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "truncated": {
+                      "type": "boolean"
+                    },
+                    "wallets": {
+                      "type": "array",
+                      "description": "Per-wallet transfer freshness and drill-down summary.",
+                      "items": {
+                        "type": "object"
+                      }
+                    },
+                    "aggregate": {
+                      "type": "object"
+                    },
+                    "coverage": {
+                      "type": "object",
+                      "properties": {
+                        "coverage_status": {
+                          "type": "string",
+                          "enum": [
+                            "deep",
+                            "medium",
+                            "shallow",
+                            "unavailable"
+                          ]
+                        },
+                        "confidence": {
+                          "type": "number"
+                        },
+                        "last_refreshed_at": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "missing_fields": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "warnings": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "source_updated_at": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "caveat": {
+                      "type": "string"
+                    },
+                    "evidence_pack": {
+                      "type": "object"
+                    },
+                    "agent_decision_support": {
+                      "type": "object",
+                      "properties": {
+                        "posture": {
+                          "type": "string",
+                          "const": "evidence_only"
+                        },
+                        "confidence": {
+                          "type": "string",
+                          "enum": [
+                            "LOW",
+                            "MID",
+                            "HIGH",
+                            "UNKNOWN"
+                          ]
+                        },
+                        "evidence_summary": {
+                          "type": "string"
+                        },
+                        "decision_options": {
+                          "type": "array",
+                          "items": {
+                            "type": "object"
+                          }
+                        },
+                        "escalation_triggers": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "spend_rationale": {
+                      "type": "object",
+                      "properties": {
+                        "why_this_cost_is_worth_it": {
+                          "type": "string"
+                        },
+                        "cheaper_alternative": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "more_complete_alternative": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "explicit_delta_over_daily_plus_weekly": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "methodology": {
+                      "type": "string",
+                      "const": "scry_watchlist_snapshot_v1"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid address or mint"
+          },
+          "402": {
+            "description": "X-PAYMENT header required"
+          }
+        },
+        "x-scry-price": "$0.05",
+        "x-scry-cache-ttl-seconds": 0,
+        "x-marketplace-alias": false,
+        "operationId": "get_wallet_watchlist_snapshot",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.050000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        }
+      }
+    },
+    "/x402/pumpfun/launch-dossier": {
+      "get": {
+        "tags": [
+          "x402-paid",
+          "solana",
+          "pumpfun",
+          "pumpfun-launch-dossier",
+          "memecoin-launch",
+          "creator-history",
+          "token-creator-context",
+          "launch-window-evidence",
+          "creator-wallet-context",
+          "holder-concentration",
+          "top-holder-analysis",
+          "private-routing",
+          "transfer-reconciliation",
+          "mint-launch-relationship-evidence",
+          "x402-data-broker",
+          "solana-x402-data-marketplace"
+        ],
+        "summary": "Fetch a Pump.fun mint launch dossier",
+        "description": "[BETA] One Pump.fun or memecoin mint/launch dossier: creator context, launch-window evidence, holder context, private-routing evidence, liquidity context, and checked/unchecked fields. Use when the object is one mint or launch. Evidence only; no verdict. No API keys, no subscriptions; x402 exact payment per request.\n\nPrice: $0.30. Requires x402 exact payment.",
+        "parameters": [
+          {
+            "name": "mint",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Solana token mint address, preferably a Pump.fun or fresh memecoin mint."
+            },
+            "example": "JUPyiwrYJFskUPiHa7hkeR8VUtAeFoSYbKedZNsDvCN"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paid intelligence response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "status",
+                    "product",
+                    "mint",
+                    "supported",
+                    "launch_preflight",
+                    "creator_context",
+                    "launch_window_evidence",
+                    "coverage",
+                    "evidence_pack",
+                    "agent_decision_support",
+                    "spend_rationale",
+                    "methodology"
+                  ],
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "success",
+                        "partial",
+                        "error"
+                      ]
+                    },
+                    "product": {
+                      "type": "string",
+                      "const": "scry_pumpfun_launch_dossier"
+                    },
+                    "as_of": {
+                      "type": "string"
+                    },
+                    "sources": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "confidence_score": {
+                      "type": "number",
+                      "minimum": 0,
+                      "maximum": 1
+                    },
+                    "mint": {
+                      "type": "string"
+                    },
+                    "supported": {
+                      "type": "boolean"
+                    },
+                    "beta": {
+                      "type": "boolean"
+                    },
+                    "unsupported_reason": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "launch_preflight": {
+                      "type": "object"
+                    },
+                    "creator_context": {
+                      "type": [
+                        "object",
+                        "null"
+                      ]
+                    },
+                    "launch_window_evidence": {
+                      "type": [
+                        "object",
+                        "null"
+                      ]
+                    },
+                    "coverage": {
+                      "type": "object"
+                    },
+                    "caveat": {
+                      "type": "string"
+                    },
+                    "evidence_pack": {
+                      "type": "object"
+                    },
+                    "agent_decision_support": {
+                      "type": "object",
+                      "properties": {
+                        "posture": {
+                          "type": "string",
+                          "const": "evidence_only"
+                        },
+                        "confidence": {
+                          "type": "string",
+                          "enum": [
+                            "LOW",
+                            "MID",
+                            "HIGH",
+                            "UNKNOWN"
+                          ]
+                        },
+                        "evidence_summary": {
+                          "type": "string"
+                        },
+                        "decision_options": {
+                          "type": "array",
+                          "items": {
+                            "type": "object"
+                          }
+                        },
+                        "escalation_triggers": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "spend_rationale": {
+                      "type": "object",
+                      "properties": {
+                        "why_this_cost_is_worth_it": {
+                          "type": "string"
+                        },
+                        "cheaper_alternative": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "more_complete_alternative": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "explicit_delta_over_daily_plus_weekly": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "methodology": {
+                      "type": "string",
+                      "const": "scry_pumpfun_launch_dossier_v1_beta"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid address or mint"
+          },
+          "402": {
+            "description": "X-PAYMENT header required"
+          }
+        },
+        "x-scry-price": "$0.30",
+        "x-scry-cache-ttl-seconds": 900,
+        "x-marketplace-alias": false,
+        "operationId": "get_pumpfun_launch_dossier",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.300000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        }
+      }
+    },
+    "/x402/mint/{mint}/risk": {
+      "get": {
+        "tags": [
+          "x402-paid",
+          "solana",
+          "memecoin-risk",
+          "rug-evidence",
+          "rug-check",
+          "rug-preflight",
+          "token-risk",
+          "mint-risk",
+          "holder-concentration",
+          "holder-concentration-check",
+          "holder-concentration-api",
+          "token-holder-analysis",
+          "top-holder-concentration",
+          "top-holder-exit-pressure",
+          "holder-distribution",
+          "memecoin-holder-analysis",
+          "exit-pressure",
+          "creator-network",
+          "pumpfun",
+          "agent-api",
+          "x402-data-broker",
+          "solana-x402-data-marketplace"
+        ],
+        "summary": "Fetch risk evidence for a Solana mint",
+        "description": "[BETA] Low-cost Pump.fun or memecoin mint preflight for autonomous agents. Use when the object is one Solana mint and the caller needs rug-evidence context, holder concentration, creator context, and missing-field coverage before escalating to a launch dossier or wallet forensics. Returns rug-heuristic evidence, holder-concentration proxy, top-holder exit-pressure context, dev-wallet activity, token age, liquidity coverage, creator context, checked/unchecked sources, and missing fields. Evidence only; no verdict. No API keys, no subscriptions; x402 exact payment per request. Search aliases: solana memecoin rug evidence; solana memecoin holder concentration check; solana rug check api; x402 solana mint risk; three cent solana mint risk preflight; solana rug evidence preflight; low cost solana token holder preflight; low cost mint rug preflight. Primary object: low cost single mint preflight.\n\nPrice: $0.03. Requires x402 exact payment.",
+        "parameters": [
+          {
+            "name": "mint",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Solana token mint address"
+            },
+            "example": "JUPyiwrYJFskUPiHa7hkeR8VUtAeFoSYbKedZNsDvCN"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paid intelligence response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "product",
+                    "mint",
+                    "supported",
+                    "beta",
+                    "risk",
+                    "risk_score",
+                    "confidence",
+                    "coverage",
+                    "evidence_pack",
+                    "agent_decision_support",
+                    "spend_rationale",
+                    "methodology"
+                  ],
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "success",
+                        "partial",
+                        "error"
+                      ]
+                    },
+                    "product": {
+                      "type": "string",
+                      "const": "scry_mint_risk_beta"
+                    },
+                    "as_of": {
+                      "type": "string",
+                      "description": "Response evidence timestamp."
+                    },
+                    "sources": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "description": "Named data sources used in this response."
+                    },
+                    "confidence_score": {
+                      "type": "number",
+                      "minimum": 0,
+                      "maximum": 1
+                    },
+                    "mint": {
+                      "type": "string",
+                      "description": "Queried Solana token mint."
+                    },
+                    "supported": {
+                      "type": "boolean",
+                      "description": "False for system/stablecoin/LST/infrastructure mints."
+                    },
+                    "beta": {
+                      "type": "boolean",
+                      "description": "Mint-risk is priced and labeled as beta."
+                    },
+                    "unsupported_reason": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "risk": {
+                      "type": "string",
+                      "enum": [
+                        "LOW",
+                        "MID_STRUCTURAL",
+                        "MID_UNKNOWN",
+                        "HIGH",
+                        "UNKNOWN"
+                      ]
+                    },
+                    "risk_score": {
+                      "type": [
+                        "number",
+                        "null"
+                      ]
+                    },
+                    "confidence": {
+                      "type": "string",
+                      "enum": [
+                        "LOW",
+                        "MID",
+                        "HIGH",
+                        "UNKNOWN"
+                      ]
+                    },
+                    "sub_scores": {
+                      "type": "object",
+                      "properties": {
+                        "liquidity_pools": {
+                          "type": "number"
+                        },
+                        "holder_concentration": {
+                          "type": "number"
+                        },
+                        "top_holders_sell_pressure": {
+                          "type": "number"
+                        },
+                        "dev_wallet_activity": {
+                          "type": "number"
+                        },
+                        "token_age": {
+                          "type": "number"
+                        }
+                      }
+                    },
+                    "holder_concentration_pct_proxy": {
+                      "type": [
+                        "number",
+                        "null"
+                      ],
+                      "description": "Top-holder concentration proxy."
+                    },
+                    "holder_concentration_basis": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "enum": [
+                        "top10",
+                        "top5",
+                        "top1",
+                        null
+                      ]
+                    },
+                    "creator_wallet": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Creator/dev wallet when inferable."
+                    },
+                    "creator_in_known_creator_network": {
+                      "type": "boolean"
+                    },
+                    "creator_network_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "creator_network_size": {
+                      "type": [
+                        "number",
+                        "null"
+                      ]
+                    },
+                    "evidence_items": {
+                      "type": "array",
+                      "description": "Top evidence items used in the evidence summary."
+                    },
+                    "sample_size": {
+                      "type": "object",
+                      "properties": {
+                        "data_sources_checked": {
+                          "type": "number"
+                        },
+                        "evidence_items_count": {
+                          "type": "number"
+                        },
+                        "holder_sample_proxy": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      }
+                    },
+                    "coverage": {
+                      "type": "object",
+                      "properties": {
+                        "checked_sources": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "unchecked_sources": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "unavailable_fields": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "warnings": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "evaluated_at": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "caveat": {
+                      "type": "string"
+                    },
+                    "evidence_pack": {
+                      "type": "object",
+                      "description": "Machine-readable evidence contract for caller-defined policies."
+                    },
+                    "agent_decision_support": {
+                      "type": "object",
+                      "properties": {
+                        "posture": {
+                          "type": "string",
+                          "const": "evidence_only"
+                        },
+                        "confidence": {
+                          "type": "string",
+                          "enum": [
+                            "LOW",
+                            "MID",
+                            "HIGH",
+                            "UNKNOWN"
+                          ]
+                        },
+                        "evidence_summary": {
+                          "type": "string"
+                        },
+                        "decision_options": {
+                          "type": "array",
+                          "items": {
+                            "type": "object"
+                          }
+                        },
+                        "escalation_triggers": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "spend_rationale": {
+                      "type": "object",
+                      "properties": {
+                        "why_this_cost_is_worth_it": {
+                          "type": "string"
+                        },
+                        "cheaper_alternative": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "more_complete_alternative": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "explicit_delta_over_daily_plus_weekly": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "methodology": {
+                      "type": "string",
+                      "const": "sentinel_x402_mint_risk_v1_beta"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid address or mint"
+          },
+          "402": {
+            "description": "X-PAYMENT header required"
+          }
+        },
+        "x-scry-price": "$0.03",
+        "x-scry-cache-ttl-seconds": 1800,
+        "x-marketplace-alias": false,
+        "operationId": "get_mint_risk",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.030000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds **Scry Wallet Intelligence** (https://scry.solanahub.de) — an x402-paid Solana wallet-intelligence and forensic-evidence API for agents.

**What it offers:** 17 paid products covering wallet screening, pairwise connections, funding lineage, bundler/private-routing evidence, transfer history, PnL context, full forensic dossiers, Pump.fun cohorts and launch dossiers, mint risk, watchlists, and priority fees. Prices range from the $0.001 wallet quick-flag to the $0.30 launch dossier.

**Spend-aware by design:** agents can inspect the free freshness SLA and product catalog before paying, start with the cheapest product that answers the question, and escalate only when the returned coverage or provenance identifies an evidence gap. Responses are evidence-only and do not return trading recommendations or risk verdicts.

**Payments:** x402 exact USDC with Solana as the primary rail and Base USDC as a fallback. No API key or subscription is required.

**Agent-readable contract:** the committed OpenAPI is reproducibly generated from the live production contract and contains only the 17 purchasable actions. Every operation has a stable `operationId`, fixed USD `x-payment-info`, a summary and description; every parameter has a description and example. Pairwise wallet inputs `a` and `b` are correctly marked required, and 38 unreferenced source components are intentionally excluded. Pump.fun `limit` remains a query parameter and internal operational keys remain excluded from public samples.

**Validation (2026-07-31):**

- `pay catalog check providers/scry/wallet-intel/PAY.md --no-probe -v`: green, 17 endpoints, 0 Scry warnings/errors
- `pay catalog check providers/scry/wallet-intel/PAY.md -v`: green, 17/17 live paid gates Solana-compatible
- full registry static check at current upstream: green, 73 providers / 888 endpoints; 421 pre-existing warnings outside Scry
- deterministic sidecar-builder test: 1 passed, 0 failed
- PR scope remains exactly two provider files: `PAY.md` and `openapi.json`
