### PR TITLE
Add SolSigs — 22 Solana data endpoints

### DIFF
--- a/providers/solsigs/data/PAY.md
+++ b/providers/solsigs/data/PAY.md
@@ -10,7 +10,7 @@ openapi:
   path: openapi.json
 ---
 
-SolSigs is a Solana-native x402 service offering 22 specialist data endpoints, each priced per call in USDC ($0.001–$0.010) with no API keys, accounts, or subscriptions. All 22 resources are verified on x402scan, and the service settles directly on Solana mainnet (~400ms finality).
+SolSigs is a Solana-native x402 service offering 22 specialist data endpoints, each priced per call in USDC ($0.001–$0.015) with no API keys, accounts, or subscriptions. All 22 resources are verified on x402scan, and the service settles directly on Solana mainnet (~400ms finality).
 
 Coverage spans live DEX prices (Jupiter + Birdeye), arbitrage scanning, wallet intelligence and scoring, new-token launch detection with rug-risk scoring, whale transfer tracking, smart-money discovery, NFT floor/rarity data, staking APY comparison, prediction-market odds (Polymarket), social sentiment, dev-activity metrics, an LLM on-chain summarizer, and an intelligent RPC proxy.
 

--- a/providers/solsigs/data/PAY.md
+++ b/providers/solsigs/data/PAY.md
@@ -1,8 +1,8 @@
 ---
 name: data
 title: "SolSigs"
-description: "22 Solana data endpoints for AI agents — DEX prices, whale tracking, token-launch rug scoring, wallet intelligence, prediction markets. From $0.001/call in USDC."
-use_case: "Use for real-time Solana market data, token safety checks, wallet analysis, whale moves, and prediction-market odds."
+description: "23 Solana x402 endpoints for AI agents — DEX prices, whale tracking, token safety, wallet intelligence, prediction markets, and ProofGuard receipts. From $0.001/call in USDC."
+use_case: "Use for real-time Solana market data, token safety checks, wallet analysis, whale moves, prediction-market odds, and x402 payment/fulfillment evidence."
 category: finance
 service_url: https://solsigs.com
 version: v2
@@ -10,9 +10,9 @@ openapi:
   path: openapi.json
 ---
 
-SolSigs is a Solana-native x402 service offering 22 specialist data endpoints, each priced per call in USDC ($0.001–$0.015) with no API keys, accounts, or subscriptions. All 22 resources are verified on x402scan, and the service settles directly on Solana mainnet (~400ms finality).
+SolSigs is a Solana-native x402 service offering 23 specialist endpoints, each priced per call in USDC ($0.001–$0.015) with no API keys, accounts, or subscriptions. All resources are verified on x402scan, and the service settles directly on Solana mainnet (~400ms finality).
 
-Coverage spans live DEX prices (Jupiter + Birdeye), arbitrage scanning, wallet intelligence and scoring, new-token launch detection with rug-risk scoring, whale transfer tracking, smart-money discovery, NFT floor/rarity data, staking APY comparison, prediction-market odds (Polymarket), social sentiment, dev-activity metrics, an LLM on-chain summarizer, and an intelligent RPC proxy.
+Coverage spans live DEX prices (Jupiter + Birdeye), arbitrage scanning, wallet intelligence and scoring, new-token launch detection with rug-risk scoring, whale transfer tracking, smart-money discovery, NFT floor/rarity data, staking APY comparison, prediction-market odds (Polymarket), social sentiment, dev-activity metrics, an LLM on-chain summarizer, an intelligent RPC proxy, and ProofGuard receipt/refund evidence for x402-paid endpoint calls.
 
 Agents can also discover endpoints via the machine-readable discovery document at https://solsigs.com/.well-known/x402.json. An open-source reference agent demonstrating the full discover → pay → data loop with finalized Solscan receipts lives at https://github.com/Gra-kir/solsigs-reference-agent.
 

--- a/providers/solsigs/data/PAY.md
+++ b/providers/solsigs/data/PAY.md
@@ -1,0 +1,26 @@
+---
+name: data
+title: "SolSigs"
+description: "22 Solana data endpoints for AI agents — DEX prices, whale tracking, token-launch rug scoring, wallet intelligence, prediction markets. From $0.001/call in USDC."
+use_case: "Use for real-time Solana market data, token safety checks, wallet analysis, whale moves, and prediction-market odds."
+category: finance
+service_url: https://solsigs.com
+version: v2
+openapi:
+  path: openapi.json
+---
+
+SolSigs is a Solana-native x402 service offering 22 specialist data endpoints, each priced per call in USDC ($0.001–$0.010) with no API keys, accounts, or subscriptions. All 22 resources are verified on x402scan, and the service settles directly on Solana mainnet (~400ms finality).
+
+Coverage spans live DEX prices (Jupiter + Birdeye), arbitrage scanning, wallet intelligence and scoring, new-token launch detection with rug-risk scoring, whale transfer tracking, smart-money discovery, NFT floor/rarity data, staking APY comparison, prediction-market odds (Polymarket), social sentiment, dev-activity metrics, an LLM on-chain summarizer, and an intelligent RPC proxy.
+
+Agents can also discover endpoints via the machine-readable discovery document at https://solsigs.com/.well-known/x402.json. A free-tier claim (POST /freetier/claim, 50 calls) is available for evaluation, and an open-source reference agent demonstrating the full discover → pay → data loop with finalized Solscan receipts lives at https://github.com/Gra-kir/solsigs-reference-agent.
+
+## Spend-aware usage
+
+- Start with the cheapest endpoint that answers the task: /rpc and /dev are $0.001; /dex and /staking are $0.002.
+- Prefer a single targeted call over chained broad ones — /token-safety answers "is this token risky" directly rather than combining /launches + /wallet.
+- Batch where supported: /price accepts a token list in one call instead of per-token /dex calls.
+- Cap limit parameters (e.g. /launches, /predict) to the smallest number that answers the task.
+- Reuse mint addresses and wallet addresses across calls rather than re-resolving them.
+- Cached responses are served where upstreams rate-limit; repeat calls within a short window may be free of upstream latency but still billed — avoid tight polling loops.

--- a/providers/solsigs/data/PAY.md
+++ b/providers/solsigs/data/PAY.md
@@ -14,7 +14,7 @@ SolSigs is a Solana-native x402 service offering 22 specialist data endpoints, e
 
 Coverage spans live DEX prices (Jupiter + Birdeye), arbitrage scanning, wallet intelligence and scoring, new-token launch detection with rug-risk scoring, whale transfer tracking, smart-money discovery, NFT floor/rarity data, staking APY comparison, prediction-market odds (Polymarket), social sentiment, dev-activity metrics, an LLM on-chain summarizer, and an intelligent RPC proxy.
 
-Agents can also discover endpoints via the machine-readable discovery document at https://solsigs.com/.well-known/x402.json. A free-tier claim (POST /freetier/claim, 50 calls) is available for evaluation, and an open-source reference agent demonstrating the full discover → pay → data loop with finalized Solscan receipts lives at https://github.com/Gra-kir/solsigs-reference-agent.
+Agents can also discover endpoints via the machine-readable discovery document at https://solsigs.com/.well-known/x402.json. An open-source reference agent demonstrating the full discover → pay → data loop with finalized Solscan receipts lives at https://github.com/Gra-kir/solsigs-reference-agent.
 
 ## Spend-aware usage
 

--- a/providers/solsigs/data/openapi.json
+++ b/providers/solsigs/data/openapi.json
@@ -742,7 +742,40 @@
             "description": "x402 Payment Required"
           },
           "200": {
-            "description": "Alpha signals with confidence scores"
+            "description": "Alpha signals with confidence scores",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "signals": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "token": {
+                            "type": "string"
+                          },
+                          "signal": {
+                            "type": "string"
+                          },
+                          "confidence": {
+                            "type": "integer"
+                          },
+                          "source": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "description": "Alpha signals ranked by confidence"
+                    },
+                    "count": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "x-payment-info": {
@@ -1154,7 +1187,40 @@
             "description": "x402 Payment Required"
           },
           "200": {
-            "description": "Perps market data"
+            "description": "Perps market data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "markets": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "symbol": {
+                            "type": "string"
+                          },
+                          "fundingRate": {
+                            "type": "number"
+                          },
+                          "openInterest": {
+                            "type": "number"
+                          },
+                          "protocol": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "description": "Perpetuals market data"
+                    },
+                    "action": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "x-payment-info": {
@@ -1802,7 +1868,43 @@
             "description": "x402 Payment Required"
           },
           "200": {
-            "description": "Array of trending tokens with metrics"
+            "description": "Array of trending tokens with metrics",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "tokens": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "symbol": {
+                            "type": "string"
+                          },
+                          "mint": {
+                            "type": "string"
+                          },
+                          "priceChange24h": {
+                            "type": "number"
+                          },
+                          "volume24h": {
+                            "type": "number"
+                          },
+                          "trendScore": {
+                            "type": "number"
+                          }
+                        }
+                      },
+                      "description": "Trending tokens with metrics"
+                    },
+                    "count": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "x-payment-info": {
@@ -1848,7 +1950,41 @@
             "description": "x402 Payment Required"
           },
           "200": {
-            "description": "Trust score with detailed factors"
+            "description": "Trust score with detailed factors",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "address": {
+                      "type": "string"
+                    },
+                    "trustScore": {
+                      "type": "integer",
+                      "description": "Trust score 0-100"
+                    },
+                    "label": {
+                      "type": "string",
+                      "description": "Wallet classification label"
+                    },
+                    "factors": {
+                      "type": "object",
+                      "properties": {
+                        "age": {
+                          "type": "string"
+                        },
+                        "txCount": {
+                          "type": "integer"
+                        },
+                        "washTrading": {
+                          "type": "boolean"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "x-payment-info": {
@@ -2031,7 +2167,43 @@
         },
         "responses": {
           "200": {
-            "description": "Token trenches data"
+            "description": "Token trenches data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "tokens": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "mint": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "bondingCurveProgress": {
+                            "type": "number"
+                          },
+                          "graduated": {
+                            "type": "boolean"
+                          },
+                          "volume24h": {
+                            "type": "number"
+                          }
+                        }
+                      },
+                      "description": "PumpFun tokens with bonding curve status"
+                    },
+                    "count": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              }
+            }
           },
           "402": {
             "description": "Payment required"
@@ -2078,7 +2250,31 @@
         },
         "responses": {
           "200": {
-            "description": "LLM answer"
+            "description": "LLM answer",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "answer": {
+                      "type": "string",
+                      "description": "AI-generated answer with data-backed reasoning"
+                    },
+                    "sources": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "description": "On-chain data sources used"
+                    },
+                    "confidence": {
+                      "type": "number",
+                      "description": "Confidence score 0-1"
+                    }
+                  }
+                }
+              }
+            }
           },
           "402": {
             "description": "Payment required"

--- a/providers/solsigs/data/openapi.json
+++ b/providers/solsigs/data/openapi.json
@@ -822,14 +822,14 @@
                     "type": "string",
                     "description": "Token symbol to scan (e.g. SOL, BONK)"
                   },
-                  "minProfitPercent": {
-                    "type": "number",
-                    "description": "Minimum profit threshold"
+                  "minProfitBps": {
+                    "type": "integer",
+                    "description": "Minimum profit threshold in basis points (e.g. 10 = 0.10%)"
                   }
                 },
                 "example": {
                   "token": "SOL",
-                  "minProfitPercent": 0.5
+                  "minProfitBps": 10
                 }
               }
             }
@@ -1077,7 +1077,7 @@
                 "properties": {
                   "hours": {
                     "type": "integer",
-                    "default": 24,
+                    "default": 1,
                     "description": "Lookback window in hours"
                   },
                   "minLiquidity": {
@@ -1086,7 +1086,7 @@
                   }
                 },
                 "example": {
-                  "hours": 24,
+                  "hours": 1,
                   "minLiquidity": 10000
                 }
               }
@@ -2348,12 +2348,6 @@
         "method": "POST"
       },
       {
-        "name": "wallet_status",
-        "path": null,
-        "method": null,
-        "description": "Local Solana query — not proxied through x402 API"
-      },
-      {
         "name": "get_batch_prices",
         "path": "/price",
         "method": "POST"
@@ -2386,6 +2380,46 @@
       {
         "name": "get_social_sentiment",
         "path": "/social",
+        "method": "POST"
+      },
+      {
+        "name": "get_alpha_feed",
+        "path": "/alpha",
+        "method": "POST"
+      },
+      {
+        "name": "get_perps_intel",
+        "path": "/perps",
+        "method": "POST"
+      },
+      {
+        "name": "smart_money",
+        "path": "/smartmoney",
+        "method": "POST"
+      },
+      {
+        "name": "check_token_safety",
+        "path": "/token-safety",
+        "method": "POST"
+      },
+      {
+        "name": "get_trending_tokens",
+        "path": "/trending",
+        "method": "POST"
+      },
+      {
+        "name": "get_wallet_trust",
+        "path": "/trust",
+        "method": "POST"
+      },
+      {
+        "name": "trenches",
+        "path": "/trenches",
+        "method": "POST"
+      },
+      {
+        "name": "ask_verdict",
+        "path": "/ask",
         "method": "POST"
       }
     ]

