### PR TITLE
providers(relai): add RelAI gift card APIs (x402 USDC on Solana)

### DIFF
--- a/providers/relai/adidas/PAY.md
+++ b/providers/relai/adidas/PAY.md
@@ -1,0 +1,27 @@
+---
+name: adidas
+title: "Adidas Gift Cards (RelAI)"
+description: "Buy Adidas gift cards with USDC on Solana via x402 micropayments. Redeemable at adidas.com and adidas retail stores for sneakers, sportswear, and athletic gear. Redemption codes emailed instantly; $10–$100 denominations; gas-free."
+use_case: "Use for buying Adidas gift cards, gifting Adidas credit, sending Adidas gift cards by email, and agent-initiated Adidas gift card purchases paid in USDC on Solana."
+category: shopping
+service_url: https://adidas.x402.fi
+openapi:
+  path: openapi.json
+---
+Adidas gift cards for AI agents, paid with USDC on Solana via x402. Browse
+denominations on the free `/store/catalog/adidas` endpoint, then buy with a
+single paid `POST /store/buy/adidas-<amount>`. Available denominations:
+$10, $25, $50, $100. The redemption code is emailed to `recipient_email` instantly.
+Payment is gas-free — RelAI sponsors the Solana transaction fee.
+
+Each purchase takes `recipient_email` (required), `country_code` (ISO code from
+the endpoint's enum), and an optional `sender_name`.
+
+## Spend-aware usage
+
+- These endpoints place real, non-refundable gift card orders. Confirm the brand,
+  exact denomination, recipient email, and country with the user before paying.
+- Use the free `/store/catalog/adidas` endpoint to discover valid denominations
+  and the supported country first — do not call a paid `buy` endpoint to probe.
+- Pick the single denomination that matches the user's intended amount; never call
+  multiple `buy` endpoints to compare.

--- a/providers/relai/adidas/openapi.json
+++ b/providers/relai/adidas/openapi.json
@@ -1,0 +1,278 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Adidas Gift Cards",
+    "version": "1.0.0",
+    "description": "Adidas gift cards via x402 USDC on Solana."
+  },
+  "servers": [
+    {
+      "url": "https://adidas.x402.fi",
+      "description": "Production"
+    }
+  ],
+  "paths": {
+    "/store/catalog/adidas": {
+      "get": {
+        "operationId": "catalog_adidas",
+        "summary": "List Adidas gift card denominations",
+        "description": "Free. Returns the available Adidas gift card denominations, USDC prices, and supported country.",
+        "responses": {
+          "200": {
+            "description": "Adidas catalog",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Brand not found"
+          }
+        }
+      }
+    },
+    "/store/buy/adidas-10": {
+      "post": {
+        "operationId": "buy_adidas_10",
+        "summary": "Buy a Adidas $10 gift card",
+        "description": "Purchase a $10 Adidas gift card. Pay 10 USDC on Solana via x402; the redemption code is emailed to recipient_email instantly. Gas-free — RelAI sponsors the Solana fee.",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$10.00"
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "recipient_email",
+                  "country_code"
+                ],
+                "properties": {
+                  "recipient_email": {
+                    "type": "string",
+                    "format": "email",
+                    "description": "Email to receive the gift card"
+                  },
+                  "country_code": {
+                    "type": "string",
+                    "enum": [
+                      "BE",
+                      "ES",
+                      "PT",
+                      "US"
+                    ],
+                    "description": "ISO country code for the gift card"
+                  },
+                  "sender_name": {
+                    "type": "string",
+                    "description": "Sender name (optional)"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Redeem code returned. The gift card code is emailed to recipient_email."
+          },
+          "402": {
+            "description": "Payment Required — 10 USDC"
+          },
+          "409": {
+            "description": "Transaction already used"
+          }
+        }
+      }
+    },
+    "/store/buy/adidas-25": {
+      "post": {
+        "operationId": "buy_adidas_25",
+        "summary": "Buy a Adidas $25 gift card",
+        "description": "Purchase a $25 Adidas gift card. Pay 25 USDC on Solana via x402; the redemption code is emailed to recipient_email instantly. Gas-free — RelAI sponsors the Solana fee.",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$25.00"
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "recipient_email",
+                  "country_code"
+                ],
+                "properties": {
+                  "recipient_email": {
+                    "type": "string",
+                    "format": "email",
+                    "description": "Email to receive the gift card"
+                  },
+                  "country_code": {
+                    "type": "string",
+                    "enum": [
+                      "BE",
+                      "ES",
+                      "PT",
+                      "US"
+                    ],
+                    "description": "ISO country code for the gift card"
+                  },
+                  "sender_name": {
+                    "type": "string",
+                    "description": "Sender name (optional)"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Redeem code returned. The gift card code is emailed to recipient_email."
+          },
+          "402": {
+            "description": "Payment Required — 25 USDC"
+          },
+          "409": {
+            "description": "Transaction already used"
+          }
+        }
+      }
+    },
+    "/store/buy/adidas-50": {
+      "post": {
+        "operationId": "buy_adidas_50",
+        "summary": "Buy a Adidas $50 gift card",
+        "description": "Purchase a $50 Adidas gift card. Pay 50 USDC on Solana via x402; the redemption code is emailed to recipient_email instantly. Gas-free — RelAI sponsors the Solana fee.",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$50.00"
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "recipient_email",
+                  "country_code"
+                ],
+                "properties": {
+                  "recipient_email": {
+                    "type": "string",
+                    "format": "email",
+                    "description": "Email to receive the gift card"
+                  },
+                  "country_code": {
+                    "type": "string",
+                    "enum": [
+                      "BE",
+                      "ES",
+                      "PT",
+                      "US"
+                    ],
+                    "description": "ISO country code for the gift card"
+                  },
+                  "sender_name": {
+                    "type": "string",
+                    "description": "Sender name (optional)"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Redeem code returned. The gift card code is emailed to recipient_email."
+          },
+          "402": {
+            "description": "Payment Required — 50 USDC"
+          },
+          "409": {
+            "description": "Transaction already used"
+          }
+        }
+      }
+    },
+    "/store/buy/adidas-100": {
+      "post": {
+        "operationId": "buy_adidas_100",
+        "summary": "Buy a Adidas $100 gift card",
+        "description": "Purchase a $100 Adidas gift card. Pay 100 USDC on Solana via x402; the redemption code is emailed to recipient_email instantly. Gas-free — RelAI sponsors the Solana fee.",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$100.00"
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "recipient_email",
+                  "country_code"
+                ],
+                "properties": {
+                  "recipient_email": {
+                    "type": "string",
+                    "format": "email",
+                    "description": "Email to receive the gift card"
+                  },
+                  "country_code": {
+                    "type": "string",
+                    "enum": [
+                      "BE",
+                      "ES",
+                      "PT",
+                      "US"
+                    ],
+                    "description": "ISO country code for the gift card"
+                  },
+                  "sender_name": {
+                    "type": "string",
+                    "description": "Sender name (optional)"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Redeem code returned. The gift card code is emailed to recipient_email."
+          },
+          "402": {
+            "description": "Payment Required — 100 USDC"
+          },
+          "409": {
+            "description": "Transaction already used"
+          }
+        }
+      }
+    }
+  }
+}

