### PR TITLE
feat: add agentpulse-economy-report skill

### DIFF
--- a/providers/agentpulse/economy-report/PAY.md
+++ b/providers/agentpulse/economy-report/PAY.md
@@ -1,0 +1,19 @@
+---
+name: economy-report
+title: "AgentPulse Economy Report"
+description: "Structured JSON report on AI agent economy activity: on-chain USDC flows, transaction volume, new agent launches, trending agent services, and smart-money signals. Pay once per report. No API key required."
+use_case: "Use for a current snapshot of the AI agent economy: x402/USDC transaction volume, notable new agent launches, smart-money agent wallet movements, and trending agent services with emerging monetization patterns."
+category: data
+service_url: https://agentpulse-worker.agentpulse.workers.dev
+openapi:
+  path: openapi.json
+---
+
+AgentPulse publishes a structured report on AI agent economy activity covering the last 24-48 hours: on-chain USDC flows, transaction volume by chain, new agent launches, smart-money agent wallet movements, and trending agent services.
+
+Flat price of 0.01 USDC per report. Payment accepted on Solana mainnet (USDC SPL) and Base mainnet (USDC ERC-20) via x402 — settle on whichever chain you hold USDC on. A GET without a payment header returns a 402 challenge listing both networks.
+
+## Spend-aware usage
+
+- One call returns the full report; there is nothing to paginate or chain.
+- The report covers a 24-48 hour window — cache it and re-fetch at most a few times per day.

--- a/providers/agentpulse/economy-report/PAY.md
+++ b/providers/agentpulse/economy-report/PAY.md
@@ -3,7 +3,7 @@ name: economy-report
 title: "AgentPulse Economy Report"
 description: "Structured JSON report on AI agent economy activity: on-chain USDC flows, transaction volume, new agent launches, trending agent services, and smart-money signals. Pay once per report. No API key required."
 use_case: "Use for a current snapshot of the AI agent economy: x402/USDC transaction volume, notable new agent launches, smart-money agent wallet movements, and trending agent services with emerging monetization patterns."
-category: data
+category: finance
 service_url: https://agentpulse-worker.agentpulse.workers.dev
 openapi:
   path: openapi.json

--- a/providers/agentpulse/economy-report/openapi.json
+++ b/providers/agentpulse/economy-report/openapi.json
@@ -81,7 +81,7 @@
                       }
                     },
                     "sources": { "type": "array", "items": { "type": "string" } },
-                    "confidence_score": { "type": "number" },
+                    "confidence_score": { "type": "number", "minimum": 0, "maximum": 100 },
                     "recommendations_for_agents": { "type": "array", "items": { "type": "string" } }
                   }
                 }

--- a/providers/agentpulse/economy-report/openapi.json
+++ b/providers/agentpulse/economy-report/openapi.json
@@ -31,7 +31,7 @@
                     "x402_activity": {
                       "type": "object",
                       "properties": {
-                        "total_transactions": { "type": "number" },
+                        "total_transactions": { "type": "integer" },
                         "total_volume_usdc": { "type": "number" },
                         "top_chains": { "type": "array", "items": { "type": "string" } },
                         "key_insights": { "type": "array", "items": { "type": "string" } }
@@ -40,7 +40,7 @@
                     "new_agent_launches": {
                       "type": "object",
                       "properties": {
-                        "count": { "type": "number" },
+                        "count": { "type": "integer" },
                         "notable_launches": {
                           "type": "array",
                           "items": {

--- a/providers/agentpulse/economy-report/openapi.json
+++ b/providers/agentpulse/economy-report/openapi.json
@@ -1,0 +1,98 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "AgentPulse Economy Report",
+    "description": "Structured JSON report on AI agent economy activity: on-chain USDC flows, transaction volume, new agent launches, trending agent services, and smart-money signals.",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://agentpulse-worker.agentpulse.workers.dev"
+    }
+  ],
+  "paths": {
+    "/report": {
+      "get": {
+        "operationId": "getEconomyReport",
+        "summary": "Latest AgentPulse agent economy report",
+        "description": "Returns the latest structured agent economy report covering the last 24-48 hours. Requires x402 payment of 0.01 USDC on Solana mainnet or Base mainnet; an unpaid request returns a 402 challenge listing both payment schemes.",
+        "responses": {
+          "200": {
+            "description": "The latest agent economy report.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "report_id": { "type": "string" },
+                    "timestamp": { "type": "string", "format": "date-time" },
+                    "time_window": { "type": "string" },
+                    "summary": { "type": "string" },
+                    "x402_activity": {
+                      "type": "object",
+                      "properties": {
+                        "total_transactions": { "type": "number" },
+                        "total_volume_usdc": { "type": "number" },
+                        "top_chains": { "type": "array", "items": { "type": "string" } },
+                        "key_insights": { "type": "array", "items": { "type": "string" } }
+                      }
+                    },
+                    "new_agent_launches": {
+                      "type": "object",
+                      "properties": {
+                        "count": { "type": "number" },
+                        "notable_launches": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "name": { "type": "string" },
+                              "chain": { "type": "string" },
+                              "description": { "type": "string" },
+                              "status": { "type": "string" }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "smart_money_agent_wallets": {
+                      "type": "object",
+                      "properties": {
+                        "key_movements": { "type": "array", "items": { "type": "string" } },
+                        "insights": { "type": "array", "items": { "type": "string" } }
+                      }
+                    },
+                    "trending_agent_services": {
+                      "type": "object",
+                      "properties": {
+                        "top_services": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "name": { "type": "string" },
+                              "category": { "type": "string" },
+                              "estimated_volume": { "type": "number" },
+                              "trend": { "type": "string" }
+                            }
+                          }
+                        },
+                        "emerging_trends": { "type": "array", "items": { "type": "string" } }
+                      }
+                    },
+                    "sources": { "type": "array", "items": { "type": "string" } },
+                    "confidence_score": { "type": "number" },
+                    "recommendations_for_agents": { "type": "array", "items": { "type": "string" } }
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required. The X-PAYMENT-REQUIRED header and JSON body list accepted x402 payment schemes (Solana mainnet USDC and Base mainnet USDC)."
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds the **AgentPulse Economy Report** provider (`agentpulse/economy-report`).

Structured JSON report on AI agent economy activity: on-chain USDC flows, transaction volume, new agent launches, trending agent services, and smart-money signals. Flat 0.01 USDC per report, no API key required.

**Payment networks:** Solana mainnet (USDC SPL) and Base mainnet (USDC ERC-20) via x402 - the endpoint returns a 402 challenge listing both schemes.

`pay catalog check providers/agentpulse/economy-report/PAY.md` passes locally (live probe included: 1/1 gates compatible with Solana).

Generated with [Claude Code](https://claude.com/claude-code)