--- a/providers/solsigs/data/openapi.json
+++ b/providers/solsigs/data/openapi.json
@@ -1,2417 +1,2508 @@
 {
-  "openapi": "3.0.3",
-  "info": {
-    "title": "SolSigs \u2014 Solana Data APIs for AI Agents",
-    "version": "1.0.0",
-    "description": "22 Solana data endpoints paid via x402 micropayments in USDC. No API keys, no subscriptions \u2014 agents pay per call.",
-    "contact": {
-      "name": "SolSigs",
-      "url": "https://solsigs.com",
-      "email": "foundbychancer@gmail.com"
-    },
-    "x-logo": {
-      "url": "https://solsigs.com/favicon.ico"
-    }
-  },
-  "servers": [
-    {
-      "url": "https://solsigs.com",
-      "description": "Production"
-    }
-  ],
-  "security": [
-    {
-      "x402": []
-    }
-  ],
-  "tags": [
-    {
-      "name": "Prices",
-      "description": "Real-time DEX price data"
-    },
-    {
-      "name": "Arbitrage",
-      "description": "Cross-DEX arbitrage scanning"
-    },
-    {
-      "name": "Wallet",
-      "description": "Wallet analysis and risk scoring"
-    },
-    {
-      "name": "Tokens",
-      "description": "Token launch detection"
-    },
-    {
-      "name": "AI",
-      "description": "AI-powered market summaries"
-    },
-    {
-      "name": "RPC",
-      "description": "Pay-per-call Solana JSON-RPC relay"
-    },
-    {
-      "name": "Predictions",
-      "description": "Polymarket prediction market data"
-    },
-    {
-      "name": "NFT",
-      "description": "NFT floor prices, rarity, and wash trading detection"
-    },
-    {
-      "name": "Staking",
-      "description": "Cross-protocol staking APY comparison"
-    },
-    {
-      "name": "Whales",
-      "description": "Whale wallet tracking and smart money signals"
-    },
-    {
-      "name": "Alerts",
-      "description": "Webhook alert registration"
-    },
-    {
-      "name": "Development",
-      "description": "GitHub commit activity for Solana protocols"
-    },
-    {
-      "name": "Social",
-      "description": "On-chain social sentiment analysis"
-    }
-  ],
-  "components": {
-    "securitySchemes": {
-      "x402": {
-        "type": "http",
-        "scheme": "bearer",
-        "description": "x402 micropayment protocol. First request returns HTTP 402 with payment details. Send USDC payment on Solana, then retry with the same request. Most calls cost < $0.01 USDC.",
-        "x-402-version": "2",
-        "x-402-token": "USDC",
-        "x-402-mint": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
-      }
-    },
-    "schemas": {
-      "DexPriceResponse": {
-        "type": "object",
-        "properties": {
-          "token": {
-            "type": "string",
-            "description": "Token symbol or mint address"
-          },
-          "price_usd": {
-            "type": "number",
-            "description": "Current price in USD"
-          },
-          "liquidity_usd": {
-            "type": "number",
-            "description": "Total liquidity in USD"
-          },
-          "volume_24h_usd": {
-            "type": "number",
-            "description": "24-hour trading volume"
-          },
-          "price_change_24h_pct": {
-            "type": "number",
-            "description": "24-hour price change percentage"
-          },
-          "sources": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "description": "Data sources (Jupiter, Birdeye)"
-          }
+    "openapi": "3.0.3",
+    "info": {
+        "title": "SolSigs \u2014 Solana Data APIs for AI Agents",
+        "version": "1.0.0",
+        "description": "22 Solana data endpoints paid via x402 micropayments in USDC. No API keys, no subscriptions \u2014 agents pay per call.",
+        "contact": {
+            "name": "SolSigs",
+            "url": "https://solsigs.com",
+            "email": "foundbychancer@gmail.com"
+        },
+        "x-logo": {
+            "url": "https://solsigs.com/favicon.ico"
         }
-      },
-      "ArbitrageScanResponse": {
-        "type": "object",
-        "properties": {
-          "token": {
-            "type": "string"
-          },
-          "opportunities": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "buy_dex": {
-                  "type": "string"
-                },
-                "sell_dex": {
-                  "type": "string"
-                },
-                "profit_bps": {
-                  "type": "number",
-                  "description": "Profit in basis points"
-                },
-                "estimated_usd": {
-                  "type": "number"
-                }
-              }
+    },
+    "servers": [
+        {
+            "url": "https://solsigs.com",
+            "description": "Production"
+        }
+    ],
+    "security": [
+        {
+            "x402": []
+        }
+    ],
+    "tags": [
+        {
+            "name": "Prices",
+            "description": "Real-time DEX price data"
+        },
+        {
+            "name": "Arbitrage",
+            "description": "Cross-DEX arbitrage scanning"
+        },
+        {
+            "name": "Wallet",
+            "description": "Wallet analysis and risk scoring"
+        },
+        {
+            "name": "Tokens",
+            "description": "Token launch detection"
+        },
+        {
+            "name": "AI",
+            "description": "AI-powered market summaries"
+        },
+        {
+            "name": "RPC",
+            "description": "Pay-per-call Solana JSON-RPC relay"
+        },
+        {
+            "name": "Predictions",
+            "description": "Polymarket prediction market data"
+        },
+        {
+            "name": "NFT",
+            "description": "NFT floor prices, rarity, and wash trading detection"
+        },
+        {
+            "name": "Staking",
+            "description": "Cross-protocol staking APY comparison"
+        },
+        {
+            "name": "Whales",
+            "description": "Whale wallet tracking and smart money signals"
+        },
+        {
+            "name": "Alerts",
+            "description": "Webhook alert registration"
+        },
+        {
+            "name": "Development",
+            "description": "GitHub commit activity for Solana protocols"
+        },
+        {
+            "name": "Social",
+            "description": "On-chain social sentiment analysis"
+        },
+        {
+            "name": "ProofGuard",
+            "description": "Signed receipts and refund evidence for x402-paid agent endpoints"
+        }
+    ],
+    "components": {
+        "securitySchemes": {
+            "x402": {
+                "type": "http",
+                "scheme": "bearer",
+                "description": "x402 micropayment protocol. First request returns HTTP 402 with payment details. Send USDC payment on Solana, then retry with the same request. Most calls cost < $0.01 USDC.",
+                "x-402-version": "2",
+                "x-402-token": "USDC",
+                "x-402-mint": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
             }
-          }
-        }
-      },
-      "WalletAnalysisResponse": {
-        "type": "object",
-        "properties": {
-          "address": {
-            "type": "string"
-          },
-          "risk_score": {
-            "type": "integer",
-            "description": "0-100 risk score"
-          },
-          "age_days": {
-            "type": "integer"
-          },
-          "transaction_count": {
-            "type": "integer"
-          },
-          "flags": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "description": "Risk flags (wash_trading, rug_pull, etc.)"
-          }
-        }
-      },
-      "TokenLaunchesResponse": {
-        "type": "object",
-        "properties": {
-          "count": {
-            "type": "integer"
-          },
-          "window_hours": {
-            "type": "integer"
-          },
-          "launches": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "mint": {
-                  "type": "string"
-                },
-                "name": {
-                  "type": "string"
-                },
-                "symbol": {
-                  "type": "string"
-                },
-                "platform": {
-                  "type": "string",
-                  "description": "pump.fun, Raydium, etc."
-                },
-                "age_minutes": {
-                  "type": "integer"
-                },
-                "initial_liquidity_usd": {
-                  "type": "number"
-                }
-              }
-            }
-          }
-        }
-      },
-      "MarketSummaryResponse": {
-        "type": "object",
-        "properties": {
-          "query": {
-            "type": "string"
-          },
-          "summary": {
-            "type": "string",
-            "description": "AI-generated plain-English summary"
-          },
-          "data_points": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "label": {
-                  "type": "string"
-                },
-                "value": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      },
-      "JsonRpcRequest": {
-        "type": "object",
-        "required": [
-          "jsonrpc",
-          "method"
-        ],
-        "properties": {
-          "jsonrpc": {
-            "type": "string",
-            "enum": [
-              "2.0"
-            ]
-          },
-          "id": {
-            "type": "integer"
-          },
-          "method": {
-            "type": "string",
-            "description": "Solana JSON-RPC method"
-          },
-          "params": {
-            "type": "array",
-            "items": {},
-            "description": "RPC parameters"
-          }
-        }
-      },
-      "PredictionMarketResponse": {
-        "type": "object",
-        "properties": {
-          "markets": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "id": {
-                  "type": "string"
-                },
-                "question": {
-                  "type": "string"
-                },
-                "yes_price": {
-                  "type": "number"
-                },
-                "no_price": {
-                  "type": "number"
-                },
-                "volume_usd": {
-                  "type": "number"
-                },
-                "liquidity_usd": {
-                  "type": "number"
-                },
-                "end_date": {
-                  "type": "string"
-                },
-                "category": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      },
-      "Error402": {
-        "type": "object",
-        "properties": {
-          "error": {
-            "type": "object",
-            "properties": {
-              "code": {
-                "type": "integer",
-                "example": 402
-              },
-              "message": {
-                "type": "string",
-                "example": "Payment Required"
-              },
-              "payment": {
+        },
+        "schemas": {
+            "DexPriceResponse": {
                 "type": "object",
                 "properties": {
-                  "amount": {
-                    "type": "number",
-                    "description": "USDC amount required (6 decimals)"
-                  },
-                  "recipient": {
-                    "type": "string",
-                    "description": "Solana wallet address"
-                  },
-                  "mint": {
-                    "type": "string",
-                    "description": "USDC mint address"
-                  },
-                  "deadline": {
-                    "type": "string",
-                    "format": "date-time"
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "BatchPriceResponse": {
-        "type": "object",
-        "properties": {
-          "tokens": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "symbol": {
-                  "type": "string"
-                },
-                "price_usd": {
-                  "type": "number"
-                },
-                "change_24h": {
-                  "type": "number"
-                },
-                "volume_24h": {
-                  "type": "number"
-                },
-                "market_cap": {
-                  "type": "number"
-                },
-                "candles": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "time": {
+                    "token": {
                         "type": "string",
-                        "format": "date-time"
-                      },
-                      "open": {
-                        "type": "number"
-                      },
-                      "high": {
-                        "type": "number"
-                      },
-                      "low": {
-                        "type": "number"
-                      },
-                      "close": {
-                        "type": "number"
-                      },
-                      "volume": {
-                        "type": "number"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "NftIntelResponse": {
-        "type": "object",
-        "properties": {
-          "collection": {
-            "type": "string"
-          },
-          "floor_usdc": {
-            "type": "number"
-          },
-          "floor_sol": {
-            "type": "number"
-          },
-          "volume_24h": {
-            "type": "number"
-          },
-          "listings": {
-            "type": "integer"
-          },
-          "wash_trading_score": {
-            "type": "number",
-            "description": "0-100 wash trading probability"
-          },
-          "rarity_data": {
-            "type": "object",
-            "properties": {
-              "total_supply": {
-                "type": "integer"
-              },
-              "ranked_count": {
-                "type": "integer"
-              },
-              "top_rarities": {
-                "type": "array",
-                "items": {
-                  "type": "object",
-                  "properties": {
-                    "rank": {
-                      "type": "integer"
+                        "description": "Token symbol or mint address"
                     },
-                    "name": {
-                      "type": "string"
+                    "price_usd": {
+                        "type": "number",
+                        "description": "Current price in USD"
                     },
-                    "mint": {
-                      "type": "string"
+                    "liquidity_usd": {
+                        "type": "number",
+                        "description": "Total liquidity in USD"
                     },
-                    "price_sol": {
-                      "type": "number"
+                    "volume_24h_usd": {
+                        "type": "number",
+                        "description": "24-hour trading volume"
                     },
-                    "rarity_score": {
-                      "type": "number"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "StakingRatesResponse": {
-        "type": "object",
-        "properties": {
-          "protocols": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "name": {
-                  "type": "string"
-                },
-                "apy": {
-                  "type": "number"
-                },
-                "tvl": {
-                  "type": "number",
-                  "description": "Total value locked in USD"
-                },
-                "token": {
-                  "type": "string"
-                },
-                "unstake_days": {
-                  "type": "number"
-                },
-                "website": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      },
-      "WhaleActivityResponse": {
-        "type": "object",
-        "properties": {
-          "transfers": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "tx_signature": {
-                  "type": "string"
-                },
-                "from": {
-                  "type": "string"
-                },
-                "to": {
-                  "type": "string"
-                },
-                "amount": {
-                  "type": "number"
-                },
-                "amount_usd": {
-                  "type": "number"
-                },
-                "token": {
-                  "type": "string"
-                },
-                "timestamp": {
-                  "type": "string",
-                  "format": "date-time"
-                },
-                "whale_type": {
-                  "type": "string",
-                  "enum": [
-                    "accumulation",
-                    "distribution",
-                    "unknown"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      },
-      "AlertResponse": {
-        "type": "object",
-        "properties": {
-          "alert_id": {
-            "type": "string"
-          },
-          "created": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "expires": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "active",
-              "triggered",
-              "expired"
-            ]
-          }
-        }
-      },
-      "DevActivityResponse": {
-        "type": "object",
-        "properties": {
-          "protocol": {
-            "type": "string"
-          },
-          "repo": {
-            "type": "string"
-          },
-          "commits": {
-            "type": "integer"
-          },
-          "contributors": {
-            "type": "integer"
-          },
-          "last_commit": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "audit_status": {
-            "type": "string"
-          },
-          "ecosystem_rank": {
-            "type": "integer"
-          }
-        }
-      },
-      "SocialSentimentResponse": {
-        "type": "object",
-        "properties": {
-          "mentions": {
-            "type": "integer"
-          },
-          "sentiment_score": {
-            "type": "number",
-            "description": "-1.0 (bearish) to +1.0 (bullish)"
-          },
-          "top_influencers": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "handle": {
-                  "type": "string"
-                },
-                "followers": {
-                  "type": "integer"
-                },
-                "sentiment": {
-                  "type": "number"
-                }
-              }
-            }
-          },
-          "trending_score": {
-            "type": "number"
-          },
-          "related_tokens": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
-        }
-      }
-    }
-  },
-  "paths": {
-    "/alerts": {
-      "post": {
-        "tags": [
-          "Alerts"
-        ],
-        "summary": "Register a webhook alert",
-        "description": "Create price, volume, whale, or launch alerts that POST to your webhook when triggered.",
-        "operationId": "createAlert",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "type",
-                  "condition",
-                  "webhookUrl"
-                ],
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "price",
-                      "volume",
-                      "whale",
-                      "launch"
-                    ]
-                  },
-                  "condition": {
-                    "type": "string",
-                    "description": "Trigger condition (e.g. SOL > 200)"
-                  },
-                  "webhookUrl": {
-                    "type": "string",
-                    "format": "uri"
-                  },
-                  "expiryHours": {
-                    "type": "integer",
-                    "default": 72,
-                    "maximum": 168
-                  }
-                }
-              },
-              "example": {
-                "type": "price",
-                "condition": "SOL > 200",
-                "webhookUrl": "https://hooks.example.com/solsigs",
-                "expiryHours": 72
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Alert created",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AlertResponse"
-                }
-              }
-            }
-          },
-          "402": {
-            "description": "Payment required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error402"
-                }
-              }
-            }
-          }
-        },
-        "x-payment-info": {
-          "price": {
-            "fixed": {
-              "mode": "fixed",
-              "currency": "USD",
-              "amount": "0.005"
-            }
-          },
-          "protocols": [
-            {
-              "x402": {}
-            }
-          ]
-        }
-      }
-    },
-    "/alpha": {
-      "post": {
-        "operationId": "getAlphaFeed",
-        "summary": "Fetch alpha signals from new launches and insider wallets",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "limit": {
-                    "type": "integer",
-                    "default": 20
-                  },
-                  "min_confidence": {
-                    "type": "number",
-                    "default": 0.5
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "402": {
-            "description": "x402 Payment Required"
-          },
-          "200": {
-            "description": "Alpha signals with confidence scores",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "signals": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "token": {
-                            "type": "string"
-                          },
-                          "signal": {
-                            "type": "string"
-                          },
-                          "confidence": {
-                            "type": "integer"
-                          },
-                          "source": {
-                            "type": "string"
-                          }
-                        }
-                      },
-                      "description": "Alpha signals ranked by confidence"
-                    },
-                    "count": {
-                      "type": "integer"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-payment-info": {
-          "price": {
-            "fixed": {
-              "mode": "fixed",
-              "currency": "USD",
-              "amount": "0.006"
-            }
-          },
-          "protocols": [
-            {
-              "x402": {}
-            }
-          ]
-        }
-      }
-    },
-    "/arb": {
-      "post": {
-        "tags": [
-          "Arbitrage"
-        ],
-        "summary": "Search Solana DEXs for arbitrage opportunities",
-        "description": "Scans DEXes for profitable cross-exchange arbitrage trades.",
-        "operationId": "scanArbitrage",
-        "responses": {
-          "200": {
-            "description": "Arbitrage opportunities",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ArbitrageScanResponse"
-                }
-              }
-            }
-          },
-          "402": {
-            "description": "Payment required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error402"
-                }
-              }
-            }
-          }
-        },
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "token": {
-                    "type": "string",
-                    "description": "Token symbol to scan (e.g. SOL, BONK)"
-                  },
-                  "minProfitBps": {
-                    "type": "integer",
-                    "description": "Minimum profit threshold in basis points (e.g. 10 = 0.10%)"
-                  }
-                },
-                "example": {
-                  "token": "SOL",
-                  "minProfitBps": 10
-                }
-              }
-            }
-          }
-        },
-        "x-payment-info": {
-          "price": {
-            "fixed": {
-              "mode": "fixed",
-              "currency": "USD",
-              "amount": "0.010"
-            }
-          },
-          "protocols": [
-            {
-              "x402": {}
-            }
-          ]
-        }
-      }
-    },
-    "/dev": {
-      "post": {
-        "tags": [
-          "Development"
-        ],
-        "summary": "Fetch GitHub dev activity for a Solana protocol",
-        "description": "Track commits, contributors, and audit status to gauge protocol development health.",
-        "operationId": "getDevActivity",
-        "responses": {
-          "200": {
-            "description": "Dev activity",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/DevActivityResponse"
-                }
-              }
-            }
-          },
-          "402": {
-            "description": "Payment required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error402"
-                }
-              }
-            }
-          }
-        },
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "protocol"
-                ],
-                "properties": {
-                  "protocol": {
-                    "type": "string",
-                    "description": "Solana protocol to query"
-                  },
-                  "days": {
-                    "type": "integer",
-                    "default": 30
-                  }
-                },
-                "example": {
-                  "protocol": "Jupiter",
-                  "days": 7
-                }
-              }
-            }
-          }
-        },
-        "x-payment-info": {
-          "price": {
-            "fixed": {
-              "mode": "fixed",
-              "currency": "USD",
-              "amount": "0.001"
-            }
-          },
-          "protocols": [
-            {
-              "x402": {}
-            }
-          ]
-        }
-      }
-    },
-    "/dex": {
-      "post": {
-        "tags": [
-          "Prices"
-        ],
-        "summary": "Fetch real-time DEX prices for a Solana token",
-        "description": "Returns price, liquidity, and 24h volume from Jupiter and Birdeye aggregators.",
-        "operationId": "getDexPrice",
-        "responses": {
-          "200": {
-            "description": "Price data",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/DexPriceResponse"
-                }
-              }
-            }
-          },
-          "402": {
-            "description": "Payment required \u2014 send USDC and retry",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error402"
-                }
-              }
-            }
-          }
-        },
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "pair": {
-                    "type": "string",
-                    "description": "Token pair (e.g. SOL/USDC)"
-                  },
-                  "dex": {
-                    "type": "string",
-                    "description": "DEX to query (e.g. Jupiter, Orca)"
-                  },
-                  "token": {
-                    "type": "string",
-                    "description": "Token symbol or mint address. Alternative to pair \u2014 provide either token OR pair."
-                  }
-                },
-                "example": {
-                  "pair": "SOL/USDC",
-                  "dex": "Jupiter"
-                }
-              }
-            }
-          }
-        },
-        "x-payment-info": {
-          "price": {
-            "fixed": {
-              "mode": "fixed",
-              "currency": "USD",
-              "amount": "0.002"
-            }
-          },
-          "protocols": [
-            {
-              "x402": {}
-            }
-          ]
-        }
-      }
-    },
-    "/launches": {
-      "post": {
-        "tags": [
-          "Tokens"
-        ],
-        "summary": "Detect new token launches",
-        "description": "Spot fresh token deployments on pump.fun and Raydium.",
-        "operationId": "detectTokenLaunches",
-        "responses": {
-          "200": {
-            "description": "Recent token launches",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TokenLaunchesResponse"
-                }
-              }
-            }
-          },
-          "402": {
-            "description": "Payment required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error402"
-                }
-              }
-            }
-          }
-        },
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "hours": {
-                    "type": "integer",
-                    "default": 1,
-                    "description": "Lookback window in hours"
-                  },
-                  "minLiquidity": {
-                    "type": "number",
-                    "description": "Minimum liquidity filter in USD"
-                  }
-                },
-                "example": {
-                  "hours": 1,
-                  "minLiquidity": 10000
-                }
-              }
-            }
-          }
-        },
-        "x-payment-info": {
-          "price": {
-            "fixed": {
-              "mode": "fixed",
-              "currency": "USD",
-              "amount": "0.003"
-            }
-          },
-          "protocols": [
-            {
-              "x402": {}
-            }
-          ]
-        }
-      }
-    },
-    "/nft": {
-      "post": {
-        "tags": [
-          "NFT"
-        ],
-        "summary": "Fetch NFT collection intel and wash trading signals",
-        "description": "Floor prices, rarity rankings, and wash trading score for any Solana NFT collection.",
-        "operationId": "getNftIntel",
-        "responses": {
-          "200": {
-            "description": "NFT intel",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/NftIntelResponse"
-                }
-              }
-            }
-          },
-          "402": {
-            "description": "Payment required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error402"
-                }
-              }
-            }
-          }
-        },
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "collection"
-                ],
-                "properties": {
-                  "collection": {
-                    "type": "string",
-                    "description": "NFT collection name or symbol"
-                  },
-                  "sortBy": {
-                    "type": "string",
-                    "enum": [
-                      "floor",
-                      "volume",
-                      "rarity"
-                    ]
-                  }
-                },
-                "example": {
-                  "collection": "Mad Lads",
-                  "sortBy": "floor"
-                }
-              }
-            }
-          }
-        },
-        "x-payment-info": {
-          "price": {
-            "fixed": {
-              "mode": "fixed",
-              "currency": "USD",
-              "amount": "0.004"
-            }
-          },
-          "protocols": [
-            {
-              "x402": {}
-            }
-          ]
-        }
-      }
-    },
-    "/perps": {
-      "post": {
-        "operationId": "getPerpsIntel",
-        "summary": "Fetch Solana perps markets, funding rates, open interest",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "action": {
-                    "type": "string",
-                    "enum": [
-                      "markets",
-                      "positions",
-                      "funding"
-                    ]
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "402": {
-            "description": "x402 Payment Required"
-          },
-          "200": {
-            "description": "Perps market data",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "markets": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "symbol": {
-                            "type": "string"
-                          },
-                          "fundingRate": {
-                            "type": "number"
-                          },
-                          "openInterest": {
-                            "type": "number"
-                          },
-                          "protocol": {
-                            "type": "string"
-                          }
-                        }
-                      },
-                      "description": "Perpetuals market data"
-                    },
-                    "action": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-payment-info": {
-          "price": {
-            "fixed": {
-              "mode": "fixed",
-              "currency": "USD",
-              "amount": "0.005"
-            }
-          },
-          "protocols": [
-            {
-              "x402": {}
-            }
-          ]
-        }
-      }
-    },
-    "/predict": {
-      "post": {
-        "tags": [
-          "Predictions"
-        ],
-        "summary": "Fetch Polymarket prediction market odds and volume",
-        "description": "Search and discover Polymarket prediction markets by keyword, category, and limit.",
-        "operationId": "getPredictionMarket",
-        "responses": {
-          "200": {
-            "description": "Prediction markets",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PredictionMarketResponse"
-                }
-              }
-            }
-          },
-          "402": {
-            "description": "Payment required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error402"
-                }
-              }
-            }
-          }
-        },
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "query": {
-                    "type": "string",
-                    "description": "Search term. Empty = trending markets."
-                  },
-                  "category": {
-                    "type": "string",
-                    "enum": [
-                      "crypto",
-                      "politics",
-                      "sports",
-                      "science",
-                      "economics",
-                      "world",
-                      "pop-culture",
-                      "gaming",
-                      "space"
-                    ],
-                    "description": "Filter by category"
-                  },
-                  "limit": {
-                    "type": "integer",
-                    "default": 10,
-                    "maximum": 20,
-                    "description": "Max markets to return (max 20)"
-                  }
-                },
-                "example": {
-                  "query": "Bitcoin",
-                  "limit": 10
-                }
-              }
-            }
-          }
-        },
-        "x-payment-info": {
-          "price": {
-            "fixed": {
-              "mode": "fixed",
-              "currency": "USD",
-              "amount": "0.003"
-            }
-          },
-          "protocols": [
-            {
-              "x402": {}
-            }
-          ]
-        }
-      }
-    },
-    "/price": {
-      "post": {
-        "tags": [
-          "Prices"
-        ],
-        "summary": "Fetch batch token prices with OHLCV candle history",
-        "description": "Get real-time prices, OHLCV candlestick data, volume, and market cap for multiple tokens at once.",
-        "operationId": "getBatchPrices",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "tokens": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    },
-                    "default": [
-                      "SOL"
-                    ],
-                    "description": "Token symbols or mint addresses"
-                  },
-                  "period": {
-                    "type": "string",
-                    "enum": [
-                      "1h",
-                      "4h",
-                      "1d",
-                      "7d"
-                    ],
-                    "description": "Candlestick period"
-                  }
-                }
-              },
-              "example": {
-                "tokens": [
-                  "SOL",
-                  "BONK"
-                ],
-                "period": "1h"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Batch price data",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BatchPriceResponse"
-                }
-              }
-            }
-          },
-          "402": {
-            "description": "Payment required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error402"
-                }
-              }
-            }
-          }
-        },
-        "x-payment-info": {
-          "price": {
-            "fixed": {
-              "mode": "fixed",
-              "currency": "USD",
-              "amount": "0.003"
-            }
-          },
-          "protocols": [
-            {
-              "x402": {}
-            }
-          ]
-        }
-      }
-    },
-    "/rpc": {
-      "post": {
-        "tags": [
-          "RPC"
-        ],
-        "summary": "Pay-per-call Solana RPC relay",
-        "description": "Access the Helius RPC endpoint with built-in rate limiting. Standard JSON-RPC 2.0 interface.",
-        "operationId": "rpcRelay",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/JsonRpcRequest"
-              },
-              "example": {
-                "jsonrpc": "2.0",
-                "id": 1,
-                "method": "getBalance",
-                "params": [
-                  "7EcDhSYGxXyscszYEp35KHN8vvw3svAuLKTzXwCFLtV"
-                ]
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "JSON-RPC response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object"
-                }
-              }
-            }
-          },
-          "402": {
-            "description": "Payment required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error402"
-                }
-              }
-            }
-          }
-        },
-        "x-payment-info": {
-          "price": {
-            "fixed": {
-              "mode": "fixed",
-              "currency": "USD",
-              "amount": "0.001"
-            }
-          },
-          "protocols": [
-            {
-              "x402": {}
-            }
-          ]
-        }
-      }
-    },
-    "/smartmoney": {
-      "post": {
-        "summary": "Fetch top smart-money wallets with copy-trade signals",
-        "description": "Track top Solana trader wallets, copy-trade signals, portfolio analysis",
-        "operationId": "smartMoney",
-        "tags": [
-          "solana",
-          "wallet",
-          "copy-trading"
-        ],
-        "requestBody": {
-          "required": false,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "minScore": {
-                    "type": "number"
-                  },
-                  "topN": {
-                    "type": "integer"
-                  },
-                  "wallets": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Smart money wallet data with copy-trade signals",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object"
-                }
-              }
-            }
-          },
-          "402": {
-            "description": "Payment required"
-          }
-        },
-        "x-payment-info": {
-          "price": {
-            "fixed": {
-              "mode": "fixed",
-              "currency": "USD",
-              "amount": "0.008"
-            }
-          },
-          "protocols": [
-            {
-              "x402": {}
-            }
-          ]
-        }
-      }
-    },
-    "/social": {
-      "post": {
-        "tags": [
-          "Social"
-        ],
-        "summary": "Analyze on-chain social sentiment for a Solana token",
-        "description": "Track mentions, influencer activity, and trending scores for tokens and NFTs.",
-        "operationId": "getSocialSentiment",
-        "responses": {
-          "200": {
-            "description": "Social sentiment",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SocialSentimentResponse"
-                }
-              }
-            }
-          },
-          "402": {
-            "description": "Payment required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error402"
-                }
-              }
-            }
-          }
-        },
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "query"
-                ],
-                "properties": {
-                  "query": {
-                    "type": "string",
-                    "description": "Search query (token, topic, or keyword)"
-                  },
-                  "source": {
-                    "type": "string",
-                    "enum": [
-                      "twitter",
-                      "dune",
-                      "combined"
-                    ],
-                    "default": "combined"
-                  },
-                  "hours": {
-                    "type": "integer",
-                    "default": 24
-                  }
-                },
-                "example": {
-                  "query": "SOL",
-                  "source": "combined",
-                  "hours": 24
-                }
-              }
-            }
-          }
-        },
-        "x-payment-info": {
-          "price": {
-            "fixed": {
-              "mode": "fixed",
-              "currency": "USD",
-              "amount": "0.004"
-            }
-          },
-          "protocols": [
-            {
-              "x402": {}
-            }
-          ]
-        }
-      }
-    },
-    "/staking": {
-      "post": {
-        "tags": [
-          "Staking"
-        ],
-        "summary": "Compare staking APY across protocols",
-        "description": "Cross-protocol staking APY comparison for Marinade, Jito, Blaze, and Sanctum.",
-        "operationId": "getStakingRates",
-        "responses": {
-          "200": {
-            "description": "Staking rates",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/StakingRatesResponse"
-                }
-              }
-            }
-          },
-          "402": {
-            "description": "Payment required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error402"
-                }
-              }
-            }
-          }
-        },
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "validator": {
-                    "type": "string",
-                    "description": "Validator address to query"
-                  },
-                  "sortBy": {
-                    "type": "string",
-                    "enum": [
-                      "apy",
-                      "stake",
-                      "reliability"
-                    ]
-                  },
-                  "protocol": {
-                    "type": "string",
-                    "enum": [
-                      "all",
-                      "marinade",
-                      "jito",
-                      "blaze",
-                      "sanctum"
-                    ],
-                    "default": "all",
-                    "description": "Protocol filter: all, marinade, jito, blaze, or sanctum"
-                  }
-                },
-                "example": {
-                  "sortBy": "apy"
-                }
-              }
-            }
-          }
-        },
-        "x-payment-info": {
-          "price": {
-            "fixed": {
-              "mode": "fixed",
-              "currency": "USD",
-              "amount": "0.002"
-            }
-          },
-          "protocols": [
-            {
-              "x402": {}
-            }
-          ]
-        }
-      }
-    },
-    "/summary": {
-      "post": {
-        "tags": [
-          "AI"
-        ],
-        "summary": "Generate an AI summary of Solana market conditions",
-        "description": "Natural-language analysis of Solana market conditions. Ask about memecoin activity, NFT volume, DeFi TVL, or general overview.",
-        "operationId": "getMarketSummary",
-        "responses": {
-          "200": {
-            "description": "AI-generated summary",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/MarketSummaryResponse"
-                }
-              }
-            }
-          },
-          "402": {
-            "description": "Payment required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error402"
-                }
-              }
-            }
-          }
-        },
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "token": {
-                    "type": "string",
-                    "description": "Token to summarize"
-                  },
-                  "sections": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    },
-                    "description": "Sections to include"
-                  },
-                  "query": {
-                    "type": "string",
-                    "default": "solana market overview",
-                    "description": "What you want to know about"
-                  }
-                },
-                "example": {
-                  "token": "SOL",
-                  "sections": [
-                    "price",
-                    "volume",
-                    "social"
-                  ]
-                }
-              }
-            }
-          }
-        },
-        "x-payment-info": {
-          "price": {
-            "fixed": {
-              "mode": "fixed",
-              "currency": "USD",
-              "amount": "0.008"
-            }
-          },
-          "protocols": [
-            {
-              "x402": {}
-            }
-          ]
-        }
-      }
-    },
-    "/token-safety": {
-      "post": {
-        "operationId": "checkTokenSafety",
-        "summary": "Fetch a token safety report with rug-risk flags",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "mint": {
-                    "type": "string",
-                    "description": "Token mint address"
-                  }
-                },
-                "required": [
-                  "mint"
-                ]
-              }
-            }
-          }
-        },
-        "responses": {
-          "402": {
-            "description": "x402 Payment Required"
-          },
-          "200": {
-            "description": "Safety assessment with risk score and findings"
-          }
-        },
-        "x-payment-info": {
-          "price": {
-            "fixed": {
-              "mode": "fixed",
-              "currency": "USD",
-              "amount": "0.005"
-            }
-          },
-          "protocols": [
-            {
-              "x402": {}
-            }
-          ]
-        }
-      }
-    },
-    "/trending": {
-      "post": {
-        "operationId": "getTrendingTokens",
-        "summary": "Fetch trending Solana tokens by volume and momentum",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "limit": {
-                    "type": "integer",
-                    "default": 20
-                  },
-                  "sort_by": {
-                    "type": "string",
-                    "enum": [
-                      "volume",
-                      "price_change",
-                      "social_score"
-                    ]
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "402": {
-            "description": "x402 Payment Required"
-          },
-          "200": {
-            "description": "Array of trending tokens with metrics",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "tokens": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "symbol": {
-                            "type": "string"
-                          },
-                          "mint": {
-                            "type": "string"
-                          },
-                          "priceChange24h": {
-                            "type": "number"
-                          },
-                          "volume24h": {
-                            "type": "number"
-                          },
-                          "trendScore": {
-                            "type": "number"
-                          }
-                        }
-                      },
-                      "description": "Trending tokens with metrics"
-                    },
-                    "count": {
-                      "type": "integer"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-payment-info": {
-          "price": {
-            "fixed": {
-              "mode": "fixed",
-              "currency": "USD",
-              "amount": "0.004"
-            }
-          },
-          "protocols": [
-            {
-              "x402": {}
-            }
-          ]
-        }
-      }
-    },
-    "/trust": {
-      "post": {
-        "operationId": "getWalletTrust",
-        "summary": "Fetch a wallet trust score with age and behaviour data",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "address": {
-                    "type": "string",
-                    "description": "Wallet address to score"
-                  }
-                },
-                "required": [
-                  "address"
-                ]
-              }
-            }
-          }
-        },
-        "responses": {
-          "402": {
-            "description": "x402 Payment Required"
-          },
-          "200": {
-            "description": "Trust score with detailed factors",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "address": {
-                      "type": "string"
-                    },
-                    "trustScore": {
-                      "type": "integer",
-                      "description": "Trust score 0-100"
-                    },
-                    "label": {
-                      "type": "string",
-                      "description": "Wallet classification label"
-                    },
-                    "factors": {
-                      "type": "object",
-                      "properties": {
-                        "age": {
-                          "type": "string"
-                        },
-                        "txCount": {
-                          "type": "integer"
-                        },
-                        "washTrading": {
-                          "type": "boolean"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "x-payment-info": {
-          "price": {
-            "fixed": {
-              "mode": "fixed",
-              "currency": "USD",
-              "amount": "0.003"
-            }
-          },
-          "protocols": [
-            {
-              "x402": {}
-            }
-          ]
-        }
-      }
-    },
-    "/wallet": {
-      "post": {
-        "tags": [
-          "Wallet"
-        ],
-        "summary": "Analyze a Solana wallet for risk and activity patterns",
-        "description": "Risk scoring, transaction pattern analysis, wash trading and rug pull detection.",
-        "operationId": "analyzeWallet",
-        "responses": {
-          "200": {
-            "description": "Wallet analysis",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/WalletAnalysisResponse"
-                }
-              }
-            }
-          },
-          "402": {
-            "description": "Payment required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error402"
-                }
-              }
-            }
-          }
-        },
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "address"
-                ],
-                "properties": {
-                  "address": {
-                    "type": "string",
-                    "description": "Solana wallet address to query"
-                  }
-                },
-                "example": {
-                  "address": "7EcDhSYGxXyscszYEp35KHN8vvw3svAuLKTzXwCFLtV"
-                }
-              }
-            }
-          }
-        },
-        "x-payment-info": {
-          "price": {
-            "fixed": {
-              "mode": "fixed",
-              "currency": "USD",
-              "amount": "0.005"
-            }
-          },
-          "protocols": [
-            {
-              "x402": {}
-            }
-          ]
-        }
-      }
-    },
-    "/whale": {
-      "post": {
-        "tags": [
-          "Whales"
-        ],
-        "summary": "Fetch whale transfers and smart money signals",
-        "description": "Detect large transfers, accumulation patterns, and distribution events on Solana.",
-        "operationId": "getWhaleActivity",
-        "responses": {
-          "200": {
-            "description": "Whale activity",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/WhaleActivityResponse"
-                }
-              }
-            }
-          },
-          "402": {
-            "description": "Payment required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error402"
-                }
-              }
-            }
-          }
-        },
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "token": {
-                    "type": "string",
-                    "description": "Token to watch for whale activity"
-                  },
-                  "minValue": {
-                    "type": "number",
-                    "description": "Minimum transaction value in USD"
-                  }
-                },
-                "example": {
-                  "token": "SOL",
-                  "minValue": 100000
-                }
-              }
-            }
-          }
-        },
-        "x-payment-info": {
-          "price": {
-            "fixed": {
-              "mode": "fixed",
-              "currency": "USD",
-              "amount": "0.006"
-            }
-          },
-          "protocols": [
-            {
-              "x402": {}
-            }
-          ]
-        }
-      }
-    },
-    "/trenches": {
-      "post": {
-        "summary": "Search newest low-cap Solana token listings",
-        "operationId": "trenches",
-        "requestBody": {
-          "required": false,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "action": {
-                    "type": "string",
-                    "enum": [
-                      "feed",
-                      "detail",
-                      "search"
-                    ]
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Token trenches data",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "tokens": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "mint": {
-                            "type": "string"
-                          },
-                          "name": {
-                            "type": "string"
-                          },
-                          "bondingCurveProgress": {
-                            "type": "number"
-                          },
-                          "graduated": {
-                            "type": "boolean"
-                          },
-                          "volume24h": {
-                            "type": "number"
-                          }
-                        }
-                      },
-                      "description": "PumpFun tokens with bonding curve status"
-                    },
-                    "count": {
-                      "type": "integer"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "402": {
-            "description": "Payment required"
-          }
-        },
-        "x-payment-info": {
-          "price": {
-            "fixed": {
-              "mode": "fixed",
-              "currency": "USD",
-              "amount": "0.008"
-            }
-          },
-          "protocols": [
-            {
-              "x402": {}
-            }
-          ]
-        }
-      }
-    },
-    "/ask": {
-      "post": {
-        "summary": "Generate an LLM verdict for any Solana DeFi question",
-        "operationId": "askVerdict",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "query": {
-                    "type": "string",
-                    "description": "Solana/DeFi question in plain English, e.g. 'is JUP worth staking?'"
-                  }
-                },
-                "required": [
-                  "query"
-                ]
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "LLM answer",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "answer": {
-                      "type": "string",
-                      "description": "AI-generated answer with data-backed reasoning"
+                    "price_change_24h_pct": {
+                        "type": "number",
+                        "description": "24-hour price change percentage"
                     },
                     "sources": {
-                      "type": "array",
-                      "items": {
-                        "type": "string"
-                      },
-                      "description": "On-chain data sources used"
-                    },
-                    "confidence": {
-                      "type": "number",
-                      "description": "Confidence score 0-1"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "Data sources (Jupiter, Birdeye)"
                     }
-                  }
                 }