--- a/providers/relai/airbnb/PAY.md
+++ b/providers/relai/airbnb/PAY.md
@@ -1,0 +1,27 @@
+---
+name: airbnb
+title: "Airbnb Gift Cards (RelAI)"
+description: "Buy Airbnb gift cards with USDC on Solana via x402 micropayments. Redeemable on airbnb.com toward stays, experiences, and vacation rentals worldwide. Redemption codes emailed instantly; $25–$100 denominations; gas-free."
+use_case: "Use for buying Airbnb gift cards, gifting Airbnb credit, sending Airbnb gift cards by email, and agent-initiated Airbnb gift card purchases paid in USDC on Solana."
+category: shopping
+service_url: https://airbnb.x402.fi
+openapi:
+  path: openapi.json
+---
+Airbnb gift cards for AI agents, paid with USDC on Solana via x402. Browse
+denominations on the free `/store/catalog/airbnb` endpoint, then buy with a
+single paid `POST /store/buy/airbnb-<amount>`. Available denominations:
+$25, $50, $100. The redemption code is emailed to `recipient_email` instantly.
+Payment is gas-free — RelAI sponsors the Solana transaction fee.
+
+Each purchase takes `recipient_email` (required), `country_code` (ISO code from
+the endpoint's enum), and an optional `sender_name`.
+
+## Spend-aware usage
+
+- These endpoints place real, non-refundable gift card orders. Confirm the brand,
+  exact denomination, recipient email, and country with the user before paying.
+- Use the free `/store/catalog/airbnb` endpoint to discover valid denominations
+  and the supported country first — do not call a paid `buy` endpoint to probe.
+- Pick the single denomination that matches the user's intended amount; never call
+  multiple `buy` endpoints to compare.

--- a/providers/relai/airbnb/openapi.json
+++ b/providers/relai/airbnb/openapi.json
@@ -1,0 +1,215 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Airbnb Gift Cards",
+    "version": "1.0.0",
+    "description": "Airbnb gift cards via x402 USDC on Solana."
+  },
+  "servers": [
+    {
+      "url": "https://airbnb.x402.fi",
+      "description": "Production"
+    }
+  ],
+  "paths": {
+    "/store/catalog/airbnb": {
+      "get": {
+        "operationId": "catalog_airbnb",
+        "summary": "List Airbnb gift card denominations",
+        "description": "Free. Returns the available Airbnb gift card denominations, USDC prices, and supported country.",
+        "responses": {
+          "200": {
+            "description": "Airbnb catalog",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Brand not found"
+          }
+        }
+      }
+    },
+    "/store/buy/airbnb-25": {
+      "post": {
+        "operationId": "buy_airbnb_25",
+        "summary": "Buy a Airbnb $25 gift card",
+        "description": "Purchase a $25 Airbnb gift card. Pay 25 USDC on Solana via x402; the redemption code is emailed to recipient_email instantly. Gas-free — RelAI sponsors the Solana fee.",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$25.00"
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "recipient_email",
+                  "country_code"
+                ],
+                "properties": {
+                  "recipient_email": {
+                    "type": "string",
+                    "format": "email",
+                    "description": "Email to receive the gift card"
+                  },
+                  "country_code": {
+                    "type": "string",
+                    "enum": [
+                      "CA",
+                      "MX",
+                      "US"
+                    ],
+                    "description": "ISO country code for the gift card"
+                  },
+                  "sender_name": {
+                    "type": "string",
+                    "description": "Sender name (optional)"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Redeem code returned. The gift card code is emailed to recipient_email."
+          },
+          "402": {
+            "description": "Payment Required — 25 USDC"
+          },
+          "409": {
+            "description": "Transaction already used"
+          }
+        }
+      }
+    },
+    "/store/buy/airbnb-50": {
+      "post": {
+        "operationId": "buy_airbnb_50",
+        "summary": "Buy a Airbnb $50 gift card",
+        "description": "Purchase a $50 Airbnb gift card. Pay 50 USDC on Solana via x402; the redemption code is emailed to recipient_email instantly. Gas-free — RelAI sponsors the Solana fee.",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$50.00"
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "recipient_email",
+                  "country_code"
+                ],
+                "properties": {
+                  "recipient_email": {
+                    "type": "string",
+                    "format": "email",
+                    "description": "Email to receive the gift card"
+                  },
+                  "country_code": {
+                    "type": "string",
+                    "enum": [
+                      "CA",
+                      "MX",
+                      "US"
+                    ],
+                    "description": "ISO country code for the gift card"
+                  },
+                  "sender_name": {
+                    "type": "string",
+                    "description": "Sender name (optional)"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Redeem code returned. The gift card code is emailed to recipient_email."
+          },
+          "402": {
+            "description": "Payment Required — 50 USDC"
+          },
+          "409": {
+            "description": "Transaction already used"
+          }
+        }
+      }
+    },
+    "/store/buy/airbnb-100": {
+      "post": {
+        "operationId": "buy_airbnb_100",
+        "summary": "Buy a Airbnb $100 gift card",
+        "description": "Purchase a $100 Airbnb gift card. Pay 100 USDC on Solana via x402; the redemption code is emailed to recipient_email instantly. Gas-free — RelAI sponsors the Solana fee.",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$100.00"
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "recipient_email",
+                  "country_code"
+                ],
+                "properties": {
+                  "recipient_email": {
+                    "type": "string",
+                    "format": "email",
+                    "description": "Email to receive the gift card"
+                  },
+                  "country_code": {
+                    "type": "string",
+                    "enum": [
+                      "CA",
+                      "MX",
+                      "US"
+                    ],
+                    "description": "ISO country code for the gift card"
+                  },
+                  "sender_name": {
+                    "type": "string",
+                    "description": "Sender name (optional)"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Redeem code returned. The gift card code is emailed to recipient_email."
+          },
+          "402": {
+            "description": "Payment Required — 100 USDC"
+          },
+          "409": {
+            "description": "Transaction already used"
+          }
+        }
+      }
+    }
+  }
+}