-              }
+            },
+            "ArbitrageScanResponse": {
+                "type": "object",
+                "properties": {
+                    "token": {
+                        "type": "string"
+                    },
+                    "opportunities": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "buy_dex": {
+                                    "type": "string"
+                                },
+                                "sell_dex": {
+                                    "type": "string"
+                                },
+                                "profit_bps": {
+                                    "type": "number",
+                                    "description": "Profit in basis points"
+                                },
+                                "estimated_usd": {
+                                    "type": "number"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "WalletAnalysisResponse": {
+                "type": "object",
+                "properties": {
+                    "address": {
+                        "type": "string"
+                    },
+                    "risk_score": {
+                        "type": "integer",
+                        "description": "0-100 risk score"
+                    },
+                    "age_days": {
+                        "type": "integer"
+                    },
+                    "transaction_count": {
+                        "type": "integer"
+                    },
+                    "flags": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "Risk flags (wash_trading, rug_pull, etc.)"
+                    }
+                }
+            },
+            "TokenLaunchesResponse": {
+                "type": "object",
+                "properties": {
+                    "count": {
+                        "type": "integer"
+                    },
+                    "window_hours": {
+                        "type": "integer"
+                    },
+                    "launches": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "mint": {
+                                    "type": "string"
+                                },
+                                "name": {
+                                    "type": "string"
+                                },
+                                "symbol": {
+                                    "type": "string"
+                                },
+                                "platform": {
+                                    "type": "string",
+                                    "description": "pump.fun, Raydium, etc."
+                                },
+                                "age_minutes": {
+                                    "type": "integer"
+                                },
+                                "initial_liquidity_usd": {
+                                    "type": "number"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "MarketSummaryResponse": {
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string"
+                    },
+                    "summary": {
+                        "type": "string",
+                        "description": "AI-generated plain-English summary"
+                    },
+                    "data_points": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "label": {
+                                    "type": "string"
+                                },
+                                "value": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "JsonRpcRequest": {
+                "type": "object",
+                "required": [
+                    "jsonrpc",
+                    "method"
+                ],
+                "properties": {
+                    "jsonrpc": {
+                        "type": "string",
+                        "enum": [
+                            "2.0"
+                        ]
+                    },
+                    "id": {
+                        "type": "integer"
+                    },
+                    "method": {
+                        "type": "string",
+                        "description": "Solana JSON-RPC method"
+                    },
+                    "params": {
+                        "type": "array",
+                        "items": {},
+                        "description": "RPC parameters"
+                    }
+                }
+            },
+            "PredictionMarketResponse": {
+                "type": "object",
+                "properties": {
+                    "markets": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "string"
+                                },
+                                "question": {
+                                    "type": "string"
+                                },
+                                "yes_price": {
+                                    "type": "number"
+                                },
+                                "no_price": {
+                                    "type": "number"
+                                },
+                                "volume_usd": {
+                                    "type": "number"
+                                },
+                                "liquidity_usd": {
+                                    "type": "number"
+                                },
+                                "end_date": {
+                                    "type": "string"
+                                },
+                                "category": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "Error402": {
+                "type": "object",
+                "properties": {
+                    "error": {
+                        "type": "object",
+                        "properties": {
+                            "code": {
+                                "type": "integer",
+                                "example": 402
+                            },
+                            "message": {
+                                "type": "string",
+                                "example": "Payment Required"
+                            },
+                            "payment": {
+                                "type": "object",
+                                "properties": {
+                                    "amount": {
+                                        "type": "number",
+                                        "description": "USDC amount required (6 decimals)"
+                                    },
+                                    "recipient": {
+                                        "type": "string",
+                                        "description": "Solana wallet address"
+                                    },
+                                    "mint": {
+                                        "type": "string",
+                                        "description": "USDC mint address"
+                                    },
+                                    "deadline": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "BatchPriceResponse": {
+                "type": "object",
+                "properties": {
+                    "tokens": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "symbol": {
+                                    "type": "string"
+                                },
+                                "price_usd": {
+                                    "type": "number"
+                                },
+                                "change_24h": {
+                                    "type": "number"
+                                },
+                                "volume_24h": {
+                                    "type": "number"
+                                },
+                                "market_cap": {
+                                    "type": "number"
+                                },
+                                "candles": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "time": {
+                                                "type": "string",
+                                                "format": "date-time"
+                                            },
+                                            "open": {
+                                                "type": "number"
+                                            },
+                                            "high": {
+                                                "type": "number"
+                                            },
+                                            "low": {
+                                                "type": "number"
+                                            },
+                                            "close": {
+                                                "type": "number"
+                                            },
+                                            "volume": {
+                                                "type": "number"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "NftIntelResponse": {
+                "type": "object",
+                "properties": {
+                    "collection": {
+                        "type": "string"
+                    },
+                    "floor_usdc": {
+                        "type": "number"
+                    },
+                    "floor_sol": {
+                        "type": "number"
+                    },
+                    "volume_24h": {
+                        "type": "number"
+                    },
+                    "listings": {
+                        "type": "integer"
+                    },
+                    "wash_trading_score": {
+                        "type": "number",
+                        "description": "0-100 wash trading probability"
+                    },
+                    "rarity_data": {
+                        "type": "object",
+                        "properties": {
+                            "total_supply": {
+                                "type": "integer"
+                            },
+                            "ranked_count": {
+                                "type": "integer"
+                            },
+                            "top_rarities": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "rank": {
+                                            "type": "integer"
+                                        },
+                                        "name": {
+                                            "type": "string"
+                                        },
+                                        "mint": {
+                                            "type": "string"
+                                        },
+                                        "price_sol": {
+                                            "type": "number"
+                                        },
+                                        "rarity_score": {
+                                            "type": "number"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "StakingRatesResponse": {
+                "type": "object",
+                "properties": {
+                    "protocols": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                },
+                                "apy": {
+                                    "type": "number"
+                                },
+                                "tvl": {
+                                    "type": "number",
+                                    "description": "Total value locked in USD"
+                                },
+                                "token": {
+                                    "type": "string"
+                                },
+                                "unstake_days": {
+                                    "type": "number"
+                                },
+                                "website": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "WhaleActivityResponse": {
+                "type": "object",
+                "properties": {
+                    "transfers": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "tx_signature": {
+                                    "type": "string"
+                                },
+                                "from": {
+                                    "type": "string"
+                                },
+                                "to": {
+                                    "type": "string"
+                                },
+                                "amount": {
+                                    "type": "number"
+                                },
+                                "amount_usd": {
+                                    "type": "number"
+                                },
+                                "token": {
+                                    "type": "string"
+                                },
+                                "timestamp": {
+                                    "type": "string",
+                                    "format": "date-time"
+                                },
+                                "whale_type": {
+                                    "type": "string",
+                                    "enum": [
+                                        "accumulation",
+                                        "distribution",
+                                        "unknown"
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "AlertResponse": {
+                "type": "object",
+                "properties": {
+                    "alert_id": {
+                        "type": "string"
+                    },
+                    "created": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "expires": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "active",
+                            "triggered",
+                            "expired"
+                        ]
+                    }
+                }
+            },
+            "DevActivityResponse": {
+                "type": "object",
+                "properties": {
+                    "protocol": {
+                        "type": "string"
+                    },
+                    "repo": {
+                        "type": "string"
+                    },
+                    "commits": {
+                        "type": "integer"
+                    },
+                    "contributors": {
+                        "type": "integer"
+                    },
+                    "last_commit": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "audit_status": {
+                        "type": "string"
+                    },
+                    "ecosystem_rank": {
+                        "type": "integer"
+                    }
+                }
+            },
+            "SocialSentimentResponse": {
+                "type": "object",
+                "properties": {
+                    "mentions": {
+                        "type": "integer"
+                    },
+                    "sentiment_score": {
+                        "type": "number",
+                        "description": "-1.0 (bearish) to +1.0 (bullish)"
+                    },
+                    "top_influencers": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "handle": {
+                                    "type": "string"
+                                },
+                                "followers": {
+                                    "type": "integer"
+                                },
+                                "sentiment": {
+                                    "type": "number"
+                                }
+                            }
+                        }
+                    },
+                    "trending_score": {
+                        "type": "number"
+                    },
+                    "related_tokens": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                }
             }
-          },
-          "402": {
-            "description": "Payment required"
-          }
-        },
-        "x-payment-info": {
-          "price": {
-            "fixed": {
-              "mode": "fixed",
-              "currency": "USD",
-              "amount": "0.015"
-            }
-          },
-          "protocols": [
-            {
-              "x402": {}
-            }
-          ]
         }
-      }
+    },
+    "paths": {
+        "/alerts": {
+            "post": {
+                "tags": [
+                    "Alerts"
+                ],
+                "summary": "Register a webhook alert",
+                "description": "Create price, volume, whale, or launch alerts that POST to your webhook when triggered.",
+                "operationId": "createAlert",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "type",
+                                    "condition",
+                                    "webhookUrl"
+                                ],
+                                "properties": {
+                                    "type": {
+                                        "type": "string",
+                                        "enum": [
+                                            "price",
+                                            "volume",
+                                            "whale",
+                                            "launch"
+                                        ]
+                                    },
+                                    "condition": {
+                                        "type": "string",
+                                        "description": "Trigger condition (e.g. SOL > 200)"
+                                    },
+                                    "webhookUrl": {
+                                        "type": "string",
+                                        "format": "uri"
+                                    },
+                                    "expiryHours": {
+                                        "type": "integer",
+                                        "default": 72,
+                                        "maximum": 168
+                                    }
+                                }
+                            },
+                            "example": {
+                                "type": "price",
+                                "condition": "SOL > 200",
+                                "webhookUrl": "https://hooks.example.com/solsigs",
+                                "expiryHours": 72
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Alert created",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AlertResponse"
+                                }
+                            }
+                        }
+                    },
+                    "402": {
+                        "description": "Payment required",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error402"
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-payment-info": {
+                    "price": {
+                        "fixed": {
+                            "mode": "fixed",
+                            "currency": "USD",
+                            "amount": "0.005"
+                        }
+                    },
+                    "protocols": [
+                        {
+                            "x402": {}
+                        }
+                    ]
+                }
+            }
+        },
+        "/alpha": {
+            "post": {
+                "operationId": "getAlphaFeed",
+                "summary": "Fetch alpha signals from new launches and insider wallets",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "limit": {
+                                        "type": "integer",
+                                        "default": 20
+                                    },
+                                    "min_confidence": {
+                                        "type": "number",
+                                        "default": 0.5
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "402": {
+                        "description": "x402 Payment Required"
+                    },
+                    "200": {
+                        "description": "Alpha signals with confidence scores"
+                    }
+                },
+                "x-payment-info": {
+                    "price": {
+                        "fixed": {
+                            "mode": "fixed",
+                            "currency": "USD",
+                            "amount": "0.006"
+                        }
+                    },
+                    "protocols": [
+                        {
+                            "x402": {}
+                        }
+                    ]
+                }
+            }
+        },
+        "/arb": {
+            "post": {
+                "tags": [
+                    "Arbitrage"
+                ],
+                "summary": "Search Solana DEXs for arbitrage opportunities",
+                "description": "Scans DEXes for profitable cross-exchange arbitrage trades.",
+                "operationId": "scanArbitrage",
+                "parameters": [
+                    {
+                        "name": "token",
+                        "in": "query",
+                        "schema": {
+                            "type": "string",
+                            "default": "SOL"
+                        },
+                        "description": "Token symbol or mint address (e.g. 'SOL' or a base58 mint)"
+                    },
+                    {
+                        "name": "minProfitBps",
+                        "in": "query",
+                        "description": "Minimum profit in basis points (1 bps = 0.01%)",
+                        "schema": {
+                            "type": "integer",
+                            "default": 10
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Arbitrage opportunities",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ArbitrageScanResponse"
+                                }
+                            }
+                        }
+                    },
+                    "402": {
+                        "description": "Payment required",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error402"
+                                }
+                            }
+                        }
+                    }
+                },
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "token": {
+                                        "type": "string",
+                                        "description": "Token symbol to scan (e.g. SOL, BONK)"
+                                    },
+                                    "minProfitPercent": {
+                                        "type": "number",
+                                        "description": "Minimum profit threshold"
+                                    }
+                                },
+                                "example": {
+                                    "token": "SOL",
+                                    "minProfitPercent": 0.5
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-payment-info": {
+                    "price": {
+                        "fixed": {
+                            "mode": "fixed",
+                            "currency": "USD",
+                            "amount": "0.010"
+                        }
+                    },
+                    "protocols": [
+                        {
+                            "x402": {}
+                        }
+                    ]
+                }
+            }
+        },
+        "/dev": {
+            "post": {
+                "tags": [
+                    "Development"
+                ],
+                "summary": "Fetch GitHub dev activity for a Solana protocol",
+                "description": "Track commits, contributors, and audit status to gauge protocol development health.",
+                "operationId": "getDevActivity",
+                "parameters": [
+                    {
+                        "name": "protocol",
+                        "in": "query",
+                        "required": true,
+                        "description": "Protocol name (e.g. jupiter, marinade, drift)",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "example": "jupiter"
+                    },
+                    {
+                        "name": "days",
+                        "in": "query",
+                        "description": "Look-back window in days",
+                        "schema": {
+                            "type": "integer",
+                            "default": 30
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Dev activity",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/DevActivityResponse"
+                                }
+                            }
+                        }
+                    },
+                    "402": {
+                        "description": "Payment required",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error402"
+                                }
+                            }
+                        }
+                    }
+                },
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "protocol"
+                                ],
+                                "properties": {
+                                    "protocol": {
+                                        "type": "string",
+                                        "description": "Solana protocol to query"
+                                    },
+                                    "days": {
+                                        "type": "integer",
+                                        "default": 30
+                                    }
+                                },
+                                "example": {
+                                    "protocol": "Jupiter",
+                                    "days": 7
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-payment-info": {
+                    "price": {
+                        "fixed": {
+                            "mode": "fixed",
+                            "currency": "USD",
+                            "amount": "0.001"
+                        }
+                    },
+                    "protocols": [
+                        {
+                            "x402": {}
+                        }
+                    ]
+                }
+            }
+        },
+        "/dex": {
+            "post": {
+                "tags": [
+                    "Prices"
+                ],
+                "summary": "Fetch real-time DEX prices for a Solana token",
+                "description": "Returns price, liquidity, and 24h volume from Jupiter and Birdeye aggregators.",
+                "operationId": "getDexPrice",
+                "parameters": [
+                    {
+                        "name": "token",
+                        "in": "query",
+                        "description": "Token symbol or mint address",
+                        "schema": {
+                            "type": "string",
+                            "default": "SOL"
+                        },
+                        "example": "SOL"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Price data",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/DexPriceResponse"
+                                }
+                            }
+                        }
+                    },
+                    "402": {
+                        "description": "Payment required \u2014 send USDC and retry",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error402"
+                                }
+                            }
+                        }
+                    }
+                },
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "pair": {
+                                        "type": "string",
+                                        "description": "Token pair (e.g. SOL/USDC)"
+                                    },
+                                    "dex": {
+                                        "type": "string",
+                                        "description": "DEX to query (e.g. Jupiter, Orca)"
+                                    }
+                                },
+                                "example": {
+                                    "pair": "SOL/USDC",
+                                    "dex": "Jupiter"
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-payment-info": {
+                    "price": {
+                        "fixed": {
+                            "mode": "fixed",
+                            "currency": "USD",
+                            "amount": "0.002"
+                        }
+                    },
+                    "protocols": [
+                        {
+                            "x402": {}
+                        }
+                    ]
+                }
+            }
+        },
+        "/launches": {
+            "post": {
+                "tags": [
+                    "Tokens"
+                ],
+                "summary": "Detect new token launches",
+                "description": "Spot fresh token deployments on pump.fun and Raydium.",
+                "operationId": "detectTokenLaunches",
+                "parameters": [
+                    {
+                        "name": "hours",
+                        "in": "query",
+                        "description": "Look-back window in hours",
+                        "schema": {
+                            "type": "integer",
+                            "default": 1
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Recent token launches",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/TokenLaunchesResponse"
+                                }
+                            }
+                        }
+                    },
+                    "402": {
+                        "description": "Payment required",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error402"
+                                }
+                            }
+                        }
+                    }
+                },
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "hours": {
+                                        "type": "integer",
+                                        "default": 24,
+                                        "description": "Lookback window in hours"
+                                    },
+                                    "minLiquidity": {
+                                        "type": "number",
+                                        "description": "Minimum liquidity filter in USD"
+                                    }
+                                },
+                                "example": {
+                                    "hours": 24,
+                                    "minLiquidity": 10000
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-payment-info": {
+                    "price": {
+                        "fixed": {
+                            "mode": "fixed",
+                            "currency": "USD",
+                            "amount": "0.003"
+                        }
+                    },
+                    "protocols": [
+                        {
+                            "x402": {}
+                        }
+                    ]
+                }
+            }
+        },
+        "/nft": {
+            "post": {
+                "tags": [
+                    "NFT"
+                ],
+                "summary": "Fetch NFT collection intel and wash trading signals",
+                "description": "Floor prices, rarity rankings, and wash trading score for any Solana NFT collection.",
+                "operationId": "getNftIntel",
+                "parameters": [
+                    {
+                        "name": "collection",
+                        "in": "query",
+                        "required": true,
+                        "description": "Collection slug (e.g. mad-lads, degen-ape)",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "example": "mad-lads"
+                    },
+                    {
+                        "name": "sortBy",
+                        "in": "query",
+                        "description": "Sort by floor, volume, or rarity",
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "floor",
+                                "volume",
+                                "rarity"
+                            ]
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "NFT intel",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/NftIntelResponse"
+                                }
+                            }
+                        }
+                    },
+                    "402": {
+                        "description": "Payment required",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error402"
+                                }
+                            }
+                        }
+                    }
+                },
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "collection"
+                                ],
+                                "properties": {
+                                    "collection": {
+                                        "type": "string",
+                                        "description": "NFT collection name or symbol"
+                                    },
+                                    "sortBy": {
+                                        "type": "string",
+                                        "enum": [
+                                            "floor",
+                                            "volume",
+                                            "rarity"
+                                        ]
+                                    }
+                                },
+                                "example": {
+                                    "collection": "Mad Lads",
+                                    "sortBy": "floor"
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-payment-info": {
+                    "price": {
+                        "fixed": {
+                            "mode": "fixed",
+                            "currency": "USD",
+                            "amount": "0.004"
+                        }
+                    },
+                    "protocols": [
+                        {
+                            "x402": {}
+                        }
+                    ]
+                }
+            }
+        },
+        "/perps": {
+            "post": {
+                "operationId": "getPerpsIntel",
+                "summary": "Fetch Solana perps markets, funding rates, open interest",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "action": {
+                                        "type": "string",
+                                        "enum": [
+                                            "markets",
+                                            "positions",
+                                            "funding"
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "402": {
+                        "description": "x402 Payment Required"
+                    },
+                    "200": {
+                        "description": "Perps market data"
+                    }
+                },
+                "x-payment-info": {
+                    "price": {
+                        "fixed": {
+                            "mode": "fixed",
+                            "currency": "USD",
+                            "amount": "0.005"
+                        }
+                    },
+                    "protocols": [
+                        {
+                            "x402": {}
+                        }
+                    ]
+                }
+            }
+        },
+        "/predict": {
+            "post": {
+                "tags": [
+                    "Predictions"
+                ],
+                "summary": "Fetch Polymarket prediction market odds and volume",
+                "description": "Search Polymarket YES/NO contracts \u2014 elections, sports, crypto, economics, pop culture. Sourced from Polymarket Gamma API.",
+                "operationId": "getPredictionMarket",
+                "parameters": [
+                    {
+                        "name": "query",
+                        "in": "query",
+                        "description": "Search term. Empty = trending markets.",
+                        "schema": {
+                            "type": "string",
+                            "default": ""
+                        },
+                        "example": "Bitcoin"
+                    },
+                    {
+                        "name": "category",
+                        "in": "query",
+                        "description": "Filter by category",
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "crypto",
+                                "politics",
+                                "sports",
+                                "science",
+                                "economics",
+                                "world",
+                                "pop-culture",
+                                "gaming",
+                                "space"
+                            ]
+                        }
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "Max markets to return (max 20)",
+                        "schema": {
+                            "type": "integer",
+                            "default": 10,
+                            "maximum": 20
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Prediction markets",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PredictionMarketResponse"
+                                }
+                            }
+                        }
+                    },
+                    "402": {
+                        "description": "Payment required",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error402"
+                                }
+                            }
+                        }
+                    }
+                },
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "token": {
+                                        "type": "string",
+                                        "description": "Token to generate prediction for"
+                                    },
+                                    "horizon": {
+                                        "type": "string",
+                                        "enum": [
+                                            "1h",
+                                            "24h",
+                                            "7d"
+                                        ],
+                                        "default": "24h"
+                                    }
+                                },
+                                "example": {
+                                    "token": "SOL",
+                                    "horizon": "24h"
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-payment-info": {
+                    "price": {
+                        "fixed": {
+                            "mode": "fixed",
+                            "currency": "USD",
+                            "amount": "0.003"
+                        }
+                    },
+                    "protocols": [
+                        {
+                            "x402": {}
+                        }
+                    ]
+                }
+            }
+        },
+        "/price": {
+            "post": {
+                "tags": [
+                    "Prices"
+                ],
+                "summary": "Fetch batch token prices with OHLCV candle history",
+                "description": "Get real-time prices, OHLCV candlestick data, volume, and market cap for multiple tokens at once.",
+                "operationId": "getBatchPrices",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "tokens": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "default": [
+                                            "SOL"
+                                        ],
+                                        "description": "Token symbols or mint addresses"
+                                    },
+                                    "period": {
+                                        "type": "string",
+                                        "enum": [
+                                            "1h",
+                                            "4h",
+                                            "1d",
+                                            "7d"
+                                        ],
+                                        "description": "Candlestick period"
+                                    }
+                                }
+                            },
+                            "example": {
+                                "tokens": [
+                                    "SOL",
+                                    "BONK"
+                                ],
+                                "period": "1h"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Batch price data",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/BatchPriceResponse"
+                                }
+                            }
+                        }
+                    },
+                    "402": {
+                        "description": "Payment required",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error402"
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-payment-info": {
+                    "price": {
+                        "fixed": {
+                            "mode": "fixed",
+                            "currency": "USD",
+                            "amount": "0.003"
+                        }
+                    },
+                    "protocols": [
+                        {
+                            "x402": {}
+                        }
+                    ]
+                }
+            }
+        },
+        "/rpc": {
+            "post": {
+                "tags": [
+                    "RPC"
+                ],
+                "summary": "Pay-per-call Solana RPC relay",
+                "description": "Access the Helius RPC endpoint with built-in rate limiting. Standard JSON-RPC 2.0 interface.",
+                "operationId": "rpcRelay",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/JsonRpcRequest"
+                            },
+                            "example": {
+                                "jsonrpc": "2.0",
+                                "id": 1,
+                                "method": "getBalance",
+                                "params": [
+                                    "7EcDhSYGxXyscszYEp35KHN8vvw3svAuLKTzXwCFLtV"
+                                ]
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "JSON-RPC response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "402": {
+                        "description": "Payment required",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error402"
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-payment-info": {
+                    "price": {
+                        "fixed": {
+                            "mode": "fixed",
+                            "currency": "USD",
+                            "amount": "0.001"
+                        }
+                    },
+                    "protocols": [
+                        {
+                            "x402": {}
+                        }
+                    ]
+                }
+            }
+        },
+        "/smartmoney": {
+            "post": {
+                "summary": "Fetch top smart-money wallets with copy-trade signals",
+                "description": "Track top Solana trader wallets, copy-trade signals, portfolio analysis",
+                "operationId": "smartMoney",
+                "tags": [
+                    "solana",
+                    "wallet",
+                    "copy-trading"
+                ],
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "minScore": {
+                                        "type": "number"
+                                    },
+                                    "topN": {
+                                        "type": "integer"
+                                    },
+                                    "wallets": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Smart money wallet data with copy-trade signals",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "402": {
+                        "description": "Payment required"
+                    }
+                },
+                "x-402": {
+                    "price": "0.008",
+                    "asset": "USDC"
+                },
+                "x-payment-info": {
+                    "price": {
+                        "fixed": {
+                            "mode": "fixed",
+                            "currency": "USD",
+                            "amount": "0.008"
+                        }
+                    },
+                    "protocols": [
+                        {
+                            "x402": {}
+                        }
+                    ]
+                }
+            }
+        },
+        "/social": {
+            "post": {
+                "tags": [
+                    "Social"
+                ],
+                "summary": "Analyze on-chain social sentiment for a Solana token",
+                "description": "Track mentions, influencer activity, and trending scores for tokens and NFTs.",
+                "operationId": "getSocialSentiment",
+                "parameters": [
+                    {
+                        "name": "query",
+                        "in": "query",
+                        "required": true,
+                        "description": "Search term (token symbol, NFT, or keyword)",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "example": "SOL"
+                    },
+                    {
+                        "name": "source",
+                        "in": "query",
+                        "description": "Data source filter",
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "twitter",
+                                "dune",
+                                "combined"
+                            ],
+                            "default": "combined"
+                        }
+                    },
+                    {
+                        "name": "hours",
+                        "in": "query",
+                        "description": "Look-back window in hours",
+                        "schema": {
+                            "type": "integer",
+                            "default": 24
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Social sentiment",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SocialSentimentResponse"
+                                }
+                            }
+                        }
+                    },
+                    "402": {
+                        "description": "Payment required",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error402"
+                                }
+                            }
+                        }
+                    }
+                },
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "query"
+                                ],
+                                "properties": {
+                                    "query": {
+                                        "type": "string",
+                                        "description": "Search query (token, topic, or keyword)"
+                                    },
+                                    "source": {
+                                        "type": "string",
+                                        "enum": [
+                                            "twitter",
+                                            "dune",
+                                            "combined"
+                                        ],
+                                        "default": "combined"
+                                    },
+                                    "hours": {
+                                        "type": "integer",
+                                        "default": 24
+                                    }
+                                },
+                                "example": {
+                                    "query": "SOL",
+                                    "source": "combined",
+                                    "hours": 24
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-payment-info": {
+                    "price": {
+                        "fixed": {
+                            "mode": "fixed",
+                            "currency": "USD",
+                            "amount": "0.004"
+                        }
+                    },
+                    "protocols": [
+                        {
+                            "x402": {}
+                        }
+                    ]
+                }
+            }
+        },
+        "/staking": {
+            "post": {
+                "tags": [
+                    "Staking"
+                ],
+                "summary": "Compare staking APY across protocols",
+                "description": "Cross-protocol staking APY comparison for Marinade, Jito, Blaze, and Sanctum.",
+                "operationId": "getStakingRates",
+                "parameters": [
+                    {
+                        "name": "protocol",
+                        "in": "query",
+                        "description": "Protocol filter",
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "all",
+                                "marinade",
+                                "jito",
+                                "blaze",
+                                "sanctum"
+                            ],
+                            "default": "all"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Staking rates",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/StakingRatesResponse"
+                                }
+                            }
+                        }
+                    },
+                    "402": {
+                        "description": "Payment required",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error402"
+                                }
+                            }
+                        }
+                    }
+                },
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "validator": {
+                                        "type": "string",
+                                        "description": "Validator address to query"
+                                    },
+                                    "sortBy": {
+                                        "type": "string",
+                                        "enum": [
+                                            "apy",
+                                            "stake",
+                                            "reliability"
+                                        ]
+                                    }
+                                },
+                                "example": {
+                                    "sortBy": "apy"
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-payment-info": {
+                    "price": {
+                        "fixed": {
+                            "mode": "fixed",
+                            "currency": "USD",
+                            "amount": "0.002"
+                        }
+                    },
+                    "protocols": [
+                        {
+                            "x402": {}
+                        }
+                    ]
+                }
+            }
+        },
+        "/summary": {
+            "post": {
+                "tags": [
+                    "AI"
+                ],
+                "summary": "Generate an AI summary of Solana market conditions",
+                "description": "Natural-language analysis of Solana market conditions. Ask about memecoin activity, NFT volume, DeFi TVL, or general overview.",
+                "operationId": "getMarketSummary",
+                "parameters": [
+                    {
+                        "name": "query",
+                        "in": "query",
+                        "description": "What you want to know about",
+                        "schema": {
+                            "type": "string",
+                            "default": "solana market overview"
+                        },
+                        "example": "memecoin activity"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "AI-generated summary",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MarketSummaryResponse"
+                                }
+                            }
+                        }
+                    },
+                    "402": {
+                        "description": "Payment required",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error402"
+                                }
+                            }
+                        }
+                    }
+                },
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "token": {
+                                        "type": "string",
+                                        "description": "Token to summarize"
+                                    },
+                                    "sections": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "description": "Sections to include"
+                                    }
+                                },
+                                "example": {
+                                    "token": "SOL",
+                                    "sections": [
+                                        "price",
+                                        "volume",
+                                        "social"
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-payment-info": {
+                    "price": {
+                        "fixed": {
+                            "mode": "fixed",
+                            "currency": "USD",
+                            "amount": "0.008"
+                        }
+                    },
+                    "protocols": [
+                        {
+                            "x402": {}
+                        }
+                    ]
+                }
+            }
+        },
+        "/token-safety": {
+            "post": {
+                "operationId": "checkTokenSafety",
+                "summary": "Fetch a token safety report with rug-risk flags",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "mint": {
+                                        "type": "string",
+                                        "description": "Token mint address"
+                                    }
+                                },
+                                "required": [
+                                    "mint"
+                                ]
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "402": {
+                        "description": "x402 Payment Required"
+                    },
+                    "200": {
+                        "description": "Safety assessment with risk score and findings"
+                    }
+                },
+                "x-payment-info": {
+                    "price": {
+                        "fixed": {
+                            "mode": "fixed",
+                            "currency": "USD",
+                            "amount": "0.005"
+                        }
+                    },
+                    "protocols": [
+                        {
+                            "x402": {}
+                        }
+                    ]
+                }
+            }
+        },
+        "/trending": {
+            "post": {
+                "operationId": "getTrendingTokens",
+                "summary": "Fetch trending Solana tokens by volume and momentum",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "limit": {
+                                        "type": "integer",
+                                        "default": 20
+                                    },
+                                    "sort_by": {
+                                        "type": "string",
+                                        "enum": [
+                                            "volume",
+                                            "price_change",
+                                            "social_score"
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "402": {
+                        "description": "x402 Payment Required"
+                    },
+                    "200": {
+                        "description": "Array of trending tokens with metrics"
+                    }
+                },
+                "x-payment-info": {
+                    "price": {
+                        "fixed": {
+                            "mode": "fixed",
+                            "currency": "USD",
+                            "amount": "0.004"
+                        }
+                    },
+                    "protocols": [
+                        {
+                            "x402": {}
+                        }
+                    ]
+                }
+            }
+        },
+        "/trust": {
+            "post": {
+                "operationId": "getWalletTrust",
+                "summary": "Fetch a wallet trust score with age and behaviour data",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "address": {
+                                        "type": "string",
+                                        "description": "Wallet address to score"
+                                    }
+                                },
+                                "required": [
+                                    "address"
+                                ]
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "402": {
+                        "description": "x402 Payment Required"
+                    },
+                    "200": {
+                        "description": "Trust score with detailed factors"
+                    }
+                },
+                "x-payment-info": {
+                    "price": {
+                        "fixed": {
+                            "mode": "fixed",
+                            "currency": "USD",
+                            "amount": "0.003"
+                        }
+                    },
+                    "protocols": [
+                        {
+                            "x402": {}
+                        }
+                    ]
+                }
+            }
+        },
+        "/wallet": {
+            "post": {
+                "tags": [
+                    "Wallet"
+                ],
+                "summary": "Analyze a Solana wallet for risk and activity patterns",
+                "description": "Risk scoring, transaction pattern analysis, wash trading and rug pull detection.",
+                "operationId": "analyzeWallet",
+                "parameters": [
+                    {
+                        "name": "address",
+                        "in": "query",
+                        "required": true,
+                        "description": "Solana wallet address (base58)",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "example": "7EcDhSYGxXyscszYEp35KHN8vvw3svAuLKTzXwCFLtV"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Wallet analysis",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/WalletAnalysisResponse"
+                                }
+                            }
+                        }
+                    },
+                    "402": {
+                        "description": "Payment required",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error402"
+                                }
+                            }
+                        }
+                    }
+                },
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "address"
+                                ],
+                                "properties": {
+                                    "address": {
+                                        "type": "string",
+                                        "description": "Solana wallet address to query"
+                                    }
+                                },
+                                "example": {
+                                    "address": "7EcDhSYGxXyscszYEp35KHN8vvw3svAuLKTzXwCFLtV"
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-payment-info": {
+                    "price": {
+                        "fixed": {
+                            "mode": "fixed",
+                            "currency": "USD",
+                            "amount": "0.005"
+                        }
+                    },
+                    "protocols": [
+                        {
+                            "x402": {}
+                        }
+                    ]
+                }
+            }
+        },
+        "/whale": {
+            "post": {
+                "tags": [
+                    "Whales"
+                ],
+                "summary": "Fetch whale transfers and smart money signals",
+                "description": "Detect large transfers, accumulation patterns, and distribution events on Solana.",
+                "operationId": "getWhaleActivity",
+                "parameters": [
+                    {
+                        "name": "minAmount",
+                        "in": "query",
+                        "description": "Minimum transfer amount in USD",
+                        "schema": {
+                            "type": "number",
+                            "default": 100000
+                        }
+                    },
+                    {
+                        "name": "token",
+                        "in": "query",
+                        "description": "Filter by token symbol or mint",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "hours",
+                        "in": "query",
+                        "description": "Look-back window in hours",
+                        "schema": {
+                            "type": "integer",
+                            "default": 24
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Whale activity",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/WhaleActivityResponse"
+                                }
+                            }
+                        }
+                    },
+                    "402": {
+                        "description": "Payment required",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error402"
+                                }
+                            }
+                        }
+                    }
+                },
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "token": {
+                                        "type": "string",
+                                        "description": "Token to watch for whale activity"
+                                    },
+                                    "minValue": {
+                                        "type": "number",
+                                        "description": "Minimum transaction value in USD"
+                                    }
+                                },
+                                "example": {
+                                    "token": "SOL",
+                                    "minValue": 100000
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-payment-info": {
+                    "price": {
+                        "fixed": {
+                            "mode": "fixed",
+                            "currency": "USD",
+                            "amount": "0.006"
+                        }
+                    },
+                    "protocols": [
+                        {
+                            "x402": {}
+                        }
+                    ]
+                }
+            }
+        },
+        "/trenches": {
+            "post": {
+                "summary": "Search newest low-cap Solana token listings",
+                "operationId": "trenches",
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "action": {
+                                        "type": "string",
+                                        "enum": [
+                                            "feed",
+                                            "detail",
+                                            "search"
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Token trenches data"
+                    },
+                    "402": {
+                        "description": "Payment required"
+                    }
+                },
+                "x-payment-info": {
+                    "price": {
+                        "fixed": {
+                            "mode": "fixed",
+                            "currency": "USD",
+                            "amount": "0.008"
+                        }
+                    },
+                    "protocols": [
+                        {
+                            "x402": {}
+                        }
+                    ]
+                }
+            }
+        },
+        "/ask": {
+            "post": {
+                "summary": "Generate an LLM verdict for any Solana DeFi question",
+                "operationId": "askVerdict",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "query": {
+                                        "type": "string",
+                                        "description": "Solana/DeFi question in plain English, e.g. 'is JUP worth staking?'"
+                                    }
+                                },
+                                "required": [
+                                    "query"
+                                ]
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "LLM answer"
+                    },
+                    "402": {
+                        "description": "Payment required"
+                    }
+                },
+                "x-payment-info": {
+                    "price": {
+                        "fixed": {
+                            "mode": "fixed",
+                            "currency": "USD",
+                            "amount": "0.015"
+                        }
+                    },
+                    "protocols": [
+                        {
+                            "x402": {}
+                        }
+                    ]
+                }
+            }
+        },
+        "/proofguard/evaluate": {
+            "post": {
+                "tags": [
+                    "ProofGuard"
+                ],
+                "summary": "Evaluate an x402-paid endpoint with ProofGuard receipts",
+                "description": "Returns a trust score, payment expectation receipt, fulfillment receipt, and refund-evidence package. Third-party caller-supplied observations are marked self_attested; SolSigs endpoints are marked solsigs_instrumented.",
+                "operationId": "evaluateProofGuard",
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "endpoint": {
+                                        "type": "string",
+                                        "format": "uri",
+                                        "default": "https://solsigs.com"
+                                    },
+                                    "route": {
+                                        "type": "string",
+                                        "default": "/dex"
+                                    },
+                                    "method": {
+                                        "type": "string",
+                                        "default": "POST"
+                                    },
+                                    "verification_mode": {
+                                        "type": "string",
+                                        "enum": [
+                                            "solsigs_instrumented",
+                                            "proofguard_probed",
+                                            "self_attested"
+                                        ]
+                                    },
+                                    "stats": {
+                                        "type": "object"
+                                    },
+                                    "observed": {
+                                        "type": "object"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "ProofGuard result",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "ok": {
+                                            "type": "boolean"
+                                        },
+                                        "product": {
+                                            "type": "string"
+                                        },
+                                        "verification_mode": {
+                                            "type": "string"
+                                        },
+                                        "claim_boundary": {
+                                            "type": "string"
+                                        },
+                                        "trust_score": {
+                                            "type": "object"
+                                        },
+                                        "expectation_receipt": {
+                                            "type": "object"
+                                        },
+                                        "fulfillment_receipt": {
+                                            "type": "object"
+                                        },
+                                        "refund_evidence_package": {
+                                            "type": "object"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "402": {
+                        "description": "Payment required",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error402"
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-payment-info": {
+                    "price": {
+                        "fixed": {
+                            "mode": "fixed",
+                            "currency": "USD",
+                            "amount": "0.003"
+                        }
+                    },
+                    "protocols": [
+                        {
+                            "x402": {}
+                        }
+                    ]
+                }
+            }
+        }
+    },
+    "x-mcp-integration": {
+        "server": "solsigs-mcp",
+        "transport": "sse",
+        "endpoint": "/mcp/sse",
+        "tools": [
+            {
+                "name": "get_dex_price",
+                "path": "/dex",
+                "method": "POST"
+            },
+            {
+                "name": "scan_arbitrage",
+                "path": "/arb",
+                "method": "POST"
+            },
+            {
+                "name": "analyze_wallet",
+                "path": "/wallet",
+                "method": "POST"
+            },
+            {
+                "name": "detect_token_launches",
+                "path": "/launches",
+                "method": "POST"
+            },
+            {
+                "name": "get_market_summary",
+                "path": "/summary",
+                "method": "POST"
+            },
+            {
+                "name": "rpc_relay",
+                "path": "/rpc",
+                "method": "POST"
+            },
+            {
+                "name": "get_prediction_market",
+                "path": "/predict",
+                "method": "POST"
+            },
+            {
+                "name": "wallet_status",
+                "path": null,
+                "method": null,
+                "description": "Local Solana query \u2014 not proxied through x402 API"
+            },
+            {
+                "name": "get_batch_prices",
+                "path": "/price",
+                "method": "POST"
+            },
+            {
+                "name": "get_nft_intel",
+                "path": "/nft",
+                "method": "POST"
+            },
+            {
+                "name": "get_staking_rates",
+                "path": "/staking",
+                "method": "POST"
+            },
+            {
+                "name": "get_whale_activity",
+                "path": "/whale",
+                "method": "POST"
+            },
+            {
+                "name": "create_alert",
+                "path": "/alerts",
+                "method": "POST"
+            },
+            {
+                "name": "get_dev_activity",
+                "path": "/dev",
+                "method": "POST"
+            },
+            {
+                "name": "get_social_sentiment",
+                "path": "/social",
+                "method": "POST"
+            }
+        ]
     }
-  },
-  "x-mcp-integration": {
-    "server": "solsigs-mcp",
-    "transport": "sse",
-    "endpoint": "/mcp/sse",
-    "tools": [
-      {
-        "name": "get_dex_price",
-        "path": "/dex",
-        "method": "POST"
-      },
-      {
-        "name": "scan_arbitrage",
-        "path": "/arb",
-        "method": "POST"
-      },
-      {
-        "name": "analyze_wallet",
-        "path": "/wallet",
-        "method": "POST"
-      },
-      {
-        "name": "detect_token_launches",
-        "path": "/launches",
-        "method": "POST"
-      },
-      {
-        "name": "get_market_summary",
-        "path": "/summary",
-        "method": "POST"
-      },
-      {
-        "name": "rpc_relay",
-        "path": "/rpc",
-        "method": "POST"
-      },
-      {
-        "name": "get_prediction_market",
-        "path": "/predict",
-        "method": "POST"
-      },
-      {
-        "name": "get_batch_prices",
-        "path": "/price",
-        "method": "POST"
-      },
-      {
-        "name": "get_nft_intel",
-        "path": "/nft",
-        "method": "POST"
-      },
-      {
-        "name": "get_staking_rates",
-        "path": "/staking",
-        "method": "POST"
-      },
-      {
-        "name": "get_whale_activity",
-        "path": "/whale",
-        "method": "POST"
-      },
-      {
-        "name": "create_alert",
-        "path": "/alerts",
-        "method": "POST"
-      },
-      {
-        "name": "get_dev_activity",
-        "path": "/dev",
-        "method": "POST"
-      },
-      {
-        "name": "get_social_sentiment",
-        "path": "/social",
-        "method": "POST"
-      },
-      {
-        "name": "get_alpha_feed",
-        "path": "/alpha",
-        "method": "POST"
-      },
-      {
-        "name": "get_perps_intel",
-        "path": "/perps",
-        "method": "POST"
-      },
-      {
-        "name": "smart_money",
-        "path": "/smartmoney",
-        "method": "POST"
-      },
-      {
-        "name": "check_token_safety",
-        "path": "/token-safety",
-        "method": "POST"
-      },
-      {
-        "name": "get_trending_tokens",
-        "path": "/trending",
-        "method": "POST"
-      },
-      {
-        "name": "get_wallet_trust",
-        "path": "/trust",
-        "method": "POST"
-      },
-      {
-        "name": "trenches",
-        "path": "/trenches",
-        "method": "POST"
-      },
-      {
-        "name": "ask_verdict",
-        "path": "/ask",
-        "method": "POST"
-      }
-    ]
-  }
 }

--- a/providers/solsigs/data/openapi.json
+++ b/providers/solsigs/data/openapi.json
@@ -912,18 +912,6 @@
         "summary": "Fetch real-time DEX prices for a Solana token",
         "description": "Returns price, liquidity, and 24h volume from Jupiter and Birdeye aggregators.",
         "operationId": "getDexPrice",
-        "parameters": [
-          {
-            "name": "token",
-            "in": "query",
-            "description": "Token symbol or mint address",
-            "schema": {
-              "type": "string",
-              "default": "SOL"
-            },
-            "example": "SOL"
-          }
-        ],
         "responses": {
           "200": {
             "description": "Price data",
@@ -960,6 +948,10 @@
                   "dex": {
                     "type": "string",
                     "description": "DEX to query (e.g. Jupiter, Orca)"
+                  },
+                  "token": {
+                    "type": "string",
+                    "description": "Token symbol or mint address. Alternative to pair \u2014 provide either token OR pair."
                   }
                 },
                 "example": {
@@ -1189,47 +1181,6 @@
         "summary": "Fetch Polymarket prediction market odds and volume",
         "description": "Search and discover Polymarket prediction markets by keyword, category, and limit.",
         "operationId": "getPredictionMarket",
-        "parameters": [
-          {
-            "name": "query",
-            "in": "query",
-            "description": "Search term. Empty = trending markets.",
-            "schema": {
-              "type": "string",
-              "default": ""
-            },
-            "example": "Bitcoin"
-          },
-          {
-            "name": "category",
-            "in": "query",
-            "description": "Filter by category",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "crypto",
-                "politics",
-                "sports",
-                "science",
-                "economics",
-                "world",
-                "pop-culture",
-                "gaming",
-                "space"
-              ]
-            }
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "description": "Max markets to return (max 20)",
-            "schema": {
-              "type": "integer",
-              "default": 10,
-              "maximum": 20
-            }
-          }
-        ],
         "responses": {
           "200": {
             "description": "Prediction markets",

--- a/providers/solsigs/data/openapi.json
+++ b/providers/solsigs/data/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "SolSigs — Solana Data APIs for AI Agents",
     "version": "1.0.0",
-    "description": "20 Solana data endpoints paid via x402 micropayments in USDC. No API keys, no subscriptions — agents pay per call.",
+    "description": "22 Solana data endpoints paid via x402 micropayments in USDC. No API keys, no subscriptions — agents pay per call.",
     "contact": {
       "name": "SolSigs",
       "url": "https://solsigs.com",
@@ -703,7 +703,7 @@
             "fixed": {
               "mode": "fixed",
               "currency": "USD",
-              "amount": "0.002"
+              "amount": "0.005"
             }
           },
           "protocols": [
@@ -840,7 +840,7 @@
             "fixed": {
               "mode": "fixed",
               "currency": "USD",
-              "amount": "0.002"
+              "amount": "0.010"
             }
           },
           "protocols": [
@@ -934,7 +934,7 @@
             "fixed": {
               "mode": "fixed",
               "currency": "USD",
-              "amount": "0.002"
+              "amount": "0.001"
             }
           },
           "protocols": [
@@ -1098,7 +1098,7 @@
             "fixed": {
               "mode": "fixed",
               "currency": "USD",
-              "amount": "0.002"
+              "amount": "0.003"
             }
           },
           "protocols": [
@@ -1200,7 +1200,7 @@
             "fixed": {
               "mode": "fixed",
               "currency": "USD",
-              "amount": "0.002"
+              "amount": "0.004"
             }
           },
           "protocols": [
@@ -1243,11 +1243,18 @@
           }
         },
         "x-payment-info": {
-          "asset": "USDC",
-          "network": "SOLANA",
-          "amount": 5000,
-          "currency": "USD",
-          "price": "$0.005"
+          "price": {
+            "fixed": {
+              "mode": "fixed",
+              "currency": "USD",
+              "amount": "0.005"
+            }
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
         }
       }
     },