--- a/providers/relai/amazon/PAY.md
+++ b/providers/relai/amazon/PAY.md
@@ -1,0 +1,27 @@
+---
+name: amazon
+title: "Amazon Gift Cards (RelAI)"
+description: "Buy Amazon gift cards with USDC on Solana via x402 micropayments. Redeemable on amazon.com for millions of products across electronics, books, household goods, fashion, and more. Redemption codes emailed instantly; $10–$100 denominations; gas-free."
+use_case: "Use for buying Amazon gift cards, gifting Amazon credit, sending Amazon gift cards by email, and agent-initiated Amazon gift card purchases paid in USDC on Solana."
+category: shopping
+service_url: https://amazon.x402.fi
+openapi:
+  path: openapi.json
+---
+Amazon gift cards for AI agents, paid with USDC on Solana via x402. Browse
+denominations on the free `/store/catalog/amazon` endpoint, then buy with a
+single paid `POST /store/buy/amazon-<amount>`. Available denominations:
+$10, $25, $50, $100. The redemption code is emailed to `recipient_email` instantly.
+Payment is gas-free — RelAI sponsors the Solana transaction fee.
+
+Each purchase takes `recipient_email` (required), `country_code` (ISO code from
+the endpoint's enum), and an optional `sender_name`.
+
+## Spend-aware usage
+
+- These endpoints place real, non-refundable gift card orders. Confirm the brand,
+  exact denomination, recipient email, and country with the user before paying.
+- Use the free `/store/catalog/amazon` endpoint to discover valid denominations
+  and the supported country first — do not call a paid `buy` endpoint to probe.
+- Pick the single denomination that matches the user's intended amount; never call
+  multiple `buy` endpoints to compare.

--- a/providers/relai/amazon/openapi.json
+++ b/providers/relai/amazon/openapi.json
@@ -1,0 +1,306 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Amazon Gift Cards",
+    "version": "1.0.0",
+    "description": "Amazon gift cards via x402 USDC on Solana."
+  },
+  "servers": [
+    {
+      "url": "https://amazon.x402.fi",
+      "description": "Production"
+    }
+  ],
+  "paths": {
+    "/store/catalog/amazon": {
+      "get": {
+        "operationId": "catalog_amazon",
+        "summary": "List Amazon gift card denominations",
+        "description": "Free. Returns the available Amazon gift card denominations, USDC prices, and supported country.",
+        "responses": {
+          "200": {
+            "description": "Amazon catalog",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Brand not found"
+          }
+        }
+      }
+    },
+    "/store/buy/amazon-10": {
+      "post": {
+        "operationId": "buy_amazon_10",
+        "summary": "Buy a Amazon $10 gift card",
+        "description": "Purchase a $10 Amazon gift card. Pay 10 USDC on Solana via x402; the redemption code is emailed to recipient_email instantly. Gas-free — RelAI sponsors the Solana fee.",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$10.00"
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "recipient_email",
+                  "country_code"
+                ],
+                "properties": {
+                  "recipient_email": {
+                    "type": "string",
+                    "format": "email",
+                    "description": "Email to receive the gift card"
+                  },
+                  "country_code": {
+                    "type": "string",
+                    "enum": [
+                      "AE",
+                      "AT",
+                      "AU",
+                      "CA",
+                      "DE",
+                      "FR",
+                      "GB",
+                      "IT",
+                      "MX",
+                      "SA",
+                      "US"
+                    ],
+                    "description": "ISO country code for the gift card"
+                  },
+                  "sender_name": {
+                    "type": "string",
+                    "description": "Sender name (optional)"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Redeem code returned. The gift card code is emailed to recipient_email."
+          },
+          "402": {
+            "description": "Payment Required — 10 USDC"
+          },
+          "409": {
+            "description": "Transaction already used"
+          }
+        }
+      }
+    },
+    "/store/buy/amazon-25": {
+      "post": {
+        "operationId": "buy_amazon_25",
+        "summary": "Buy a Amazon $25 gift card",
+        "description": "Purchase a $25 Amazon gift card. Pay 25 USDC on Solana via x402; the redemption code is emailed to recipient_email instantly. Gas-free — RelAI sponsors the Solana fee.",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$25.00"
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "recipient_email",
+                  "country_code"
+                ],
+                "properties": {
+                  "recipient_email": {
+                    "type": "string",
+                    "format": "email",
+                    "description": "Email to receive the gift card"
+                  },
+                  "country_code": {
+                    "type": "string",
+                    "enum": [
+                      "AE",
+                      "AT",
+                      "AU",
+                      "CA",
+                      "DE",
+                      "FR",
+                      "GB",
+                      "IT",
+                      "MX",
+                      "SA",
+                      "US"
+                    ],
+                    "description": "ISO country code for the gift card"
+                  },
+                  "sender_name": {
+                    "type": "string",
+                    "description": "Sender name (optional)"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Redeem code returned. The gift card code is emailed to recipient_email."
+          },
+          "402": {
+            "description": "Payment Required — 25 USDC"
+          },
+          "409": {
+            "description": "Transaction already used"
+          }
+        }
+      }
+    },
+    "/store/buy/amazon-50": {
+      "post": {
+        "operationId": "buy_amazon_50",
+        "summary": "Buy a Amazon $50 gift card",
+        "description": "Purchase a $50 Amazon gift card. Pay 50 USDC on Solana via x402; the redemption code is emailed to recipient_email instantly. Gas-free — RelAI sponsors the Solana fee.",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$50.00"
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "recipient_email",
+                  "country_code"
+                ],
+                "properties": {
+                  "recipient_email": {
+                    "type": "string",
+                    "format": "email",
+                    "description": "Email to receive the gift card"
+                  },
+                  "country_code": {
+                    "type": "string",
+                    "enum": [
+                      "AE",
+                      "AT",
+                      "AU",
+                      "CA",
+                      "DE",
+                      "FR",
+                      "GB",
+                      "IT",
+                      "MX",
+                      "SA",
+                      "US"
+                    ],
+                    "description": "ISO country code for the gift card"
+                  },
+                  "sender_name": {
+                    "type": "string",
+                    "description": "Sender name (optional)"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Redeem code returned. The gift card code is emailed to recipient_email."
+          },
+          "402": {
+            "description": "Payment Required — 50 USDC"
+          },
+          "409": {
+            "description": "Transaction already used"
+          }
+        }
+      }
+    },
+    "/store/buy/amazon-100": {
+      "post": {
+        "operationId": "buy_amazon_100",
+        "summary": "Buy a Amazon $100 gift card",
+        "description": "Purchase a $100 Amazon gift card. Pay 100 USDC on Solana via x402; the redemption code is emailed to recipient_email instantly. Gas-free — RelAI sponsors the Solana fee.",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$100.00"
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "recipient_email",
+                  "country_code"
+                ],
+                "properties": {
+                  "recipient_email": {
+                    "type": "string",
+                    "format": "email",
+                    "description": "Email to receive the gift card"
+                  },
+                  "country_code": {
+                    "type": "string",
+                    "enum": [
+                      "AE",
+                      "AT",
+                      "AU",
+                      "CA",
+                      "DE",
+                      "FR",
+                      "GB",
+                      "IT",
+                      "MX",
+                      "SA",
+                      "US"
+                    ],
+                    "description": "ISO country code for the gift card"
+                  },
+                  "sender_name": {
+                    "type": "string",
+                    "description": "Sender name (optional)"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Redeem code returned. The gift card code is emailed to recipient_email."
+          },
+          "402": {
+            "description": "Payment Required — 100 USDC"
+          },
+          "409": {
+            "description": "Transaction already used"
+          }
+        }
+      }
+    }
+  }
+}