@@ -1356,7 +1363,7 @@
             "fixed": {
               "mode": "fixed",
               "currency": "USD",
-              "amount": "0.002"
+              "amount": "0.003"
             }
           },
           "protocols": [
@@ -1441,7 +1448,7 @@
             "fixed": {
               "mode": "fixed",
               "currency": "USD",
-              "amount": "0.002"
+              "amount": "0.003"
             }
           },
           "protocols": [
@@ -1505,7 +1512,7 @@
             "fixed": {
               "mode": "fixed",
               "currency": "USD",
-              "amount": "0.002"
+              "amount": "0.001"
             }
           },
           "protocols": [
@@ -1574,7 +1581,7 @@
             "fixed": {
               "mode": "fixed",
               "currency": "USD",
-              "amount": "0.002"
+              "amount": "0.008"
             }
           },
           "protocols": [
@@ -1692,7 +1699,7 @@
             "fixed": {
               "mode": "fixed",
               "currency": "USD",
-              "amount": "0.002"
+              "amount": "0.004"
             }
           },
           "protocols": [
@@ -1872,7 +1879,7 @@
             "fixed": {
               "mode": "fixed",
               "currency": "USD",
-              "amount": "0.002"
+              "amount": "0.008"
             }
           },
           "protocols": [
@@ -1914,11 +1921,18 @@
           }
         },
         "x-payment-info": {
-          "asset": "USDC",
-          "network": "SOLANA",
-          "amount": 5000,
-          "currency": "USD",
-          "price": "$0.005"
+          "price": {
+            "fixed": {
+              "mode": "fixed",
+              "currency": "USD",
+              "amount": "0.005"
+            }
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
         }
       }
     },
@@ -1958,11 +1972,18 @@
           }
         },
         "x-payment-info": {
-          "asset": "USDC",
-          "network": "SOLANA",
-          "amount": 4000,
-          "currency": "USD",
-          "price": "$0.004"
+          "price": {
+            "fixed": {
+              "mode": "fixed",
+              "currency": "USD",
+              "amount": "0.004"
+            }
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
         }
       }
     },
@@ -1997,11 +2018,18 @@
           }
         },
         "x-payment-info": {
-          "asset": "USDC",
-          "network": "SOLANA",
-          "amount": 3000,
-          "currency": "USD",
-          "price": "$0.003"
+          "price": {
+            "fixed": {
+              "mode": "fixed",
+              "currency": "USD",
+              "amount": "0.003"
+            }
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
         }
       }
     },
@@ -2074,7 +2102,7 @@
             "fixed": {
               "mode": "fixed",
               "currency": "USD",
-              "amount": "0.002"
+              "amount": "0.005"
             }
           },
           "protocols": [
@@ -2172,7 +2200,7 @@
             "fixed": {
               "mode": "fixed",
               "currency": "USD",
-              "amount": "0.002"
+              "amount": "0.006"
             }
           },
           "protocols": [
@@ -2216,8 +2244,18 @@
           }
         },
         "x-payment-info": {
-          "amount": 0.003,
-          "currency": "USDC"
+          "price": {
+            "fixed": {
+              "mode": "fixed",
+              "currency": "USD",
+              "amount": "0.008"
+            }
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
         }
       }
     },
@@ -2253,8 +2291,18 @@
           }
         },
         "x-payment-info": {
-          "amount": 0.006,
-          "currency": "USDC"
+          "price": {
+            "fixed": {
+              "mode": "fixed",
+              "currency": "USD",
+              "amount": "0.015"
+            }
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
         }
       }
     }
@@ -2267,27 +2315,27 @@
       {
         "name": "get_dex_price",
         "path": "/dex",
-        "method": "GET"
+        "method": "POST"
       },
       {
         "name": "scan_arbitrage",
         "path": "/arb",
-        "method": "GET"
+        "method": "POST"
       },
       {
         "name": "analyze_wallet",
         "path": "/wallet",
-        "method": "GET"
+        "method": "POST"
       },
       {
         "name": "detect_token_launches",
         "path": "/launches",
-        "method": "GET"
+        "method": "POST"
       },
       {
         "name": "get_market_summary",
         "path": "/summary",
-        "method": "GET"
+        "method": "POST"
       },
       {
         "name": "rpc_relay",
@@ -2297,7 +2345,7 @@
       {
         "name": "get_prediction_market",
         "path": "/predict",
-        "method": "GET"
+        "method": "POST"
       },
       {
         "name": "wallet_status",
@@ -2313,17 +2361,17 @@
       {
         "name": "get_nft_intel",
         "path": "/nft",
-        "method": "GET"
+        "method": "POST"
       },
       {
         "name": "get_staking_rates",
         "path": "/staking",
-        "method": "GET"
+        "method": "POST"
       },
       {
         "name": "get_whale_activity",
         "path": "/whale",
-        "method": "GET"
+        "method": "POST"
       },
       {
         "name": "create_alert",
@@ -2333,12 +2381,12 @@
       {
         "name": "get_dev_activity",
         "path": "/dev",
-        "method": "GET"
+        "method": "POST"
       },
       {
         "name": "get_social_sentiment",
         "path": "/social",
-        "method": "GET"
+        "method": "POST"
       }
     ]
   }

--- a/providers/solsigs/data/openapi.json
+++ b/providers/solsigs/data/openapi.json
@@ -1458,10 +1458,6 @@
             "description": "Payment required"
           }
         },