--- a/providers/relai/netflix/PAY.md
+++ b/providers/relai/netflix/PAY.md
@@ -1,0 +1,27 @@
+---
+name: netflix
+title: "Netflix Gift Cards (RelAI)"
+description: "Buy Netflix gift cards with USDC on Solana via x402 micropayments. Netflix digital gift card. Redemption codes emailed instantly; $20–$100 denominations; gas-free."
+use_case: "Use for buying Netflix gift cards, gifting Netflix credit, sending Netflix gift cards by email, and agent-initiated Netflix gift card purchases paid in USDC on Solana."
+category: shopping
+service_url: https://netflix.x402.fi
+openapi:
+  path: openapi.json
+---
+Netflix gift cards for AI agents, paid with USDC on Solana via x402. Browse
+denominations on the free `/store/catalog/netflix` endpoint, then buy with a
+single paid `POST /store/buy/netflix-<amount>`. Available denominations:
+$20, $50, $60, $100. The redemption code is emailed to `recipient_email` instantly.
+Payment is gas-free — RelAI sponsors the Solana transaction fee.
+
+Each purchase takes `recipient_email` (required), `country_code` (ISO code from
+the endpoint's enum), and an optional `sender_name`.
+
+## Spend-aware usage
+
+- These endpoints place real, non-refundable gift card orders. Confirm the brand,
+  exact denomination, recipient email, and country with the user before paying.
+- Use the free `/store/catalog/netflix` endpoint to discover valid denominations
+  and the supported country first — do not call a paid `buy` endpoint to probe.
+- Pick the single denomination that matches the user's intended amount; never call
+  multiple `buy` endpoints to compare.

--- a/providers/relai/netflix/openapi.json
+++ b/providers/relai/netflix/openapi.json
@@ -1,0 +1,326 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Netflix Gift Cards",
+    "version": "1.0.0",
+    "description": "Netflix gift cards via x402 USDC on Solana."
+  },
+  "servers": [
+    {
+      "url": "https://netflix.x402.fi",
+      "description": "Production"
+    }
+  ],
+  "paths": {
+    "/store/catalog/netflix": {
+      "get": {
+        "operationId": "catalog_netflix",
+        "summary": "List Netflix gift card denominations",
+        "description": "Free. Returns the available Netflix gift card denominations, USDC prices, and supported country.",
+        "responses": {
+          "200": {
+            "description": "Netflix catalog",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Brand not found"
+          }
+        }
+      }
+    },
+    "/store/buy/netflix-20": {
+      "post": {
+        "operationId": "buy_netflix_20",
+        "summary": "Buy a Netflix $20 gift card",
+        "description": "Purchase a $20 Netflix gift card. Pay 20 USDC on Solana via x402; the redemption code is emailed to recipient_email instantly. Gas-free — RelAI sponsors the Solana fee.",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$20.00"
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "recipient_email",
+                  "country_code"
+                ],
+                "properties": {
+                  "recipient_email": {
+                    "type": "string",
+                    "format": "email",
+                    "description": "Email to receive the gift card"
+                  },
+                  "country_code": {
+                    "type": "string",
+                    "enum": [
+                      "AE",
+                      "AT",
+                      "BE",
+                      "BR",
+                      "CY",
+                      "DE",
+                      "ES",
+                      "FI",
+                      "FR",
+                      "GB",
+                      "GR",
+                      "IE",
+                      "IT",
+                      "NL",
+                      "PT",
+                      "US"
+                    ],
+                    "description": "ISO country code for the gift card"
+                  },
+                  "sender_name": {
+                    "type": "string",
+                    "description": "Sender name (optional)"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Redeem code returned. The gift card code is emailed to recipient_email."
+          },
+          "402": {
+            "description": "Payment Required — 20 USDC"
+          },
+          "409": {
+            "description": "Transaction already used"
+          }
+        }
+      }
+    },
+    "/store/buy/netflix-50": {
+      "post": {
+        "operationId": "buy_netflix_50",
+        "summary": "Buy a Netflix $50 gift card",
+        "description": "Purchase a $50 Netflix gift card. Pay 50 USDC on Solana via x402; the redemption code is emailed to recipient_email instantly. Gas-free — RelAI sponsors the Solana fee.",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$50.00"
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "recipient_email",
+                  "country_code"
+                ],
+                "properties": {
+                  "recipient_email": {
+                    "type": "string",
+                    "format": "email",
+                    "description": "Email to receive the gift card"
+                  },
+                  "country_code": {
+                    "type": "string",
+                    "enum": [
+                      "AE",
+                      "AT",
+                      "BE",
+                      "BR",
+                      "CY",
+                      "DE",
+                      "ES",
+                      "FI",
+                      "FR",
+                      "GB",
+                      "GR",
+                      "IE",
+                      "IT",
+                      "NL",
+                      "PT",
+                      "US"
+                    ],
+                    "description": "ISO country code for the gift card"
+                  },
+                  "sender_name": {
+                    "type": "string",
+                    "description": "Sender name (optional)"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Redeem code returned. The gift card code is emailed to recipient_email."
+          },
+          "402": {
+            "description": "Payment Required — 50 USDC"
+          },
+          "409": {
+            "description": "Transaction already used"
+          }
+        }
+      }
+    },
+    "/store/buy/netflix-60": {
+      "post": {
+        "operationId": "buy_netflix_60",
+        "summary": "Buy a Netflix $60 gift card",
+        "description": "Purchase a $60 Netflix gift card. Pay 60 USDC on Solana via x402; the redemption code is emailed to recipient_email instantly. Gas-free — RelAI sponsors the Solana fee.",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$60.00"
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "recipient_email",
+                  "country_code"
+                ],
+                "properties": {
+                  "recipient_email": {
+                    "type": "string",
+                    "format": "email",
+                    "description": "Email to receive the gift card"
+                  },
+                  "country_code": {
+                    "type": "string",
+                    "enum": [
+                      "AE",
+                      "AT",
+                      "BE",
+                      "BR",
+                      "CY",
+                      "DE",
+                      "ES",
+                      "FI",
+                      "FR",
+                      "GB",
+                      "GR",
+                      "IE",
+                      "IT",
+                      "NL",
+                      "PT",
+                      "US"
+                    ],
+                    "description": "ISO country code for the gift card"
+                  },
+                  "sender_name": {
+                    "type": "string",
+                    "description": "Sender name (optional)"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Redeem code returned. The gift card code is emailed to recipient_email."
+          },
+          "402": {
+            "description": "Payment Required — 60 USDC"
+          },
+          "409": {
+            "description": "Transaction already used"
+          }
+        }
+      }
+    },
+    "/store/buy/netflix-100": {
+      "post": {
+        "operationId": "buy_netflix_100",
+        "summary": "Buy a Netflix $100 gift card",
+        "description": "Purchase a $100 Netflix gift card. Pay 100 USDC on Solana via x402; the redemption code is emailed to recipient_email instantly. Gas-free — RelAI sponsors the Solana fee.",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$100.00"
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "recipient_email",
+                  "country_code"
+                ],
+                "properties": {
+                  "recipient_email": {
+                    "type": "string",
+                    "format": "email",
+                    "description": "Email to receive the gift card"
+                  },
+                  "country_code": {
+                    "type": "string",
+                    "enum": [
+                      "AE",
+                      "AT",
+                      "BE",
+                      "BR",
+                      "CY",
+                      "DE",
+                      "ES",
+                      "FI",
+                      "FR",
+                      "GB",
+                      "GR",
+                      "IE",
+                      "IT",
+                      "NL",
+                      "PT",
+                      "US"
+                    ],
+                    "description": "ISO country code for the gift card"
+                  },
+                  "sender_name": {
+                    "type": "string",
+                    "description": "Sender name (optional)"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Redeem code returned. The gift card code is emailed to recipient_email."
+          },
+          "402": {
+            "description": "Payment Required — 100 USDC"
+          },
+          "409": {
+            "description": "Transaction already used"
+          }
+        }
+      }
+    }
+  }
+}

--- a/providers/relai/nike/PAY.md
+++ b/providers/relai/nike/PAY.md
@@ -1,0 +1,27 @@
+---
+name: nike
+title: "Nike Gift Cards (RelAI)"
+description: "Buy Nike gift cards with USDC on Solana via x402 micropayments. Nike digital gift card. Redemption codes emailed instantly; $10–$100 denominations; gas-free."
+use_case: "Use for buying Nike gift cards, gifting Nike credit, sending Nike gift cards by email, and agent-initiated Nike gift card purchases paid in USDC on Solana."
+category: shopping
+service_url: https://nike.x402.fi
+openapi:
+  path: openapi.json
+---
+Nike gift cards for AI agents, paid with USDC on Solana via x402. Browse
+denominations on the free `/store/catalog/nike` endpoint, then buy with a
+single paid `POST /store/buy/nike-<amount>`. Available denominations:
+$10, $25, $50, $100. The redemption code is emailed to `recipient_email` instantly.
+Payment is gas-free — RelAI sponsors the Solana transaction fee.
+
+Each purchase takes `recipient_email` (required), `country_code` (ISO code from
+the endpoint's enum), and an optional `sender_name`.
+
+## Spend-aware usage
+
+- These endpoints place real, non-refundable gift card orders. Confirm the brand,
+  exact denomination, recipient email, and country with the user before paying.
+- Use the free `/store/catalog/nike` endpoint to discover valid denominations
+  and the supported country first — do not call a paid `buy` endpoint to probe.
+- Pick the single denomination that matches the user's intended amount; never call
+  multiple `buy` endpoints to compare.

--- a/providers/relai/nike/openapi.json
+++ b/providers/relai/nike/openapi.json
@@ -1,0 +1,282 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Nike Gift Cards",
+    "version": "1.0.0",
+    "description": "Nike gift cards via x402 USDC on Solana."
+  },
+  "servers": [
+    {
+      "url": "https://nike.x402.fi",
+      "description": "Production"
+    }
+  ],
+  "paths": {
+    "/store/catalog/nike": {
+      "get": {
+        "operationId": "catalog_nike",
+        "summary": "List Nike gift card denominations",
+        "description": "Free. Returns the available Nike gift card denominations, USDC prices, and supported country.",
+        "responses": {
+          "200": {
+            "description": "Nike catalog",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Brand not found"
+          }
+        }
+      }
+    },
+    "/store/buy/nike-10": {
+      "post": {
+        "operationId": "buy_nike_10",
+        "summary": "Buy a Nike $10 gift card",
+        "description": "Purchase a $10 Nike gift card. Pay 10 USDC on Solana via x402; the redemption code is emailed to recipient_email instantly. Gas-free — RelAI sponsors the Solana fee.",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$10.00"
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "recipient_email",
+                  "country_code"
+                ],
+                "properties": {
+                  "recipient_email": {
+                    "type": "string",
+                    "format": "email",
+                    "description": "Email to receive the gift card"
+                  },
+                  "sender_name": {
+                    "type": "string",
+                    "description": "Sender name (optional)"
+                  },
+                  "country_code": {
+                    "type": "string",
+                    "enum": [
+                      "BE",
+                      "BR",
+                      "DE",
+                      "IE",
+                      "US"
+                    ],
+                    "description": "Country code for regional availability"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Redeem code returned. The gift card code is emailed to recipient_email."
+          },
+          "402": {
+            "description": "Payment Required — 10 USDC"
+          },
+          "409": {
+            "description": "Transaction already used"
+          }
+        }
+      }
+    },
+    "/store/buy/nike-25": {
+      "post": {
+        "operationId": "buy_nike_25",
+        "summary": "Buy a Nike $25 gift card",
+        "description": "Purchase a $25 Nike gift card. Pay 25 USDC on Solana via x402; the redemption code is emailed to recipient_email instantly. Gas-free — RelAI sponsors the Solana fee.",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$25.00"
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "recipient_email",
+                  "country_code"
+                ],
+                "properties": {
+                  "recipient_email": {
+                    "type": "string",
+                    "format": "email",
+                    "description": "Email to receive the gift card"
+                  },
+                  "sender_name": {
+                    "type": "string",
+                    "description": "Sender name (optional)"
+                  },
+                  "country_code": {
+                    "type": "string",
+                    "enum": [
+                      "BE",
+                      "BR",
+                      "DE",
+                      "IE",
+                      "US"
+                    ],
+                    "description": "Country code for regional availability"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Redeem code returned. The gift card code is emailed to recipient_email."
+          },
+          "402": {
+            "description": "Payment Required — 25 USDC"
+          },
+          "409": {
+            "description": "Transaction already used"
+          }
+        }
+      }
+    },
+    "/store/buy/nike-50": {
+      "post": {
+        "operationId": "buy_nike_50",
+        "summary": "Buy a Nike $50 gift card",
+        "description": "Purchase a $50 Nike gift card. Pay 50 USDC on Solana via x402; the redemption code is emailed to recipient_email instantly. Gas-free — RelAI sponsors the Solana fee.",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$50.00"
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "recipient_email",
+                  "country_code"
+                ],
+                "properties": {
+                  "recipient_email": {
+                    "type": "string",
+                    "format": "email",
+                    "description": "Email to receive the gift card"
+                  },
+                  "sender_name": {
+                    "type": "string",
+                    "description": "Sender name (optional)"
+                  },
+                  "country_code": {
+                    "type": "string",
+                    "enum": [
+                      "BE",
+                      "BR",
+                      "DE",
+                      "IE",
+                      "US"
+                    ],
+                    "description": "Country code for regional availability"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Redeem code returned. The gift card code is emailed to recipient_email."
+          },
+          "402": {
+            "description": "Payment Required — 50 USDC"
+          },
+          "409": {
+            "description": "Transaction already used"
+          }
+        }
+      }
+    },
+    "/store/buy/nike-100": {
+      "post": {
+        "operationId": "buy_nike_100",
+        "summary": "Buy a Nike $100 gift card",
+        "description": "Purchase a $100 Nike gift card. Pay 100 USDC on Solana via x402; the redemption code is emailed to recipient_email instantly. Gas-free — RelAI sponsors the Solana fee.",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$100.00"
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "recipient_email",
+                  "country_code"
+                ],
+                "properties": {
+                  "recipient_email": {
+                    "type": "string",
+                    "format": "email",
+                    "description": "Email to receive the gift card"
+                  },
+                  "sender_name": {
+                    "type": "string",
+                    "description": "Sender name (optional)"
+                  },
+                  "country_code": {
+                    "type": "string",
+                    "enum": [
+                      "BE",
+                      "BR",
+                      "DE",
+                      "IE",
+                      "US"
+                    ],
+                    "description": "Country code for regional availability"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Redeem code returned. The gift card code is emailed to recipient_email."
+          },
+          "402": {
+            "description": "Payment Required — 100 USDC"
+          },
+          "409": {
+            "description": "Transaction already used"
+          }
+        }
+      }
+    }
+  }
+}