-        "x-402": {
-          "price": "0.008",
-          "asset": "USDC"
-        },
         "x-payment-info": {
           "price": {
             "fixed": {
@@ -1569,24 +1565,6 @@
         "summary": "Compare staking APY across protocols",
         "description": "Cross-protocol staking APY comparison for Marinade, Jito, Blaze, and Sanctum.",
         "operationId": "getStakingRates",
-        "parameters": [
-          {
-            "name": "protocol",
-            "in": "query",
-            "description": "Protocol filter",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "all",
-                "marinade",
-                "jito",
-                "blaze",
-                "sanctum"
-              ],
-              "default": "all"
-            }
-          }
-        ],
         "responses": {
           "200": {
             "description": "Staking rates",
@@ -1627,6 +1605,18 @@
                       "stake",
                       "reliability"
                     ]
+                  },
+                  "protocol": {
+                    "type": "string",
+                    "enum": [
+                      "all",
+                      "marinade",
+                      "jito",
+                      "blaze",
+                      "sanctum"
+                    ],
+                    "default": "all",
+                    "description": "Protocol filter: all, marinade, jito, blaze, or sanctum"
                   }
                 },
                 "example": {
@@ -1660,18 +1650,6 @@
         "summary": "Generate an AI summary of Solana market conditions",
         "description": "Natural-language analysis of Solana market conditions. Ask about memecoin activity, NFT volume, DeFi TVL, or general overview.",
         "operationId": "getMarketSummary",
-        "parameters": [
-          {
-            "name": "query",
-            "in": "query",
-            "description": "What you want to know about",
-            "schema": {
-              "type": "string",
-              "default": "solana market overview"
-            },
-            "example": "memecoin activity"
-          }
-        ],
         "responses": {
           "200": {
             "description": "AI-generated summary",
@@ -1711,6 +1689,11 @@
                       "type": "string"
                     },
                     "description": "Sections to include"
+                  },
+                  "query": {
+                    "type": "string",
+                    "default": "solana market overview",
+                    "description": "What you want to know about"
                   }
                 },
                 "example": {

--- a/providers/solsigs/data/openapi.json
+++ b/providers/solsigs/data/openapi.json
@@ -1,9 +1,9 @@
 {
   "openapi": "3.0.3",
   "info": {
-    "title": "SolSigs — Solana Data APIs for AI Agents",
+    "title": "SolSigs \u2014 Solana Data APIs for AI Agents",
     "version": "1.0.0",
-    "description": "22 Solana data endpoints paid via x402 micropayments in USDC. No API keys, no subscriptions — agents pay per call.",
+    "description": "22 Solana data endpoints paid via x402 micropayments in USDC. No API keys, no subscriptions \u2014 agents pay per call.",
     "contact": {
       "name": "SolSigs",
       "url": "https://solsigs.com",
@@ -769,26 +769,6 @@
         "summary": "Search Solana DEXs for arbitrage opportunities",
         "description": "Scans DEXes for profitable cross-exchange arbitrage trades.",
         "operationId": "scanArbitrage",
-        "parameters": [
-          {
-            "name": "token",
-            "in": "query",
-            "schema": {
-              "type": "string",
-              "default": "SOL"
-            },
-            "description": "Token symbol or mint address (e.g. 'SOL' or a base58 mint)"
-          },
-          {
-            "name": "minProfitBps",
-            "in": "query",
-            "description": "Minimum profit in basis points (1 bps = 0.01%)",
-            "schema": {
-              "type": "integer",
-              "default": 10
-            }
-          }
-        ],
         "responses": {
           "200": {
             "description": "Arbitrage opportunities",
@@ -859,27 +839,6 @@
         "summary": "Fetch GitHub dev activity for a Solana protocol",
         "description": "Track commits, contributors, and audit status to gauge protocol development health.",
         "operationId": "getDevActivity",
-        "parameters": [
-          {
-            "name": "protocol",
-            "in": "query",
-            "required": true,
-            "description": "Protocol name (e.g. jupiter, marinade, drift)",
-            "schema": {
-              "type": "string"
-            },
-            "example": "jupiter"
-          },
-          {
-            "name": "days",
-            "in": "query",
-            "description": "Look-back window in days",
-            "schema": {
-              "type": "integer",
-              "default": 30
-            }
-          }
-        ],
         "responses": {
           "200": {
             "description": "Dev activity",
@@ -977,7 +936,7 @@
             }
           },
           "402": {
-            "description": "Payment required — send USDC and retry",
+            "description": "Payment required \u2014 send USDC and retry",
             "content": {
               "application/json": {
                 "schema": {
@@ -1035,17 +994,6 @@
         "summary": "Detect new token launches",
         "description": "Spot fresh token deployments on pump.fun and Raydium.",
         "operationId": "detectTokenLaunches",
-        "parameters": [
-          {
-            "name": "hours",
-            "in": "query",
-            "description": "Look-back window in hours",
-            "schema": {
-              "type": "integer",
-              "default": 1
-            }
-          }
-        ],
         "responses": {
           "200": {
             "description": "Recent token launches",
@@ -1117,31 +1065,6 @@
         "summary": "Fetch NFT collection intel and wash trading signals",
         "description": "Floor prices, rarity rankings, and wash trading score for any Solana NFT collection.",
         "operationId": "getNftIntel",
-        "parameters": [
-          {
-            "name": "collection",
-            "in": "query",
-            "required": true,
-            "description": "Collection slug (e.g. mad-lads, degen-ape)",
-            "schema": {
-              "type": "string"
-            },
-            "example": "mad-lads"
-          },
-          {
-            "name": "sortBy",
-            "in": "query",
-            "description": "Sort by floor, volume, or rarity",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "floor",
-                "volume",
-                "rarity"
-              ]
-            }
-          }
-        ],
         "responses": {
           "200": {
             "description": "NFT intel",
@@ -1264,7 +1187,7 @@
           "Predictions"
         ],
         "summary": "Fetch Polymarket prediction market odds and volume",
-        "description": "Search Polymarket YES/NO contracts — elections, sports, crypto, economics, pop culture. Sourced from Polymarket Gamma API.",
+        "description": "Search and discover Polymarket prediction markets by keyword, category, and limit.",
         "operationId": "getPredictionMarket",
         "parameters": [
           {
@@ -1336,23 +1259,35 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "token": {
+                  "query": {
                     "type": "string",
-                    "description": "Token to generate prediction for"
+                    "description": "Search term. Empty = trending markets."
                   },
-                  "horizon": {
+                  "category": {
                     "type": "string",
                     "enum": [
-                      "1h",
-                      "24h",
-                      "7d"
+                      "crypto",
+                      "politics",
+                      "sports",
+                      "science",
+                      "economics",
+                      "world",
+                      "pop-culture",
+                      "gaming",
+                      "space"
                     ],
-                    "default": "24h"
+                    "description": "Filter by category"
+                  },
+                  "limit": {
+                    "type": "integer",
+                    "default": 10,
+                    "maximum": 20,
+                    "description": "Max markets to return (max 20)"
                   }
                 },
                 "example": {
-                  "token": "SOL",
-                  "horizon": "24h"
+                  "query": "Bitcoin",
+                  "limit": 10
                 }
               }
             }
@@ -1600,41 +1535,6 @@
         "summary": "Analyze on-chain social sentiment for a Solana token",
         "description": "Track mentions, influencer activity, and trending scores for tokens and NFTs.",
         "operationId": "getSocialSentiment",
-        "parameters": [
-          {
-            "name": "query",
-            "in": "query",
-            "required": true,
-            "description": "Search term (token symbol, NFT, or keyword)",
-            "schema": {
-              "type": "string"
-            },
-            "example": "SOL"
-          },
-          {
-            "name": "source",
-            "in": "query",
-            "description": "Data source filter",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "twitter",
-                "dune",
-                "combined"
-              ],
-              "default": "combined"
-            }
-          },
-          {
-            "name": "hours",
-            "in": "query",
-            "description": "Look-back window in hours",
-            "schema": {
-              "type": "integer",
-              "default": 24
-            }
-          }
-        ],
         "responses": {
           "200": {
             "description": "Social sentiment",
@@ -2041,18 +1941,6 @@
         "summary": "Analyze a Solana wallet for risk and activity patterns",
         "description": "Risk scoring, transaction pattern analysis, wash trading and rug pull detection.",
         "operationId": "analyzeWallet",
-        "parameters": [
-          {
-            "name": "address",
-            "in": "query",
-            "required": true,
-            "description": "Solana wallet address (base58)",
-            "schema": {
-              "type": "string"
-            },
-            "example": "7EcDhSYGxXyscszYEp35KHN8vvw3svAuLKTzXwCFLtV"
-          }
-        ],
         "responses": {
           "200": {
             "description": "Wallet analysis",
@@ -2121,34 +2009,6 @@
         "summary": "Fetch whale transfers and smart money signals",
         "description": "Detect large transfers, accumulation patterns, and distribution events on Solana.",
         "operationId": "getWhaleActivity",
-        "parameters": [
-          {
-            "name": "minAmount",
-            "in": "query",
-            "description": "Minimum transfer amount in USD",
-            "schema": {
-              "type": "number",
-              "default": 100000
-            }
-          },
-          {
-            "name": "token",
-            "in": "query",
-            "description": "Filter by token symbol or mint",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "hours",
-            "in": "query",
-            "description": "Look-back window in hours",
-            "schema": {
-              "type": "integer",
-              "default": 24
-            }
-          }
-        ],
         "responses": {
           "200": {
             "description": "Whale activity",

--- a/providers/solsigs/data/openapi.json
+++ b/providers/solsigs/data/openapi.json
@@ -1,0 +1,2345 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "SolSigs — Solana Data APIs for AI Agents",
+    "version": "1.0.0",
+    "description": "20 Solana data endpoints paid via x402 micropayments in USDC. No API keys, no subscriptions — agents pay per call.",
+    "contact": {
+      "name": "SolSigs",
+      "url": "https://solsigs.com",
+      "email": "foundbychancer@gmail.com"
+    },
+    "x-logo": {
+      "url": "https://solsigs.com/favicon.ico"
+    }
+  },
+  "servers": [
+    {
+      "url": "https://solsigs.com",
+      "description": "Production"
+    }
+  ],
+  "security": [
+    {
+      "x402": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Prices",
+      "description": "Real-time DEX price data"
+    },
+    {
+      "name": "Arbitrage",
+      "description": "Cross-DEX arbitrage scanning"
+    },
+    {
+      "name": "Wallet",
+      "description": "Wallet analysis and risk scoring"
+    },
+    {
+      "name": "Tokens",
+      "description": "Token launch detection"
+    },
+    {
+      "name": "AI",
+      "description": "AI-powered market summaries"
+    },
+    {
+      "name": "RPC",
+      "description": "Pay-per-call Solana JSON-RPC relay"
+    },
+    {
+      "name": "Predictions",
+      "description": "Polymarket prediction market data"
+    },
+    {
+      "name": "NFT",
+      "description": "NFT floor prices, rarity, and wash trading detection"
+    },
+    {
+      "name": "Staking",
+      "description": "Cross-protocol staking APY comparison"
+    },
+    {
+      "name": "Whales",
+      "description": "Whale wallet tracking and smart money signals"
+    },
+    {
+      "name": "Alerts",
+      "description": "Webhook alert registration"
+    },
+    {
+      "name": "Development",
+      "description": "GitHub commit activity for Solana protocols"
+    },
+    {
+      "name": "Social",
+      "description": "On-chain social sentiment analysis"
+    }
+  ],
+  "components": {
+    "securitySchemes": {
+      "x402": {
+        "type": "http",
+        "scheme": "bearer",
+        "description": "x402 micropayment protocol. First request returns HTTP 402 with payment details. Send USDC payment on Solana, then retry with the same request. Most calls cost < $0.01 USDC.",
+        "x-402-version": "2",
+        "x-402-token": "USDC",
+        "x-402-mint": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+      }
+    },
+    "schemas": {
+      "DexPriceResponse": {
+        "type": "object",
+        "properties": {
+          "token": {
+            "type": "string",
+            "description": "Token symbol or mint address"
+          },
+          "price_usd": {
+            "type": "number",
+            "description": "Current price in USD"
+          },
+          "liquidity_usd": {
+            "type": "number",
+            "description": "Total liquidity in USD"
+          },
+          "volume_24h_usd": {
+            "type": "number",
+            "description": "24-hour trading volume"
+          },
+          "price_change_24h_pct": {
+            "type": "number",
+            "description": "24-hour price change percentage"
+          },
+          "sources": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Data sources (Jupiter, Birdeye)"
+          }
+        }
+      },
+      "ArbitrageScanResponse": {
+        "type": "object",
+        "properties": {
+          "token": {
+            "type": "string"
+          },
+          "opportunities": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "buy_dex": {
+                  "type": "string"
+                },
+                "sell_dex": {
+                  "type": "string"
+                },
+                "profit_bps": {
+                  "type": "number",
+                  "description": "Profit in basis points"
+                },
+                "estimated_usd": {
+                  "type": "number"
+                }
+              }
+            }
+          }
+        }
+      },
+      "WalletAnalysisResponse": {
+        "type": "object",
+        "properties": {
+          "address": {
+            "type": "string"
+          },
+          "risk_score": {
+            "type": "integer",
+            "description": "0-100 risk score"
+          },
+          "age_days": {
+            "type": "integer"
+          },
+          "transaction_count": {
+            "type": "integer"
+          },
+          "flags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Risk flags (wash_trading, rug_pull, etc.)"
+          }
+        }
+      },
+      "TokenLaunchesResponse": {
+        "type": "object",
+        "properties": {
+          "count": {
+            "type": "integer"
+          },
+          "window_hours": {
+            "type": "integer"
+          },
+          "launches": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "mint": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "symbol": {
+                  "type": "string"
+                },
+                "platform": {
+                  "type": "string",
+                  "description": "pump.fun, Raydium, etc."
+                },
+                "age_minutes": {
+                  "type": "integer"
+                },
+                "initial_liquidity_usd": {
+                  "type": "number"
+                }
+              }
+            }
+          }
+        }
+      },
+      "MarketSummaryResponse": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string"
+          },
+          "summary": {
+            "type": "string",
+            "description": "AI-generated plain-English summary"
+          },
+          "data_points": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "label": {
+                  "type": "string"
+                },
+                "value": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "JsonRpcRequest": {
+        "type": "object",
+        "required": [
+          "jsonrpc",
+          "method"
+        ],
+        "properties": {
+          "jsonrpc": {
+            "type": "string",
+            "enum": [
+              "2.0"
+            ]
+          },
+          "id": {
+            "type": "integer"
+          },
+          "method": {
+            "type": "string",
+            "description": "Solana JSON-RPC method"
+          },
+          "params": {
+            "type": "array",
+            "items": {},
+            "description": "RPC parameters"
+          }
+        }
+      },
+      "PredictionMarketResponse": {
+        "type": "object",
+        "properties": {
+          "markets": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "question": {
+                  "type": "string"
+                },
+                "yes_price": {
+                  "type": "number"
+                },
+                "no_price": {
+                  "type": "number"
+                },
+                "volume_usd": {
+                  "type": "number"
+                },
+                "liquidity_usd": {
+                  "type": "number"
+                },
+                "end_date": {
+                  "type": "string"
+                },
+                "category": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "Error402": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "type": "object",
+            "properties": {
+              "code": {
+                "type": "integer",
+                "example": 402
+              },
+              "message": {
+                "type": "string",
+                "example": "Payment Required"
+              },
+              "payment": {
+                "type": "object",
+                "properties": {
+                  "amount": {
+                    "type": "number",
+                    "description": "USDC amount required (6 decimals)"
+                  },
+                  "recipient": {
+                    "type": "string",
+                    "description": "Solana wallet address"
+                  },
+                  "mint": {
+                    "type": "string",
+                    "description": "USDC mint address"
+                  },
+                  "deadline": {
+                    "type": "string",
+                    "format": "date-time"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "BatchPriceResponse": {
+        "type": "object",
+        "properties": {
+          "tokens": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "symbol": {
+                  "type": "string"
+                },
+                "price_usd": {
+                  "type": "number"
+                },
+                "change_24h": {
+                  "type": "number"
+                },
+                "volume_24h": {
+                  "type": "number"
+                },
+                "market_cap": {
+                  "type": "number"
+                },
+                "candles": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "time": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "open": {
+                        "type": "number"
+                      },
+                      "high": {
+                        "type": "number"
+                      },
+                      "low": {
+                        "type": "number"
+                      },
+                      "close": {
+                        "type": "number"
+                      },
+                      "volume": {
+                        "type": "number"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "NftIntelResponse": {
+        "type": "object",
+        "properties": {
+          "collection": {
+            "type": "string"
+          },
+          "floor_usdc": {
+            "type": "number"
+          },
+          "floor_sol": {
+            "type": "number"
+          },
+          "volume_24h": {
+            "type": "number"
+          },
+          "listings": {
+            "type": "integer"
+          },
+          "wash_trading_score": {
+            "type": "number",
+            "description": "0-100 wash trading probability"
+          },
+          "rarity_data": {
+            "type": "object",
+            "properties": {
+              "total_supply": {
+                "type": "integer"
+              },
+              "ranked_count": {
+                "type": "integer"
+              },
+              "top_rarities": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "rank": {
+                      "type": "integer"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "mint": {
+                      "type": "string"
+                    },
+                    "price_sol": {
+                      "type": "number"
+                    },
+                    "rarity_score": {
+                      "type": "number"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "StakingRatesResponse": {
+        "type": "object",
+        "properties": {
+          "protocols": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "apy": {
+                  "type": "number"
+                },
+                "tvl": {
+                  "type": "number",
+                  "description": "Total value locked in USD"
+                },
+                "token": {
+                  "type": "string"
+                },
+                "unstake_days": {
+                  "type": "number"
+                },
+                "website": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "WhaleActivityResponse": {
+        "type": "object",
+        "properties": {
+          "transfers": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "tx_signature": {
+                  "type": "string"
+                },
+                "from": {
+                  "type": "string"
+                },
+                "to": {
+                  "type": "string"
+                },
+                "amount": {
+                  "type": "number"
+                },
+                "amount_usd": {
+                  "type": "number"
+                },
+                "token": {
+                  "type": "string"
+                },
+                "timestamp": {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "whale_type": {
+                  "type": "string",
+                  "enum": [
+                    "accumulation",
+                    "distribution",
+                    "unknown"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "AlertResponse": {
+        "type": "object",
+        "properties": {
+          "alert_id": {
+            "type": "string"
+          },
+          "created": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "expires": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "active",
+              "triggered",
+              "expired"
+            ]
+          }
+        }
+      },
+      "DevActivityResponse": {
+        "type": "object",
+        "properties": {
+          "protocol": {
+            "type": "string"
+          },
+          "repo": {
+            "type": "string"
+          },
+          "commits": {
+            "type": "integer"
+          },
+          "contributors": {
+            "type": "integer"
+          },
+          "last_commit": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "audit_status": {
+            "type": "string"
+          },
+          "ecosystem_rank": {
+            "type": "integer"
+          }
+        }
+      },
+      "SocialSentimentResponse": {
+        "type": "object",
+        "properties": {
+          "mentions": {
+            "type": "integer"
+          },
+          "sentiment_score": {
+            "type": "number",
+            "description": "-1.0 (bearish) to +1.0 (bullish)"
+          },
+          "top_influencers": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "handle": {
+                  "type": "string"
+                },
+                "followers": {
+                  "type": "integer"
+                },
+                "sentiment": {
+                  "type": "number"
+                }
+              }
+            }
+          },
+          "trending_score": {
+            "type": "number"
+          },
+          "related_tokens": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  },
+  "paths": {
+    "/alerts": {
+      "post": {
+        "tags": [
+          "Alerts"
+        ],
+        "summary": "Register a webhook alert",
+        "description": "Create price, volume, whale, or launch alerts that POST to your webhook when triggered.",
+        "operationId": "createAlert",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "type",
+                  "condition",
+                  "webhookUrl"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "price",
+                      "volume",
+                      "whale",
+                      "launch"
+                    ]
+                  },
+                  "condition": {
+                    "type": "string",
+                    "description": "Trigger condition (e.g. SOL > 200)"
+                  },
+                  "webhookUrl": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "expiryHours": {
+                    "type": "integer",
+                    "default": 72,
+                    "maximum": 168
+                  }
+                }
+              },
+              "example": {
+                "type": "price",
+                "condition": "SOL > 200",
+                "webhookUrl": "https://hooks.example.com/solsigs",
+                "expiryHours": 72
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Alert created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AlertResponse"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error402"
+                }
+              }
+            }
+          }
+        },
+        "x-payment-info": {
+          "price": {
+            "fixed": {
+              "mode": "fixed",
+              "currency": "USD",
+              "amount": "0.002"
+            }
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        }
+      }
+    },
+    "/alpha": {
+      "post": {
+        "operationId": "getAlphaFeed",
+        "summary": "Fetch alpha signals from new launches and insider wallets",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "limit": {
+                    "type": "integer",
+                    "default": 20
+                  },
+                  "min_confidence": {
+                    "type": "number",
+                    "default": 0.5
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "402": {
+            "description": "x402 Payment Required"
+          },
+          "200": {
+            "description": "Alpha signals with confidence scores"
+          }
+        },
+        "x-payment-info": {
+          "price": {
+            "fixed": {
+              "mode": "fixed",
+              "currency": "USD",
+              "amount": "0.006"
+            }
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        }
+      }
+    },
+    "/arb": {
+      "post": {
+        "tags": [
+          "Arbitrage"
+        ],
+        "summary": "Search Solana DEXs for arbitrage opportunities",
+        "description": "Scans DEXes for profitable cross-exchange arbitrage trades.",
+        "operationId": "scanArbitrage",
+        "parameters": [
+          {
+            "name": "token",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "default": "SOL"
+            },
+            "description": "Token symbol or mint address (e.g. 'SOL' or a base58 mint)"
+          },
+          {
+            "name": "minProfitBps",
+            "in": "query",
+            "description": "Minimum profit in basis points (1 bps = 0.01%)",
+            "schema": {
+              "type": "integer",
+              "default": 10
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Arbitrage opportunities",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ArbitrageScanResponse"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error402"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "token": {
+                    "type": "string",
+                    "description": "Token symbol to scan (e.g. SOL, BONK)"
+                  },
+                  "minProfitPercent": {
+                    "type": "number",
+                    "description": "Minimum profit threshold"
+                  }
+                },
+                "example": {
+                  "token": "SOL",
+                  "minProfitPercent": 0.5
+                }
+              }
+            }
+          }
+        },
+        "x-payment-info": {
+          "price": {
+            "fixed": {
+              "mode": "fixed",
+              "currency": "USD",
+              "amount": "0.002"
+            }
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        }
+      }
+    },
+    "/dev": {
+      "post": {
+        "tags": [
+          "Development"
+        ],
+        "summary": "Fetch GitHub dev activity for a Solana protocol",
+        "description": "Track commits, contributors, and audit status to gauge protocol development health.",
+        "operationId": "getDevActivity",
+        "parameters": [
+          {
+            "name": "protocol",
+            "in": "query",
+            "required": true,
+            "description": "Protocol name (e.g. jupiter, marinade, drift)",
+            "schema": {
+              "type": "string"
+            },
+            "example": "jupiter"
+          },
+          {
+            "name": "days",
+            "in": "query",
+            "description": "Look-back window in days",
+            "schema": {
+              "type": "integer",
+              "default": 30
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Dev activity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DevActivityResponse"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error402"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "protocol"
+                ],
+                "properties": {
+                  "protocol": {
+                    "type": "string",
+                    "description": "Solana protocol to query"
+                  },
+                  "days": {
+                    "type": "integer",
+                    "default": 30
+                  }
+                },
+                "example": {
+                  "protocol": "Jupiter",
+                  "days": 7
+                }
+              }
+            }
+          }
+        },
+        "x-payment-info": {
+          "price": {
+            "fixed": {
+              "mode": "fixed",
+              "currency": "USD",
+              "amount": "0.002"
+            }
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        }
+      }
+    },
+    "/dex": {
+      "post": {
+        "tags": [
+          "Prices"
+        ],
+        "summary": "Fetch real-time DEX prices for a Solana token",
+        "description": "Returns price, liquidity, and 24h volume from Jupiter and Birdeye aggregators.",
+        "operationId": "getDexPrice",
+        "parameters": [
+          {
+            "name": "token",
+            "in": "query",
+            "description": "Token symbol or mint address",
+            "schema": {
+              "type": "string",
+              "default": "SOL"
+            },
+            "example": "SOL"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Price data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DexPriceResponse"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required — send USDC and retry",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error402"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "pair": {
+                    "type": "string",
+                    "description": "Token pair (e.g. SOL/USDC)"
+                  },
+                  "dex": {
+                    "type": "string",
+                    "description": "DEX to query (e.g. Jupiter, Orca)"
+                  }
+                },
+                "example": {
+                  "pair": "SOL/USDC",
+                  "dex": "Jupiter"
+                }
+              }
+            }
+          }
+        },
+        "x-payment-info": {
+          "price": {
+            "fixed": {
+              "mode": "fixed",
+              "currency": "USD",
+              "amount": "0.002"
+            }
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        }
+      }
+    },
+    "/launches": {
+      "post": {
+        "tags": [
+          "Tokens"
+        ],
+        "summary": "Detect new token launches",
+        "description": "Spot fresh token deployments on pump.fun and Raydium.",
+        "operationId": "detectTokenLaunches",
+        "parameters": [
+          {
+            "name": "hours",
+            "in": "query",
+            "description": "Look-back window in hours",
+            "schema": {
+              "type": "integer",
+              "default": 1
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Recent token launches",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TokenLaunchesResponse"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error402"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "hours": {
+                    "type": "integer",
+                    "default": 24,
+                    "description": "Lookback window in hours"
+                  },
+                  "minLiquidity": {
+                    "type": "number",
+                    "description": "Minimum liquidity filter in USD"
+                  }
+                },
+                "example": {
+                  "hours": 24,
+                  "minLiquidity": 10000
+                }
+              }
+            }
+          }
+        },
+        "x-payment-info": {
+          "price": {
+            "fixed": {
+              "mode": "fixed",
+              "currency": "USD",
+              "amount": "0.002"
+            }
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        }
+      }
+    },
+    "/nft": {
+      "post": {
+        "tags": [
+          "NFT"
+        ],
+        "summary": "Fetch NFT collection intel and wash trading signals",
+        "description": "Floor prices, rarity rankings, and wash trading score for any Solana NFT collection.",
+        "operationId": "getNftIntel",
+        "parameters": [
+          {
+            "name": "collection",
+            "in": "query",
+            "required": true,
+            "description": "Collection slug (e.g. mad-lads, degen-ape)",
+            "schema": {
+              "type": "string"
+            },
+            "example": "mad-lads"
+          },
+          {
+            "name": "sortBy",
+            "in": "query",
+            "description": "Sort by floor, volume, or rarity",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "floor",
+                "volume",
+                "rarity"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "NFT intel",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NftIntelResponse"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error402"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "collection"
+                ],
+                "properties": {
+                  "collection": {
+                    "type": "string",
+                    "description": "NFT collection name or symbol"
+                  },
+                  "sortBy": {
+                    "type": "string",
+                    "enum": [
+                      "floor",
+                      "volume",
+                      "rarity"
+                    ]
+                  }
+                },
+                "example": {
+                  "collection": "Mad Lads",
+                  "sortBy": "floor"
+                }
+              }
+            }
+          }
+        },
+        "x-payment-info": {
+          "price": {
+            "fixed": {
+              "mode": "fixed",
+              "currency": "USD",
+              "amount": "0.002"
+            }
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        }
+      }
+    },
+    "/perps": {
+      "post": {
+        "operationId": "getPerpsIntel",
+        "summary": "Fetch Solana perps markets, funding rates, open interest",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "action": {
+                    "type": "string",
+                    "enum": [
+                      "markets",
+                      "positions",
+                      "funding"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "402": {
+            "description": "x402 Payment Required"
+          },
+          "200": {
+            "description": "Perps market data"
+          }
+        },
+        "x-payment-info": {
+          "asset": "USDC",
+          "network": "SOLANA",
+          "amount": 5000,
+          "currency": "USD",
+          "price": "$0.005"
+        }
+      }
+    },
+    "/predict": {
+      "post": {
+        "tags": [
+          "Predictions"
+        ],
+        "summary": "Fetch Polymarket prediction market odds and volume",
+        "description": "Search Polymarket YES/NO contracts — elections, sports, crypto, economics, pop culture. Sourced from Polymarket Gamma API.",
+        "operationId": "getPredictionMarket",
+        "parameters": [
+          {
+            "name": "query",
+            "in": "query",
+            "description": "Search term. Empty = trending markets.",
+            "schema": {
+              "type": "string",
+              "default": ""
+            },
+            "example": "Bitcoin"
+          },
+          {
+            "name": "category",
+            "in": "query",
+            "description": "Filter by category",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "crypto",
+                "politics",
+                "sports",
+                "science",
+                "economics",
+                "world",
+                "pop-culture",
+                "gaming",
+                "space"
+              ]
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Max markets to return (max 20)",
+            "schema": {
+              "type": "integer",
+              "default": 10,
+              "maximum": 20
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Prediction markets",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PredictionMarketResponse"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error402"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "token": {
+                    "type": "string",
+                    "description": "Token to generate prediction for"
+                  },
+                  "horizon": {
+                    "type": "string",
+                    "enum": [
+                      "1h",
+                      "24h",
+                      "7d"
+                    ],
+                    "default": "24h"
+                  }
+                },
+                "example": {
+                  "token": "SOL",
+                  "horizon": "24h"
+                }
+              }
+            }
+          }
+        },
+        "x-payment-info": {
+          "price": {
+            "fixed": {
+              "mode": "fixed",
+              "currency": "USD",
+              "amount": "0.002"
+            }
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        }
+      }
+    },
+    "/price": {
+      "post": {
+        "tags": [
+          "Prices"
+        ],
+        "summary": "Fetch batch token prices with OHLCV candle history",
+        "description": "Get real-time prices, OHLCV candlestick data, volume, and market cap for multiple tokens at once.",
+        "operationId": "getBatchPrices",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "tokens": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "default": [
+                      "SOL"
+                    ],
+                    "description": "Token symbols or mint addresses"
+                  },
+                  "period": {
+                    "type": "string",
+                    "enum": [
+                      "1h",
+                      "4h",
+                      "1d",
+                      "7d"
+                    ],
+                    "description": "Candlestick period"
+                  }
+                }
+              },
+              "example": {
+                "tokens": [
+                  "SOL",
+                  "BONK"
+                ],
+                "period": "1h"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Batch price data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BatchPriceResponse"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error402"
+                }
+              }
+            }
+          }
+        },
+        "x-payment-info": {
+          "price": {
+            "fixed": {
+              "mode": "fixed",
+              "currency": "USD",
+              "amount": "0.002"
+            }
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        }
+      }
+    },
+    "/rpc": {
+      "post": {
+        "tags": [
+          "RPC"
+        ],
+        "summary": "Pay-per-call Solana RPC relay",
+        "description": "Access the Helius RPC endpoint with built-in rate limiting. Standard JSON-RPC 2.0 interface.",
+        "operationId": "rpcRelay",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JsonRpcRequest"
+              },
+              "example": {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "getBalance",
+                "params": [
+                  "7EcDhSYGxXyscszYEp35KHN8vvw3svAuLKTzXwCFLtV"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "JSON-RPC response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error402"
+                }
+              }
+            }
+          }
+        },
+        "x-payment-info": {
+          "price": {
+            "fixed": {
+              "mode": "fixed",
+              "currency": "USD",
+              "amount": "0.002"
+            }
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        }
+      }
+    },
+    "/smartmoney": {
+      "post": {
+        "summary": "Fetch top smart-money wallets with copy-trade signals",
+        "description": "Track top Solana trader wallets, copy-trade signals, portfolio analysis",
+        "operationId": "smartMoney",
+        "tags": [
+          "solana",
+          "wallet",
+          "copy-trading"
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "minScore": {
+                    "type": "number"
+                  },
+                  "topN": {
+                    "type": "integer"
+                  },
+                  "wallets": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Smart money wallet data with copy-trade signals",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required"
+          }
+        },
+        "x-402": {
+          "price": "0.008",
+          "asset": "USDC"
+        },
+        "x-payment-info": {
+          "price": {
+            "fixed": {
+              "mode": "fixed",
+              "currency": "USD",
+              "amount": "0.002"
+            }
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        }
+      }
+    },
+    "/social": {
+      "post": {
+        "tags": [
+          "Social"
+        ],
+        "summary": "Analyze on-chain social sentiment for a Solana token",
+        "description": "Track mentions, influencer activity, and trending scores for tokens and NFTs.",
+        "operationId": "getSocialSentiment",
+        "parameters": [
+          {
+            "name": "query",
+            "in": "query",
+            "required": true,
+            "description": "Search term (token symbol, NFT, or keyword)",
+            "schema": {
+              "type": "string"
+            },
+            "example": "SOL"
+          },
+          {
+            "name": "source",
+            "in": "query",
+            "description": "Data source filter",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "twitter",
+                "dune",
+                "combined"
+              ],
+              "default": "combined"
+            }
+          },
+          {
+            "name": "hours",
+            "in": "query",
+            "description": "Look-back window in hours",
+            "schema": {
+              "type": "integer",
+              "default": 24
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Social sentiment",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SocialSentimentResponse"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error402"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "query"
+                ],
+                "properties": {
+                  "query": {
+                    "type": "string",
+                    "description": "Search query (token, topic, or keyword)"
+                  },
+                  "source": {
+                    "type": "string",
+                    "enum": [
+                      "twitter",
+                      "dune",
+                      "combined"
+                    ],
+                    "default": "combined"
+                  },
+                  "hours": {
+                    "type": "integer",
+                    "default": 24
+                  }
+                },
+                "example": {
+                  "query": "SOL",
+                  "source": "combined",
+                  "hours": 24
+                }
+              }
+            }
+          }
+        },
+        "x-payment-info": {
+          "price": {
+            "fixed": {
+              "mode": "fixed",
+              "currency": "USD",
+              "amount": "0.002"
+            }
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        }
+      }
+    },
+    "/staking": {
+      "post": {
+        "tags": [
+          "Staking"
+        ],
+        "summary": "Compare staking APY across protocols",
+        "description": "Cross-protocol staking APY comparison for Marinade, Jito, Blaze, and Sanctum.",
+        "operationId": "getStakingRates",
+        "parameters": [
+          {
+            "name": "protocol",
+            "in": "query",
+            "description": "Protocol filter",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "all",
+                "marinade",
+                "jito",
+                "blaze",
+                "sanctum"
+              ],
+              "default": "all"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Staking rates",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StakingRatesResponse"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error402"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "validator": {
+                    "type": "string",
+                    "description": "Validator address to query"
+                  },
+                  "sortBy": {
+                    "type": "string",
+                    "enum": [
+                      "apy",
+                      "stake",
+                      "reliability"
+                    ]
+                  }
+                },
+                "example": {
+                  "sortBy": "apy"
+                }
+              }
+            }
+          }
+        },
+        "x-payment-info": {
+          "price": {
+            "fixed": {
+              "mode": "fixed",
+              "currency": "USD",
+              "amount": "0.002"
+            }
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        }
+      }
+    },
+    "/summary": {
+      "post": {
+        "tags": [
+          "AI"
+        ],
+        "summary": "Generate an AI summary of Solana market conditions",
+        "description": "Natural-language analysis of Solana market conditions. Ask about memecoin activity, NFT volume, DeFi TVL, or general overview.",
+        "operationId": "getMarketSummary",
+        "parameters": [
+          {
+            "name": "query",
+            "in": "query",
+            "description": "What you want to know about",
+            "schema": {
+              "type": "string",
+              "default": "solana market overview"
+            },
+            "example": "memecoin activity"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "AI-generated summary",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MarketSummaryResponse"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error402"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "token": {
+                    "type": "string",
+                    "description": "Token to summarize"
+                  },
+                  "sections": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Sections to include"
+                  }
+                },
+                "example": {
+                  "token": "SOL",
+                  "sections": [
+                    "price",
+                    "volume",
+                    "social"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "x-payment-info": {
+          "price": {
+            "fixed": {
+              "mode": "fixed",
+              "currency": "USD",
+              "amount": "0.002"
+            }
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        }
+      }
+    },
+    "/token-safety": {
+      "post": {
+        "operationId": "checkTokenSafety",
+        "summary": "Fetch a token safety report with rug-risk flags",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "mint": {
+                    "type": "string",
+                    "description": "Token mint address"
+                  }
+                },
+                "required": [
+                  "mint"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "402": {
+            "description": "x402 Payment Required"
+          },
+          "200": {
+            "description": "Safety assessment with risk score and findings"
+          }
+        },
+        "x-payment-info": {
+          "asset": "USDC",
+          "network": "SOLANA",
+          "amount": 5000,
+          "currency": "USD",
+          "price": "$0.005"
+        }
+      }
+    },
+    "/trending": {
+      "post": {
+        "operationId": "getTrendingTokens",
+        "summary": "Fetch trending Solana tokens by volume and momentum",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "limit": {
+                    "type": "integer",
+                    "default": 20
+                  },
+                  "sort_by": {
+                    "type": "string",
+                    "enum": [
+                      "volume",
+                      "price_change",
+                      "social_score"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "402": {
+            "description": "x402 Payment Required"
+          },
+          "200": {
+            "description": "Array of trending tokens with metrics"
+          }
+        },
+        "x-payment-info": {
+          "asset": "USDC",
+          "network": "SOLANA",
+          "amount": 4000,
+          "currency": "USD",
+          "price": "$0.004"
+        }
+      }
+    },
+    "/trust": {
+      "post": {
+        "operationId": "getWalletTrust",
+        "summary": "Fetch a wallet trust score with age and behaviour data",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "address": {
+                    "type": "string",
+                    "description": "Wallet address to score"
+                  }
+                },
+                "required": [
+                  "address"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "402": {
+            "description": "x402 Payment Required"
+          },
+          "200": {
+            "description": "Trust score with detailed factors"
+          }
+        },
+        "x-payment-info": {
+          "asset": "USDC",
+          "network": "SOLANA",
+          "amount": 3000,
+          "currency": "USD",
+          "price": "$0.003"
+        }
+      }
+    },
+    "/wallet": {
+      "post": {
+        "tags": [
+          "Wallet"
+        ],
+        "summary": "Analyze a Solana wallet for risk and activity patterns",
+        "description": "Risk scoring, transaction pattern analysis, wash trading and rug pull detection.",
+        "operationId": "analyzeWallet",
+        "parameters": [
+          {
+            "name": "address",
+            "in": "query",
+            "required": true,
+            "description": "Solana wallet address (base58)",
+            "schema": {
+              "type": "string"
+            },
+            "example": "7EcDhSYGxXyscszYEp35KHN8vvw3svAuLKTzXwCFLtV"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Wallet analysis",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WalletAnalysisResponse"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error402"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "address"
+                ],
+                "properties": {
+                  "address": {
+                    "type": "string",
+                    "description": "Solana wallet address to query"
+                  }
+                },
+                "example": {
+                  "address": "7EcDhSYGxXyscszYEp35KHN8vvw3svAuLKTzXwCFLtV"
+                }
+              }
+            }
+          }
+        },
+        "x-payment-info": {
+          "price": {
+            "fixed": {
+              "mode": "fixed",
+              "currency": "USD",
+              "amount": "0.002"
+            }
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        }
+      }
+    },
+    "/whale": {
+      "post": {
+        "tags": [
+          "Whales"
+        ],
+        "summary": "Fetch whale transfers and smart money signals",
+        "description": "Detect large transfers, accumulation patterns, and distribution events on Solana.",
+        "operationId": "getWhaleActivity",
+        "parameters": [
+          {
+            "name": "minAmount",
+            "in": "query",
+            "description": "Minimum transfer amount in USD",
+            "schema": {
+              "type": "number",
+              "default": 100000
+            }
+          },
+          {
+            "name": "token",
+            "in": "query",
+            "description": "Filter by token symbol or mint",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "hours",
+            "in": "query",
+            "description": "Look-back window in hours",
+            "schema": {
+              "type": "integer",
+              "default": 24
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Whale activity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WhaleActivityResponse"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error402"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "token": {
+                    "type": "string",
+                    "description": "Token to watch for whale activity"
+                  },
+                  "minValue": {
+                    "type": "number",
+                    "description": "Minimum transaction value in USD"
+                  }
+                },
+                "example": {
+                  "token": "SOL",
+                  "minValue": 100000
+                }
+              }
+            }
+          }
+        },
+        "x-payment-info": {
+          "price": {
+            "fixed": {
+              "mode": "fixed",
+              "currency": "USD",
+              "amount": "0.002"
+            }
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        }
+      }
+    },
+    "/trenches": {
+      "post": {
+        "summary": "Search newest low-cap Solana token listings",
+        "operationId": "trenches",
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "action": {
+                    "type": "string",
+                    "enum": [
+                      "feed",
+                      "detail",
+                      "search"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Token trenches data"
+          },
+          "402": {
+            "description": "Payment required"
+          }
+        },
+        "x-payment-info": {
+          "amount": 0.003,
+          "currency": "USDC"
+        }
+      }
+    },
+    "/ask": {
+      "post": {
+        "summary": "Generate an LLM verdict for any Solana DeFi question",
+        "operationId": "askVerdict",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "query": {
+                    "type": "string",
+                    "description": "Solana/DeFi question in plain English, e.g. 'is JUP worth staking?'"
+                  }
+                },
+                "required": [
+                  "query"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "LLM answer"
+          },
+          "402": {
+            "description": "Payment required"
+          }
+        },
+        "x-payment-info": {
+          "amount": 0.006,
+          "currency": "USDC"
+        }
+      }
+    }
+  },
+  "x-mcp-integration": {
+    "server": "solsigs-mcp",
+    "transport": "sse",
+    "endpoint": "/mcp/sse",
+    "tools": [
+      {
+        "name": "get_dex_price",
+        "path": "/dex",
+        "method": "GET"
+      },
+      {
+        "name": "scan_arbitrage",
+        "path": "/arb",
+        "method": "GET"
+      },
+      {
+        "name": "analyze_wallet",
+        "path": "/wallet",
+        "method": "GET"
+      },
+      {
+        "name": "detect_token_launches",
+        "path": "/launches",
+        "method": "GET"
+      },
+      {
+        "name": "get_market_summary",
+        "path": "/summary",
+        "method": "GET"
+      },
+      {
+        "name": "rpc_relay",
+        "path": "/rpc",
+        "method": "POST"
+      },
+      {
+        "name": "get_prediction_market",
+        "path": "/predict",
+        "method": "GET"
+      },
+      {
+        "name": "wallet_status",
+        "path": null,
+        "method": null,
+        "description": "Local Solana query — not proxied through x402 API"
+      },
+      {
+        "name": "get_batch_prices",
+        "path": "/price",
+        "method": "POST"
+      },
+      {
+        "name": "get_nft_intel",
+        "path": "/nft",
+        "method": "GET"
+      },
+      {
+        "name": "get_staking_rates",
+        "path": "/staking",
+        "method": "GET"
+      },
+      {
+        "name": "get_whale_activity",
+        "path": "/whale",
+        "method": "GET"
+      },
+      {
+        "name": "create_alert",
+        "path": "/alerts",
+        "method": "POST"
+      },
+      {
+        "name": "get_dev_activity",
+        "path": "/dev",
+        "method": "GET"
+      },
+      {
+        "name": "get_social_sentiment",
+        "path": "/social",
+        "method": "GET"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Adds SolSigs (solsigs.com) — 22 Solana-native x402 data endpoints for AI agents: DEX prices, whale tracking, token-launch rug scoring, wallet intelligence, prediction markets and more, $0.001–$0.010/call in USDC.

- All 22 resources verified on x402scan: https://www.x402scan.com/server/e52b109e-420a-4e86-adf0-be7b5e12b302
- Machine-readable discovery doc: https://solsigs.com/.well-known/x402.json
- Open-source reference agent with finalized mainnet receipts: https://github.com/Gra-kir/solsigs-reference-agent
- Free tier available for evaluation (POST /freetier/claim)

Submitted following email invitation from Rish (Solana Foundation AI Growth).

`pay catalog check providers/solsigs/data/PAY.md`: **PAY.md check successful — 22 endpoints tested, 22/22 gates compatible with Solana.**