--- a/providers/relai/playstation/PAY.md
+++ b/providers/relai/playstation/PAY.md
@@ -1,0 +1,27 @@
+---
+name: playstation
+title: "PlayStation Gift Cards (RelAI)"
+description: "Buy PlayStation gift cards with USDC on Solana via x402 micropayments. PlayStation digital gift card. Redemption codes emailed instantly; $25–$100 denominations; gas-free."
+use_case: "Use for buying PlayStation gift cards, gifting PlayStation credit, sending PlayStation gift cards by email, and agent-initiated PlayStation gift card purchases paid in USDC on Solana."
+category: shopping
+service_url: https://playstation.x402.fi
+openapi:
+  path: openapi.json
+---
+PlayStation gift cards for AI agents, paid with USDC on Solana via x402. Browse
+denominations on the free `/store/catalog/playstation` endpoint, then buy with a
+single paid `POST /store/buy/playstation-<amount>`. Available denominations:
+$25, $50, $75, $100. The redemption code is emailed to `recipient_email` instantly.
+Payment is gas-free — RelAI sponsors the Solana transaction fee.
+
+Each purchase takes `recipient_email` (required), `country_code` (ISO code from
+the endpoint's enum), and an optional `sender_name`.
+
+## Spend-aware usage
+
+- These endpoints place real, non-refundable gift card orders. Confirm the brand,
+  exact denomination, recipient email, and country with the user before paying.
+- Use the free `/store/catalog/playstation` endpoint to discover valid denominations
+  and the supported country first — do not call a paid `buy` endpoint to probe.
+- Pick the single denomination that matches the user's intended amount; never call
+  multiple `buy` endpoints to compare.

--- a/providers/relai/playstation/openapi.json
+++ b/providers/relai/playstation/openapi.json
@@ -1,0 +1,306 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "PlayStation Gift Cards",
+    "version": "1.0.0",
+    "description": "PlayStation gift cards via x402 USDC on Solana."
+  },
+  "servers": [
+    {
+      "url": "https://playstation.x402.fi",
+      "description": "Production"
+    }
+  ],
+  "paths": {
+    "/store/catalog/playstation": {
+      "get": {
+        "operationId": "catalog_playstation",
+        "summary": "List PlayStation gift card denominations",
+        "description": "Free. Returns the available PlayStation gift card denominations, USDC prices, and supported country.",
+        "responses": {
+          "200": {
+            "description": "PlayStation catalog",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Brand not found"
+          }
+        }
+      }
+    },
+    "/store/buy/playstation-25": {
+      "post": {
+        "operationId": "buy_playstation_25",
+        "summary": "Buy a PlayStation $25 gift card",
+        "description": "Purchase a $25 PlayStation gift card. Pay 25 USDC on Solana via x402; the redemption code is emailed to recipient_email instantly. Gas-free — RelAI sponsors the Solana fee.",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$25.00"
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "recipient_email",
+                  "country_code"
+                ],
+                "properties": {
+                  "recipient_email": {
+                    "type": "string",
+                    "format": "email",
+                    "description": "Email to receive the gift card"
+                  },
+                  "sender_name": {
+                    "type": "string",
+                    "description": "Sender name (optional)"
+                  },
+                  "country_code": {
+                    "type": "string",
+                    "enum": [
+                      "AT",
+                      "BE",
+                      "BR",
+                      "CA",
+                      "DE",
+                      "ES",
+                      "FI",
+                      "IT",
+                      "PL",
+                      "PT",
+                      "SE"
+                    ],
+                    "description": "Country code for regional availability"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Redeem code returned. The gift card code is emailed to recipient_email."
+          },
+          "402": {
+            "description": "Payment Required — 25 USDC"
+          },
+          "409": {
+            "description": "Transaction already used"
+          }
+        }
+      }
+    },
+    "/store/buy/playstation-50": {
+      "post": {
+        "operationId": "buy_playstation_50",
+        "summary": "Buy a PlayStation $50 gift card",
+        "description": "Purchase a $50 PlayStation gift card. Pay 50 USDC on Solana via x402; the redemption code is emailed to recipient_email instantly. Gas-free — RelAI sponsors the Solana fee.",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$50.00"
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "recipient_email",
+                  "country_code"
+                ],
+                "properties": {
+                  "recipient_email": {
+                    "type": "string",
+                    "format": "email",
+                    "description": "Email to receive the gift card"
+                  },
+                  "sender_name": {
+                    "type": "string",
+                    "description": "Sender name (optional)"
+                  },
+                  "country_code": {
+                    "type": "string",
+                    "enum": [
+                      "AT",
+                      "BE",
+                      "BR",
+                      "CA",
+                      "DE",
+                      "ES",
+                      "FI",
+                      "IT",
+                      "PL",
+                      "PT",
+                      "SE"
+                    ],
+                    "description": "Country code for regional availability"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Redeem code returned. The gift card code is emailed to recipient_email."
+          },
+          "402": {
+            "description": "Payment Required — 50 USDC"
+          },
+          "409": {
+            "description": "Transaction already used"
+          }
+        }
+      }
+    },
+    "/store/buy/playstation-75": {
+      "post": {
+        "operationId": "buy_playstation_75",
+        "summary": "Buy a PlayStation $75 gift card",
+        "description": "Purchase a $75 PlayStation gift card. Pay 75 USDC on Solana via x402; the redemption code is emailed to recipient_email instantly. Gas-free — RelAI sponsors the Solana fee.",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$75.00"
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "recipient_email",
+                  "country_code"
+                ],
+                "properties": {
+                  "recipient_email": {
+                    "type": "string",
+                    "format": "email",
+                    "description": "Email to receive the gift card"
+                  },
+                  "sender_name": {
+                    "type": "string",
+                    "description": "Sender name (optional)"
+                  },
+                  "country_code": {
+                    "type": "string",
+                    "enum": [
+                      "AT",
+                      "BE",
+                      "BR",
+                      "CA",
+                      "DE",
+                      "ES",
+                      "FI",
+                      "IT",
+                      "PL",
+                      "PT",
+                      "SE"
+                    ],
+                    "description": "Country code for regional availability"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Redeem code returned. The gift card code is emailed to recipient_email."
+          },
+          "402": {
+            "description": "Payment Required — 75 USDC"
+          },
+          "409": {
+            "description": "Transaction already used"
+          }
+        }
+      }
+    },
+    "/store/buy/playstation-100": {
+      "post": {
+        "operationId": "buy_playstation_100",
+        "summary": "Buy a PlayStation $100 gift card",
+        "description": "Purchase a $100 PlayStation gift card. Pay 100 USDC on Solana via x402; the redemption code is emailed to recipient_email instantly. Gas-free — RelAI sponsors the Solana fee.",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$100.00"
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "recipient_email",
+                  "country_code"
+                ],
+                "properties": {
+                  "recipient_email": {
+                    "type": "string",
+                    "format": "email",
+                    "description": "Email to receive the gift card"
+                  },
+                  "sender_name": {
+                    "type": "string",
+                    "description": "Sender name (optional)"
+                  },
+                  "country_code": {
+                    "type": "string",
+                    "enum": [
+                      "AT",
+                      "BE",
+                      "BR",
+                      "CA",
+                      "DE",
+                      "ES",
+                      "FI",
+                      "IT",
+                      "PL",
+                      "PT",
+                      "SE"
+                    ],
+                    "description": "Country code for regional availability"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Redeem code returned. The gift card code is emailed to recipient_email."
+          },
+          "402": {
+            "description": "Payment Required — 100 USDC"
+          },
+          "409": {
+            "description": "Transaction already used"
+          }
+        }
+      }
+    }
+  }
+}

--- a/providers/relai/starbucks/PAY.md
+++ b/providers/relai/starbucks/PAY.md
@@ -1,0 +1,27 @@
+---
+name: starbucks
+title: "Starbucks Gift Cards (RelAI)"
+description: "Buy Starbucks gift cards with USDC on Solana via x402 micropayments. Starbucks digital gift card. Redemption codes emailed instantly; $10–$100 denominations; gas-free."
+use_case: "Use for buying Starbucks gift cards, gifting Starbucks credit, sending Starbucks gift cards by email, and agent-initiated Starbucks gift card purchases paid in USDC on Solana."
+category: shopping
+service_url: https://starbucks.x402.fi
+openapi:
+  path: openapi.json
+---
+Starbucks gift cards for AI agents, paid with USDC on Solana via x402. Browse
+denominations on the free `/store/catalog/starbucks` endpoint, then buy with a
+single paid `POST /store/buy/starbucks-<amount>`. Available denominations:
+$10, $25, $50, $100. The redemption code is emailed to `recipient_email` instantly.
+Payment is gas-free — RelAI sponsors the Solana transaction fee.
+
+Each purchase takes `recipient_email` (required), `country_code` (ISO code from
+the endpoint's enum), and an optional `sender_name`.
+
+## Spend-aware usage
+
+- These endpoints place real, non-refundable gift card orders. Confirm the brand,
+  exact denomination, recipient email, and country with the user before paying.
+- Use the free `/store/catalog/starbucks` endpoint to discover valid denominations
+  and the supported country first — do not call a paid `buy` endpoint to probe.
+- Pick the single denomination that matches the user's intended amount; never call
+  multiple `buy` endpoints to compare.

--- a/providers/relai/starbucks/openapi.json
+++ b/providers/relai/starbucks/openapi.json
@@ -1,0 +1,266 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Starbucks Gift Cards",
+    "version": "1.0.0",
+    "description": "Starbucks gift cards via x402 USDC on Solana."
+  },
+  "servers": [
+    {
+      "url": "https://starbucks.x402.fi",
+      "description": "Production"
+    }
+  ],
+  "paths": {
+    "/store/catalog/starbucks": {
+      "get": {
+        "operationId": "catalog_starbucks",
+        "summary": "List Starbucks gift card denominations",
+        "description": "Free. Returns the available Starbucks gift card denominations, USDC prices, and supported country.",
+        "responses": {
+          "200": {
+            "description": "Starbucks catalog",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Brand not found"
+          }
+        }
+      }
+    },
+    "/store/buy/starbucks-10": {
+      "post": {
+        "operationId": "buy_starbucks_10",
+        "summary": "Buy a Starbucks $10 gift card",
+        "description": "Purchase a $10 Starbucks gift card. Pay 10 USDC on Solana via x402; the redemption code is emailed to recipient_email instantly. Gas-free — RelAI sponsors the Solana fee.",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$10.00"
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "recipient_email",
+                  "country_code"
+                ],
+                "properties": {
+                  "recipient_email": {
+                    "type": "string",
+                    "format": "email",
+                    "description": "Email to receive the gift card"
+                  },
+                  "sender_name": {
+                    "type": "string",
+                    "description": "Sender name (optional)"
+                  },
+                  "country_code": {
+                    "type": "string",
+                    "enum": [
+                      "US"
+                    ],
+                    "description": "Country code for regional availability"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Redeem code returned. The gift card code is emailed to recipient_email."
+          },
+          "402": {
+            "description": "Payment Required — 10 USDC"
+          },
+          "409": {
+            "description": "Transaction already used"
+          }
+        }
+      }
+    },
+    "/store/buy/starbucks-25": {
+      "post": {
+        "operationId": "buy_starbucks_25",
+        "summary": "Buy a Starbucks $25 gift card",
+        "description": "Purchase a $25 Starbucks gift card. Pay 25 USDC on Solana via x402; the redemption code is emailed to recipient_email instantly. Gas-free — RelAI sponsors the Solana fee.",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$25.00"
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "recipient_email",
+                  "country_code"
+                ],
+                "properties": {
+                  "recipient_email": {
+                    "type": "string",
+                    "format": "email",
+                    "description": "Email to receive the gift card"
+                  },
+                  "sender_name": {
+                    "type": "string",
+                    "description": "Sender name (optional)"
+                  },
+                  "country_code": {
+                    "type": "string",
+                    "enum": [
+                      "US"
+                    ],
+                    "description": "Country code for regional availability"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Redeem code returned. The gift card code is emailed to recipient_email."
+          },
+          "402": {
+            "description": "Payment Required — 25 USDC"
+          },
+          "409": {
+            "description": "Transaction already used"
+          }
+        }
+      }
+    },
+    "/store/buy/starbucks-50": {
+      "post": {
+        "operationId": "buy_starbucks_50",
+        "summary": "Buy a Starbucks $50 gift card",
+        "description": "Purchase a $50 Starbucks gift card. Pay 50 USDC on Solana via x402; the redemption code is emailed to recipient_email instantly. Gas-free — RelAI sponsors the Solana fee.",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$50.00"
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "recipient_email",
+                  "country_code"
+                ],
+                "properties": {
+                  "recipient_email": {
+                    "type": "string",
+                    "format": "email",
+                    "description": "Email to receive the gift card"
+                  },
+                  "sender_name": {
+                    "type": "string",
+                    "description": "Sender name (optional)"
+                  },
+                  "country_code": {
+                    "type": "string",
+                    "enum": [
+                      "US"
+                    ],
+                    "description": "Country code for regional availability"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Redeem code returned. The gift card code is emailed to recipient_email."
+          },
+          "402": {
+            "description": "Payment Required — 50 USDC"
+          },
+          "409": {
+            "description": "Transaction already used"
+          }
+        }
+      }
+    },
+    "/store/buy/starbucks-100": {
+      "post": {
+        "operationId": "buy_starbucks_100",
+        "summary": "Buy a Starbucks $100 gift card",
+        "description": "Purchase a $100 Starbucks gift card. Pay 100 USDC on Solana via x402; the redemption code is emailed to recipient_email instantly. Gas-free — RelAI sponsors the Solana fee.",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$100.00"
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "recipient_email",
+                  "country_code"
+                ],
+                "properties": {
+                  "recipient_email": {
+                    "type": "string",
+                    "format": "email",
+                    "description": "Email to receive the gift card"
+                  },
+                  "sender_name": {
+                    "type": "string",
+                    "description": "Sender name (optional)"
+                  },
+                  "country_code": {
+                    "type": "string",
+                    "enum": [
+                      "US"
+                    ],
+                    "description": "Country code for regional availability"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Redeem code returned. The gift card code is emailed to recipient_email."
+          },
+          "402": {
+            "description": "Payment Required — 100 USDC"
+          },
+          "409": {
+            "description": "Transaction already used"
+          }
+        }
+      }
+    }
+  }
+}

--- a/providers/relai/uber/PAY.md
+++ b/providers/relai/uber/PAY.md
@@ -1,0 +1,27 @@
+---
+name: uber
+title: "Uber Gift Cards (RelAI)"
+description: "Buy Uber gift cards with USDC on Solana via x402 micropayments. Uber digital gift card. Redemption codes emailed instantly; $25–$100 denominations; gas-free."
+use_case: "Use for buying Uber gift cards, gifting Uber credit, sending Uber gift cards by email, and agent-initiated Uber gift card purchases paid in USDC on Solana."
+category: shopping
+service_url: https://uber.x402.fi
+openapi:
+  path: openapi.json
+---
+Uber gift cards for AI agents, paid with USDC on Solana via x402. Browse
+denominations on the free `/store/catalog/uber` endpoint, then buy with a
+single paid `POST /store/buy/uber-<amount>`. Available denominations:
+$25, $50, $100. The redemption code is emailed to `recipient_email` instantly.
+Payment is gas-free — RelAI sponsors the Solana transaction fee.
+
+Each purchase takes `recipient_email` (required), `country_code` (ISO code from
+the endpoint's enum), and an optional `sender_name`.
+
+## Spend-aware usage
+
+- These endpoints place real, non-refundable gift card orders. Confirm the brand,
+  exact denomination, recipient email, and country with the user before paying.
+- Use the free `/store/catalog/uber` endpoint to discover valid denominations
+  and the supported country first — do not call a paid `buy` endpoint to probe.
+- Pick the single denomination that matches the user's intended amount; never call
+  multiple `buy` endpoints to compare.

--- a/providers/relai/uber/openapi.json
+++ b/providers/relai/uber/openapi.json
@@ -1,0 +1,218 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Uber Gift Cards",
+    "version": "1.0.0",
+    "description": "Uber gift cards via x402 USDC on Solana."
+  },
+  "servers": [
+    {
+      "url": "https://uber.x402.fi",
+      "description": "Production"
+    }
+  ],
+  "paths": {
+    "/store/catalog/uber": {
+      "get": {
+        "operationId": "catalog_uber",
+        "summary": "List Uber gift card denominations",
+        "description": "Free. Returns the available Uber gift card denominations, USDC prices, and supported country.",
+        "responses": {
+          "200": {
+            "description": "Uber catalog",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Brand not found"
+          }
+        }
+      }
+    },
+    "/store/buy/uber-25": {
+      "post": {
+        "operationId": "buy_uber_25",
+        "summary": "Buy a Uber $25 gift card",
+        "description": "Purchase a $25 Uber gift card. Pay 25 USDC on Solana via x402; the redemption code is emailed to recipient_email instantly. Gas-free — RelAI sponsors the Solana fee.",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$25.00"
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "recipient_email",
+                  "country_code"
+                ],
+                "properties": {
+                  "recipient_email": {
+                    "type": "string",
+                    "format": "email",
+                    "description": "Email to receive the gift card"
+                  },
+                  "sender_name": {
+                    "type": "string",
+                    "description": "Sender name (optional)"
+                  },
+                  "country_code": {
+                    "type": "string",
+                    "enum": [
+                      "AU",
+                      "BR",
+                      "IN",
+                      "US"
+                    ],
+                    "description": "Country code for regional availability"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Redeem code returned. The gift card code is emailed to recipient_email."
+          },
+          "402": {
+            "description": "Payment Required — 25 USDC"
+          },
+          "409": {
+            "description": "Transaction already used"
+          }
+        }
+      }
+    },
+    "/store/buy/uber-50": {
+      "post": {
+        "operationId": "buy_uber_50",
+        "summary": "Buy a Uber $50 gift card",
+        "description": "Purchase a $50 Uber gift card. Pay 50 USDC on Solana via x402; the redemption code is emailed to recipient_email instantly. Gas-free — RelAI sponsors the Solana fee.",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$50.00"
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "recipient_email",
+                  "country_code"
+                ],
+                "properties": {
+                  "recipient_email": {
+                    "type": "string",
+                    "format": "email",
+                    "description": "Email to receive the gift card"
+                  },
+                  "sender_name": {
+                    "type": "string",
+                    "description": "Sender name (optional)"
+                  },
+                  "country_code": {
+                    "type": "string",
+                    "enum": [
+                      "AU",
+                      "BR",
+                      "IN",
+                      "US"
+                    ],
+                    "description": "Country code for regional availability"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Redeem code returned. The gift card code is emailed to recipient_email."
+          },
+          "402": {
+            "description": "Payment Required — 50 USDC"
+          },
+          "409": {
+            "description": "Transaction already used"
+          }
+        }
+      }
+    },
+    "/store/buy/uber-100": {
+      "post": {
+        "operationId": "buy_uber_100",
+        "summary": "Buy a Uber $100 gift card",
+        "description": "Purchase a $100 Uber gift card. Pay 100 USDC on Solana via x402; the redemption code is emailed to recipient_email instantly. Gas-free — RelAI sponsors the Solana fee.",
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$100.00"
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "recipient_email",
+                  "country_code"
+                ],
+                "properties": {
+                  "recipient_email": {
+                    "type": "string",
+                    "format": "email",
+                    "description": "Email to receive the gift card"
+                  },
+                  "sender_name": {
+                    "type": "string",
+                    "description": "Sender name (optional)"
+                  },
+                  "country_code": {
+                    "type": "string",
+                    "enum": [
+                      "AU",
+                      "BR",
+                      "IN",
+                      "US"
+                    ],
+                    "description": "Country code for regional availability"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Redeem code returned. The gift card code is emailed to recipient_email."
+          },
+          "402": {
+            "description": "Payment Required — 100 USDC"
+          },
+          "409": {
+            "description": "Transaction already used"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## RelAI gift cards — x402 USDC on Solana

Adds eight gift-card brands as `relai/<brand>` providers. RelAI operates the
x402 store directly; payments settle in USDC on Solana mainnet.

**Brands:** Amazon, Nike, Adidas, Uber, Airbnb, Starbucks, PlayStation, Netflix

- **Free discovery** — `GET /store/catalog/<brand>`: available denominations,
  USDC prices, and supported country.
- **Paid purchase** — `POST /store/buy/<brand>-<amount>`: returns an x402 **402**
  challenge, settled in **USDC on Solana mainnet**, gas-free (RelAI sponsors the
  network fee). The redemption code is emailed to the recipient.

Each `openapi.json` is generated from the live store catalog and the live 402
challenges (denominations, per-brand country enums), so every listing matches
production exactly.

## Validation

`npx @solana/pay catalog check` passes on all eight providers — **31 paid
endpoints, all Solana-compatible** (4/4 or 3/3 gates per brand). The
whole-registry static check (`check . --no-probe`) passes with no new issues.

Each provider follows the two-level layout (`providers/relai/<brand>/PAY.md` +
`openapi.json`), category `shopping`, with the OpenAPI committed as a sidecar.
