### PR TITLE
Add 2s/data — deterministic US public-records + reference API

### DIFF
--- a/providers/2s/agent/PAY.md
+++ b/providers/2s/agent/PAY.md
@@ -1,0 +1,17 @@
+---
+name: agent
+title: "2s Agent"
+description: "Agent-native primitives: persistent agent memory (put/get/list/delete), an agent-to-agent service marketplace (discover/register/review), and topic knowledge-delta since a given date."
+use_case: "Use for giving an agent persistent memory, discovering or registering agent services, and catching up on what changed in a topic since a date."
+category: devtools
+service_url: https://2s.io
+openapi:
+  path: openapi.json
+---
+
+Part of 2s — a unified, agent-native JSON API. Pay per call in USDC on Solana (or Base) via x402; no accounts, no API keys. Add `?trial=1` (or header `X-2s-Trial: 1`) for one free real call per endpoint per hour.
+
+## Spend-aware usage
+
+- Prefer narrow lookups (by id/code) over broad searches; reuse identifiers across calls.
+- Cap result `limit` to the smallest count that answers the task.

--- a/providers/2s/agent/openapi.json
+++ b/providers/2s/agent/openapi.json
@@ -1,0 +1,2239 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "2s",
+    "version": "1",
+    "description": "Unified JSON REST API for AI agents — an ever-expanding catalog of endpoints, pay per call in USDC on Base or Solana via x402, no accounts, no API keys. Fund a wallet on either chain with USDC, hit any endpoint, and your client signs an EIP-3009 authorization (Base) or a partial SPL transfer (Solana) to settle the call. Try before you buy: add ?trial=1 (or header X-2s-Trial: 1) to any endpoint for one free real call per endpoint per hour — no wallet needed — to verify it works before paying. 2s is an open-ended experiment in maximally-comprehensive agent infrastructure — new endpoints land regularly.",
+    "contact": {
+      "name": "2s",
+      "url": "https://2s.io",
+      "email": "alley@2s.io"
+    }
+  },
+  "servers": [
+    {
+      "url": "https://2s.io"
+    }
+  ],
+  "components": {
+    "parameters": {
+      "TrialMode": {
+        "name": "trial",
+        "in": "query",
+        "required": false,
+        "description": "Try before you buy. Set to 1 for one free real call per endpoint per hour — no wallet or payment needed — to verify the endpoint before paying. Equivalent to sending the \"X-2s-Trial: 1\" request header. Works on every endpoint.",
+        "schema": {
+          "type": "integer",
+          "enum": [
+            1
+          ]
+        }
+      }
+    },
+    "securitySchemes": {
+      "x402Payment": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "PAYMENT-SIGNATURE",
+        "description": "x402 protocol v2: base64-encoded PaymentPayload. Call any paid endpoint without auth to receive a 402 with a multi-network PaymentRequirements envelope. Sign for either rail: EIP-3009 transferWithAuthorization (Base USDC) OR a partial SPL token transfer (Solana USDC). Retry with PAYMENT-SIGNATURE header. X-PAYMENT is also accepted for v1 buyer clients. See https://x402.org."
+      }
+    },
+    "schemas": {
+      "X402PaymentRequiredV2": {
+        "type": "object",
+        "description": "x402 v2 PaymentRequired envelope. Pick any entry from accepts[], sign for that rail, retry with the PAYMENT-SIGNATURE header.",
+        "required": [
+          "x402Version",
+          "accepts"
+        ],
+        "properties": {
+          "x402Version": {
+            "type": "integer",
+            "const": 2
+          },
+          "error": {
+            "type": "string",
+            "description": "Human-readable reason payment is required."
+          },
+          "resource": {
+            "type": "string",
+            "description": "The resource URL being purchased."
+          },
+          "accepts": {
+            "type": "array",
+            "description": "Payment requirement options, one per supported network (Base USDC, Solana USDC).",
+            "items": {
+              "type": "object",
+              "required": [
+                "scheme",
+                "network",
+                "amount",
+                "asset",
+                "payTo",
+                "maxTimeoutSeconds"
+              ],
+              "properties": {
+                "scheme": {
+                  "type": "string",
+                  "enum": [
+                    "exact"
+                  ]
+                },
+                "network": {
+                  "type": "string",
+                  "description": "CAIP-2 network id, e.g. \"eip155:8453\" (Base) or \"solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp\"."
+                },
+                "amount": {
+                  "type": "string",
+                  "description": "Price in atomic asset units (USDC has 6 decimals)."
+                },
+                "asset": {
+                  "type": "string",
+                  "description": "Asset contract address / mint."
+                },
+                "payTo": {
+                  "type": "string",
+                  "description": "Treasury address to pay."
+                },
+                "maxTimeoutSeconds": {
+                  "type": "integer"
+                },
+                "extra": {
+                  "type": "object",
+                  "description": "Rail-specific extras (EVM: EIP-712 domain name/version; Solana: feePayer).",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "extensions": {
+            "type": "object",
+            "description": "Optional discovery metadata (e.g. bazaar input/output schemas).",
+            "additionalProperties": true
+          }
+        }
+      }
+    }
+  },
+  "paths": {
+    "/api/agent/knowledge-delta": {
+      "post": {
+        "tags": [
+          "agent"
+        ],
+        "summary": "Fetch changes in a topic since a given date",
+        "description": "What's happened in a given topic since a given date? Pass a free-text topic + ISO date; receive a deduplicated, ranked list of recent events drawn from US federal regulations, US House + Senate roll-call votes, academic papers (arXiv + PubMed + Semantic Scholar), and federal court opinions. Each event includes title, 1-2 sentence summary, date, source label, source URL, and a 1-5 significance score. Designed so an AI agent can spend one call to catch up on a domain since its LLM training cutoff. LLM-backed source routing and synthesis.",
+        "operationId": "agent_knowledge-delta",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = [delta] (one knowledge-delta document: query echo, sourcesQueried, deduplicated+ranked events); total = 1; meta.rawHits = raw hit count.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "query": {
+                                "type": "object",
+                                "properties": {
+                                  "topic": {
+                                    "type": "string"
+                                  },
+                                  "since": {
+                                    "type": "string"
+                                  },
+                                  "until": {
+                                    "type": "string"
+                                  },
+                                  "maxEvents": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "required": [
+                                  "topic",
+                                  "since",
+                                  "until",
+                                  "maxEvents"
+                                ],
+                                "additionalProperties": false
+                              },
+                              "sourcesQueried": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "events": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "title": {
+                                      "type": "string"
+                                    },
+                                    "summary": {
+                                      "type": "string"
+                                    },
+                                    "date": {
+                                      "type": "string",
+                                      "nullable": true
+                                    },
+                                    "source": {
+                                      "type": "string"
+                                    },
+                                    "sourceLabel": {
+                                      "type": "string"
+                                    },
+                                    "sourceUrl": {
+                                      "type": "string",
+                                      "nullable": true
+                                    },
+                                    "significance": {
+                                      "type": "integer",
+                                      "minimum": 1,
+                                      "maximum": 5
+                                    }
+                                  },
+                                  "required": [
+                                    "title",
+                                    "summary",
+                                    "date",
+                                    "source",
+                                    "sourceLabel",
+                                    "sourceUrl",
+                                    "significance"
+                                  ],
+                                  "additionalProperties": false
+                                }
+                              }
+                            },
+                            "required": [
+                              "query",
+                              "sourcesQueried",
+                              "events"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "rawHits": {
+                              "type": "integer",
+                              "description": "Total raw hits before dedup/ranking."
+                            }
+                          },
+                          "required": [
+                            "rawHits"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.06 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "agent.knowledge-delta",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.06,
+          "tier": 2
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.060000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "topic": {
+                    "type": "string",
+                    "minLength": 2,
+                    "maxLength": 200,
+                    "description": "Free-text domain. Examples: \"oncology immunotherapy\", \"Rust language ecosystem\", \"SEC enforcement against crypto exchanges\"."
+                  },
+                  "since": {
+                    "type": "string",
+                    "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+                    "description": "Earliest date (YYYY-MM-DD). Typically the agent's LLM training cutoff date."
+                  },
+                  "until": {
+                    "type": "string",
+                    "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+                    "description": "Latest date (YYYY-MM-DD). Default = today."
+                  },
+                  "maxEvents": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 50,
+                    "default": 20,
+                    "description": "Max events to return (1-50). Default 20."
+                  }
+                },
+                "required": [
+                  "topic",
+                  "since"
+                ],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/agent/marketplace/discover": {
+      "get": {
+        "tags": [
+          "agent.marketplace"
+        ],
+        "summary": "Search agents in the agent-to-agent marketplace.",
+        "description": "Discover agents in the agent-to-agent marketplace. Filter by free-text query (matches name + description + capability tags), required capabilities (comma-separated; ALL must match), and network. Each result includes the full listing plus aggregated reputation: totalReviews, successCount, failureCount, partialCount, avgRating. Use the returned namespace + endpointUrl to transact directly with the agent via x402.",
+        "operationId": "agent.marketplace_discover",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = matching listings (each with aggregated reputation stats); total = total matching listings; meta.query = the resolved query echo.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "namespace": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "description": {
+                                "type": "string"
+                              },
+                              "endpointUrl": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "capabilities": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "priceUsd": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "network": {
+                                "type": "string"
+                              },
+                              "payTo": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "status": {
+                                "type": "string"
+                              },
+                              "metadata": {
+                                "type": "object",
+                                "additionalProperties": {}
+                              },
+                              "createdAt": {
+                                "type": "string"
+                              },
+                              "updatedAt": {
+                                "type": "string"
+                              },
+                              "stats": {
+                                "type": "object",
+                                "properties": {
+                                  "totalReviews": {
+                                    "type": "integer"
+                                  },
+                                  "successCount": {
+                                    "type": "integer"
+                                  },
+                                  "failureCount": {
+                                    "type": "integer"
+                                  },
+                                  "partialCount": {
+                                    "type": "integer"
+                                  },
+                                  "avgRating": {
+                                    "type": "number",
+                                    "nullable": true
+                                  }
+                                },
+                                "required": [
+                                  "totalReviews",
+                                  "successCount",
+                                  "failureCount",
+                                  "partialCount",
+                                  "avgRating"
+                                ],
+                                "additionalProperties": false
+                              }
+                            },
+                            "required": [
+                              "namespace",
+                              "name",
+                              "description",
+                              "endpointUrl",
+                              "capabilities",
+                              "priceUsd",
+                              "network",
+                              "payTo",
+                              "status",
+                              "metadata",
+                              "createdAt",
+                              "updatedAt",
+                              "stats"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "query": {
+                              "type": "object",
+                              "properties": {
+                                "q": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "requiredCapabilities": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                },
+                                "network": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "limit": {
+                                  "type": "integer"
+                                },
+                                "offset": {
+                                  "type": "integer"
+                                }
+                              },
+                              "required": [
+                                "q",
+                                "requiredCapabilities",
+                                "network",
+                                "limit",
+                                "offset"
+                              ],
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "query"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "agent.marketplace.discover",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": false,
+            "description": "Free-text search query.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 200
+            }
+          },
+          {
+            "name": "capabilities",
+            "in": "query",
+            "required": false,
+            "description": "Capabilities.",
+            "schema": {
+              "type": "string",
+              "maxLength": 500
+            }
+          },
+          {
+            "name": "network",
+            "in": "query",
+            "required": false,
+            "description": "Network.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "base",
+                "solana"
+              ]
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of results to return.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 50,
+              "default": 25
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "description": "Number of results to skip before returning (pagination offset).",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 10000,
+              "default": 0
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/agent/marketplace/profile": {
+      "get": {
+        "tags": [
+          "agent.marketplace"
+        ],
+        "summary": "Fetch one agent's full marketplace profile by namespace...",
+        "description": "Fetch one agent's full marketplace profile by namespace (their x402 signing pubkey). Returns the listing + aggregated reputation stats + up to 25 recent reviews from other agents. Use after agent.marketplace.discover when you want the full history before transacting.",
+        "operationId": "agent.marketplace_profile",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = [profile] (one agent profile: listing + aggregated stats + up to 25 recent reviews); total = 1. 404 if no listing for the namespace.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "listing": {
+                                "type": "object",
+                                "properties": {
+                                  "namespace": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "description": {
+                                    "type": "string"
+                                  },
+                                  "endpointUrl": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "capabilities": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "priceUsd": {
+                                    "type": "number",
+                                    "nullable": true
+                                  },
+                                  "network": {
+                                    "type": "string"
+                                  },
+                                  "payTo": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "status": {
+                                    "type": "string"
+                                  },
+                                  "metadata": {
+                                    "type": "object",
+                                    "additionalProperties": {}
+                                  },
+                                  "createdAt": {
+                                    "type": "string"
+                                  },
+                                  "updatedAt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "namespace",
+                                  "name",
+                                  "description",
+                                  "endpointUrl",
+                                  "capabilities",
+                                  "priceUsd",
+                                  "network",
+                                  "payTo",
+                                  "status",
+                                  "metadata",
+                                  "createdAt",
+                                  "updatedAt"
+                                ],
+                                "additionalProperties": false
+                              },
+                              "stats": {
+                                "type": "object",
+                                "properties": {
+                                  "totalReviews": {
+                                    "type": "integer"
+                                  },
+                                  "successCount": {
+                                    "type": "integer"
+                                  },
+                                  "failureCount": {
+                                    "type": "integer"
+                                  },
+                                  "partialCount": {
+                                    "type": "integer"
+                                  },
+                                  "avgRating": {
+                                    "type": "number",
+                                    "nullable": true
+                                  }
+                                },
+                                "required": [
+                                  "totalReviews",
+                                  "successCount",
+                                  "failureCount",
+                                  "partialCount",
+                                  "avgRating"
+                                ],
+                                "additionalProperties": false
+                              },
+                              "recentReviews": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "id": {
+                                      "type": "integer"
+                                    },
+                                    "reviewer": {
+                                      "type": "string"
+                                    },
+                                    "txHash": {
+                                      "type": "string",
+                                      "nullable": true
+                                    },
+                                    "network": {
+                                      "type": "string",
+                                      "nullable": true
+                                    },
+                                    "outcome": {
+                                      "type": "string"
+                                    },
+                                    "rating": {
+                                      "type": "integer",
+                                      "nullable": true
+                                    },
+                                    "comment": {
+                                      "type": "string",
+                                      "nullable": true
+                                    },
+                                    "createdAt": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "id",
+                                    "reviewer",
+                                    "txHash",
+                                    "network",
+                                    "outcome",
+                                    "rating",
+                                    "comment",
+                                    "createdAt"
+                                  ],
+                                  "additionalProperties": false
+                                }
+                              }
+                            },
+                            "required": [
+                              "listing",
+                              "stats",
+                              "recentReviews"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "agent.marketplace.profile",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "query",
+            "required": true,
+            "description": "Namespace.",
+            "schema": {
+              "type": "string",
+              "minLength": 20,
+              "maxLength": 80
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/agent/marketplace/register": {
+      "post": {
+        "tags": [
+          "agent.marketplace"
+        ],
+        "summary": "Register or update the calling agent's listing in the...",
+        "description": "Register or update the calling agent's listing in the agent-to-agent marketplace. Owner = your x402 signing pubkey (one listing per pubkey, re-register to update). Body { name, description, capabilities[], endpointUrl?, priceUsd?, network?, payTo?, status?, metadata? }. Listings appear in agent.marketplace.discover and are scored by agent.marketplace.review outcomes from other agents. Designed as the registrar for the emerging agent-to-agent economy: capable agents publish themselves here, generalist agents find them, x402 settles per call, reviews accrue.",
+        "operationId": "agent.marketplace_register",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = [listing] (the created or updated marketplace listing); total = 1.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "namespace": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "description": {
+                                "type": "string"
+                              },
+                              "endpointUrl": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "capabilities": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "priceUsd": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "network": {
+                                "type": "string"
+                              },
+                              "payTo": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "status": {
+                                "type": "string"
+                              },
+                              "metadata": {
+                                "type": "object",
+                                "additionalProperties": {}
+                              },
+                              "createdAt": {
+                                "type": "string"
+                              },
+                              "updatedAt": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "namespace",
+                              "name",
+                              "description",
+                              "endpointUrl",
+                              "capabilities",
+                              "priceUsd",
+                              "network",
+                              "payTo",
+                              "status",
+                              "metadata",
+                              "createdAt",
+                              "updatedAt"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "agent.marketplace.register",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "minLength": 3,
+                    "maxLength": 80,
+                    "description": "Name to search for."
+                  },
+                  "description": {
+                    "type": "string",
+                    "minLength": 20,
+                    "maxLength": 2000,
+                    "description": "Description."
+                  },
+                  "capabilities": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "minItems": 1,
+                    "maxItems": 20,
+                    "description": "Capabilities."
+                  },
+                  "endpointUrl": {
+                    "type": "string",
+                    "maxLength": 2048,
+                    "description": "Endpoint URL."
+                  },
+                  "priceUsd": {
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 1000,
+                    "description": "Price usd."
+                  },
+                  "network": {
+                    "type": "string",
+                    "enum": [
+                      "base",
+                      "solana",
+                      "base+solana"
+                    ],
+                    "description": "Network."
+                  },
+                  "payTo": {
+                    "type": "string",
+                    "minLength": 20,
+                    "maxLength": 80,
+                    "description": "Pay to."
+                  },
+                  "status": {
+                    "type": "string",
+                    "enum": [
+                      "active",
+                      "paused",
+                      "removed"
+                    ],
+                    "description": "Filter results by status."
+                  },
+                  "metadata": {
+                    "type": "object",
+                    "additionalProperties": {},
+                    "description": "Metadata."
+                  }
+                },
+                "required": [
+                  "name",
+                  "description",
+                  "capabilities"
+                ],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/agent/marketplace/review": {
+      "post": {
+        "tags": [
+          "agent.marketplace"
+        ],
+        "summary": "Post a review of another agent in the marketplace.",
+        "description": "Post a review of another agent in the marketplace. Reviewer = your x402 signing pubkey; reviewed = target agent's namespace. Outcome is one of 'success' | 'failure' | 'partial'. Optional rating (1-5), comment (≤500 chars), txHash (the on-chain settlement of the underlying agent-to-agent transaction) and network. Reviews are insert-only — they form an append-only reputation log. One review per (reviewer, reviewed, txHash) when txHash is set.",
+        "operationId": "agent.marketplace_review",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = [review] (the newly created append-only review record); total = 1.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "integer"
+                              },
+                              "reviewer": {
+                                "type": "string"
+                              },
+                              "reviewed": {
+                                "type": "string"
+                              },
+                              "outcome": {
+                                "type": "string"
+                              },
+                              "rating": {
+                                "type": "integer",
+                                "nullable": true
+                              },
+                              "comment": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "txHash": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "network": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "createdAt": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "reviewer",
+                              "reviewed",
+                              "outcome",
+                              "rating",
+                              "comment",
+                              "txHash",
+                              "network",
+                              "createdAt"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "agent.marketplace.review",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "reviewed": {
+                    "type": "string",
+                    "minLength": 20,
+                    "maxLength": 80,
+                    "description": "Reviewed."
+                  },
+                  "outcome": {
+                    "type": "string",
+                    "enum": [
+                      "success",
+                      "failure",
+                      "partial"
+                    ],
+                    "description": "Outcome."
+                  },
+                  "rating": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 5,
+                    "description": "Rating."
+                  },
+                  "comment": {
+                    "type": "string",
+                    "maxLength": 500,
+                    "description": "Comment."
+                  },
+                  "txHash": {
+                    "type": "string",
+                    "minLength": 10,
+                    "maxLength": 200,
+                    "description": "Tx hash."
+                  },
+                  "network": {
+                    "type": "string",
+                    "enum": [
+                      "base",
+                      "solana"
+                    ],
+                    "description": "Network."
+                  }
+                },
+                "required": [
+                  "reviewed",
+                  "outcome"
+                ],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/agent/memory/delete": {
+      "post": {
+        "tags": [
+          "agent.memory"
+        ],
+        "summary": "Delete a memory entry from the calling agent's namespace.",
+        "description": "Delete a memory entry from the calling agent's namespace. Idempotent — deleting a non-existent key returns { deleted: false } without erroring. Response { key, deleted }.",
+        "operationId": "agent.memory_delete",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = [confirmation] (key + whether an entry was deleted); total = 1. Idempotent — deleting a missing key returns deleted:false.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "key": {
+                                "type": "string"
+                              },
+                              "deleted": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key",
+                              "deleted"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "agent.memory.delete",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "key": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 200,
+                    "description": "Key."
+                  }
+                },
+                "required": [
+                  "key"
+                ],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/agent/memory/get": {
+      "get": {
+        "tags": [
+          "agent.memory"
+        ],
+        "summary": "Read a memory entry for the calling agent.",
+        "description": "Read a memory entry for the calling agent. Namespace = your x402 signing pubkey. Returns 404 if the key doesn't exist in your namespace (or has expired via TTL). Response { key, value, etag, sizeBytes, createdAt, updatedAt, expiresAt }.",
+        "operationId": "agent.memory_get",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = [entry] (the stored entry: key, value, etag, size, timestamps); total = 1. 404 if the key is absent or expired.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "key": {
+                                "type": "string"
+                              },
+                              "value": {},
+                              "etag": {
+                                "type": "string"
+                              },
+                              "sizeBytes": {
+                                "type": "integer"
+                              },
+                              "createdAt": {
+                                "type": "string"
+                              },
+                              "updatedAt": {
+                                "type": "string"
+                              },
+                              "expiresAt": {
+                                "type": "string",
+                                "nullable": true
+                              }
+                            },
+                            "required": [
+                              "key",
+                              "etag",
+                              "sizeBytes",
+                              "createdAt",
+                              "updatedAt",
+                              "expiresAt"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "agent.memory.get",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "key",
+            "in": "query",
+            "required": true,
+            "description": "Key.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 200
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/agent/memory/list": {
+      "get": {
+        "tags": [
+          "agent.memory"
+        ],
+        "summary": "List keys in the calling agent's memory namespace.",
+        "description": "List keys in the calling agent's memory namespace. Cursor-paginated, newest-first by updatedAt. Returns metadata only (key, etag, sizeBytes, timestamps) — fetch values via agent.memory.get. Optional prefix filters to keys starting with that prefix. Use the returned nextCursor verbatim on the next call to page forward.",
+        "operationId": "agent.memory_list",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A page of memory keys + metadata.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "key": {
+                                "type": "string"
+                              },
+                              "etag": {
+                                "type": "string"
+                              },
+                              "sizeBytes": {
+                                "type": "integer"
+                              },
+                              "createdAt": {
+                                "type": "string"
+                              },
+                              "updatedAt": {
+                                "type": "string"
+                              },
+                              "expiresAt": {
+                                "type": "string",
+                                "nullable": true
+                              }
+                            },
+                            "required": [
+                              "key",
+                              "etag",
+                              "sizeBytes",
+                              "createdAt",
+                              "updatedAt",
+                              "expiresAt"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "nextCursor": {
+                          "type": "string",
+                          "nullable": true
+                        }
+                      },
+                      "required": [
+                        "items",
+                        "nextCursor"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "agent.memory.list",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "legacy",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "prefix",
+            "in": "query",
+            "required": false,
+            "description": "Prefix.",
+            "schema": {
+              "type": "string",
+              "maxLength": 200
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of results to return.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 25
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "required": false,
+            "description": "Opaque pagination cursor returned by a previous response.",
+            "schema": {
+              "type": "string",
+              "maxLength": 500
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/agent/memory/put": {
+      "post": {
+        "tags": [
+          "agent.memory"
+        ],
+        "summary": "Create or replace a memory entry for the calling agent.",
+        "description": "Write or replace a memory entry for the calling agent. Namespace = your x402 signing pubkey (each unique paying wallet gets its own private KV store). Body { key, value, ttlSeconds? }. Returns { key, etag, sizeBytes, createdAt, updatedAt, expiresAt }. Key 1-200 chars from [A-Za-z0-9._/-]. Value is arbitrary JSON, max 64 KiB serialized. Optional ttlSeconds (1..31536000) sets an automatic expiry; omit to persist indefinitely. Quota: 10000 keys per namespace. Stateless agents finally have somewhere to persist across sessions.",
+        "operationId": "agent.memory_put",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = [confirmation] (the written entry: key, new etag, size, timestamps); total = 1.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "key": {
+                                "type": "string"
+                              },
+                              "etag": {
+                                "type": "string"
+                              },
+                              "sizeBytes": {
+                                "type": "integer"
+                              },
+                              "createdAt": {
+                                "type": "string"
+                              },
+                              "updatedAt": {
+                                "type": "string"
+                              },
+                              "expiresAt": {
+                                "type": "string",
+                                "nullable": true
+                              }
+                            },
+                            "required": [
+                              "key",
+                              "etag",
+                              "sizeBytes",
+                              "createdAt",
+                              "updatedAt",
+                              "expiresAt"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "agent.memory.put",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "key": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 200,
+                    "description": "Key."
+                  },
+                  "value": {
+                    "description": "Value."
+                  },
+                  "ttlSeconds": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 31536000,
+                    "description": "Ttl seconds."
+                  }
+                },
+                "required": [
+                  "key",
+                  "value"
+                ],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/providers/2s/ai/PAY.md
+++ b/providers/2s/ai/PAY.md
@@ -1,0 +1,17 @@
+---
+name: ai
+title: "2s Ai"
+description: "AI and search endpoints: text summarization, translation, structured extraction, image description, audio transcription, plus web and news search."
+use_case: "Use for summarizing or translating text, extracting structured data, transcribing audio, describing images, and searching the web or news."
+category: ai_ml
+service_url: https://2s.io
+openapi:
+  path: openapi.json
+---
+
+Part of 2s — a unified, agent-native JSON API. Pay per call in USDC on Solana (or Base) via x402; no accounts, no API keys. Add `?trial=1` (or header `X-2s-Trial: 1`) for one free real call per endpoint per hour.
+
+## Spend-aware usage
+
+- Prefer narrow lookups (by id/code) over broad searches; reuse identifiers across calls.
+- Cap result `limit` to the smallest count that answers the task.

--- a/providers/2s/ai/openapi.json
+++ b/providers/2s/ai/openapi.json
@@ -1,0 +1,2347 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "2s",
+    "version": "1",
+    "description": "Unified JSON REST API for AI agents — an ever-expanding catalog of endpoints, pay per call in USDC on Base or Solana via x402, no accounts, no API keys. Fund a wallet on either chain with USDC, hit any endpoint, and your client signs an EIP-3009 authorization (Base) or a partial SPL transfer (Solana) to settle the call. Try before you buy: add ?trial=1 (or header X-2s-Trial: 1) to any endpoint for one free real call per endpoint per hour — no wallet needed — to verify it works before paying. 2s is an open-ended experiment in maximally-comprehensive agent infrastructure — new endpoints land regularly.",
+    "contact": {
+      "name": "2s",
+      "url": "https://2s.io",
+      "email": "alley@2s.io"
+    }
+  },
+  "servers": [
+    {
+      "url": "https://2s.io"
+    }
+  ],
+  "components": {
+    "parameters": {
+      "TrialMode": {
+        "name": "trial",
+        "in": "query",
+        "required": false,
+        "description": "Try before you buy. Set to 1 for one free real call per endpoint per hour — no wallet or payment needed — to verify the endpoint before paying. Equivalent to sending the \"X-2s-Trial: 1\" request header. Works on every endpoint.",
+        "schema": {
+          "type": "integer",
+          "enum": [
+            1
+          ]
+        }
+      }
+    },
+    "securitySchemes": {
+      "x402Payment": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "PAYMENT-SIGNATURE",
+        "description": "x402 protocol v2: base64-encoded PaymentPayload. Call any paid endpoint without auth to receive a 402 with a multi-network PaymentRequirements envelope. Sign for either rail: EIP-3009 transferWithAuthorization (Base USDC) OR a partial SPL token transfer (Solana USDC). Retry with PAYMENT-SIGNATURE header. X-PAYMENT is also accepted for v1 buyer clients. See https://x402.org."
+      }
+    },
+    "schemas": {
+      "X402PaymentRequiredV2": {
+        "type": "object",
+        "description": "x402 v2 PaymentRequired envelope. Pick any entry from accepts[], sign for that rail, retry with the PAYMENT-SIGNATURE header.",
+        "required": [
+          "x402Version",
+          "accepts"
+        ],
+        "properties": {
+          "x402Version": {
+            "type": "integer",
+            "const": 2
+          },
+          "error": {
+            "type": "string",
+            "description": "Human-readable reason payment is required."
+          },
+          "resource": {
+            "type": "string",
+            "description": "The resource URL being purchased."
+          },
+          "accepts": {
+            "type": "array",
+            "description": "Payment requirement options, one per supported network (Base USDC, Solana USDC).",
+            "items": {
+              "type": "object",
+              "required": [
+                "scheme",
+                "network",
+                "amount",
+                "asset",
+                "payTo",
+                "maxTimeoutSeconds"
+              ],
+              "properties": {
+                "scheme": {
+                  "type": "string",
+                  "enum": [
+                    "exact"
+                  ]
+                },
+                "network": {
+                  "type": "string",
+                  "description": "CAIP-2 network id, e.g. \"eip155:8453\" (Base) or \"solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp\"."
+                },
+                "amount": {
+                  "type": "string",
+                  "description": "Price in atomic asset units (USDC has 6 decimals)."
+                },
+                "asset": {
+                  "type": "string",
+                  "description": "Asset contract address / mint."
+                },
+                "payTo": {
+                  "type": "string",
+                  "description": "Treasury address to pay."
+                },
+                "maxTimeoutSeconds": {
+                  "type": "integer"
+                },
+                "extra": {
+                  "type": "object",
+                  "description": "Rail-specific extras (EVM: EIP-712 domain name/version; Solana: feePayer).",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "extensions": {
+            "type": "object",
+            "description": "Optional discovery metadata (e.g. bazaar input/output schemas).",
+            "additionalProperties": true
+          }
+        }
+      }
+    }
+  },
+  "paths": {
+    "/api/ai/describe-image": {
+      "post": {
+        "tags": [
+          "ai"
+        ],
+        "summary": "Analyze an image. POST { imageUrl, instruction? }. Returns...",
+        "description": "Describe an image. POST { imageUrl, instruction? }. Returns { imageUrl, altText (5-15 word accessibility text), description (2-3 sentences), contentType (photograph|illustration|screenshot|diagram|document|mixed|other), text (verbatim OCR transcription, \"\" if none), mainObjects[], dominantColors[] (hex) }. Accepts JPEG, PNG, GIF, WebP. 1MB image size cap.",
+        "operationId": "ai_describe-image",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = [description] (one structured image description: altText, description, OCR text, main objects, dominant colors); total = 1.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "imageUrl": {
+                                "type": "string"
+                              },
+                              "altText": {
+                                "type": "string",
+                                "description": "Short accessibility text (~5-15 words)."
+                              },
+                              "description": {
+                                "type": "string",
+                                "description": "2-3 sentence description."
+                              },
+                              "contentType": {
+                                "type": "string",
+                                "enum": [
+                                  "photograph",
+                                  "illustration",
+                                  "screenshot",
+                                  "diagram",
+                                  "document",
+                                  "mixed",
+                                  "other"
+                                ]
+                              },
+                              "text": {
+                                "type": "string",
+                                "description": "Verbatim OCR transcription, \"\" if no text present."
+                              },
+                              "mainObjects": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "description": "Salient objects/subjects in the image."
+                              },
+                              "dominantColors": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "description": "Hex color codes (e.g. \"#1a3b5f\") of dominant colors."
+                              }
+                            },
+                            "required": [
+                              "imageUrl",
+                              "altText",
+                              "description",
+                              "contentType",
+                              "text",
+                              "mainObjects",
+                              "dominantColors"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.018 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "ai.describe-image",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.018,
+          "tier": 2
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.018000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "imageUrl": {
+                    "type": "string",
+                    "format": "uri",
+                    "maxLength": 2048,
+                    "description": "HTTPS URL of a JPEG, PNG, GIF, or WebP image (≤1MB)."
+                  },
+                  "instruction": {
+                    "type": "string",
+                    "maxLength": 1000,
+                    "description": "Optional caller-supplied focus hint, e.g. \"describe the chart axes\"."
+                  }
+                },
+                "required": [
+                  "imageUrl"
+                ],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/ai/extract": {
+      "post": {
+        "tags": [
+          "ai"
+        ],
+        "summary": "Extract structured data from a webpage.",
+        "description": "Extract structured data from a webpage. POST { url, schema, instruction? }. The schema is a JSON Schema object (top-level type:\"object\") describing the shape you want back; output is guaranteed to conform. Returns { url, finalUrl, extracted, meta:{ truncated } }.",
+        "operationId": "ai_extract",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = [extraction] (one object: the schema-conforming extracted data, source URLs, truncation flag); total = 1.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "url": {
+                                "type": "string",
+                                "description": "Requested URL."
+                              },
+                              "finalUrl": {
+                                "type": "string",
+                                "description": "Final URL after redirects."
+                              },
+                              "extracted": {
+                                "type": "object",
+                                "additionalProperties": {},
+                                "description": "The extracted object, conforming to the caller-supplied JSON Schema."
+                              },
+                              "truncated": {
+                                "type": "boolean",
+                                "description": "True if the source page was truncated before extraction."
+                              }
+                            },
+                            "required": [
+                              "url",
+                              "finalUrl",
+                              "extracted",
+                              "truncated"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.039 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "ai.extract",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.039,
+          "tier": 2
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.039000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "url": {
+                    "type": "string",
+                    "format": "uri",
+                    "maxLength": 2048,
+                    "description": "URL to process."
+                  },
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": {},
+                    "description": "Schema."
+                  },
+                  "instruction": {
+                    "type": "string",
+                    "maxLength": 2000,
+                    "description": "Instruction."
+                  }
+                },
+                "required": [
+                  "url",
+                  "schema"
+                ],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/ai/screenshot": {
+      "post": {
+        "tags": [
+          "ai"
+        ],
+        "summary": "Render a URL as a screenshot.",
+        "description": "Render a URL as a screenshot. POST { url, width?, height?, fullPage?, format?, quality?, waitUntil?, timeoutMs?, deviceScaleFactor?, blockAds? }. Returns raw image bytes (no JSON envelope) with X-2s-Render-Ms and X-2s-Image-Bytes headers. Viewport clamped 320-3840 × 320-2160. Timeout clamped 1-15s. Defaults: 1280×720 PNG, networkidle2 wait, ad-blocking on. Use cases: visual verification, archival, change detection, OG-card generation, RSS thumbnails.",
+        "operationId": "ai_screenshot",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Raw image bytes (PNG / JPEG / WebP per `format`). X-2s-Render-Ms + X-2s-Image-Bytes response headers describe the render. No JSON envelope on success.",
+            "content": {
+              "image/*": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0075 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "ai.screenshot",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0075,
+          "tier": 2
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "legacy",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.007500"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "url": {
+                    "type": "string",
+                    "format": "uri",
+                    "maxLength": 2048,
+                    "description": "HTTPS URL to render."
+                  },
+                  "width": {
+                    "type": "integer",
+                    "minimum": 320,
+                    "maximum": 3840,
+                    "description": "Viewport width (320-3840). Default 1280."
+                  },
+                  "height": {
+                    "type": "integer",
+                    "minimum": 320,
+                    "maximum": 2160,
+                    "description": "Viewport height (320-2160). Default 720."
+                  },
+                  "fullPage": {
+                    "type": "boolean",
+                    "description": "Capture the full scrollable page instead of the viewport."
+                  },
+                  "format": {
+                    "type": "string",
+                    "enum": [
+                      "png",
+                      "jpeg",
+                      "webp"
+                    ],
+                    "description": "Image format. Default png."
+                  },
+                  "quality": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 100,
+                    "description": "JPEG/WebP quality 1-100. Ignored for PNG."
+                  },
+                  "waitUntil": {
+                    "type": "string",
+                    "enum": [
+                      "load",
+                      "domcontentloaded",
+                      "networkidle0",
+                      "networkidle2"
+                    ],
+                    "description": "Wait condition before snap. Default networkidle2."
+                  },
+                  "timeoutMs": {
+                    "type": "integer",
+                    "minimum": 1000,
+                    "maximum": 15000,
+                    "description": "Render timeout in milliseconds (1000-15000). Default 8000."
+                  },
+                  "deviceScaleFactor": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 3,
+                    "description": "Pixel density multiplier 1-3. Default 1."
+                  },
+                  "blockAds": {
+                    "type": "boolean",
+                    "description": "Block ads + trackers. Default true."
+                  }
+                },
+                "required": [
+                  "url"
+                ],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/ai/summarize": {
+      "post": {
+        "tags": [
+          "ai"
+        ],
+        "summary": "Summarize a webpage. POST { url, instruction? }. Returns {...",
+        "description": "Summarize a webpage. POST { url, instruction? }. Returns { url, finalUrl, summary (1-3 sentences), keyPoints (3-7 bullets), title, audience, estimatedReadingMinutes, meta:{ truncated } }. Sibling to /api/ai/extract — use extract when you need a typed payload conforming to your own schema; use summarize when you want a ready-made digest.",
+        "operationId": "ai_summarize",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = [summary] (one structured page summary: summary, keyPoints, title, audience, reading time); total = 1.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "url": {
+                                "type": "string",
+                                "description": "Requested URL."
+                              },
+                              "finalUrl": {
+                                "type": "string",
+                                "description": "Final URL after redirects."
+                              },
+                              "summary": {
+                                "type": "string",
+                                "description": "1-3 sentence digest."
+                              },
+                              "keyPoints": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "description": "3-7 bullet key points."
+                              },
+                              "title": {
+                                "type": "string",
+                                "description": "Page title."
+                              },
+                              "audience": {
+                                "type": "string",
+                                "description": "Inferred target audience."
+                              },
+                              "estimatedReadingMinutes": {
+                                "type": "integer",
+                                "description": "Estimated reading time in minutes."
+                              },
+                              "truncated": {
+                                "type": "boolean",
+                                "description": "True if the source page was truncated before summarizing."
+                              }
+                            },
+                            "required": [
+                              "url",
+                              "finalUrl",
+                              "summary",
+                              "keyPoints",
+                              "title",
+                              "audience",
+                              "estimatedReadingMinutes",
+                              "truncated"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0315 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "ai.summarize",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0315,
+          "tier": 2
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.031500"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "url": {
+                    "type": "string",
+                    "format": "uri",
+                    "maxLength": 2048,
+                    "description": "URL to process."
+                  },
+                  "instruction": {
+                    "type": "string",
+                    "maxLength": 1000,
+                    "description": "Instruction."
+                  }
+                },
+                "required": [
+                  "url"
+                ],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/ai/translate": {
+      "post": {
+        "tags": [
+          "ai"
+        ],
+        "summary": "Translate text. POST { text, targetLanguage...",
+        "description": "Translate text. POST { text, targetLanguage, sourceLanguage? } — language codes are BCP-47 (e.g. \"en\", \"es-MX\", \"zh-Hans\"). Source auto-detected when omitted. Returns { text, targetLanguage, detectedSourceLanguage, confidence (high|medium|low) }. Best for short-to-medium passages; chunk long documents on your side.",
+        "operationId": "ai_translate",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = [translation] (one result: translated text, detected source language, confidence); total = 1.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "text": {
+                                "type": "string",
+                                "description": "Translated text in targetLanguage."
+                              },
+                              "targetLanguage": {
+                                "type": "string"
+                              },
+                              "detectedSourceLanguage": {
+                                "type": "string",
+                                "description": "BCP-47 source language tag (echoed when supplied, detected otherwise)."
+                              },
+                              "confidence": {
+                                "type": "string",
+                                "enum": [
+                                  "high",
+                                  "medium",
+                                  "low"
+                                ],
+                                "description": "Model confidence in the translation."
+                              }
+                            },
+                            "required": [
+                              "text",
+                              "targetLanguage",
+                              "detectedSourceLanguage",
+                              "confidence"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.01425 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "ai.translate",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.01425,
+          "tier": 2
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.014250"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "text": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 6000,
+                    "description": "Source text to translate (1-6000 chars)."
+                  },
+                  "targetLanguage": {
+                    "type": "string",
+                    "minLength": 2,
+                    "maxLength": 20,
+                    "description": "Target language as BCP-47 (e.g. \"en\", \"es-MX\", \"zh-Hans\")."
+                  },
+                  "sourceLanguage": {
+                    "type": "string",
+                    "minLength": 2,
+                    "maxLength": 20,
+                    "description": "Source language as BCP-47. Auto-detected when omitted."
+                  }
+                },
+                "required": [
+                  "text",
+                  "targetLanguage"
+                ],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/news/hn-item": {
+      "get": {
+        "tags": [
+          "news"
+        ],
+        "summary": "Fetch a specific Hacker News item (story, comment, job...",
+        "description": "Fetch a specific Hacker News item (story, comment, job, poll) by its numeric ID. Returns id, type, author, time (unix + ISO), title, URL, text, score, descendant count, kid count, parent (for comments), dead/deleted flags, canonical news.ycombinator.com URL.",
+        "operationId": "news_hn-item",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = [HN item] (story/comment/job/poll by id); total = 1, or items = [] / total = 0 when the id is unknown.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "integer"
+                              },
+                              "type": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "by": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "time": {
+                                "type": "integer",
+                                "nullable": true
+                              },
+                              "timeIso": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "title": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "url": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "text": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "score": {
+                                "type": "integer",
+                                "nullable": true
+                              },
+                              "descendantsCount": {
+                                "type": "integer",
+                                "nullable": true
+                              },
+                              "kidsCount": {
+                                "type": "integer"
+                              },
+                              "parent": {
+                                "type": "integer",
+                                "nullable": true
+                              },
+                              "deleted": {
+                                "type": "boolean"
+                              },
+                              "dead": {
+                                "type": "boolean"
+                              },
+                              "hnUrl": {
+                                "type": "string",
+                                "format": "uri"
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "type",
+                              "by",
+                              "time",
+                              "timeIso",
+                              "title",
+                              "url",
+                              "text",
+                              "score",
+                              "descendantsCount",
+                              "kidsCount",
+                              "parent",
+                              "deleted",
+                              "dead",
+                              "hnUrl"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "news.hn-item",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "query",
+            "required": true,
+            "description": "Unique identifier of the record to fetch.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 1000000000
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/news/hn-top": {
+      "get": {
+        "tags": [
+          "news"
+        ],
+        "summary": "Fetch the Hacker News top-items feed",
+        "description": "Hacker News feed of items. Pass kind = top (default) | new | best | ask | show | job to pick the feed. Returns each item's id, type, author, time (unix + ISO), title, URL, text (for self-posts), score, descendant + kid counts, parent (for comments), dead/deleted flags, and canonical news.ycombinator.com URL. Default limit = 30, max 100. Useful for tech-sentiment + topic tracking.",
+        "operationId": "news_hn-top",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = Hacker News feed items; total = null (HN feeds report no true count); meta.kind echoes the requested feed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "integer"
+                              },
+                              "type": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "by": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "time": {
+                                "type": "integer",
+                                "nullable": true
+                              },
+                              "timeIso": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "title": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "url": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "text": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "score": {
+                                "type": "integer",
+                                "nullable": true
+                              },
+                              "descendantsCount": {
+                                "type": "integer",
+                                "nullable": true
+                              },
+                              "kidsCount": {
+                                "type": "integer"
+                              },
+                              "parent": {
+                                "type": "integer",
+                                "nullable": true
+                              },
+                              "deleted": {
+                                "type": "boolean"
+                              },
+                              "dead": {
+                                "type": "boolean"
+                              },
+                              "hnUrl": {
+                                "type": "string",
+                                "format": "uri"
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "type",
+                              "by",
+                              "time",
+                              "timeIso",
+                              "title",
+                              "url",
+                              "text",
+                              "score",
+                              "descendantsCount",
+                              "kidsCount",
+                              "parent",
+                              "deleted",
+                              "dead",
+                              "hnUrl"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "kind": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "kind"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "news.hn-top",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "kind",
+            "in": "query",
+            "required": false,
+            "description": "Kind.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "top",
+                "new",
+                "best",
+                "ask",
+                "show",
+                "job"
+              ],
+              "default": "top"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of results to return.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 30
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/news/search": {
+      "get": {
+        "tags": [
+          "news"
+        ],
+        "summary": "Search live news for recent headlines",
+        "description": "Live news search. Returns recent headlines with title, URL, snippet, publisher source, relative age, and a breaking-news flag — real-time coverage past any model training cutoff. Supports count (1-20), offset, country (2-letter), and freshness (pd=past day, pw=past week, pm=past month, py=past year). Use for current events, market-moving developments, monitoring, and \"what happened with X\" questions. For general web results see /api/search/web; for Hacker News specifically see /api/news/hn-top.",
+        "operationId": "news_search",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = recent news headlines (publisher, age, breaking flag); total = null (Brave reports no count); meta.query echoes the search.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "title": {
+                                "type": "string"
+                              },
+                              "url": {
+                                "type": "string"
+                              },
+                              "description": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "source": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "Publisher hostname."
+                              },
+                              "age": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "Relative recency, e.g. \"5 hours ago\"."
+                              },
+                              "breaking": {
+                                "type": "boolean"
+                              },
+                              "thumbnail": {
+                                "type": "string",
+                                "nullable": true
+                              }
+                            },
+                            "required": [
+                              "title",
+                              "url",
+                              "description",
+                              "source",
+                              "age",
+                              "breaking",
+                              "thumbnail"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "query": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "query"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.009 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "news.search",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.009,
+          "tier": 2
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.009000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": true,
+            "description": "News query.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 400
+            }
+          },
+          {
+            "name": "count",
+            "in": "query",
+            "required": false,
+            "description": "Count.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 20,
+              "default": 10
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "description": "Number of results to skip before returning (pagination offset).",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 9,
+              "default": 0
+            }
+          },
+          {
+            "name": "country",
+            "in": "query",
+            "required": false,
+            "description": "Country name or ISO country code.",
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-zA-Z]{2}$"
+            }
+          },
+          {
+            "name": "freshness",
+            "in": "query",
+            "required": false,
+            "description": "Freshness.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "pd",
+                "pw",
+                "pm",
+                "py"
+              ]
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/search/web": {
+      "get": {
+        "tags": [
+          "search"
+        ],
+        "summary": "Search the live web for ranked results",
+        "description": "Live web search. Returns ranked results with title, URL, snippet description, site name, and page age — fresh information past any model training cutoff. Supports count (1-20), offset for paging, country (2-letter, e.g. US), freshness (pd=past day, pw=past week, pm=past month, py=past year, or a YYYY-MM-DDtoYYYY-MM-DD range), and safesearch (off/moderate/strict). Use for current events, fact verification, finding documentation, and research. Independent search index. For news-specific results with sources and timestamps see /api/news/search.",
+        "operationId": "search_web",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = ranked live web results (title, url, snippet, site, age); total = null (Brave reports no count); meta.query echoes the search, meta.moreAvailable signals another offset page.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "title": {
+                                "type": "string"
+                              },
+                              "url": {
+                                "type": "string"
+                              },
+                              "description": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "siteName": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "age": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "Relative page age when known, e.g. \"2 days ago\"."
+                              },
+                              "language": {
+                                "type": "string",
+                                "nullable": true
+                              }
+                            },
+                            "required": [
+                              "title",
+                              "url",
+                              "description",
+                              "siteName",
+                              "age",
+                              "language"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "query": {
+                              "type": "string"
+                            },
+                            "moreAvailable": {
+                              "type": "boolean",
+                              "description": "True when another offset page exists."
+                            }
+                          },
+                          "required": [
+                            "query",
+                            "moreAvailable"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.009 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "search.web",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.009,
+          "tier": 2
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.009000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": true,
+            "description": "Search query.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 400
+            }
+          },
+          {
+            "name": "count",
+            "in": "query",
+            "required": false,
+            "description": "Count.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 20,
+              "default": 10
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "description": "Number of results to skip before returning (pagination offset).",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 9,
+              "default": 0
+            }
+          },
+          {
+            "name": "country",
+            "in": "query",
+            "required": false,
+            "description": "Country name or ISO country code.",
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-zA-Z]{2}$"
+            }
+          },
+          {
+            "name": "freshness",
+            "in": "query",
+            "required": false,
+            "description": "Freshness.",
+            "schema": {
+              "type": "string",
+              "pattern": "^(pd|pw|pm|py|\\d{4}-\\d{2}-\\d{2}to\\d{4}-\\d{2}-\\d{2})$"
+            }
+          },
+          {
+            "name": "safesearch",
+            "in": "query",
+            "required": false,
+            "description": "Safesearch.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "off",
+                "moderate",
+                "strict"
+              ]
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/transcribe/audio": {
+      "post": {
+        "tags": [
+          "transcribe"
+        ],
+        "summary": "Transcribe an audio file to text.",
+        "description": "Transcribe an audio file to text. POST { url, language?, diarize? } — the audio is fetched from your URL (wav, mp3, m4a/aac, ogg/opus, flac, webm; up to 15 MB and 15 minutes per call — split longer recordings and call once per segment). Returns the full punctuated transcript, overall confidence, audio duration, detected or specified language (BCP-47, e.g. \"en\", \"es\"), word-level timestamps with confidences, and — with diarize=true — speaker-segmented utterances (who said what, when). High-accuracy speech recognition for meeting notes, podcast processing, voicemail handling, and media monitoring.",
+        "operationId": "transcribe_audio",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = [one transcript] (full punctuated text, confidence, duration, language, word timestamps, optional speaker diarization); total = 1; meta.wordCount = word count.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "transcript": {
+                                "type": "string",
+                                "description": "Full punctuated transcript."
+                              },
+                              "confidence": {
+                                "type": "number"
+                              },
+                              "durationSeconds": {
+                                "type": "number"
+                              },
+                              "language": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "words": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "word": {
+                                      "type": "string"
+                                    },
+                                    "start": {
+                                      "type": "number"
+                                    },
+                                    "end": {
+                                      "type": "number"
+                                    },
+                                    "confidence": {
+                                      "type": "number"
+                                    },
+                                    "speaker": {
+                                      "type": "number",
+                                      "nullable": true
+                                    }
+                                  },
+                                  "required": [
+                                    "word",
+                                    "start",
+                                    "end",
+                                    "confidence",
+                                    "speaker"
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                "description": "Word-level timestamps (seconds)."
+                              },
+                              "utterances": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "speaker": {
+                                      "type": "number",
+                                      "nullable": true
+                                    },
+                                    "start": {
+                                      "type": "number"
+                                    },
+                                    "end": {
+                                      "type": "number"
+                                    },
+                                    "text": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "speaker",
+                                    "start",
+                                    "end",
+                                    "text"
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                "description": "Speaker turns; populated when diarize=true."
+                              }
+                            },
+                            "required": [
+                              "transcript",
+                              "confidence",
+                              "durationSeconds",
+                              "language",
+                              "words",
+                              "utterances"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "wordCount": {
+                              "type": "integer",
+                              "description": "Number of words in the transcript."
+                            }
+                          },
+                          "required": [
+                            "wordCount"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0675 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "transcribe.audio",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0675,
+          "tier": 2
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.067500"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "url": {
+                    "type": "string",
+                    "format": "uri",
+                    "maxLength": 2048,
+                    "description": "Public audio URL. Caps: 15 MB, 15 minutes."
+                  },
+                  "language": {
+                    "type": "string",
+                    "pattern": "^[a-z]{2,3}(-[A-Za-z0-9]{2,8})?$",
+                    "description": "Two-letter ISO language code."
+                  },
+                  "diarize": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Diarize."
+                  }
+                },
+                "required": [
+                  "url"
+                ],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/providers/2s/finance/PAY.md
+++ b/providers/2s/finance/PAY.md
@@ -1,0 +1,17 @@
+---
+name: finance
+title: "2s Finance"
+description: "Financial and economic data endpoints: SEC EDGAR filings, insider + 13F holdings, stock quotes, FX rates, crypto market/chain data, FRED macro series (CPI, yield curve, recession), Treasury, BLS, and World Bank indicators."
+use_case: "Use for company financials and SEC filings, stock/FX/crypto quotes, inflation and CPI lookups, yield-curve and macro-indicator data, and economic time series."
+category: finance
+service_url: https://2s.io
+openapi:
+  path: openapi.json
+---
+
+Part of 2s — a unified, agent-native JSON API. Pay per call in USDC on Solana (or Base) via x402; no accounts, no API keys. Add `?trial=1` (or header `X-2s-Trial: 1`) for one free real call per endpoint per hour.
+
+## Spend-aware usage
+
+- Prefer narrow lookups (by id/code) over broad searches; reuse identifiers across calls.
+- Cap result `limit` to the smallest count that answers the task.

--- a/providers/2s/finance/openapi.json
+++ b/providers/2s/finance/openapi.json
@@ -1,0 +1,7453 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "2s",
+    "version": "1",
+    "description": "Unified JSON REST API for AI agents — an ever-expanding catalog of endpoints, pay per call in USDC on Base or Solana via x402, no accounts, no API keys. Fund a wallet on either chain with USDC, hit any endpoint, and your client signs an EIP-3009 authorization (Base) or a partial SPL transfer (Solana) to settle the call. Try before you buy: add ?trial=1 (or header X-2s-Trial: 1) to any endpoint for one free real call per endpoint per hour — no wallet needed — to verify it works before paying. 2s is an open-ended experiment in maximally-comprehensive agent infrastructure — new endpoints land regularly.",
+    "contact": {
+      "name": "2s",
+      "url": "https://2s.io",
+      "email": "alley@2s.io"
+    }
+  },
+  "servers": [
+    {
+      "url": "https://2s.io"
+    }
+  ],
+  "components": {
+    "parameters": {
+      "TrialMode": {
+        "name": "trial",
+        "in": "query",
+        "required": false,
+        "description": "Try before you buy. Set to 1 for one free real call per endpoint per hour — no wallet or payment needed — to verify the endpoint before paying. Equivalent to sending the \"X-2s-Trial: 1\" request header. Works on every endpoint.",
+        "schema": {
+          "type": "integer",
+          "enum": [
+            1
+          ]
+        }
+      }
+    },
+    "securitySchemes": {
+      "x402Payment": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "PAYMENT-SIGNATURE",
+        "description": "x402 protocol v2: base64-encoded PaymentPayload. Call any paid endpoint without auth to receive a 402 with a multi-network PaymentRequirements envelope. Sign for either rail: EIP-3009 transferWithAuthorization (Base USDC) OR a partial SPL token transfer (Solana USDC). Retry with PAYMENT-SIGNATURE header. X-PAYMENT is also accepted for v1 buyer clients. See https://x402.org."
+      }
+    },
+    "schemas": {
+      "X402PaymentRequiredV2": {
+        "type": "object",
+        "description": "x402 v2 PaymentRequired envelope. Pick any entry from accepts[], sign for that rail, retry with the PAYMENT-SIGNATURE header.",
+        "required": [
+          "x402Version",
+          "accepts"
+        ],
+        "properties": {
+          "x402Version": {
+            "type": "integer",
+            "const": 2
+          },
+          "error": {
+            "type": "string",
+            "description": "Human-readable reason payment is required."
+          },
+          "resource": {
+            "type": "string",
+            "description": "The resource URL being purchased."
+          },
+          "accepts": {
+            "type": "array",
+            "description": "Payment requirement options, one per supported network (Base USDC, Solana USDC).",
+            "items": {
+              "type": "object",
+              "required": [
+                "scheme",
+                "network",
+                "amount",
+                "asset",
+                "payTo",
+                "maxTimeoutSeconds"
+              ],
+              "properties": {
+                "scheme": {
+                  "type": "string",
+                  "enum": [
+                    "exact"
+                  ]
+                },
+                "network": {
+                  "type": "string",
+                  "description": "CAIP-2 network id, e.g. \"eip155:8453\" (Base) or \"solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp\"."
+                },
+                "amount": {
+                  "type": "string",
+                  "description": "Price in atomic asset units (USDC has 6 decimals)."
+                },
+                "asset": {
+                  "type": "string",
+                  "description": "Asset contract address / mint."
+                },
+                "payTo": {
+                  "type": "string",
+                  "description": "Treasury address to pay."
+                },
+                "maxTimeoutSeconds": {
+                  "type": "integer"
+                },
+                "extra": {
+                  "type": "object",
+                  "description": "Rail-specific extras (EVM: EIP-712 domain name/version; Solana: feePayer).",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "extensions": {
+            "type": "object",
+            "description": "Optional discovery metadata (e.g. bazaar input/output schemas).",
+            "additionalProperties": true
+          }
+        }
+      }
+    }
+  },
+  "paths": {
+    "/api/bls/series": {
+      "get": {
+        "tags": [
+          "bls"
+        ],
+        "summary": "Fetch US Bureau of Labor Statistics time-series data.",
+        "description": "US Bureau of Labor Statistics time-series data. Pass seriesIds = comma-separated BLS series IDs (1-10 per call), optional startYear + endYear bracket (max 10 years). Each observation: year, period (M01-M12 monthly, Q01-Q04 quarterly, A01 annual, S01/S02 semiannual), periodName, value (verbatim string from BLS) + numericValue (parsed number), latest flag, footnote texts. Common series IDs: LNS14000000 (unemployment rate), CUUR0000SA0 (CPI-U all items), CES0000000001 (nonfarm employment), LNS11300000 (labor force participation). Unauthenticated upstream — ~25 queries/day per IP.",
+        "operationId": "bls_series",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = one entry per requested BLS series (seriesId, catalog, observations); total = number of series returned; meta.status is the upstream REQUEST_SUCCEEDED flag; meta.query echoes the request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "seriesId": {
+                                "type": "string"
+                              },
+                              "catalog": {
+                                "type": "object",
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "nullable": true
+                              },
+                              "observations": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "year": {
+                                      "type": "string"
+                                    },
+                                    "period": {
+                                      "type": "string"
+                                    },
+                                    "periodName": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    },
+                                    "numericValue": {
+                                      "type": "number",
+                                      "nullable": true
+                                    },
+                                    "latest": {
+                                      "type": "boolean"
+                                    },
+                                    "footnotes": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "required": [
+                                    "year",
+                                    "period",
+                                    "periodName",
+                                    "value",
+                                    "numericValue",
+                                    "latest",
+                                    "footnotes"
+                                  ],
+                                  "additionalProperties": false
+                                }
+                              }
+                            },
+                            "required": [
+                              "seriesId",
+                              "catalog",
+                              "observations"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "query": {
+                              "type": "object",
+                              "properties": {
+                                "seriesIds": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                },
+                                "startYear": {
+                                  "type": "integer",
+                                  "nullable": true
+                                },
+                                "endYear": {
+                                  "type": "integer",
+                                  "nullable": true
+                                }
+                              },
+                              "required": [
+                                "seriesIds",
+                                "startYear",
+                                "endYear"
+                              ],
+                              "additionalProperties": false
+                            },
+                            "status": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "query",
+                            "status"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "bls.series",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "seriesIds",
+            "in": "query",
+            "required": true,
+            "description": "Series ids.",
+            "schema": {
+              "type": "string",
+              "minLength": 4,
+              "maxLength": 400
+            }
+          },
+          {
+            "name": "startYear",
+            "in": "query",
+            "required": false,
+            "description": "Start year.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1900,
+              "maximum": 2100
+            }
+          },
+          {
+            "name": "endYear",
+            "in": "query",
+            "required": false,
+            "description": "End year.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1900,
+              "maximum": 2100
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/crypto/address-validate": {
+      "get": {
+        "tags": [
+          "crypto"
+        ],
+        "summary": "Validate a cryptocurrency address with full checksum...",
+        "description": "Validate a cryptocurrency address with full checksum verification (not just regex). Returns {chain, address, valid, canonical, format, reason}. Chains: btc (P2PKH, P2SH, Bech32 SegWit v0, Taproot Bech32m), eth (full EIP-55 checksum; non-checksummed flagged), sol (Ed25519 32-byte Base58), ltc (Base58Check L.../M.../3... + ltc1 Bech32), trx (T-prefix Base58Check 0x41), xrp (r-prefix custom Base58), bch (legacy Base58Check + bitcoincash:q... CashAddr). Catches typos via cryptographic checksum; canonical field returns the checksummed/lowercased form.",
+        "operationId": "crypto_address-validate",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = [validation result] (chain, address, valid, canonical, format, reason); total = 1.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.001 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "crypto.address-validate",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.001,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "chain",
+            "in": "query",
+            "required": true,
+            "description": "Chain.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "btc",
+                "eth",
+                "sol",
+                "ltc",
+                "trx",
+                "xrp",
+                "bch"
+              ]
+            }
+          },
+          {
+            "name": "address",
+            "in": "query",
+            "required": true,
+            "description": "Street address or full address string.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 100
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/crypto/ens-resolve": {
+      "get": {
+        "tags": [
+          "crypto"
+        ],
+        "summary": "Resolve ENS (Ethereum Name Service) names and addresses...",
+        "description": "Resolve ENS (Ethereum Name Service) names and addresses live on Ethereum mainnet. Pass query as either an ENS name (e.g. \"vitalik.eth\") → returns the Ethereum address it points to, or a 0x address → returns its primary ENS name (reverse record). Either way it also returns the profile text records: avatar, email, url, twitter (com.twitter), github (com.github), and description. A live on-chain lookup agents can't do from their sandbox, and ENS records change after training cutoffs. Wallet UX, address-book resolution, on-chain identity. Returns address:null for an unregistered or unset name.",
+        "operationId": "crypto_ens-resolve",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = [ENS resolution] (query, name, address, profile records); total = 1.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "query": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "address": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "records": {
+                                "type": "object",
+                                "properties": {
+                                  "avatar": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "email": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "url": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "twitter": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "github": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "description": {
+                                    "type": "string",
+                                    "nullable": true
+                                  }
+                                },
+                                "required": [
+                                  "avatar",
+                                  "email",
+                                  "url",
+                                  "twitter",
+                                  "github",
+                                  "description"
+                                ],
+                                "additionalProperties": false
+                              }
+                            },
+                            "required": [
+                              "query",
+                              "name",
+                              "address",
+                              "records"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.001 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "crypto.ens-resolve",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.001,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "query",
+            "in": "query",
+            "required": true,
+            "description": "Free-text search query.",
+            "schema": {
+              "type": "string",
+              "minLength": 3,
+              "maxLength": 255
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/crypto/fear-greed": {
+      "get": {
+        "tags": [
+          "crypto"
+        ],
+        "summary": "Fetch Crypto Fear & Greed Index - a 0-100 market-sentiment...",
+        "description": "The Crypto Fear & Greed Index — a 0–100 market-sentiment gauge (0 = Extreme Fear, 100 = Extreme Greed) updated daily. Returns the current value + its classification (Extreme Fear/Fear/Neutral/Greed/Extreme Greed) and timestamp; pass limit (up to 90) for recent history. Useful as a contrarian sentiment signal. Source: alternative.me.",
+        "operationId": "crypto_fear-greed",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = readings (newest first); total = count.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "value": {
+                                "type": "number",
+                                "description": "0–100 (0 = extreme fear, 100 = extreme greed)."
+                              },
+                              "classification": {
+                                "type": "string"
+                              },
+                              "timestamp": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "value",
+                              "classification",
+                              "timestamp"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "crypto.fear-greed",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of results to return.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 90
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/crypto/gas-oracle": {
+      "get": {
+        "tags": [
+          "crypto"
+        ],
+        "summary": "Fetch Live EVM gas oracle.",
+        "description": "Live EVM gas oracle. Returns latest block baseFeePerGas + slow/standard/fast tiers derived from priority-fee percentiles (p25/p50/p75) over the trailing 4 blocks, plus a 21,000-gas transfer cost estimate in the chain native unit. Chains: base, ethereum, polygon, arbitrum, optimism. Real-time post-training data, ~5s freshness.",
+        "operationId": "crypto_gas-oracle",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = [gas oracle] (latest block baseFee, slow/standard/fast priority tiers, 21k transfer estimate); total = 1.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.001 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "crypto.gas-oracle",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.001,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "chain",
+            "in": "query",
+            "required": true,
+            "description": "EVM chain to query: base | ethereum | polygon | arbitrum | optimism.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "base",
+                "ethereum",
+                "polygon",
+                "arbitrum",
+                "optimism"
+              ]
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/crypto/global": {
+      "get": {
+        "tags": [
+          "crypto"
+        ],
+        "summary": "Fetch Whole-crypto-market overview: total market cap (USD)",
+        "description": "Whole-crypto-market overview: total market cap (USD), total 24h volume, 24h market-cap % change, Bitcoin + Ethereum dominance, count of active cryptocurrencies and markets. Source: CoinGecko.",
+        "operationId": "crypto_global",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = [global market overview]; total = 1.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "totalMarketCapUsd": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "totalVolume24hUsd": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "marketCapChange24hPct": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "btcDominancePct": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "ethDominancePct": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "activeCryptocurrencies": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "markets": {
+                                "type": "number",
+                                "nullable": true
+                              }
+                            },
+                            "required": [
+                              "totalMarketCapUsd",
+                              "totalVolume24hUsd",
+                              "marketCapChange24hPct",
+                              "btcDominancePct",
+                              "ethDominancePct",
+                              "activeCryptocurrencies",
+                              "markets"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "crypto.global",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/crypto/markets": {
+      "get": {
+        "tags": [
+          "crypto"
+        ],
+        "summary": "Fetch Top cryptocurrencies by market cap with live price",
+        "description": "Top cryptocurrencies by market cap with live price, market cap, 24h volume, and 24h + 7d % change. Pass limit (1–100, default 20). Source: CoinGecko. For a single token use crypto.token-price; for the whole-market overview use crypto.global.",
+        "operationId": "crypto_markets",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = top coins by market cap; total = count.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "rank": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "id": {
+                                "type": "string"
+                              },
+                              "symbol": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "priceUsd": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "marketCapUsd": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "volume24hUsd": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "change24hPct": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "change7dPct": {
+                                "type": "number",
+                                "nullable": true
+                              }
+                            },
+                            "required": [
+                              "rank",
+                              "id",
+                              "symbol",
+                              "name",
+                              "priceUsd",
+                              "marketCapUsd",
+                              "volume24hUsd",
+                              "change24hPct",
+                              "change7dPct"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.00144 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "crypto.markets",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.00144,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001440"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of results to return.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/crypto/token-price": {
+      "get": {
+        "tags": [
+          "crypto"
+        ],
+        "summary": "Fetch Current spot price and market data for crypto assets.",
+        "description": "Current spot price and market data for crypto assets. Pass ids as comma-separated CoinGecko asset ids (e.g. bitcoin, ethereum, solana, usd-coin — lowercase id, not ticker symbol; up to 25 per call) and optionally vs (comma-separated fiat/crypto quote currencies, default usd). Returns per-asset price, market cap, 24h volume, and 24h percent change, plus the data timestamp. Live market data past any training cutoff. Price data by CoinGecko.",
+        "operationId": "crypto_token-price",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = per-asset spot price/market cap/24h volume/24h change per quote currency; total = null (no upstream count); meta.asOf is the data timestamp.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string",
+                                "description": "CoinGecko asset id."
+                              },
+                              "quotes": {
+                                "type": "object",
+                                "additionalProperties": {
+                                  "type": "object",
+                                  "properties": {
+                                    "price": {
+                                      "type": "number",
+                                      "nullable": true
+                                    },
+                                    "marketCap": {
+                                      "type": "number",
+                                      "nullable": true
+                                    },
+                                    "volume24h": {
+                                      "type": "number",
+                                      "nullable": true
+                                    },
+                                    "change24hPct": {
+                                      "type": "number",
+                                      "nullable": true
+                                    }
+                                  },
+                                  "required": [
+                                    "price",
+                                    "marketCap",
+                                    "volume24h",
+                                    "change24hPct"
+                                  ],
+                                  "additionalProperties": false
+                                }
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "quotes"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "asOf": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "asOf"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "crypto.token-price",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 2
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "ids",
+            "in": "query",
+            "required": true,
+            "description": "Comma-separated CoinGecko asset ids (lowercase), e.g. \"bitcoin,ethereum\". Max 25.",
+            "schema": {
+              "allOf": [
+                {
+                  "type": "string",
+                  "minLength": 2,
+                  "maxLength": 600
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "pattern": "^[a-z0-9-]+$"
+                  },
+                  "minItems": 1,
+                  "maxItems": 25
+                }
+              ]
+            }
+          },
+          {
+            "name": "vs",
+            "in": "query",
+            "required": false,
+            "description": "Vs.",
+            "schema": {
+              "allOf": [
+                {
+                  "anyOf": [
+                    {
+                      "not": {}
+                    },
+                    {
+                      "type": "string",
+                      "maxLength": 60
+                    }
+                  ],
+                  "default": "usd"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "pattern": "^[a-z]{2,10}$"
+                  },
+                  "minItems": 1,
+                  "maxItems": 5
+                }
+              ]
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/crypto/trending": {
+      "get": {
+        "tags": [
+          "crypto"
+        ],
+        "summary": "Fetch most-searched trending cryptocurrencies on CoinGecko...",
+        "description": "The most-searched trending cryptocurrencies on CoinGecko right now (last 24h), each with symbol, name, market-cap rank, and price. A real-time popularity/attention signal. Source: CoinGecko.",
+        "operationId": "crypto_trending",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = trending coins (most-searched first); total = count.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string"
+                              },
+                              "symbol": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "marketCapRank": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "priceUsd": {
+                                "type": "number",
+                                "nullable": true
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "symbol",
+                              "name",
+                              "marketCapRank",
+                              "priceUsd"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "crypto.trending",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/crypto/tx": {
+      "get": {
+        "tags": [
+          "crypto"
+        ],
+        "summary": "Fetch Live EVM transaction status and receipt lookup.",
+        "description": "Live EVM transaction status and receipt lookup. Give a transaction hash + chain and get back whether it mined successfully, reverted, or is still pending in the mempool, plus block number, confirmations, timestamp, sender and recipient, value transferred (native unit), gas used, effective gas price, total fee paid, any contract created, and event-log count. Chains: base, ethereum, polygon, arbitrum, optimism. Real-time post-training chain state — use it to confirm a payment settled, detect a reverted transaction, or wait for confirmations before acting. Unknown hash returns 404. Sibling of /api/crypto/gas-oracle (fees) and /api/crypto/address-validate (format).",
+        "operationId": "crypto_tx",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = [the transaction] with status (success | reverted | pending), block, confirmations, from/to, value (native), gasUsed, effectiveGasPriceGwei, feeNative, contractAddress, logCount; total = 1. 404 if the hash is unknown on that chain.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.001 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "crypto.tx",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.001,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "chain",
+            "in": "query",
+            "required": true,
+            "description": "EVM chain to query: base | ethereum | polygon | arbitrum | optimism.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "base",
+                "ethereum",
+                "polygon",
+                "arbitrum",
+                "optimism"
+              ]
+            }
+          },
+          {
+            "name": "hash",
+            "in": "query",
+            "required": true,
+            "description": "Transaction hash: 0x followed by 64 hex characters.",
+            "schema": {
+              "type": "string",
+              "pattern": "^0x[0-9a-fA-F]{64}$"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/econ/commodity": {
+      "get": {
+        "tags": [
+          "econ"
+        ],
+        "summary": "Fetch Latest benchmark commodity price with the prior value",
+        "description": "Latest benchmark commodity price with the prior value + % change. Pass commodity for one, or omit for all. Commodities: wti, brent, natural-gas, gasoline, diesel, heating-oil, propane, copper, aluminum, corn, wheat, sugar — i.e. crude oil (WTI + Brent), natural gas, gasoline, diesel, heating oil, propane, gold, copper, aluminum, corn, wheat, sugar. Each result names the FRED series ID + unit ($/barrel, $/gallon, $/troy oz, $/metric ton...). Daily benchmarks report a daily date; global-price series are monthly. Source: EIA / LBMA / IMF via FRED (St. Louis Fed).",
+        "operationId": "econ_commodity",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = commodity prices; total = commodities returned.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "commodity": {
+                                "type": "string"
+                              },
+                              "seriesId": {
+                                "type": "string"
+                              },
+                              "label": {
+                                "type": "string"
+                              },
+                              "unit": {
+                                "type": "string"
+                              },
+                              "price": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "asOf": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "previous": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "changePct": {
+                                "type": "number",
+                                "nullable": true,
+                                "description": "% change vs the prior observation."
+                              }
+                            },
+                            "required": [
+                              "commodity",
+                              "seriesId",
+                              "label",
+                              "unit",
+                              "price",
+                              "asOf",
+                              "previous",
+                              "changePct"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.00144 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "econ.commodity",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.00144,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001440"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "commodity",
+            "in": "query",
+            "required": false,
+            "description": "Commodity.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "wti",
+                "brent",
+                "natural-gas",
+                "gasoline",
+                "diesel",
+                "heating-oil",
+                "propane",
+                "copper",
+                "aluminum",
+                "corn",
+                "wheat",
+                "sugar"
+              ]
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/econ/indicator": {
+      "get": {
+        "tags": [
+          "econ"
+        ],
+        "summary": "Fetch Latest reading of a curated US macroeconomic indicator...",
+        "description": "Latest reading of a curated US macroeconomic indicator, with the prior + year-ago values and YoY % change. Pass indicator for one, or omit for all. Indicators: unemployment-rate, fed-funds-rate, nonfarm-payrolls, jobless-claims, labor-force-participation, real-gdp, gdp-growth, 10y-treasury, 2y-treasury, 3m-treasury, 30y-mortgage, consumer-sentiment, housing-starts, retail-sales, industrial-production, m2, personal-saving-rate — i.e. unemployment rate, fed funds rate, nonfarm payrolls, jobless claims, labor-force participation, real GDP + GDP growth, 2y/3m/10y Treasury yields, 30y mortgage rate, consumer sentiment, housing starts, retail sales, industrial production, M2, personal saving rate. Each result names the FRED series ID + units. Source: BLS/BEA/Fed/Treasury via FRED (St. Louis Fed). For inflation specifically use inflation.rates; for any raw series use bls.series.",
+        "operationId": "econ_indicator",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = indicator readings; total = indicators returned.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "indicator": {
+                                "type": "string"
+                              },
+                              "seriesId": {
+                                "type": "string"
+                              },
+                              "label": {
+                                "type": "string"
+                              },
+                              "units": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "asOf": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "previous": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "yearAgo": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "changeYoYPct": {
+                                "type": "number",
+                                "nullable": true,
+                                "description": "% change vs year ago (most meaningful for level series; for rate series compare value vs yearAgo directly)."
+                              }
+                            },
+                            "required": [
+                              "indicator",
+                              "seriesId",
+                              "label",
+                              "units",
+                              "value",
+                              "asOf",
+                              "previous",
+                              "yearAgo",
+                              "changeYoYPct"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.00144 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "econ.indicator",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.00144,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001440"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "indicator",
+            "in": "query",
+            "required": false,
+            "description": "Indicator.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "unemployment-rate",
+                "fed-funds-rate",
+                "nonfarm-payrolls",
+                "jobless-claims",
+                "labor-force-participation",
+                "real-gdp",
+                "gdp-growth",
+                "10y-treasury",
+                "2y-treasury",
+                "3m-treasury",
+                "30y-mortgage",
+                "consumer-sentiment",
+                "housing-starts",
+                "retail-sales",
+                "industrial-production",
+                "m2",
+                "personal-saving-rate"
+              ]
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/econ/recession": {
+      "get": {
+        "tags": [
+          "econ"
+        ],
+        "summary": "Fetch Composite US recession-signal dashboard: the NY Fed",
+        "description": "Composite US recession-signal dashboard: the NY Fed model's recession probability (12 months ahead, %), the Sahm-rule real-time indicator (≥0.50 signals a recession has begun), and the 10-Year minus 2-Year Treasury spread (negative = inverted, a classic precursor). Returns each gauge with its latest value, date, a triggered/inverted flag, and a plain-language note, plus a count of signals currently flashing. A read of the standard gauges — not a forecast. Source: NY Fed / BLS / US Treasury via FRED.",
+        "operationId": "econ_recession",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = [the recession-signal dashboard]; total = 1.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "recessionProbability": {
+                                "type": "object",
+                                "properties": {
+                                  "value": {
+                                    "type": "number",
+                                    "nullable": true
+                                  },
+                                  "asOf": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "note": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "value",
+                                  "asOf",
+                                  "note"
+                                ],
+                                "additionalProperties": false
+                              },
+                              "sahmRule": {
+                                "type": "object",
+                                "properties": {
+                                  "value": {
+                                    "type": "number",
+                                    "nullable": true
+                                  },
+                                  "asOf": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "triggered": {
+                                    "type": "boolean"
+                                  },
+                                  "note": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "value",
+                                  "asOf",
+                                  "triggered",
+                                  "note"
+                                ],
+                                "additionalProperties": false
+                              },
+                              "yieldCurve": {
+                                "type": "object",
+                                "properties": {
+                                  "spread10y2yPct": {
+                                    "type": "number",
+                                    "nullable": true
+                                  },
+                                  "asOf": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "inverted": {
+                                    "type": "boolean"
+                                  },
+                                  "note": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "spread10y2yPct",
+                                  "asOf",
+                                  "inverted",
+                                  "note"
+                                ],
+                                "additionalProperties": false
+                              },
+                              "signalsTriggered": {
+                                "type": "integer"
+                              }
+                            },
+                            "required": [
+                              "recessionProbability",
+                              "sahmRule",
+                              "yieldCurve",
+                              "signalsTriggered"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.00144 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "econ.recession",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.00144,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001440"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/econ/yield-curve": {
+      "get": {
+        "tags": [
+          "econ"
+        ],
+        "summary": "Fetch Current US Treasury yield curve - the market yield",
+        "description": "Current US Treasury yield curve — the market yield at every constant-maturity tenor from 1 month to 30 years (1M, 3M, 6M, 1Y, 2Y, 3Y, 5Y, 7Y, 10Y, 20Y, 30Y), each as a percent as of its latest date. Also returns the 2s10s spread (10Y − 2Y), the 3m10y spread (10Y − 3M), and an inverted flag (true when 2s10s is negative — a classic recession signal). Daily data. Source: US Treasury constant-maturity rates via FRED (St. Louis Fed).",
+        "operationId": "econ_yield-curve",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = yield points by maturity; meta = spreads + inversion flag.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "maturity": {
+                                "type": "string"
+                              },
+                              "months": {
+                                "type": "number"
+                              },
+                              "seriesId": {
+                                "type": "string"
+                              },
+                              "yield": {
+                                "type": "number",
+                                "nullable": true,
+                                "description": "Constant-maturity yield, percent."
+                              },
+                              "asOf": {
+                                "type": "string",
+                                "nullable": true
+                              }
+                            },
+                            "required": [
+                              "maturity",
+                              "months",
+                              "seriesId",
+                              "yield",
+                              "asOf"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "spread2s10s": {
+                              "type": "number",
+                              "nullable": true,
+                              "description": "10Y − 2Y, percentage points."
+                            },
+                            "spread3m10y": {
+                              "type": "number",
+                              "nullable": true,
+                              "description": "10Y − 3M, percentage points."
+                            },
+                            "inverted": {
+                              "type": "boolean",
+                              "description": "True when 2s10s is negative (recession signal)."
+                            },
+                            "asOf": {
+                              "type": "string",
+                              "nullable": true
+                            }
+                          },
+                          "required": [
+                            "spread2s10s",
+                            "spread3m10y",
+                            "inverted",
+                            "asOf"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.00144 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "econ.yield-curve",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.00144,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001440"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/finance/company-facts": {
+      "get": {
+        "tags": [
+          "finance"
+        ],
+        "summary": "Fetch Curated XBRL financial metrics for a US public company",
+        "description": "Curated XBRL financial metrics for a US public company by stock ticker. Pulls SEC EDGAR's companyfacts JSON (per-CIK XBRL filings) and extracts a top-line set of ~15 financial metrics with their most recent annual + quarterly values. Each metric returns: end date, start date (or null for balance-sheet snapshots), value, fiscal year/period, originating form (10-K/10-Q), and filed date. Available metric keys (pass any comma-separated subset via the metrics param, or omit to get all): revenue, grossProfit, operatingIncome, netIncome, eps, epsDiluted, rdExpense, totalAssets, totalLiabilities, stockholdersEquity, cash, longTermDebt, operatingCashFlow, capex, sharesOutstanding. Backed by SEC.gov; underlying data is public-domain US government records.",
+        "operationId": "finance_company-facts",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = curated XBRL metric series (~15 top-line financial facts, each with recent annual + quarterly history); meta = company identity + query echo. For fundamentals + filings + insider trades merged by ticker in one call, see /api/finance/company-profile.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "key": {
+                                "type": "string"
+                              },
+                              "concept": {
+                                "type": "string"
+                              },
+                              "label": {
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "type": "string"
+                              },
+                              "unit": {
+                                "type": "string"
+                              },
+                              "annual": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "end": {
+                                      "type": "string"
+                                    },
+                                    "start": {
+                                      "type": "string",
+                                      "nullable": true
+                                    },
+                                    "val": {
+                                      "type": "number"
+                                    },
+                                    "fiscalYear": {
+                                      "type": "integer"
+                                    },
+                                    "fiscalPeriod": {
+                                      "type": "string"
+                                    },
+                                    "form": {
+                                      "type": "string"
+                                    },
+                                    "filed": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "end",
+                                    "start",
+                                    "val",
+                                    "fiscalYear",
+                                    "fiscalPeriod",
+                                    "form",
+                                    "filed"
+                                  ],
+                                  "additionalProperties": false
+                                }
+                              },
+                              "quarterly": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "end": {
+                                      "type": "string"
+                                    },
+                                    "start": {
+                                      "type": "string",
+                                      "nullable": true
+                                    },
+                                    "val": {
+                                      "type": "number"
+                                    },
+                                    "fiscalYear": {
+                                      "type": "integer"
+                                    },
+                                    "fiscalPeriod": {
+                                      "type": "string"
+                                    },
+                                    "form": {
+                                      "type": "string"
+                                    },
+                                    "filed": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "end",
+                                    "start",
+                                    "val",
+                                    "fiscalYear",
+                                    "fiscalPeriod",
+                                    "form",
+                                    "filed"
+                                  ],
+                                  "additionalProperties": false
+                                }
+                              }
+                            },
+                            "required": [
+                              "key",
+                              "concept",
+                              "label",
+                              "namespace",
+                              "unit",
+                              "annual",
+                              "quarterly"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "query": {
+                              "type": "object",
+                              "properties": {
+                                "ticker": {
+                                  "type": "string"
+                                },
+                                "metrics": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "annualLimit": {
+                                  "type": "number"
+                                },
+                                "quarterlyLimit": {
+                                  "type": "number"
+                                }
+                              },
+                              "required": [
+                                "ticker",
+                                "metrics",
+                                "annualLimit",
+                                "quarterlyLimit"
+                              ],
+                              "additionalProperties": false
+                            },
+                            "cik": {
+                              "type": "string"
+                            },
+                            "ticker": {
+                              "type": "string"
+                            },
+                            "entityName": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "query",
+                            "cik",
+                            "ticker",
+                            "entityName"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0048 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "finance.company-facts",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0048,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.004800"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "ticker",
+            "in": "query",
+            "required": true,
+            "description": "US stock ticker (case-insensitive). Examples: AAPL, GOOGL, BRK.B.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 10,
+              "pattern": "^[A-Za-z][A-Za-z0-9.-]{0,9}$"
+            }
+          },
+          {
+            "name": "metrics",
+            "in": "query",
+            "required": false,
+            "description": "Comma-separated subset of metric keys to return. Available: revenue, grossProfit, operatingIncome, netIncome, eps, epsDiluted, rdExpense, totalAssets, totalLiabilities, stockholdersEquity, cash, longTermDebt, operatingCashFlow, capex, sharesOutstanding. Omit to get all ~15.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 500,
+              "pattern": "^[a-zA-Z]+(,[a-zA-Z]+)*$"
+            }
+          },
+          {
+            "name": "annualLimit",
+            "in": "query",
+            "required": false,
+            "description": "Max annual (FY) values per metric, most recent first. Default 4, max 20.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 20,
+              "default": 4
+            }
+          },
+          {
+            "name": "quarterlyLimit",
+            "in": "query",
+            "required": false,
+            "description": "Max quarterly (Q1-Q4) values per metric, most recent first. Default 4, max 20. Pass 0 to skip quarterly entirely.",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 20,
+              "default": 4
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/finance/company-profile": {
+      "get": {
+        "tags": [
+          "finance"
+        ],
+        "summary": "Fetch Company 360 - a US public company's SEC picture in one",
+        "description": "Company 360 — a US public company's SEC picture in one call by ticker. Merges three SEC sources: recent filings (10-K/10-Q/8-K and all form types, with links), curated XBRL fundamentals (revenue, net income, EPS, assets, etc. — annual + quarterly series), and recent insider transactions (Form 4 buys/sells by officers & directors). Each section reports found/error independently. Equity research, due diligence, monitoring. Pass ticker (required); optional formType filters the filings section, limit caps each list. Individual sources: /api/finance/sec-filings, /api/finance/company-facts, /api/finance/insider-trades.",
+        "operationId": "finance_company-profile",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ticker": {
+                          "type": "string"
+                        },
+                        "filings": {
+                          "type": "object",
+                          "properties": {
+                            "found": {
+                              "type": "boolean"
+                            },
+                            "error": {
+                              "type": "string",
+                              "nullable": true
+                            },
+                            "count": {
+                              "type": "number",
+                              "nullable": true
+                            },
+                            "filings": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "additionalProperties": {}
+                              }
+                            }
+                          },
+                          "required": [
+                            "found",
+                            "error",
+                            "count",
+                            "filings"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "fundamentals": {
+                          "type": "object",
+                          "properties": {
+                            "found": {
+                              "type": "boolean"
+                            },
+                            "error": {
+                              "type": "string",
+                              "nullable": true
+                            },
+                            "entityName": {
+                              "type": "string",
+                              "nullable": true
+                            },
+                            "metrics": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "additionalProperties": {}
+                              }
+                            }
+                          },
+                          "required": [
+                            "found",
+                            "error",
+                            "entityName",
+                            "metrics"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "insiderTrades": {
+                          "type": "object",
+                          "properties": {
+                            "found": {
+                              "type": "boolean"
+                            },
+                            "error": {
+                              "type": "string",
+                              "nullable": true
+                            },
+                            "cik": {
+                              "type": "string",
+                              "nullable": true
+                            },
+                            "count": {
+                              "type": "number",
+                              "nullable": true
+                            },
+                            "filings": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "additionalProperties": {}
+                              }
+                            }
+                          },
+                          "required": [
+                            "found",
+                            "error",
+                            "cik",
+                            "count",
+                            "filings"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "sources": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
+                        }
+                      },
+                      "required": [
+                        "ticker",
+                        "filings",
+                        "fundamentals",
+                        "insiderTrades",
+                        "sources"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.00576 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "finance.company-profile",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.00576,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "legacy",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.005760"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "ticker",
+            "in": "query",
+            "required": true,
+            "description": "Ticker.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 8
+            }
+          },
+          {
+            "name": "formType",
+            "in": "query",
+            "required": false,
+            "description": "Form type.",
+            "schema": {
+              "type": "string",
+              "maxLength": 20
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of results to return.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 50,
+              "default": 10
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/finance/insider-trades": {
+      "get": {
+        "tags": [
+          "finance"
+        ],
+        "summary": "Fetch Recent SEC Form 4 insider transactions for a US public...",
+        "description": "Recent SEC Form 4 insider transactions for a US public company by ticker. Returns parsed transactions: insider name + relationship (director, officer/title, 10%+ owner), transaction date, SEC code (P=purchase, S=sale, A=grant, D=disposition, M=exercise, F=tax-withholding, G=gift), security title, shares, price/share, total USD value, post-transaction balance, direct vs indirect ownership. Each filing pulled separately and parsed from raw XML — bounded by limit (1-10, default 5). Backed by SEC.gov; underlying Form 4 filings are public records. For insider trades + filings + fundamentals merged by ticker in one call, see /api/finance/company-profile.",
+        "operationId": "finance_insider-trades",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = parsed Form 4 filings (owner relationship + per-transaction details); meta = issuer identity + query echo. total is null (items is the fetched window, not the issuer's full Form 4 history).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "accessionNumber": {
+                                "type": "string"
+                              },
+                              "filingDate": {
+                                "type": "string"
+                              },
+                              "periodOfReport": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "formXmlUrl": {
+                                "type": "string",
+                                "format": "uri"
+                              },
+                              "documentUrl": {
+                                "type": "string",
+                                "format": "uri"
+                              },
+                              "reportingOwner": {
+                                "type": "object",
+                                "properties": {
+                                  "cik": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "isDirector": {
+                                    "type": "boolean"
+                                  },
+                                  "isOfficer": {
+                                    "type": "boolean"
+                                  },
+                                  "officerTitle": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "isTenPercentOwner": {
+                                    "type": "boolean"
+                                  },
+                                  "isOther": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "cik",
+                                  "name",
+                                  "isDirector",
+                                  "isOfficer",
+                                  "officerTitle",
+                                  "isTenPercentOwner",
+                                  "isOther"
+                                ],
+                                "additionalProperties": false
+                              },
+                              "transactions": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "securityTitle": {
+                                      "type": "string"
+                                    },
+                                    "transactionDate": {
+                                      "type": "string",
+                                      "nullable": true
+                                    },
+                                    "code": {
+                                      "type": "string",
+                                      "nullable": true
+                                    },
+                                    "acquiredOrDisposed": {
+                                      "type": "string",
+                                      "enum": [
+                                        "A",
+                                        "D"
+                                      ],
+                                      "nullable": true
+                                    },
+                                    "shares": {
+                                      "type": "number",
+                                      "nullable": true
+                                    },
+                                    "pricePerShare": {
+                                      "type": "number",
+                                      "nullable": true
+                                    },
+                                    "totalValueUsd": {
+                                      "type": "number",
+                                      "nullable": true
+                                    },
+                                    "sharesOwnedFollowing": {
+                                      "type": "number",
+                                      "nullable": true
+                                    },
+                                    "ownership": {
+                                      "type": "string",
+                                      "enum": [
+                                        "D",
+                                        "I"
+                                      ],
+                                      "nullable": true
+                                    },
+                                    "isDerivative": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "securityTitle",
+                                    "transactionDate",
+                                    "code",
+                                    "acquiredOrDisposed",
+                                    "shares",
+                                    "pricePerShare",
+                                    "totalValueUsd",
+                                    "sharesOwnedFollowing",
+                                    "ownership",
+                                    "isDerivative"
+                                  ],
+                                  "additionalProperties": false
+                                }
+                              }
+                            },
+                            "required": [
+                              "accessionNumber",
+                              "filingDate",
+                              "periodOfReport",
+                              "formXmlUrl",
+                              "documentUrl",
+                              "reportingOwner",
+                              "transactions"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "query": {
+                              "type": "object",
+                              "properties": {
+                                "ticker": {
+                                  "type": "string"
+                                },
+                                "limit": {
+                                  "type": "number"
+                                }
+                              },
+                              "required": [
+                                "ticker",
+                                "limit"
+                              ],
+                              "additionalProperties": false
+                            },
+                            "cik": {
+                              "type": "string"
+                            },
+                            "ticker": {
+                              "type": "string"
+                            },
+                            "issuerName": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "query",
+                            "cik",
+                            "ticker",
+                            "issuerName"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0072 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "finance.insider-trades",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0072,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.007200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "ticker",
+            "in": "query",
+            "required": true,
+            "description": "US stock ticker (case-insensitive). Examples: AAPL, GOOGL, TSLA.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 10,
+              "pattern": "^[A-Za-z][A-Za-z0-9.-]{0,9}$"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Max Form 4 filings to fetch + parse (1-10). Each is an extra upstream call so we bound this tight. Default 5.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 10,
+              "default": 5
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/finance/sec-filings": {
+      "get": {
+        "tags": [
+          "finance"
+        ],
+        "summary": "Fetch Recent SEC EDGAR filings for a US publicly-traded",
+        "description": "Recent SEC EDGAR filings for a US publicly-traded company by stock ticker. Resolves ticker → CIK via SEC's company_tickers.json, then fetches the company's submissions index from data.sec.gov. Returns company metadata (name, CIK, SIC industry classification, exchanges, fiscal year-end, state of incorporation) plus filings with form type, filing date, report date, accession number, primary-document URL, and filing-index URL. Filter to one form type (10-K, 10-Q, 8-K, 4, 13F-HR, SC 13G, S-1, etc.) via formType param. Default 20 results, max 100. Backed by SEC.gov; underlying filings are public-domain US government records. For filings + fundamentals + insider trades merged by ticker in one call, see /api/finance/company-profile.",
+        "operationId": "finance_sec-filings",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = recent SEC filings with direct document URLs; meta.company = issuer metadata. total is null (EDGAR's \"recent\" window is not the company's full filing history).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "accessionNumber": {
+                                "type": "string"
+                              },
+                              "form": {
+                                "type": "string"
+                              },
+                              "filingDate": {
+                                "type": "string"
+                              },
+                              "reportDate": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "acceptanceDateTime": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "primaryDocument": {
+                                "type": "string"
+                              },
+                              "documentUrl": {
+                                "type": "string",
+                                "format": "uri"
+                              },
+                              "filingIndexUrl": {
+                                "type": "string",
+                                "format": "uri"
+                              },
+                              "isXBRL": {
+                                "type": "boolean"
+                              },
+                              "size": {
+                                "type": "integer"
+                              }
+                            },
+                            "required": [
+                              "accessionNumber",
+                              "form",
+                              "filingDate",
+                              "reportDate",
+                              "acceptanceDateTime",
+                              "primaryDocument",
+                              "documentUrl",
+                              "filingIndexUrl",
+                              "isXBRL",
+                              "size"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "query": {
+                              "type": "object",
+                              "properties": {
+                                "ticker": {
+                                  "type": "string"
+                                },
+                                "formType": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "limit": {
+                                  "type": "number"
+                                }
+                              },
+                              "required": [
+                                "ticker",
+                                "formType",
+                                "limit"
+                              ],
+                              "additionalProperties": false
+                            },
+                            "company": {
+                              "type": "object",
+                              "properties": {
+                                "cik": {
+                                  "type": "string"
+                                },
+                                "ticker": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "sicDescription": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "exchanges": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                },
+                                "fiscalYearEnd": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "stateOfIncorporation": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "category": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "website": {
+                                  "type": "string",
+                                  "nullable": true
+                                }
+                              },
+                              "required": [
+                                "cik",
+                                "ticker",
+                                "name",
+                                "sicDescription",
+                                "exchanges",
+                                "fiscalYearEnd",
+                                "stateOfIncorporation",
+                                "category",
+                                "website"
+                              ],
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "query",
+                            "company"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0036 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "finance.sec-filings",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0036,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.003600"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "ticker",
+            "in": "query",
+            "required": true,
+            "description": "Stock ticker symbol (case-insensitive). Examples: AAPL, GOOGL, BRK.B, JNJ.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 10,
+              "pattern": "^[A-Za-z][A-Za-z0-9.-]{0,9}$"
+            }
+          },
+          {
+            "name": "formType",
+            "in": "query",
+            "required": false,
+            "description": "Optional filter to a single SEC form type, e.g., \"10-K\", \"10-Q\", \"8-K\", \"13F-HR\", \"4\", \"S-1\", \"SC 13G\".",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 20,
+              "pattern": "^[A-Za-z0-9./-]+$"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Max filings to return (1-100). Default 20.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 20
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/finance/thirteen-f": {
+      "get": {
+        "tags": [
+          "finance"
+        ],
+        "summary": "Fetch Parsed institutional holdings from a 13F-HR filing.",
+        "description": "Parsed institutional holdings from a 13F-HR filing. By investment-manager CIK (e.g. 1067983 = Berkshire Hathaway). Returns each holding's nameOfIssuer, cusip, market value (whole USD per the modern Form 13F convention), shares/principal amount + type, putCall flag for options, and voting authority (sole/shared/none). Sorted by value descending. Pass formType for amendments (13F-HR/A) or non-filings (13F-NT). Backed by SEC.gov; underlying 13F filings are public records.",
+        "operationId": "finance_thirteen-f",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = top N institutional holdings sorted by value descending; total = positions in the filing before the cap; meta = manager identity, source filing, filing-wide total value, query echo.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "nameOfIssuer": {
+                                "type": "string"
+                              },
+                              "titleOfClass": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "cusip": {
+                                "type": "string"
+                              },
+                              "valueUsd": {
+                                "type": "number"
+                              },
+                              "sharesOrPrinAmt": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "sharesOrPrinAmtType": {
+                                "type": "string",
+                                "enum": [
+                                  "SH",
+                                  "PRN"
+                                ],
+                                "nullable": true
+                              },
+                              "investmentDiscretion": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "putCall": {
+                                "type": "string",
+                                "enum": [
+                                  "PUT",
+                                  "CALL"
+                                ],
+                                "nullable": true
+                              },
+                              "votingAuthority": {
+                                "type": "object",
+                                "properties": {
+                                  "sole": {
+                                    "type": "number",
+                                    "nullable": true
+                                  },
+                                  "shared": {
+                                    "type": "number",
+                                    "nullable": true
+                                  },
+                                  "none": {
+                                    "type": "number",
+                                    "nullable": true
+                                  }
+                                },
+                                "required": [
+                                  "sole",
+                                  "shared",
+                                  "none"
+                                ],
+                                "additionalProperties": false
+                              }
+                            },
+                            "required": [
+                              "nameOfIssuer",
+                              "titleOfClass",
+                              "cusip",
+                              "valueUsd",
+                              "sharesOrPrinAmt",
+                              "sharesOrPrinAmtType",
+                              "investmentDiscretion",
+                              "putCall",
+                              "votingAuthority"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "query": {
+                              "type": "object",
+                              "properties": {
+                                "managerCik": {
+                                  "type": "string"
+                                },
+                                "formType": {
+                                  "type": "string"
+                                },
+                                "limit": {
+                                  "type": "number"
+                                }
+                              },
+                              "required": [
+                                "managerCik",
+                                "formType",
+                                "limit"
+                              ],
+                              "additionalProperties": false
+                            },
+                            "cik": {
+                              "type": "string"
+                            },
+                            "managerName": {
+                              "type": "string"
+                            },
+                            "filing": {
+                              "type": "object",
+                              "properties": {
+                                "accessionNumber": {
+                                  "type": "string"
+                                },
+                                "form": {
+                                  "type": "string"
+                                },
+                                "filingDate": {
+                                  "type": "string"
+                                },
+                                "periodOfReport": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "infoTableUrl": {
+                                  "type": "string",
+                                  "format": "uri"
+                                },
+                                "documentUrl": {
+                                  "type": "string",
+                                  "format": "uri"
+                                }
+                              },
+                              "required": [
+                                "accessionNumber",
+                                "form",
+                                "filingDate",
+                                "periodOfReport",
+                                "infoTableUrl",
+                                "documentUrl"
+                              ],
+                              "additionalProperties": false
+                            },
+                            "totalValueUsd": {
+                              "type": "number"
+                            }
+                          },
+                          "required": [
+                            "query",
+                            "cik",
+                            "managerName",
+                            "filing",
+                            "totalValueUsd"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0072 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "finance.thirteen-f",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0072,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.007200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "managerCik",
+            "in": "query",
+            "required": true,
+            "description": "Investment manager's CIK (numeric). Berkshire Hathaway=1067983, Renaissance=1037389, Bridgewater=1350694, Vanguard=102909, BlackRock=1364742.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 10,
+              "pattern": "^\\d+$"
+            }
+          },
+          {
+            "name": "formType",
+            "in": "query",
+            "required": false,
+            "description": "13F filing variant. Default 13F-HR (original report). Use 13F-HR/A for amendments, 13F-NT for notice of non-filings.",
+            "schema": {
+              "type": "string",
+              "minLength": 3,
+              "maxLength": 20,
+              "pattern": "^13F-[A-Z/]{2,10}$",
+              "default": "13F-HR"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Max holdings to return, sorted by value descending. (1-200). Default 25.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 200,
+              "default": 25
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/fx/rates": {
+      "get": {
+        "tags": [
+          "fx"
+        ],
+        "summary": "Fetch Daily reference exchange rates from the European",
+        "description": "Daily reference exchange rates from the European Central Bank (via Frankfurter). 30+ major currencies. Pass base = 3-letter ISO 4217 currency (default USD), optional symbols = comma-separated target codes (default = all available), optional date = YYYY-MM-DD for historical rates (history back to 1999, business days only; omit for latest), optional amount to convert (default 1). Returns base, date, amount, and a map of currency code → rate.",
+        "operationId": "fx_rates",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = [{ currency, rate }] for each target currency (rate already scaled by amount); total = number of target currencies; meta carries base, date, amount.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "currency": {
+                                "type": "string"
+                              },
+                              "rate": {
+                                "type": "number"
+                              }
+                            },
+                            "required": [
+                              "currency",
+                              "rate"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "base": {
+                              "type": "string"
+                            },
+                            "date": {
+                              "type": "string"
+                            },
+                            "amount": {
+                              "type": "number"
+                            }
+                          },
+                          "required": [
+                            "base",
+                            "date",
+                            "amount"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "fx.rates",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "base",
+            "in": "query",
+            "required": false,
+            "description": "Base.",
+            "schema": {
+              "type": "string",
+              "pattern": "^[A-Za-z]{3}$",
+              "default": "USD"
+            }
+          },
+          {
+            "name": "symbols",
+            "in": "query",
+            "required": false,
+            "description": "Symbols.",
+            "schema": {
+              "type": "string",
+              "minLength": 3,
+              "maxLength": 200
+            }
+          },
+          {
+            "name": "date",
+            "in": "query",
+            "required": false,
+            "description": "Date in YYYY-MM-DD format.",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+            }
+          },
+          {
+            "name": "amount",
+            "in": "query",
+            "required": false,
+            "description": "Amount.",
+            "schema": {
+              "type": "number",
+              "exclusiveMinimum": true,
+              "minimum": 0,
+              "maximum": 1000000000,
+              "default": 1
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/fx/timeseries": {
+      "get": {
+        "tags": [
+          "fx"
+        ],
+        "summary": "Fetch Historical daily exchange-rate series from",
+        "description": "Historical daily exchange-rate series from the European Central Bank (via Frankfurter), with computed summary statistics. Pass base = 3-letter ISO 4217 currency (default USD), start = YYYY-MM-DD, optional end = YYYY-MM-DD (default = latest available), optional symbols = comma-separated target codes (default all), optional amount to scale rates (default 1). Range is capped at 366 days. Returns, per target currency, first/last/min/max/mean rate plus absolute and percentage change over the window, alongside the full daily series. ECB publishes on business days only; weekends and holidays are omitted.",
+        "operationId": "fx_timeseries",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = per-currency summary stats (first/last/min/max/mean/change/pctChange/count); total = number of target currencies; meta carries base, resolved start/end, amount, observation count, and the full daily series keyed by date.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "currency": {
+                                "type": "string"
+                              },
+                              "first": {
+                                "type": "number"
+                              },
+                              "last": {
+                                "type": "number"
+                              },
+                              "min": {
+                                "type": "number"
+                              },
+                              "max": {
+                                "type": "number"
+                              },
+                              "mean": {
+                                "type": "number"
+                              },
+                              "change": {
+                                "type": "number"
+                              },
+                              "pctChange": {
+                                "type": "number"
+                              },
+                              "count": {
+                                "type": "number"
+                              }
+                            },
+                            "required": [
+                              "currency",
+                              "first",
+                              "last",
+                              "min",
+                              "max",
+                              "mean",
+                              "change",
+                              "pctChange",
+                              "count"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "base": {
+                              "type": "string"
+                            },
+                            "start": {
+                              "type": "string"
+                            },
+                            "end": {
+                              "type": "string"
+                            },
+                            "amount": {
+                              "type": "number"
+                            },
+                            "observations": {
+                              "type": "number"
+                            },
+                            "series": {
+                              "type": "object",
+                              "additionalProperties": {
+                                "type": "object",
+                                "additionalProperties": {
+                                  "type": "number"
+                                }
+                              }
+                            }
+                          },
+                          "required": [
+                            "base",
+                            "start",
+                            "end",
+                            "amount",
+                            "observations",
+                            "series"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.00144 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "fx.timeseries",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.00144,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001440"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "base",
+            "in": "query",
+            "required": false,
+            "description": "Base currency (3-letter ISO 4217). Default USD.",
+            "schema": {
+              "type": "string",
+              "pattern": "^[A-Za-z]{3}$",
+              "default": "USD"
+            }
+          },
+          {
+            "name": "symbols",
+            "in": "query",
+            "required": false,
+            "description": "Comma-separated target currency codes. Default: all available.",
+            "schema": {
+              "type": "string",
+              "minLength": 3,
+              "maxLength": 200
+            }
+          },
+          {
+            "name": "start",
+            "in": "query",
+            "required": true,
+            "description": "Inclusive start date YYYY-MM-DD.",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+            }
+          },
+          {
+            "name": "end",
+            "in": "query",
+            "required": false,
+            "description": "Inclusive end date YYYY-MM-DD. Default: latest available.",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+            }
+          },
+          {
+            "name": "amount",
+            "in": "query",
+            "required": false,
+            "description": "Amount of base currency to scale rates by. Default 1.",
+            "schema": {
+              "type": "number",
+              "exclusiveMinimum": true,
+              "minimum": 0,
+              "maximum": 1000000000,
+              "default": 1
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/inflation/calculator": {
+      "get": {
+        "tags": [
+          "inflation"
+        ],
+        "summary": "Calculate a US dollar amount for inflation between two dates...",
+        "description": "Adjust a US dollar amount for inflation between two dates ('what is $100 in 1990 worth today?'). Pass amount, from (YYYY-MM-DD or YYYY), and optional to (defaults to the latest CPI month). Uses CPI-U (CPIAUCNS — the same not-seasonally-adjusted all-items index as the official BLS inflation calculator), data back to 1913. Returns the inflation-adjusted amount, cumulative inflation %, annualized rate, and the CPI index values used on each date. Source: BLS CPI via FRED (St. Louis Fed).",
+        "operationId": "inflation_calculator",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = [the inflation-adjusted result]; total = 1.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "amount": {
+                                "type": "number"
+                              },
+                              "from": {
+                                "type": "string"
+                              },
+                              "to": {
+                                "type": "string"
+                              },
+                              "adjustedAmount": {
+                                "type": "number"
+                              },
+                              "cumulativeInflationPct": {
+                                "type": "number"
+                              },
+                              "annualizedPct": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "cpiFrom": {
+                                "type": "number"
+                              },
+                              "cpiFromDate": {
+                                "type": "string"
+                              },
+                              "cpiTo": {
+                                "type": "number"
+                              },
+                              "cpiToDate": {
+                                "type": "string"
+                              },
+                              "seriesId": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "amount",
+                              "from",
+                              "to",
+                              "adjustedAmount",
+                              "cumulativeInflationPct",
+                              "annualizedPct",
+                              "cpiFrom",
+                              "cpiFromDate",
+                              "cpiTo",
+                              "cpiToDate",
+                              "seriesId"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "inflation.calculator",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "amount",
+            "in": "query",
+            "required": true,
+            "description": "Amount.",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "from",
+            "in": "query",
+            "required": true,
+            "description": "Start of the range.",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}(-\\d{2}(-\\d{2})?)?$"
+            }
+          },
+          {
+            "name": "to",
+            "in": "query",
+            "required": false,
+            "description": "End of the range.",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}(-\\d{2}(-\\d{2})?)?$"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/inflation/expectations": {
+      "get": {
+        "tags": [
+          "inflation"
+        ],
+        "summary": "Fetch Current US inflation expectations - what markets and...",
+        "description": "Current US inflation expectations — what markets and consumers expect future inflation to be. Returns the 5-year and 10-year TIPS breakeven rates, the 5-Year/5-Year forward inflation expectation (the Fed-watched long-run gauge), and the University of Michigan 1-year consumer inflation expectation. Each value is a percent as of its latest date. Market-based breakevens update daily. Source: Federal Reserve / Treasury via FRED (St. Louis Fed).",
+        "operationId": "inflation_expectations",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = expectation gauges (each a percent); total = gauges returned.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "measure": {
+                                "type": "string"
+                              },
+                              "seriesId": {
+                                "type": "string"
+                              },
+                              "label": {
+                                "type": "string"
+                              },
+                              "rate": {
+                                "type": "number",
+                                "nullable": true,
+                                "description": "Expected inflation, percent."
+                              },
+                              "asOf": {
+                                "type": "string",
+                                "nullable": true
+                              }
+                            },
+                            "required": [
+                              "measure",
+                              "seriesId",
+                              "label",
+                              "rate",
+                              "asOf"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "inflation.expectations",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/inflation/hicp": {
+      "get": {
+        "tags": [
+          "inflation"
+        ],
+        "summary": "Fetch EU harmonized inflation - the latest HICP annual rate",
+        "description": "EU harmonized inflation — the latest HICP annual rate of change (the official, cross-country-comparable inflation rate) for the EU, euro area, and each member state. Pass country as a Eurostat geo code (DE, FR, EL for Greece, EA20 = euro area, EU27_2020 = EU) for one, or omit for all (sorted highest inflation first). All-items index (COICOP CP00). Source: Eurostat (free, no key). For US inflation use inflation.rates.",
+        "operationId": "inflation_hicp",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = HICP annual rates by geo (all-items); total = rows returned.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "geo": {
+                                "type": "string",
+                                "description": "Eurostat geo code."
+                              },
+                              "area": {
+                                "type": "string",
+                                "description": "Country / aggregate name."
+                              },
+                              "annualRatePct": {
+                                "type": "number",
+                                "nullable": true,
+                                "description": "HICP annual rate of change (inflation rate), percent."
+                              },
+                              "period": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "Reference month (YYYY-MM)."
+                              }
+                            },
+                            "required": [
+                              "geo",
+                              "area",
+                              "annualRatePct",
+                              "period"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "inflation.hicp",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "country",
+            "in": "query",
+            "required": false,
+            "description": "Country name or ISO country code.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 10,
+              "pattern": "^[A-Za-z0-9_]+$"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/inflation/rates": {
+      "get": {
+        "tags": [
+          "inflation"
+        ],
+        "summary": "Fetch Current US inflation rates by measure, with the index",
+        "description": "Current US inflation rates by measure, with the index level plus computed year-over-year and month-over-month % change. Pass measure for one, or omit for all. Measures: cpi, cpi-nsa, core-cpi, cpi-w, pce, core-pce, ppi, cpi-food, cpi-energy, cpi-shelter, cpi-medical, import-prices, export-prices — i.e. headline CPI (SA + NSA), core CPI, CPI-W, PCE, core PCE (the Fed's 2% target gauge), PPI final demand, and CPI by category (food, energy, shelter, medical) + import/export prices. The YoY change is the headline \"inflation rate\". Each result names the FRED series ID used. Source: BLS/BEA via FRED (St. Louis Fed). For raw access to any other series use bls.series; this is the curated, rate-computed layer.",
+        "operationId": "inflation_rates",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = inflation measures (index + YoY/MoM); total = measures returned.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "measure": {
+                                "type": "string"
+                              },
+                              "seriesId": {
+                                "type": "string"
+                              },
+                              "label": {
+                                "type": "string"
+                              },
+                              "index": {
+                                "type": "number",
+                                "nullable": true,
+                                "description": "The price-index level."
+                              },
+                              "asOf": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "Date of the latest observation."
+                              },
+                              "changeMoM": {
+                                "type": "number",
+                                "nullable": true,
+                                "description": "% change vs the prior period."
+                              },
+                              "changeYoY": {
+                                "type": "number",
+                                "nullable": true,
+                                "description": "% change vs ~1 year earlier — the inflation rate."
+                              }
+                            },
+                            "required": [
+                              "measure",
+                              "seriesId",
+                              "label",
+                              "index",
+                              "asOf",
+                              "changeMoM",
+                              "changeYoY"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.00144 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "inflation.rates",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.00144,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001440"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "measure",
+            "in": "query",
+            "required": false,
+            "description": "Measure.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "cpi",
+                "cpi-nsa",
+                "core-cpi",
+                "cpi-w",
+                "pce",
+                "core-pce",
+                "ppi",
+                "cpi-food",
+                "cpi-energy",
+                "cpi-shelter",
+                "cpi-medical",
+                "import-prices",
+                "export-prices"
+              ]
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/stocks/quote": {
+      "get": {
+        "tags": [
+          "stocks"
+        ],
+        "summary": "Fetch Latest daily stock quote for a US-listed ticker.",
+        "description": "Latest daily stock quote for a US-listed ticker. Returns the most recent completed trading session: open, high, low, close, volume, VWAP, and trade count, plus the change and percent change versus the prior session, and company reference data (name, primary exchange, security type, currency, market cap). NOTE: this plan tier serves end-of-day / delayed data (the response flags delayed=true), suitable for daily snapshots, fundamentals context, and post-close analysis rather than real-time trading. Pass ticker as a US symbol (e.g. AAPL, MSFT, BRK.B). Market data by Massive (formerly Polygon.io).",
+        "operationId": "stocks_quote",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = [one ticker’s latest daily quote with change vs prior session + company metadata]; total = 1.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "ticker": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "exchange": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "Primary listing exchange MIC, e.g. XNAS, XNYS."
+                              },
+                              "type": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "Security type, e.g. CS (common stock), ETF."
+                              },
+                              "currency": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "marketCapUSD": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "date": {
+                                "type": "string",
+                                "description": "Date of the latest completed daily bar (yyyy-mm-dd)."
+                              },
+                              "open": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "high": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "low": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "close": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "volume": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "vwap": {
+                                "type": "number",
+                                "nullable": true,
+                                "description": "Volume-weighted average price for the bar."
+                              },
+                              "transactions": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "previousClose": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "change": {
+                                "type": "number",
+                                "nullable": true,
+                                "description": "close − previousClose."
+                              },
+                              "changePercent": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "delayed": {
+                                "type": "boolean",
+                                "description": "True — this tier serves end-of-day / delayed data, not real-time."
+                              }
+                            },
+                            "required": [
+                              "ticker",
+                              "name",
+                              "exchange",
+                              "type",
+                              "currency",
+                              "marketCapUSD",
+                              "date",
+                              "open",
+                              "high",
+                              "low",
+                              "close",
+                              "volume",
+                              "vwap",
+                              "transactions",
+                              "previousClose",
+                              "change",
+                              "changePercent",
+                              "delayed"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0018 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "stocks.quote",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0018,
+          "tier": 2
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001800"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "ticker",
+            "in": "query",
+            "required": true,
+            "description": "US-listed ticker symbol.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 12,
+              "pattern": "^[A-Za-z][A-Za-z0-9.\\-]{0,11}$"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/tax/vat": {
+      "get": {
+        "tags": [
+          "tax"
+        ],
+        "summary": "Validate a European Union VAT number against the official...",
+        "description": "Validate a European Union VAT number against the official VIES (VAT Information Exchange System) register in real time. Confirms whether the VAT identifier is currently registered for intra-EU trade and, when the member state discloses them, returns the registered business name and address. Covers the 27 EU member states (Greece as EL) plus Northern Ireland (XI); Great Britain (GB) is not in VIES. Pass either a full identifier (vat=DE811569869) or country + number. Returns {valid, countryCode, vatNumber, name, address, requestDate, reason}. When a member-state register is temporarily down, returns a retryable 503 rather than a false negative. Data from the European Commission VIES service.",
+        "operationId": "tax_vat",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = [VAT check result]; total = 1.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "input": {
+                                "type": "string"
+                              },
+                              "valid": {
+                                "type": "boolean",
+                                "description": "True only when VIES confirms the number is currently registered."
+                              },
+                              "countryCode": {
+                                "type": "string"
+                              },
+                              "vatNumber": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "Registered legal name, when the member state discloses it."
+                              },
+                              "address": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "Registered address (single line), when disclosed."
+                              },
+                              "requestDate": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "VIES request timestamp (ISO 8601)."
+                              },
+                              "reason": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "Why valid is false, when applicable."
+                              }
+                            },
+                            "required": [
+                              "input",
+                              "valid",
+                              "countryCode",
+                              "vatNumber",
+                              "name",
+                              "address",
+                              "requestDate",
+                              "reason"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.001 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "tax.vat",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.001,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "vat",
+            "in": "query",
+            "required": false,
+            "description": "Full VAT identifier: 2-letter country prefix + number, e.g. \"DE811569869\" or \"NL810433941B01\" (spaces/dots/hyphens allowed).",
+            "schema": {
+              "type": "string",
+              "minLength": 3,
+              "maxLength": 20
+            }
+          },
+          {
+            "name": "country",
+            "in": "query",
+            "required": false,
+            "description": "2-letter VAT country prefix, e.g. \"DE\". Greece is EL (GR also accepted); Northern Ireland is XI. Use with number.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 2
+            }
+          },
+          {
+            "name": "number",
+            "in": "query",
+            "required": false,
+            "description": "The VAT number without the country prefix, e.g. \"811569869\". Use with country.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 18
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/tax/vat-rates": {
+      "get": {
+        "tags": [
+          "tax"
+        ],
+        "summary": "Fetch Current EU VAT rates by member state - standard rate",
+        "description": "Current EU VAT rates by member state — standard rate plus reduced/super-reduced/parking/zero rates. Pass `country` (ISO 2-letter; Greece is EL) for one state, or omit it for all 27. Each result returns the standard rate, the list of reduced rates in force, every rate category with its percentage, and the date the rates are in force. Source: European Commission TEDB (Taxes in Europe Database), refreshed regularly. Pairs with tax.vat (which validates a specific VAT number against the live VIES register).",
+        "operationId": "tax_vat-rates",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = per-member-state VAT rate summaries; total = number of states returned.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "memberState": {
+                                "type": "string",
+                                "description": "ISO 2-letter member-state code (Greece = EL)."
+                              },
+                              "standardRate": {
+                                "type": "number",
+                                "nullable": true,
+                                "description": "Standard VAT rate (%)."
+                              },
+                              "reducedRates": {
+                                "type": "array",
+                                "items": {
+                                  "type": "number"
+                                },
+                                "description": "Reduced rates in force (%), ascending."
+                              },
+                              "categories": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "category": {
+                                      "type": "string"
+                                    },
+                                    "rate": {
+                                      "type": "number"
+                                    }
+                                  },
+                                  "required": [
+                                    "category",
+                                    "rate"
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                "description": "Every rate category (STANDARD/REDUCED/…) with its percentage."
+                              },
+                              "situationOn": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "Date the rates are in force (YYYY-MM-DD)."
+                              }
+                            },
+                            "required": [
+                              "memberState",
+                              "standardRate",
+                              "reducedRates",
+                              "categories",
+                              "situationOn"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.001 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "tax.vat-rates",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.001,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "country",
+            "in": "query",
+            "required": false,
+            "description": "Country name or ISO country code.",
+            "schema": {
+              "type": "string",
+              "pattern": "^[A-Za-z]{2}$"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/treasury/cash": {
+      "get": {
+        "tags": [
+          "treasury"
+        ],
+        "summary": "Fetch Daily Treasury Statement (DTS) operating cash balance",
+        "description": "Daily Treasury Statement (DTS) operating cash balance via US Treasury Fiscal Data. Returns daily snapshots of the Treasury General Account (TGA) at the Federal Reserve plus tax-and-loan accounts and Federal Reserve deposit accounts. Each row carries record_date, account_type, close_today_bal, open_today_bal, open_month_bal, open_fiscal_year_bal. Useful for liquidity-tracking agents and macro researchers watching the Treasury Cash Balance heading into Treasury auctions, debt-ceiling pinch-points, etc. Fiscal Data filter syntax.",
+        "operationId": "treasury_cash",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = Daily Treasury Statement cash balance.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "page": {
+                          "type": "object",
+                          "properties": {
+                            "number": {
+                              "type": "integer"
+                            },
+                            "size": {
+                              "type": "integer"
+                            },
+                            "pages": {
+                              "type": "integer",
+                              "nullable": true
+                            }
+                          },
+                          "required": [
+                            "number",
+                            "size",
+                            "pages"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "additionalProperties": {}
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "treasury.cash",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "fields",
+            "in": "query",
+            "required": false,
+            "description": "Fields.",
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-z][a-z0-9_]*(,[a-z][a-z0-9_]*)*$",
+              "maxLength": 400
+            }
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "description": "Filter.",
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-z][a-z0-9_]*:(eq|ne|lt|lte|gt|gte|in):[A-Za-z0-9._:\\-+/, ]+(,[a-z][a-z0-9_]*:(eq|ne|lt|lte|gt|gte|in):[A-Za-z0-9._:\\-+/, ]+)*$",
+              "maxLength": 800
+            }
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "required": false,
+            "description": "Field to sort results by.",
+            "schema": {
+              "type": "string",
+              "pattern": "^-?[a-z][a-z0-9_]*(,-?[a-z][a-z0-9_]*)*$",
+              "maxLength": 200
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "description": "Number of results to return per page.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 10000,
+              "default": 100
+            }
+          },
+          {
+            "name": "pageNumber",
+            "in": "query",
+            "required": false,
+            "description": "Page number (1-based) for paginated results.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/treasury/debt": {
+      "get": {
+        "tags": [
+          "treasury"
+        ],
+        "summary": "Fetch US National Debt - daily \"Debt to the Penny\" via US...",
+        "description": "US National Debt — daily \"Debt to the Penny\" via US Treasury Fiscal Data. Each row carries record_date, debt held by public, intragovernmental holdings, and total public debt outstanding (all USD, signed integers as strings to preserve precision). Optional `filter` uses Fiscal Data syntax: `col:op:val` joined by commas (ops: eq, lt, lte, gt, gte, in). Default sort is `-record_date` (newest first). Authoritative source for \"how much does the US owe?\" — every weekday since 1993.",
+        "operationId": "treasury_debt",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = Daily Debt to the Penny.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "page": {
+                          "type": "object",
+                          "properties": {
+                            "number": {
+                              "type": "integer"
+                            },
+                            "size": {
+                              "type": "integer"
+                            },
+                            "pages": {
+                              "type": "integer",
+                              "nullable": true
+                            }
+                          },
+                          "required": [
+                            "number",
+                            "size",
+                            "pages"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "additionalProperties": {}
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "treasury.debt",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "fields",
+            "in": "query",
+            "required": false,
+            "description": "Fields.",
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-z][a-z0-9_]*(,[a-z][a-z0-9_]*)*$",
+              "maxLength": 400
+            }
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "description": "Filter.",
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-z][a-z0-9_]*:(eq|ne|lt|lte|gt|gte|in):[A-Za-z0-9._:\\-+/, ]+(,[a-z][a-z0-9_]*:(eq|ne|lt|lte|gt|gte|in):[A-Za-z0-9._:\\-+/, ]+)*$",
+              "maxLength": 800
+            }
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "required": false,
+            "description": "Field to sort results by.",
+            "schema": {
+              "type": "string",
+              "pattern": "^-?[a-z][a-z0-9_]*(,-?[a-z][a-z0-9_]*)*$",
+              "maxLength": 200
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "description": "Number of results to return per page.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 10000,
+              "default": 100
+            }
+          },
+          {
+            "name": "pageNumber",
+            "in": "query",
+            "required": false,
+            "description": "Page number (1-based) for paginated results.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/treasury/exchange-rates": {
+      "get": {
+        "tags": [
+          "treasury"
+        ],
+        "summary": "Fetch Official US Treasury exchange rates via US Treasury",
+        "description": "Official US Treasury exchange rates via US Treasury Fiscal Data. Used by federal agencies to report foreign-currency transactions in USD. Quarterly + ad-hoc updates per country/currency pair. Each row carries record_date, country, currency, country_currency_desc, exchange_rate, effective_date. Pair with `/api/fx/rates` (ECB Frankfurter, daily market rates) for cross-validation. Use Fiscal Data filter syntax — e.g. `filter=country:eq:Brazil` to scope to a single country.",
+        "operationId": "treasury_exchange-rates",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = Official Treasury exchange rates.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "page": {
+                          "type": "object",
+                          "properties": {
+                            "number": {
+                              "type": "integer"
+                            },
+                            "size": {
+                              "type": "integer"
+                            },
+                            "pages": {
+                              "type": "integer",
+                              "nullable": true
+                            }
+                          },
+                          "required": [
+                            "number",
+                            "size",
+                            "pages"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "additionalProperties": {}
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "treasury.exchange-rates",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "fields",
+            "in": "query",
+            "required": false,
+            "description": "Fields.",
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-z][a-z0-9_]*(,[a-z][a-z0-9_]*)*$",
+              "maxLength": 400
+            }
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "description": "Filter.",
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-z][a-z0-9_]*:(eq|ne|lt|lte|gt|gte|in):[A-Za-z0-9._:\\-+/, ]+(,[a-z][a-z0-9_]*:(eq|ne|lt|lte|gt|gte|in):[A-Za-z0-9._:\\-+/, ]+)*$",
+              "maxLength": 800
+            }
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "required": false,
+            "description": "Field to sort results by.",
+            "schema": {
+              "type": "string",
+              "pattern": "^-?[a-z][a-z0-9_]*(,-?[a-z][a-z0-9_]*)*$",
+              "maxLength": 200
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "description": "Number of results to return per page.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 10000,
+              "default": 100
+            }
+          },
+          {
+            "name": "pageNumber",
+            "in": "query",
+            "required": false,
+            "description": "Page number (1-based) for paginated results.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/treasury/monthly-statement": {
+      "get": {
+        "tags": [
+          "treasury"
+        ],
+        "summary": "Fetch Monthly Treasury Statement (MTS) - Table 4: receipts",
+        "description": "Monthly Treasury Statement (MTS) — Table 4: receipts by source via US Treasury Fiscal Data. Returns monthly totals of federal government receipts grouped by classification (individual income tax, corporate income tax, social-insurance receipts, excise, customs, estate-and-gift, miscellaneous). Each row carries record_date, classification_id, classification_desc, current_month + current_fytd (fiscal year-to-date) gross_rcpt / refund / net_rcpt amounts, plus prior_fytd comparisons. Backbone of any \"how much money is the federal government bringing in\" question. Use Fiscal Data filter syntax.",
+        "operationId": "treasury_monthly-statement",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = Monthly Treasury Statement (Table 4) — federal receipts by source.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "page": {
+                          "type": "object",
+                          "properties": {
+                            "number": {
+                              "type": "integer"
+                            },
+                            "size": {
+                              "type": "integer"
+                            },
+                            "pages": {
+                              "type": "integer",
+                              "nullable": true
+                            }
+                          },
+                          "required": [
+                            "number",
+                            "size",
+                            "pages"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "additionalProperties": {}
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "treasury.monthly-statement",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "fields",
+            "in": "query",
+            "required": false,
+            "description": "Fields.",
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-z][a-z0-9_]*(,[a-z][a-z0-9_]*)*$",
+              "maxLength": 400
+            }
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "description": "Filter.",
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-z][a-z0-9_]*:(eq|ne|lt|lte|gt|gte|in):[A-Za-z0-9._:\\-+/, ]+(,[a-z][a-z0-9_]*:(eq|ne|lt|lte|gt|gte|in):[A-Za-z0-9._:\\-+/, ]+)*$",
+              "maxLength": 800
+            }
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "required": false,
+            "description": "Field to sort results by.",
+            "schema": {
+              "type": "string",
+              "pattern": "^-?[a-z][a-z0-9_]*(,-?[a-z][a-z0-9_]*)*$",
+              "maxLength": 200
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "description": "Number of results to return per page.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 10000,
+              "default": 100
+            }
+          },
+          {
+            "name": "pageNumber",
+            "in": "query",
+            "required": false,
+            "description": "Page number (1-based) for paginated results.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/worldbank/indicator": {
+      "get": {
+        "tags": [
+          "worldbank"
+        ],
+        "summary": "Fetch World Bank Open Data - fetch a time series",
+        "description": "World Bank Open Data — fetch a time series of a specific indicator for a country (or 'all'). 1000+ indicators across 200+ countries, many series going back to 1960. Indicator codes are dotted-token strings, e.g., NY.GDP.MKTP.CD (GDP current US$), SP.POP.TOTL (population total), FP.CPI.TOTL.ZG (inflation CPI annual %), SL.UEM.TOTL.ZS (unemployment %), SE.ADT.LITR.ZS (adult literacy %), SP.DYN.LE00.IN (life expectancy). Country = ISO 2-letter (e.g., US, CN), ISO 3-letter (USA, CHN), or 'all'. Optional yearFrom/yearTo bracket. Each observation: country id+name, year, numeric value (may be null for missing), obsStatus. Returns indicator name + total count + pagination metadata.",
+        "operationId": "worldbank_indicator",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = indicator observations (countryId, year, value); total = upstream total observation count; page = current page; meta carries indicator id/name + query echo.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "countryId": {
+                                "type": "string"
+                              },
+                              "countryName": {
+                                "type": "string"
+                              },
+                              "year": {
+                                "type": "integer"
+                              },
+                              "value": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "obsStatus": {
+                                "type": "string",
+                                "nullable": true
+                              }
+                            },
+                            "required": [
+                              "countryId",
+                              "countryName",
+                              "year",
+                              "value",
+                              "obsStatus"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "page": {
+                          "type": "object",
+                          "properties": {
+                            "number": {
+                              "type": "integer"
+                            },
+                            "size": {
+                              "type": "integer"
+                            },
+                            "pages": {
+                              "type": "integer",
+                              "nullable": true
+                            }
+                          },
+                          "required": [
+                            "number",
+                            "size",
+                            "pages"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "query": {
+                              "type": "object",
+                              "properties": {
+                                "country": {
+                                  "type": "string"
+                                },
+                                "indicator": {
+                                  "type": "string"
+                                },
+                                "yearFrom": {
+                                  "type": "integer",
+                                  "nullable": true
+                                },
+                                "yearTo": {
+                                  "type": "integer",
+                                  "nullable": true
+                                },
+                                "limit": {
+                                  "type": "integer"
+                                },
+                                "page": {
+                                  "type": "integer"
+                                }
+                              },
+                              "required": [
+                                "country",
+                                "indicator",
+                                "yearFrom",
+                                "yearTo",
+                                "limit",
+                                "page"
+                              ],
+                              "additionalProperties": false
+                            },
+                            "indicatorId": {
+                              "type": "string"
+                            },
+                            "indicatorName": {
+                              "type": "string",
+                              "nullable": true
+                            },
+                            "lastUpdated": {
+                              "type": "string",
+                              "nullable": true
+                            }
+                          },
+                          "required": [
+                            "query",
+                            "indicatorId",
+                            "indicatorName",
+                            "lastUpdated"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "worldbank.indicator",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "country",
+            "in": "query",
+            "required": true,
+            "description": "Country name or ISO country code.",
+            "schema": {
+              "type": "string",
+              "pattern": "^([A-Za-z]{2,3}|all)$"
+            }
+          },
+          {
+            "name": "indicator",
+            "in": "query",
+            "required": true,
+            "description": "Indicator.",
+            "schema": {
+              "type": "string",
+              "pattern": "^[A-Za-z0-9.]{3,40}$"
+            }
+          },
+          {
+            "name": "yearFrom",
+            "in": "query",
+            "required": false,
+            "description": "Year from.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1960,
+              "maximum": 2100
+            }
+          },
+          {
+            "name": "yearTo",
+            "in": "query",
+            "required": false,
+            "description": "Year to.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1960,
+              "maximum": 2100
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of results to return.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 50
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "description": "Page number (1-based) for paginated results.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 1
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/providers/2s/geo/PAY.md
+++ b/providers/2s/geo/PAY.md
@@ -1,0 +1,17 @@
+---
+name: geo
+title: "2s Geo"
+description: "Geographic and environmental data: forward/reverse geocoding, IP geolocation, elevation, timezones, points of interest, parks; weather forecasts and history, climate stations, tide and river gauges, earthquakes, and energy/solar resources."
+use_case: "Use for geocoding addresses, resolving coordinates to places, and fetching weather, climate, tide, earthquake, or timezone data for a location."
+category: maps
+service_url: https://2s.io
+openapi:
+  path: openapi.json
+---
+
+Part of 2s — a unified, agent-native JSON API. Pay per call in USDC on Solana (or Base) via x402; no accounts, no API keys. Add `?trial=1` (or header `X-2s-Trial: 1`) for one free real call per endpoint per hour.
+
+## Spend-aware usage
+
+- Prefer narrow lookups (by id/code) over broad searches; reuse identifiers across calls.
+- Cap result `limit` to the smallest count that answers the task.

--- a/providers/2s/geo/openapi.json
+++ b/providers/2s/geo/openapi.json
@@ -1,0 +1,6765 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "2s",
+    "version": "1",
+    "description": "Unified JSON REST API for AI agents — an ever-expanding catalog of endpoints, pay per call in USDC on Base or Solana via x402, no accounts, no API keys. Fund a wallet on either chain with USDC, hit any endpoint, and your client signs an EIP-3009 authorization (Base) or a partial SPL transfer (Solana) to settle the call. Try before you buy: add ?trial=1 (or header X-2s-Trial: 1) to any endpoint for one free real call per endpoint per hour — no wallet needed — to verify it works before paying. 2s is an open-ended experiment in maximally-comprehensive agent infrastructure — new endpoints land regularly.",
+    "contact": {
+      "name": "2s",
+      "url": "https://2s.io",
+      "email": "alley@2s.io"
+    }
+  },
+  "servers": [
+    {
+      "url": "https://2s.io"
+    }
+  ],
+  "components": {
+    "parameters": {
+      "TrialMode": {
+        "name": "trial",
+        "in": "query",
+        "required": false,
+        "description": "Try before you buy. Set to 1 for one free real call per endpoint per hour — no wallet or payment needed — to verify the endpoint before paying. Equivalent to sending the \"X-2s-Trial: 1\" request header. Works on every endpoint.",
+        "schema": {
+          "type": "integer",
+          "enum": [
+            1
+          ]
+        }
+      }
+    },
+    "securitySchemes": {
+      "x402Payment": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "PAYMENT-SIGNATURE",
+        "description": "x402 protocol v2: base64-encoded PaymentPayload. Call any paid endpoint without auth to receive a 402 with a multi-network PaymentRequirements envelope. Sign for either rail: EIP-3009 transferWithAuthorization (Base USDC) OR a partial SPL token transfer (Solana USDC). Retry with PAYMENT-SIGNATURE header. X-PAYMENT is also accepted for v1 buyer clients. See https://x402.org."
+      }
+    },
+    "schemas": {
+      "X402PaymentRequiredV2": {
+        "type": "object",
+        "description": "x402 v2 PaymentRequired envelope. Pick any entry from accepts[], sign for that rail, retry with the PAYMENT-SIGNATURE header.",
+        "required": [
+          "x402Version",
+          "accepts"
+        ],
+        "properties": {
+          "x402Version": {
+            "type": "integer",
+            "const": 2
+          },
+          "error": {
+            "type": "string",
+            "description": "Human-readable reason payment is required."
+          },
+          "resource": {
+            "type": "string",
+            "description": "The resource URL being purchased."
+          },
+          "accepts": {
+            "type": "array",
+            "description": "Payment requirement options, one per supported network (Base USDC, Solana USDC).",
+            "items": {
+              "type": "object",
+              "required": [
+                "scheme",
+                "network",
+                "amount",
+                "asset",
+                "payTo",
+                "maxTimeoutSeconds"
+              ],
+              "properties": {
+                "scheme": {
+                  "type": "string",
+                  "enum": [
+                    "exact"
+                  ]
+                },
+                "network": {
+                  "type": "string",
+                  "description": "CAIP-2 network id, e.g. \"eip155:8453\" (Base) or \"solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp\"."
+                },
+                "amount": {
+                  "type": "string",
+                  "description": "Price in atomic asset units (USDC has 6 decimals)."
+                },
+                "asset": {
+                  "type": "string",
+                  "description": "Asset contract address / mint."
+                },
+                "payTo": {
+                  "type": "string",
+                  "description": "Treasury address to pay."
+                },
+                "maxTimeoutSeconds": {
+                  "type": "integer"
+                },
+                "extra": {
+                  "type": "object",
+                  "description": "Rail-specific extras (EVM: EIP-712 domain name/version; Solana: feePayer).",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "extensions": {
+            "type": "object",
+            "description": "Optional discovery metadata (e.g. bazaar input/output schemas).",
+            "additionalProperties": true
+          }
+        }
+      }
+    }
+  },
+  "paths": {
+    "/api/climate/station-history": {
+      "get": {
+        "tags": [
+          "climate"
+        ],
+        "summary": "Fetch Historical daily weather observations from NOAA",
+        "description": "Historical daily weather observations from NOAA GHCN-Daily for one station and date range (up to 366 days per call): max/min/avg temperature (°C), precipitation (mm), snowfall and snow depth (mm), wind (m/s). Coverage reaches back to the 1800s for long-running stations — actual measured values for \"what was the weather on this date\", not model recall. Pass a GHCN station id (e.g. USW00094728 = NYC Central Park); find the nearest station for any coordinate with /api/climate/station-near first. dataTypes selects elements (default TMAX,TMIN,PRCP). NOAA public-domain data.",
+        "operationId": "climate_station-history",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = daily observations for one GHCN station (date + element→value map); total = days with at least one reported value; meta carries station id/name, range, and requested element codes.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "date": {
+                                "type": "string"
+                              },
+                              "values": {
+                                "type": "object",
+                                "additionalProperties": {
+                                  "type": "number",
+                                  "nullable": true
+                                },
+                                "description": "Element code → metric value (°C / mm / m/s); null when not reported that day."
+                              }
+                            },
+                            "required": [
+                              "date",
+                              "values"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "station": {
+                              "type": "string"
+                            },
+                            "stationName": {
+                              "type": "string",
+                              "nullable": true
+                            },
+                            "startDate": {
+                              "type": "string"
+                            },
+                            "endDate": {
+                              "type": "string"
+                            },
+                            "dataTypes": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "required": [
+                            "station",
+                            "stationName",
+                            "startDate",
+                            "endDate",
+                            "dataTypes"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "climate.station-history",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "station",
+            "in": "query",
+            "required": true,
+            "description": "GHCN-Daily station id (11 chars). Find one with /api/climate/station-near.",
+            "schema": {
+              "type": "string",
+              "pattern": "^[A-Z0-9]{11}$"
+            }
+          },
+          {
+            "name": "startDate",
+            "in": "query",
+            "required": true,
+            "description": "Start of the date range (YYYY-MM-DD).",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+            }
+          },
+          {
+            "name": "endDate",
+            "in": "query",
+            "required": true,
+            "description": "End of the date range (YYYY-MM-DD).",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+            }
+          },
+          {
+            "name": "dataTypes",
+            "in": "query",
+            "required": false,
+            "description": "Comma-separated element codes (TMAX, TMIN, TAVG, PRCP, SNOW, SNWD, AWND, WSF2, WSF5, EVAP). Default TMAX,TMIN,PRCP.",
+            "schema": {
+              "allOf": [
+                {
+                  "anyOf": [
+                    {
+                      "not": {}
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "default": "TMAX,TMIN,PRCP"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "TMAX",
+                      "TMIN",
+                      "TAVG",
+                      "PRCP",
+                      "SNOW",
+                      "SNWD",
+                      "AWND",
+                      "WSF2",
+                      "WSF5",
+                      "EVAP"
+                    ]
+                  },
+                  "minItems": 1,
+                  "maxItems": 10
+                }
+              ]
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/climate/station-near": {
+      "get": {
+        "tags": [
+          "climate"
+        ],
+        "summary": "Find NOAA GHCN-Daily weather stations near a coordinate.",
+        "description": "Find NOAA GHCN-Daily weather stations near a coordinate. Returns up to 100 stations within a configurable radius (default 500 km), sorted by distance. Each station includes id, name, lat/lon, elevation, country/state, and GSN/HCN/WMO flags. Backed by a ~132k-station registry refreshed monthly from ncei.noaa.gov.",
+        "operationId": "climate_station-near",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = NOAA GHCN-Daily stations near the coordinate, sorted by distance; total = null (query-bounded set); meta.query echoes the search.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "location": {
+                                "type": "object",
+                                "properties": {
+                                  "latitude": {
+                                    "type": "number"
+                                  },
+                                  "longitude": {
+                                    "type": "number"
+                                  },
+                                  "elevationM": {
+                                    "type": "number",
+                                    "nullable": true
+                                  },
+                                  "state": {
+                                    "type": "string",
+                                    "nullable": true
+                                  }
+                                },
+                                "required": [
+                                  "latitude",
+                                  "longitude",
+                                  "elevationM",
+                                  "state"
+                                ],
+                                "additionalProperties": false
+                              },
+                              "distanceKm": {
+                                "type": "number",
+                                "description": "Great-circle distance to (lat, lon), kilometers."
+                              },
+                              "flags": {
+                                "type": "object",
+                                "properties": {
+                                  "gsn": {},
+                                  "hcn": {},
+                                  "wmo": {}
+                                },
+                                "additionalProperties": false
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "name",
+                              "location",
+                              "distanceKm",
+                              "flags"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "query": {
+                              "type": "object",
+                              "properties": {
+                                "latitude": {
+                                  "type": "number"
+                                },
+                                "longitude": {
+                                  "type": "number"
+                                },
+                                "radiusKm": {
+                                  "type": "number"
+                                },
+                                "limit": {
+                                  "type": "integer"
+                                }
+                              },
+                              "required": [
+                                "latitude",
+                                "longitude",
+                                "radiusKm",
+                                "limit"
+                              ],
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "query"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.001 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "climate.station-near",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.001,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "lat",
+            "in": "query",
+            "required": true,
+            "description": "Latitude in decimal degrees (WGS84).",
+            "schema": {
+              "type": "number",
+              "minimum": -90,
+              "maximum": 90
+            }
+          },
+          {
+            "name": "lon",
+            "in": "query",
+            "required": true,
+            "description": "Longitude in decimal degrees (WGS84).",
+            "schema": {
+              "type": "number",
+              "minimum": -180,
+              "maximum": 180
+            }
+          },
+          {
+            "name": "radius_km",
+            "in": "query",
+            "required": false,
+            "description": "Search radius in kilometers.",
+            "schema": {
+              "type": "number",
+              "minimum": 1,
+              "maximum": 5000
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of results to return.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/country/lookup": {
+      "get": {
+        "tags": [
+          "country"
+        ],
+        "summary": "Look up country metadata via REST Countries.",
+        "description": "Look up country metadata via REST Countries. Pass alpha2 (2-letter ISO 3166-1), alpha3 (3-letter), or name (with optional fullText=true for exact match). Returns common + official name, ISO codes, region + subregion, independence + UN-member flags, capital(s), population, area km², landlocked flag, neighboring borders (alpha-3), timezones, currencies (code → name + symbol), languages, calling code, flag emoji + SVG/PNG URLs, lat/lng coordinates, Google Maps + OSM URLs, driving side, top-level domains.",
+        "operationId": "country_lookup",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = matched country records (usually one for code lookups, several for name fuzzy match); total = number matched; meta.query echoes the lookup.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "type": "object",
+                                "properties": {
+                                  "common": {
+                                    "type": "string"
+                                  },
+                                  "official": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "common",
+                                  "official"
+                                ],
+                                "additionalProperties": false
+                              },
+                              "alpha2": {
+                                "type": "string"
+                              },
+                              "alpha3": {
+                                "type": "string"
+                              },
+                              "numericCode": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "cioc": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "region": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "subregion": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "independent": {
+                                "type": "boolean",
+                                "nullable": true
+                              },
+                              "unMember": {
+                                "type": "boolean",
+                                "nullable": true
+                              },
+                              "capital": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "population": {
+                                "type": "integer",
+                                "nullable": true
+                              },
+                              "areaKm2": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "landlocked": {
+                                "type": "boolean",
+                                "nullable": true
+                              },
+                              "borders": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "timezones": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "currencies": {
+                                "type": "object",
+                                "additionalProperties": {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "symbol": {
+                                      "type": "string",
+                                      "nullable": true
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "symbol"
+                                  ],
+                                  "additionalProperties": false
+                                }
+                              },
+                              "languages": {
+                                "type": "object",
+                                "additionalProperties": {
+                                  "type": "string"
+                                }
+                              },
+                              "callingCode": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "flag": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "flagSvg": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "flagPng": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "coordinates": {
+                                "type": "object",
+                                "properties": {
+                                  "lat": {
+                                    "type": "number"
+                                  },
+                                  "lng": {
+                                    "type": "number"
+                                  }
+                                },
+                                "required": [
+                                  "lat",
+                                  "lng"
+                                ],
+                                "additionalProperties": false,
+                                "nullable": true
+                              },
+                              "googleMapsUrl": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "openStreetMapsUrl": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "drivingSide": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "tld": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "required": [
+                              "name",
+                              "alpha2",
+                              "alpha3",
+                              "numericCode",
+                              "cioc",
+                              "region",
+                              "subregion",
+                              "independent",
+                              "unMember",
+                              "capital",
+                              "population",
+                              "areaKm2",
+                              "landlocked",
+                              "borders",
+                              "timezones",
+                              "currencies",
+                              "languages",
+                              "callingCode",
+                              "flag",
+                              "flagSvg",
+                              "flagPng",
+                              "coordinates",
+                              "googleMapsUrl",
+                              "openStreetMapsUrl",
+                              "drivingSide",
+                              "tld"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "query": {
+                              "type": "object",
+                              "properties": {
+                                "alpha2": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "alpha3": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "name": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "fullText": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "alpha2",
+                                "alpha3",
+                                "name",
+                                "fullText"
+                              ],
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "query"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "country.lookup",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "alpha2",
+            "in": "query",
+            "required": false,
+            "description": "Alpha2.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 2,
+              "pattern": "^[A-Za-z]{2}$"
+            }
+          },
+          {
+            "name": "alpha3",
+            "in": "query",
+            "required": false,
+            "description": "Alpha3.",
+            "schema": {
+              "type": "string",
+              "minLength": 3,
+              "maxLength": 3,
+              "pattern": "^[A-Za-z]{3}$"
+            }
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "description": "Name to search for.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 80
+            }
+          },
+          {
+            "name": "fullText",
+            "in": "query",
+            "required": false,
+            "description": "Full text.",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/earth/events": {
+      "get": {
+        "tags": [
+          "earth"
+        ],
+        "summary": "Fetch Global natural events tracker via NASA EONET v3 (Earth...",
+        "description": "Global natural events tracker via NASA EONET v3 (Earth Observatory Natural Event Tracker). Returns active and historical events curated by NASA EOSDIS: wildfires, severe storms, volcanoes, floods, droughts, landslides, sea/lake ice, dust/haze, manmade incidents, water-color anomalies. Each event includes geo-located observation points with timestamps, source attribution (USGS, NWS, IRWIN, GDACS, etc.), and category. Filter by status (open/closed/all), days-back window, category, or bounding box.",
+        "operationId": "earth_events",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = NASA EONET natural events (id, title, categories, sources, geometry); total = null (EONET reports no global total); meta.title is the feed label, meta.fetched is the count returned.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string"
+                              },
+                              "title": {
+                                "type": "string"
+                              },
+                              "description": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "link": {
+                                "type": "string"
+                              },
+                              "closed": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "categories": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "id": {
+                                      "type": "string"
+                                    },
+                                    "title": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "id",
+                                    "title"
+                                  ],
+                                  "additionalProperties": false
+                                }
+                              },
+                              "sources": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "id": {
+                                      "type": "string"
+                                    },
+                                    "url": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "id",
+                                    "url"
+                                  ],
+                                  "additionalProperties": false
+                                }
+                              },
+                              "geometry": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "date": {
+                                      "type": "string"
+                                    },
+                                    "type": {
+                                      "type": "string"
+                                    },
+                                    "coordinates": {},
+                                    "magnitudeValue": {
+                                      "type": "number",
+                                      "nullable": true
+                                    },
+                                    "magnitudeUnit": {
+                                      "type": "string",
+                                      "nullable": true
+                                    }
+                                  },
+                                  "required": [
+                                    "date",
+                                    "type"
+                                  ],
+                                  "additionalProperties": false
+                                }
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "title",
+                              "description",
+                              "link",
+                              "closed",
+                              "categories",
+                              "sources",
+                              "geometry"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "title": {
+                              "type": "string"
+                            },
+                            "fetched": {
+                              "type": "integer"
+                            }
+                          },
+                          "required": [
+                            "title",
+                            "fetched"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "earth.events",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "description": "Filter results by status.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "open",
+                "closed",
+                "all"
+              ],
+              "default": "open"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of results to return.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 200,
+              "default": 20
+            }
+          },
+          {
+            "name": "days",
+            "in": "query",
+            "required": false,
+            "description": "Look-back window, in days.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 365
+            }
+          },
+          {
+            "name": "category",
+            "in": "query",
+            "required": false,
+            "description": "Filter results by category.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "drought",
+                "dustHaze",
+                "earthquakes",
+                "floods",
+                "landslides",
+                "manmade",
+                "seaLakeIce",
+                "severeStorms",
+                "snow",
+                "tempExtremes",
+                "volcanoes",
+                "waterColor",
+                "wildfires"
+              ]
+            }
+          },
+          {
+            "name": "bbox",
+            "in": "query",
+            "required": false,
+            "description": "Bbox.",
+            "schema": {
+              "type": "string",
+              "pattern": "^-?\\d+(\\.\\d+)?,-?\\d+(\\.\\d+)?,-?\\d+(\\.\\d+)?,-?\\d+(\\.\\d+)?$"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/earth/now": {
+      "get": {
+        "tags": [
+          "earth"
+        ],
+        "summary": "Fetch Situational awareness for a coordinate: recent",
+        "description": "Situational awareness for a coordinate: recent earthquakes (USGS) and active wildfires (NIFC) within a configurable radius. Returns each with distance-from-query in km, sorted nearest-first. Multi-source synthesis from free US Government feeds. Real-time, post-training data.",
+        "operationId": "earth_now",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = [snapshot] (one composite situational-awareness object: query echo, summary counts, earthquakes[], wildfires[]); total = 1; meta.errors holds per-source failures, meta.sources lists each contributing feed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "errors": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "source": {
+                                    "type": "string"
+                                  },
+                                  "message": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "source",
+                                  "message"
+                                ],
+                                "additionalProperties": false
+                              }
+                            },
+                            "sources": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "provider": {
+                                    "type": "string"
+                                  },
+                                  "license": {
+                                    "type": "string"
+                                  },
+                                  "url": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name",
+                                  "provider",
+                                  "license",
+                                  "url"
+                                ],
+                                "additionalProperties": false
+                              }
+                            }
+                          },
+                          "required": [
+                            "errors",
+                            "sources"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "earth.now",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "lat",
+            "in": "query",
+            "required": true,
+            "description": "Latitude in decimal degrees (WGS84).",
+            "schema": {
+              "type": "number",
+              "minimum": -90,
+              "maximum": 90
+            }
+          },
+          {
+            "name": "lon",
+            "in": "query",
+            "required": true,
+            "description": "Longitude in decimal degrees (WGS84).",
+            "schema": {
+              "type": "number",
+              "minimum": -180,
+              "maximum": 180
+            }
+          },
+          {
+            "name": "radius_km",
+            "in": "query",
+            "required": false,
+            "description": "Search radius in kilometers.",
+            "schema": {
+              "type": "number",
+              "minimum": 1,
+              "maximum": 1000,
+              "default": 500
+            }
+          },
+          {
+            "name": "hours",
+            "in": "query",
+            "required": false,
+            "description": "Look-back window, in hours.",
+            "schema": {
+              "type": "number",
+              "minimum": 1,
+              "maximum": 168,
+              "default": 24
+            }
+          },
+          {
+            "name": "min_magnitude",
+            "in": "query",
+            "required": false,
+            "description": "Minimum magnitude to include.",
+            "schema": {
+              "type": "number",
+              "minimum": 0,
+              "maximum": 10,
+              "default": 2
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/energy/fuel-stations": {
+      "get": {
+        "tags": [
+          "energy"
+        ],
+        "summary": "Find alternative-fuel stations across the US via NREL...",
+        "description": "Locate alternative-fuel stations across the US via NREL Alternative Fuels Data Center. Search by lat/lon + radius (miles), state, or zip. Filter by fuelType (BD=Biodiesel | CNG=Compressed Natural Gas | ELEC=Electric vehicle charging | E85=Ethanol | HY=Hydrogen | LNG=Liquefied Natural Gas | LPG=Propane | RD=Renewable Diesel), status (E=Available | P=Planned | T=Temporarily Unavailable), access (public/private), and EV network. For EV chargers, returns connector types (J1772, CHAdeMO, Tesla, etc.), Level 1/2/DC-fast counts, pricing, and access hours. Indispensable for trip-planning agents, fleet logistics, EV-adoption analysis.",
+        "operationId": "energy_fuel-stations",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = matched alternative-fuel stations; total = upstream total result count; meta.stationLocatorUrl = AFDC map link.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "stationLocatorUrl": {
+                              "type": "string",
+                              "nullable": true
+                            }
+                          },
+                          "required": [
+                            "stationLocatorUrl"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "energy.fuel-stations",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "lat",
+            "in": "query",
+            "required": false,
+            "description": "Latitude in decimal degrees (WGS84).",
+            "schema": {
+              "type": "number",
+              "minimum": -90,
+              "maximum": 90
+            }
+          },
+          {
+            "name": "lon",
+            "in": "query",
+            "required": false,
+            "description": "Longitude in decimal degrees (WGS84).",
+            "schema": {
+              "type": "number",
+              "minimum": -180,
+              "maximum": 180
+            }
+          },
+          {
+            "name": "radius",
+            "in": "query",
+            "required": false,
+            "description": "Search radius around the given point.",
+            "schema": {
+              "type": "number",
+              "minimum": 0.1,
+              "maximum": 500
+            }
+          },
+          {
+            "name": "fuelType",
+            "in": "query",
+            "required": false,
+            "description": "Fuel type.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "state",
+            "in": "query",
+            "required": false,
+            "description": "US state — two-letter postal abbreviation (e.g. CA) or full name.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 2,
+              "pattern": "^[A-Za-z]{2}$"
+            }
+          },
+          {
+            "name": "zip",
+            "in": "query",
+            "required": false,
+            "description": "US ZIP code.",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{5}$"
+            }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "description": "Filter results by status.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "all",
+                "E",
+                "P",
+                "T"
+              ]
+            }
+          },
+          {
+            "name": "accessCode",
+            "in": "query",
+            "required": false,
+            "description": "Access code.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "all",
+                "public",
+                "private"
+              ]
+            }
+          },
+          {
+            "name": "network",
+            "in": "query",
+            "required": false,
+            "description": "Network.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 80
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of results to return.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 200,
+              "default": 25
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/energy/solar-resource": {
+      "get": {
+        "tags": [
+          "energy"
+        ],
+        "summary": "Get average solar resource estimates for any...",
+        "description": "Get average solar resource estimates for any latitude/longitude via NREL. Returns annual + monthly averages for: Direct Normal Irradiance (DNI, kWh/m²/day — solar concentrators), Global Horizontal Irradiance (GHI, kWh/m²/day — flat-plate panels), and Tilted-At-Latitude irradiance (optimal fixed-panel orientation). Sourced from NREL National Solar Radiation Database (NSRDB). Useful for rooftop solar feasibility, off-grid design, and renewable-energy modeling.",
+        "operationId": "energy_solar-resource",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = [one solar-resource reading for the point] (annual + monthly DNI/GHI/tilted irradiance); total = 1.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "lat": {
+                                "type": "number"
+                              },
+                              "lon": {
+                                "type": "number"
+                              },
+                              "outputs": {
+                                "type": "object",
+                                "properties": {
+                                  "directNormalIrradianceKWhM2Day": {
+                                    "type": "object",
+                                    "properties": {
+                                      "annual": {
+                                        "type": "number",
+                                        "nullable": true
+                                      },
+                                      "monthly": {
+                                        "type": "object",
+                                        "additionalProperties": {
+                                          "type": "number"
+                                        }
+                                      }
+                                    },
+                                    "required": [
+                                      "annual",
+                                      "monthly"
+                                    ],
+                                    "additionalProperties": false
+                                  },
+                                  "globalHorizontalIrradianceKWhM2Day": {
+                                    "type": "object",
+                                    "properties": {
+                                      "annual": {
+                                        "type": "number",
+                                        "nullable": true
+                                      },
+                                      "monthly": {
+                                        "type": "object",
+                                        "additionalProperties": {
+                                          "type": "number"
+                                        }
+                                      }
+                                    },
+                                    "required": [
+                                      "annual",
+                                      "monthly"
+                                    ],
+                                    "additionalProperties": false
+                                  },
+                                  "tiltedAtLatitudeKWhM2Day": {
+                                    "type": "object",
+                                    "properties": {
+                                      "annual": {
+                                        "type": "number",
+                                        "nullable": true
+                                      },
+                                      "monthly": {
+                                        "type": "object",
+                                        "additionalProperties": {
+                                          "type": "number"
+                                        }
+                                      }
+                                    },
+                                    "required": [
+                                      "annual",
+                                      "monthly"
+                                    ],
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "required": [
+                                  "directNormalIrradianceKWhM2Day",
+                                  "globalHorizontalIrradianceKWhM2Day",
+                                  "tiltedAtLatitudeKWhM2Day"
+                                ],
+                                "additionalProperties": false
+                              },
+                              "sources": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "warnings": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "required": [
+                              "lat",
+                              "lon",
+                              "outputs",
+                              "sources",
+                              "warnings"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "energy.solar-resource",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "lat",
+            "in": "query",
+            "required": true,
+            "description": "Latitude in decimal degrees (WGS84).",
+            "schema": {
+              "type": "number",
+              "minimum": -90,
+              "maximum": 90
+            }
+          },
+          {
+            "name": "lon",
+            "in": "query",
+            "required": true,
+            "description": "Longitude in decimal degrees (WGS84).",
+            "schema": {
+              "type": "number",
+              "minimum": -180,
+              "maximum": 180
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/geo/elevation": {
+      "get": {
+        "tags": [
+          "geo"
+        ],
+        "summary": "Fetch Ground elevation above sea level for a coordinate",
+        "description": "Ground elevation above sea level for a coordinate, anywhere on Earth. Pass lat + lon. Returns elevation in meters and feet (from the Copernicus/SRTM digital elevation model, ~90m resolution). Source: Open-Meteo elevation API (keyless, CC BY 4.0).",
+        "operationId": "geo_elevation",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = [elevation for the point]; total = 1.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "lat": {
+                                "type": "number"
+                              },
+                              "lon": {
+                                "type": "number"
+                              },
+                              "elevationMeters": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "elevationFeet": {
+                                "type": "number",
+                                "nullable": true
+                              }
+                            },
+                            "required": [
+                              "lat",
+                              "lon",
+                              "elevationMeters",
+                              "elevationFeet"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.001 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "geo.elevation",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.001,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "lat",
+            "in": "query",
+            "required": true,
+            "description": "Latitude in decimal degrees (WGS84).",
+            "schema": {
+              "type": "number",
+              "minimum": -90,
+              "maximum": 90
+            }
+          },
+          {
+            "name": "lon",
+            "in": "query",
+            "required": true,
+            "description": "Longitude in decimal degrees (WGS84).",
+            "schema": {
+              "type": "number",
+              "minimum": -180,
+              "maximum": 180
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/geo/ip": {
+      "get": {
+        "tags": [
+          "geo"
+        ],
+        "summary": "Fetch Geolocate a single IPv4 or IPv6 address.",
+        "description": "Geolocate a single IPv4 or IPv6 address. Returns country (name + ISO code), region (name + code), city, ZIP, lat/lon, timezone, ISP, organization, and AS number + name. For bulk lookups (up to 100 IPs in one call) use /api/ipinfo/bulk instead. Lat/lon precision is city-level, not GPS.",
+        "operationId": "geo_ip",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = [geolocation] (ip, country, region, city, postalCode, coords, timezone, network); total = 1.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.001 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "geo.ip",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.001,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "ip",
+            "in": "query",
+            "required": true,
+            "description": "IP.",
+            "schema": {
+              "type": "string",
+              "pattern": "^(\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}|[0-9a-fA-F:]+)$",
+              "minLength": 2,
+              "maxLength": 45
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/geo/nearby": {
+      "get": {
+        "tags": [
+          "geo"
+        ],
+        "summary": "Fetch Everything around a coordinate in one call: nearby",
+        "description": "Everything around a coordinate in one call: nearby airports (IATA/ICAO, type, distance), public K-12 schools (name, district, enrollment, distance), NOAA climate stations (for chaining into /api/climate/station-history), and earthquakes from the past week (magnitude, depth, time). Pass lat/lon plus optional radiusKm (default 25, max 200) and per-category limit (default 5). Each category returns an independent found/error block, so one slow source never empties the rest. Site assessment, relocation research, travel planning, and risk screening. Each category is also a standalone endpoint (/api/airport/near, /api/edu/school-lookup, /api/climate/station-near, /api/quakes/recent).",
+        "operationId": "geo_nearby",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Per-category nearby blocks (airports, schools, climate stations, recent quakes) around a coordinate.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "lat": {
+                          "type": "number"
+                        },
+                        "lon": {
+                          "type": "number"
+                        },
+                        "radiusKm": {
+                          "type": "number"
+                        },
+                        "airports": {
+                          "type": "object",
+                          "properties": {
+                            "found": {
+                              "type": "boolean"
+                            },
+                            "error": {
+                              "type": "string",
+                              "nullable": true
+                            },
+                            "count": {
+                              "type": "number"
+                            },
+                            "items": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "additionalProperties": {}
+                              }
+                            }
+                          },
+                          "required": [
+                            "found",
+                            "error",
+                            "count",
+                            "items"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "schools": {
+                          "type": "object",
+                          "properties": {
+                            "found": {
+                              "type": "boolean"
+                            },
+                            "error": {
+                              "type": "string",
+                              "nullable": true
+                            },
+                            "count": {
+                              "type": "number"
+                            },
+                            "items": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "additionalProperties": {}
+                              }
+                            }
+                          },
+                          "required": [
+                            "found",
+                            "error",
+                            "count",
+                            "items"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "climateStations": {
+                          "type": "object",
+                          "properties": {
+                            "found": {
+                              "type": "boolean"
+                            },
+                            "error": {
+                              "type": "string",
+                              "nullable": true
+                            },
+                            "count": {
+                              "type": "number"
+                            },
+                            "items": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "additionalProperties": {}
+                              }
+                            }
+                          },
+                          "required": [
+                            "found",
+                            "error",
+                            "count",
+                            "items"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "quakes": {
+                          "type": "object",
+                          "properties": {
+                            "found": {
+                              "type": "boolean"
+                            },
+                            "error": {
+                              "type": "string",
+                              "nullable": true
+                            },
+                            "count": {
+                              "type": "number"
+                            },
+                            "items": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "additionalProperties": {}
+                              }
+                            }
+                          },
+                          "required": [
+                            "found",
+                            "error",
+                            "count",
+                            "items"
+                          ],
+                          "additionalProperties": false,
+                          "description": "Earthquakes within radiusKm (min 50km search radius) from the past 7 days, magnitude ≥ 2."
+                        },
+                        "sources": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "provider": {
+                                "type": "string"
+                              },
+                              "url": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "provider",
+                              "url"
+                            ],
+                            "additionalProperties": false
+                          }
+                        }
+                      },
+                      "required": [
+                        "lat",
+                        "lon",
+                        "radiusKm",
+                        "airports",
+                        "schools",
+                        "climateStations",
+                        "quakes",
+                        "sources"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0036 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "geo.nearby",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0036,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "legacy",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.003600"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "lat",
+            "in": "query",
+            "required": true,
+            "description": "Latitude in decimal degrees (WGS84).",
+            "schema": {
+              "type": "number",
+              "minimum": -90,
+              "maximum": 90
+            }
+          },
+          {
+            "name": "lon",
+            "in": "query",
+            "required": true,
+            "description": "Longitude in decimal degrees (WGS84).",
+            "schema": {
+              "type": "number",
+              "minimum": -180,
+              "maximum": 180
+            }
+          },
+          {
+            "name": "radiusKm",
+            "in": "query",
+            "required": false,
+            "description": "Radius km.",
+            "schema": {
+              "type": "number",
+              "minimum": 1,
+              "maximum": 200,
+              "default": 25
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of results to return.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 20,
+              "default": 5
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/geo/postal": {
+      "get": {
+        "tags": [
+          "geo"
+        ],
+        "summary": "Resolve a postal/ZIP code to its place name(s)...",
+        "description": "Resolve a postal/ZIP code to its place name(s), administrative divisions, and coordinates. Pass `postalCode` and a 2-letter `country` (default US). Returns each matching locality: place, admin1 (state/province name + code), admin2 (county/district), and lat/lon. International — covers major markets (US, GB, CA, DE, FR, AU, NL, ES, IT, CH, SE, MX). Use it to normalize and enrich addresses, derive the state/county for a ZIP, or geolocate a postal code in an ETL pipeline.",
+        "operationId": "geo_postal",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = matching localities for the postal code; total = items.length. 404-equivalent is an empty items array.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "country": {
+                                "type": "string"
+                              },
+                              "postalCode": {
+                                "type": "string"
+                              },
+                              "place": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "admin1": {
+                                "type": "object",
+                                "properties": {
+                                  "name": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "code": {
+                                    "type": "string",
+                                    "nullable": true
+                                  }
+                                },
+                                "required": [
+                                  "name",
+                                  "code"
+                                ],
+                                "additionalProperties": false,
+                                "description": "State/province."
+                              },
+                              "admin2": {
+                                "type": "object",
+                                "properties": {
+                                  "name": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "code": {
+                                    "type": "string",
+                                    "nullable": true
+                                  }
+                                },
+                                "required": [
+                                  "name",
+                                  "code"
+                                ],
+                                "additionalProperties": false,
+                                "description": "County/district."
+                              },
+                              "coords": {
+                                "type": "object",
+                                "properties": {
+                                  "lat": {
+                                    "type": "number"
+                                  },
+                                  "lon": {
+                                    "type": "number"
+                                  }
+                                },
+                                "required": [
+                                  "lat",
+                                  "lon"
+                                ],
+                                "additionalProperties": false,
+                                "nullable": true
+                              }
+                            },
+                            "required": [
+                              "country",
+                              "postalCode",
+                              "place",
+                              "admin1",
+                              "admin2",
+                              "coords"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.001 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "geo.postal",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.001,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "postalCode",
+            "in": "query",
+            "required": true,
+            "description": "Postal code.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 16
+            }
+          },
+          {
+            "name": "country",
+            "in": "query",
+            "required": false,
+            "description": "Country name or ISO country code.",
+            "schema": {
+              "type": "string",
+              "pattern": "^[A-Za-z]{2}$"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/geocode/address": {
+      "get": {
+        "tags": [
+          "geocode"
+        ],
+        "summary": "Resolve a street address to coordinates (geocode)",
+        "description": "Forward geocoding — free-text address or place name → latitude/longitude plus structured address components (houseNumber, road, suburb, city, county, state, postcode, country, countryCode). Query: q (2-500 chars), limit (1-10, default 5), country (optional 2-letter ISO 3166-1 bias). Underlying data is OpenStreetMap (ODbL). Sister: /api/geocode/reverse.",
+        "operationId": "geocode_address",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = geocode matches (formattedAddress, latitude, longitude, boundingBox, class, type, importance, structured address); total = null (no upstream total); meta.query echoes the request, meta.cacheHit flags a cache serve.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "query": {
+                              "type": "object",
+                              "properties": {
+                                "kind": {
+                                  "type": "string"
+                                },
+                                "input": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "kind",
+                                "input"
+                              ],
+                              "additionalProperties": false
+                            },
+                            "cacheHit": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "query",
+                            "cacheHit"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.001 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "geocode.address",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.001,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": true,
+            "description": "Free-text search query.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 500
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of results to return.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 10,
+              "default": 5
+            }
+          },
+          {
+            "name": "country",
+            "in": "query",
+            "required": false,
+            "description": "Country name or ISO country code.",
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-z]{2}$"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/geocode/reverse": {
+      "get": {
+        "tags": [
+          "geocode"
+        ],
+        "summary": "Fetch Reverse geocoding - latitude/longitude nearest",
+        "description": "Reverse geocoding — latitude/longitude → nearest formatted address plus structured components (houseNumber, road, suburb, city, county, state, postcode, country, countryCode). Query: lat (-90..90), lon (-180..180). Underlying data is OpenStreetMap (ODbL). Sister: /api/geocode/address.",
+        "operationId": "geocode_reverse",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = [address] (nearest formatted address + structured components; empty if none); total = items.length; meta.query echoes the request, meta.cacheHit flags a cache serve.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "query": {
+                              "type": "object",
+                              "properties": {
+                                "kind": {
+                                  "type": "string"
+                                },
+                                "input": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "kind",
+                                "input"
+                              ],
+                              "additionalProperties": false
+                            },
+                            "cacheHit": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "query",
+                            "cacheHit"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.001 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "geocode.reverse",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.001,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "lat",
+            "in": "query",
+            "required": true,
+            "description": "Latitude in decimal degrees (WGS84).",
+            "schema": {
+              "type": "number",
+              "minimum": -90,
+              "maximum": 90
+            }
+          },
+          {
+            "name": "lon",
+            "in": "query",
+            "required": true,
+            "description": "Longitude in decimal degrees (WGS84).",
+            "schema": {
+              "type": "number",
+              "minimum": -180,
+              "maximum": 180
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/park/lookup": {
+      "get": {
+        "tags": [
+          "park"
+        ],
+        "summary": "Fetch Unified read API over US National Park Service...",
+        "description": "Unified read API over US National Park Service developer.nps.gov. Pick a resource: parks (every NPS unit — historical parks, monuments, seashores, etc.), alerts (closures, dangers, info), campgrounds (NPS-operated campgrounds with reservation links), events (talks, walks, ranger programs), newsreleases (park news), thingstodo (activities by park), visitorcenters. Filter by parkCode (CSV — e.g. \"acad,yose,grca\"), state, or free-text query. Returns the upstream NPS payload verbatim (rich nested objects with images, addresses, operating hours, etc.).",
+        "operationId": "park_lookup",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = matched NPS records for the requested resource; total = upstream total available; meta echoes resource + pagination (limit, start).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "resource": {
+                              "type": "string",
+                              "enum": [
+                                "parks",
+                                "alerts",
+                                "campgrounds",
+                                "events",
+                                "newsreleases",
+                                "thingstodo",
+                                "visitorcenters"
+                              ]
+                            },
+                            "limit": {
+                              "type": "number"
+                            },
+                            "start": {
+                              "type": "number"
+                            }
+                          },
+                          "required": [
+                            "resource",
+                            "limit",
+                            "start"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "park.lookup",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "resource",
+            "in": "query",
+            "required": true,
+            "description": "Resource.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "parks",
+                "alerts",
+                "campgrounds",
+                "events",
+                "newsreleases",
+                "thingstodo",
+                "visitorcenters"
+              ]
+            }
+          },
+          {
+            "name": "parkCode",
+            "in": "query",
+            "required": false,
+            "description": "Park code.",
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-z]{2,4}(,[a-z]{2,4})*$"
+            }
+          },
+          {
+            "name": "state",
+            "in": "query",
+            "required": false,
+            "description": "US state — two-letter postal abbreviation (e.g. CA) or full name.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 2,
+              "pattern": "^[A-Za-z]{2}$"
+            }
+          },
+          {
+            "name": "q",
+            "in": "query",
+            "required": false,
+            "description": "Free-text search query.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 120
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of results to return.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 50,
+              "default": 10
+            }
+          },
+          {
+            "name": "start",
+            "in": "query",
+            "required": false,
+            "description": "Start.",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/poi/near": {
+      "get": {
+        "tags": [
+          "poi"
+        ],
+        "summary": "Find points of interest near a coordinate.",
+        "description": "Find points of interest near a coordinate. Backed by OpenStreetMap via the Overpass API (free, public, ODbL). Returns name, OSM id (e.g. node/123 — deep-linkable to openstreetmap.org), latitude, longitude, distance in meters, composed street address (when present), phone, website, opening hours, brand, and cuisine tags. Results sorted nearest-first. Supported categories: restaurant, cafe, bar, fast_food, gas_station, ev_charging, parking, atm, bank, hospital, pharmacy, clinic, doctor, dentist, police, fire_station, post_office, library, toilets, school, university, supermarket, convenience, hotel, hostel, museum, attraction, park, playground. Query: lat (-90..90), lon (-180..180), category (one of the supported names), radius_m (1-10000, default 1000), limit (1-100, default 20).",
+        "operationId": "poi_near",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = POIs near the coordinate (name, OSM id, lat/lon, distanceM, address, phone, website, openingHours, brand, cuisine, url), sorted nearest-first; total = null (query-bounded set); meta.query echoes the request, meta.nearestM is the closest distance.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "query": {
+                              "type": "object",
+                              "properties": {
+                                "latitude": {
+                                  "type": "number"
+                                },
+                                "longitude": {
+                                  "type": "number"
+                                },
+                                "category": {
+                                  "type": "string"
+                                },
+                                "radiusM": {
+                                  "type": "integer"
+                                },
+                                "limit": {
+                                  "type": "integer"
+                                }
+                              },
+                              "required": [
+                                "latitude",
+                                "longitude",
+                                "category",
+                                "radiusM",
+                                "limit"
+                              ],
+                              "additionalProperties": false
+                            },
+                            "nearestM": {
+                              "type": "number",
+                              "nullable": true
+                            }
+                          },
+                          "required": [
+                            "query",
+                            "nearestM"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.001 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "poi.near",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.001,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "lat",
+            "in": "query",
+            "required": true,
+            "description": "Latitude in decimal degrees (WGS84).",
+            "schema": {
+              "type": "number",
+              "minimum": -90,
+              "maximum": 90
+            }
+          },
+          {
+            "name": "lon",
+            "in": "query",
+            "required": true,
+            "description": "Longitude in decimal degrees (WGS84).",
+            "schema": {
+              "type": "number",
+              "minimum": -180,
+              "maximum": 180
+            }
+          },
+          {
+            "name": "category",
+            "in": "query",
+            "required": true,
+            "description": "Filter results by category.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "restaurant",
+                "cafe",
+                "bar",
+                "fast_food",
+                "gas_station",
+                "ev_charging",
+                "parking",
+                "atm",
+                "bank",
+                "hospital",
+                "pharmacy",
+                "clinic",
+                "doctor",
+                "dentist",
+                "police",
+                "fire_station",
+                "post_office",
+                "library",
+                "toilets",
+                "school",
+                "university",
+                "supermarket",
+                "convenience",
+                "hotel",
+                "hostel",
+                "museum",
+                "attraction",
+                "park",
+                "playground"
+              ]
+            }
+          },
+          {
+            "name": "radius_m",
+            "in": "query",
+            "required": false,
+            "description": "Radius m.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 10000,
+              "default": 1000
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of results to return.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 20
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/quakes/recent": {
+      "get": {
+        "tags": [
+          "quakes"
+        ],
+        "summary": "Fetch Recent earthquakes near a coordinate.",
+        "description": "Recent earthquakes near a coordinate. Returns each quake with magnitude, place name, time (ISO), latitude/longitude/depth, tsunami flag, USGS event URL, and distance-from-query in km — sorted by time descending. Real-time data, post-LLM-training-cutoff. Backed by USGS FDSN event API (public domain). Query: lat (-90..90), lon (-180..180), radius_km (1-1000, default 500), hours (1-720, default 24), min_magnitude (0-10, default 2.0).",
+        "operationId": "quakes_recent",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = recent earthquakes (magnitude, place, time, lat/lon/depth, tsunami, url, distanceKm), newest-first; total = null (query-bounded set); meta.query echoes the request, meta.largestMagnitude + meta.nearestKm summarize the set.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "query": {
+                              "type": "object",
+                              "properties": {
+                                "latitude": {
+                                  "type": "number"
+                                },
+                                "longitude": {
+                                  "type": "number"
+                                },
+                                "radiusKm": {
+                                  "type": "number"
+                                },
+                                "hours": {
+                                  "type": "number"
+                                },
+                                "minMagnitude": {
+                                  "type": "number"
+                                }
+                              },
+                              "required": [
+                                "latitude",
+                                "longitude",
+                                "radiusKm",
+                                "hours",
+                                "minMagnitude"
+                              ],
+                              "additionalProperties": false
+                            },
+                            "largestMagnitude": {
+                              "type": "number",
+                              "nullable": true
+                            },
+                            "nearestKm": {
+                              "type": "number",
+                              "nullable": true
+                            }
+                          },
+                          "required": [
+                            "query",
+                            "largestMagnitude",
+                            "nearestKm"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.001 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "quakes.recent",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.001,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "lat",
+            "in": "query",
+            "required": true,
+            "description": "Latitude in decimal degrees (WGS84).",
+            "schema": {
+              "type": "number",
+              "minimum": -90,
+              "maximum": 90
+            }
+          },
+          {
+            "name": "lon",
+            "in": "query",
+            "required": true,
+            "description": "Longitude in decimal degrees (WGS84).",
+            "schema": {
+              "type": "number",
+              "minimum": -180,
+              "maximum": 180
+            }
+          },
+          {
+            "name": "radius_km",
+            "in": "query",
+            "required": false,
+            "description": "Search radius in kilometers.",
+            "schema": {
+              "type": "number",
+              "minimum": 1,
+              "maximum": 1000,
+              "default": 500
+            }
+          },
+          {
+            "name": "hours",
+            "in": "query",
+            "required": false,
+            "description": "Look-back window, in hours.",
+            "schema": {
+              "type": "number",
+              "minimum": 1,
+              "maximum": 720,
+              "default": 24
+            }
+          },
+          {
+            "name": "min_magnitude",
+            "in": "query",
+            "required": false,
+            "description": "Minimum magnitude to include.",
+            "schema": {
+              "type": "number",
+              "minimum": 0,
+              "maximum": 10,
+              "default": 2
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/recreation/search": {
+      "get": {
+        "tags": [
+          "recreation"
+        ],
+        "summary": "Search the Recreation Information Database (RIDB) - the...",
+        "description": "Search the Recreation Information Database (RIDB) — the single source of truth for federal recreation lands and programs across NPS, USFS, BLM, USACE, BOR, FWS, NARA. Pick a resource: recareas (designated recreation areas), facilities (individual sites — campgrounds, day-use, visitor centers), campsites (individual reservable campsites with attributes), permits (special-use permits, lotteries), tours, events, activities (taxonomy lookup). Filter by free-text query, state, activity ID, or lat/lon + radius (miles, max 50). Used by every federal-recreation-related agent: trip planning, permit chasers, fishing/hunting locator, campground availability tools.",
+        "operationId": "recreation_search",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = matched RIDB records for the requested resource; total = upstream total match count; meta echoes resource + currentCount (this page).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "resource": {
+                              "type": "string",
+                              "enum": [
+                                "recareas",
+                                "facilities",
+                                "campsites",
+                                "permits",
+                                "tours",
+                                "events",
+                                "activities"
+                              ]
+                            },
+                            "currentCount": {
+                              "type": "number",
+                              "description": "Records returned on this page."
+                            }
+                          },
+                          "required": [
+                            "resource",
+                            "currentCount"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "recreation.search",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "resource",
+            "in": "query",
+            "required": true,
+            "description": "Resource.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "recareas",
+                "facilities",
+                "campsites",
+                "permits",
+                "tours",
+                "events",
+                "activities"
+              ]
+            }
+          },
+          {
+            "name": "query",
+            "in": "query",
+            "required": false,
+            "description": "Free-text search query.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 120
+            }
+          },
+          {
+            "name": "state",
+            "in": "query",
+            "required": false,
+            "description": "US state — two-letter postal abbreviation (e.g. CA) or full name.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 2,
+              "pattern": "^[A-Za-z]{2}$"
+            }
+          },
+          {
+            "name": "activity",
+            "in": "query",
+            "required": false,
+            "description": "Activity.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 99999
+            }
+          },
+          {
+            "name": "latitude",
+            "in": "query",
+            "required": false,
+            "description": "Latitude in decimal degrees (WGS84).",
+            "schema": {
+              "type": "number",
+              "minimum": -90,
+              "maximum": 90
+            }
+          },
+          {
+            "name": "longitude",
+            "in": "query",
+            "required": false,
+            "description": "Longitude in decimal degrees (WGS84).",
+            "schema": {
+              "type": "number",
+              "minimum": -180,
+              "maximum": 180
+            }
+          },
+          {
+            "name": "radius",
+            "in": "query",
+            "required": false,
+            "description": "Search radius around the given point.",
+            "schema": {
+              "type": "number",
+              "minimum": 0.1,
+              "maximum": 50
+            }
+          },
+          {
+            "name": "lastUpdated",
+            "in": "query",
+            "required": false,
+            "description": "Last updated.",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{2}-\\d{2}-\\d{4}$"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of results to return.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 50,
+              "default": 25
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "description": "Number of results to skip before returning (pagination offset).",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/sunrise/compute": {
+      "get": {
+        "tags": [
+          "sunrise"
+        ],
+        "summary": "Calculate sunrise, sunset, solar noon, and...",
+        "description": "Compute sunrise, sunset, solar noon, and civil/nautical/astronomical twilight times for a coordinate + date. Query: lat (-90..90), lon (-180..180), date (YYYY-MM-DD). All times returned as ISO 8601 UTC. At high latitudes near solstices an event may not occur (polar day/night) — those fields return null and a note is included. dayLengthMinutes is the sunrise→sunset interval.",
+        "operationId": "sunrise_compute",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = [solarTimes] (one snapshot: sunrise, sunset, solar noon, civil/nautical/astronomical twilight, dayLengthMinutes, notes); total = 1; meta.query echoes the request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "query": {
+                              "type": "object",
+                              "properties": {
+                                "latitude": {
+                                  "type": "number"
+                                },
+                                "longitude": {
+                                  "type": "number"
+                                },
+                                "date": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "latitude",
+                                "longitude",
+                                "date"
+                              ],
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "query"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.001 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "sunrise.compute",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.001,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "lat",
+            "in": "query",
+            "required": true,
+            "description": "Latitude in decimal degrees (WGS84).",
+            "schema": {
+              "type": "number",
+              "minimum": -90,
+              "maximum": 90
+            }
+          },
+          {
+            "name": "lon",
+            "in": "query",
+            "required": true,
+            "description": "Longitude in decimal degrees (WGS84).",
+            "schema": {
+              "type": "number",
+              "minimum": -180,
+              "maximum": 180
+            }
+          },
+          {
+            "name": "date",
+            "in": "query",
+            "required": true,
+            "description": "Date in YYYY-MM-DD format.",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/tides/now": {
+      "get": {
+        "tags": [
+          "tides"
+        ],
+        "summary": "Fetch Next high/low tide predictions near a coordinate.",
+        "description": "Next high/low tide predictions near a coordinate. Query: lat (-90..90), lon (-180..180), radius_km (1-500, default 100), hours (1-72, default 24). Returns { query, station:{ id, name, latitude, longitude, state, distanceKm }, predictions[{ time (station local), type: \"high\"|\"low\", heightMeters }], source }. Returns 404 NO_STATION if no NOAA tide station is within radius. Heights are referenced to MLLW (Mean Lower-Low Water).",
+        "operationId": "tides_now",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = [{ station, predictions }] (one nearest station + its tide predictions); total = 1; meta.query echoes the request, meta.datum is the height reference (MLLW). 404 NO_STATION if no station within radius.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "station": {
+                                "type": "object",
+                                "additionalProperties": {},
+                                "description": "Nearest NOAA tide station: id, name, latitude, longitude, state, distanceKm."
+                              },
+                              "predictions": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "additionalProperties": {}
+                                },
+                                "description": "Next high/low tide predictions: time (station local), type (high|low), heightMeters."
+                              }
+                            },
+                            "required": [
+                              "station",
+                              "predictions"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "query": {
+                              "type": "object",
+                              "properties": {
+                                "latitude": {
+                                  "type": "number"
+                                },
+                                "longitude": {
+                                  "type": "number"
+                                },
+                                "radiusKm": {
+                                  "type": "number"
+                                },
+                                "hours": {
+                                  "type": "number"
+                                }
+                              },
+                              "required": [
+                                "latitude",
+                                "longitude",
+                                "radiusKm",
+                                "hours"
+                              ],
+                              "additionalProperties": false
+                            },
+                            "datum": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "query",
+                            "datum"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.001 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "tides.now",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.001,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "lat",
+            "in": "query",
+            "required": true,
+            "description": "Latitude in decimal degrees (WGS84).",
+            "schema": {
+              "type": "number",
+              "minimum": -90,
+              "maximum": 90
+            }
+          },
+          {
+            "name": "lon",
+            "in": "query",
+            "required": true,
+            "description": "Longitude in decimal degrees (WGS84).",
+            "schema": {
+              "type": "number",
+              "minimum": -180,
+              "maximum": 180
+            }
+          },
+          {
+            "name": "radius_km",
+            "in": "query",
+            "required": false,
+            "description": "Search radius in kilometers.",
+            "schema": {
+              "type": "number",
+              "minimum": 1,
+              "maximum": 500,
+              "default": 100
+            }
+          },
+          {
+            "name": "hours",
+            "in": "query",
+            "required": false,
+            "description": "Look-back window, in hours.",
+            "schema": {
+              "type": "number",
+              "minimum": 1,
+              "maximum": 72,
+              "default": 24
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/timezone/lookup": {
+      "get": {
+        "tags": [
+          "timezone"
+        ],
+        "summary": "Resolve a coordinate to its IANA timezone and return the...",
+        "description": "Resolve a coordinate to its IANA timezone and return the current UTC offset, local wall time, DST status, and short abbreviation. Query: lat (-90..90), lon (-180..180), at (optional ISO 8601 instant; defaults to now). Returns { tz, abbreviation, offsetMinutes, offsetHours, localTime, observesDst, isDst, januaryOffsetMinutes, julyOffsetMinutes, instant, source }. Polygon lookup against a CC0 timezone boundary index; offsets and DST come from the runtime tzdata so transition rules stay current. Use when scheduling for a coordinate, converting timestamps to local wall time, or checking whether a location is currently observing daylight saving.",
+        "operationId": "timezone_lookup",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = [timezone] (one snapshot: tz, abbreviation, offset, localTime, DST flags, instant); total = 1.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "tz": {
+                                "type": "string",
+                                "description": "IANA timezone identifier — e.g. \"America/Los_Angeles\"."
+                              },
+                              "abbreviation": {
+                                "type": "string",
+                                "description": "Short timezone abbreviation at `instant` — e.g. \"PDT\", \"JST\"."
+                              },
+                              "offsetMinutes": {
+                                "type": "integer",
+                                "description": "UTC offset at `instant`, in signed minutes."
+                              },
+                              "offsetHours": {
+                                "type": "number",
+                                "description": "UTC offset at `instant`, in signed hours (may be fractional for 30/45-minute zones)."
+                              },
+                              "localTime": {
+                                "type": "string",
+                                "description": "ISO 8601 local wall time with offset suffix — e.g. \"2026-06-03T08:43:15-07:00\"."
+                              },
+                              "observesDst": {
+                                "type": "boolean",
+                                "description": "True if this zone has different offsets across the year."
+                              },
+                              "isDst": {
+                                "type": "boolean",
+                                "description": "True if `instant` falls inside a DST/summer-shift period for this zone."
+                              },
+                              "januaryOffsetMinutes": {
+                                "type": "integer",
+                                "description": "Offset on Jan 15 of `instant`'s year — representative northern-hemisphere winter."
+                              },
+                              "julyOffsetMinutes": {
+                                "type": "integer",
+                                "description": "Offset on Jul 15 of `instant`'s year — representative northern-hemisphere summer."
+                              },
+                              "instant": {
+                                "type": "string",
+                                "description": "UTC instant the lookup was computed at (echoed `at`, or current server time)."
+                              }
+                            },
+                            "required": [
+                              "tz",
+                              "abbreviation",
+                              "offsetMinutes",
+                              "offsetHours",
+                              "localTime",
+                              "observesDst",
+                              "isDst",
+                              "januaryOffsetMinutes",
+                              "julyOffsetMinutes",
+                              "instant"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.001 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "timezone.lookup",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.001,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "lat",
+            "in": "query",
+            "required": true,
+            "description": "Latitude in degrees, -90..90.",
+            "schema": {
+              "type": "number",
+              "minimum": -90,
+              "maximum": 90
+            }
+          },
+          {
+            "name": "lon",
+            "in": "query",
+            "required": true,
+            "description": "Longitude in degrees, -180..180.",
+            "schema": {
+              "type": "number",
+              "minimum": -180,
+              "maximum": 180
+            }
+          },
+          {
+            "name": "at",
+            "in": "query",
+            "required": false,
+            "description": "Optional ISO 8601 instant. Defaults to the current server time.",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/water/gauge": {
+      "get": {
+        "tags": [
+          "water"
+        ],
+        "summary": "Fetch Real-time US river/stream conditions from a USGS",
+        "description": "Real-time US river/stream conditions from a USGS monitoring site. Pass site = the USGS site number (e.g. 01646500 = Potomac River near Washington DC). Returns the latest readings — streamflow (cubic feet/sec), gage height (ft), and water/air temperature where available — with the site name + coordinates and observation time. Useful for flood monitoring, recreation, and hydrology. Source: USGS National Water Information System (keyless, public domain).",
+        "operationId": "water_gauge",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = latest readings per parameter; meta = site identity + location.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "parameterCode": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "unit": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "observedAt": {
+                                "type": "string",
+                                "nullable": true
+                              }
+                            },
+                            "required": [
+                              "parameterCode",
+                              "name",
+                              "value",
+                              "unit",
+                              "observedAt"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "site": {
+                              "type": "string"
+                            },
+                            "siteName": {
+                              "type": "string",
+                              "nullable": true
+                            },
+                            "latitude": {
+                              "type": "number",
+                              "nullable": true
+                            },
+                            "longitude": {
+                              "type": "number",
+                              "nullable": true
+                            }
+                          },
+                          "required": [
+                            "site",
+                            "siteName",
+                            "latitude",
+                            "longitude"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "water.gauge",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "site",
+            "in": "query",
+            "required": true,
+            "description": "Site.",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{8,15}$"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/weather/air-quality": {
+      "get": {
+        "tags": [
+          "weather"
+        ],
+        "summary": "Fetch Current air quality for any coordinate worldwide.",
+        "description": "Current air quality for any coordinate worldwide. Pass lat + lon. Returns the US AQI (+ category Good/Moderate/Unhealthy…), the European AQI, and pollutant concentrations: PM2.5, PM10, ozone, nitrogen dioxide, sulphur dioxide, carbon monoxide. Source: Open-Meteo / CAMS (keyless).",
+        "operationId": "weather_air-quality",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = [current air quality]; total = 1.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "lat": {
+                                "type": "number"
+                              },
+                              "lon": {
+                                "type": "number"
+                              },
+                              "time": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "usAqi": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "usAqiCategory": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "europeanAqi": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "pm2_5": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "pm10": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "ozone": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "nitrogenDioxide": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "sulphurDioxide": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "carbonMonoxide": {
+                                "type": "number",
+                                "nullable": true
+                              }
+                            },
+                            "required": [
+                              "lat",
+                              "lon",
+                              "time",
+                              "usAqi",
+                              "usAqiCategory",
+                              "europeanAqi",
+                              "pm2_5",
+                              "pm10",
+                              "ozone",
+                              "nitrogenDioxide",
+                              "sulphurDioxide",
+                              "carbonMonoxide"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "weather.air-quality",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "lat",
+            "in": "query",
+            "required": true,
+            "description": "Latitude in decimal degrees (WGS84).",
+            "schema": {
+              "type": "number",
+              "minimum": -90,
+              "maximum": 90
+            }
+          },
+          {
+            "name": "lon",
+            "in": "query",
+            "required": true,
+            "description": "Longitude in decimal degrees (WGS84).",
+            "schema": {
+              "type": "number",
+              "minimum": -180,
+              "maximum": 180
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/weather/alerts": {
+      "get": {
+        "tags": [
+          "weather"
+        ],
+        "summary": "Fetch Live US severe-weather alerts from the National",
+        "description": "Live US severe-weather alerts from the National Weather Service. Pass a point (\"lat,lon\") to get every active watch, warning, and advisory for that exact location, or an area (2-letter US state or marine zone code) for area-wide alerts. Optionally filter by severity or urgency. Each alert returns the event type, severity, urgency, certainty, headline, affected-area description, issuing office, recommended public response, onset / expiry / end times, and the full hazard description plus protective-action instructions. Results are sorted most-severe first and capped by limit, with the true total reported. Public-domain NOAA / National Weather Service data, refreshed in real time.",
+        "operationId": "weather_alerts",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = active alerts (most-severe first), total = full active-alert count before the limit cap, meta.scope echoes the resolved point/area. An empty items array means no active alerts for the scope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "event": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "severity": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "urgency": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "certainty": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "category": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "headline": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "areaDescription": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "senderName": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "response": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "status": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "messageType": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "effective": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "onset": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "expires": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "ends": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "description": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "instruction": {
+                                "type": "string",
+                                "nullable": true
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "event",
+                              "severity",
+                              "urgency",
+                              "certainty",
+                              "category",
+                              "headline",
+                              "areaDescription",
+                              "senderName",
+                              "response",
+                              "status",
+                              "messageType",
+                              "effective",
+                              "onset",
+                              "expires",
+                              "ends",
+                              "description",
+                              "instruction"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "scope": {
+                              "type": "object",
+                              "properties": {
+                                "point": {
+                                  "type": "object",
+                                  "properties": {
+                                    "lat": {
+                                      "type": "number"
+                                    },
+                                    "lon": {
+                                      "type": "number"
+                                    }
+                                  },
+                                  "required": [
+                                    "lat",
+                                    "lon"
+                                  ],
+                                  "additionalProperties": false,
+                                  "nullable": true
+                                },
+                                "area": {
+                                  "type": "string",
+                                  "nullable": true
+                                }
+                              },
+                              "required": [
+                                "point",
+                                "area"
+                              ],
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "scope"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "weather.alerts",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "point",
+            "in": "query",
+            "required": false,
+            "description": "Exact location as \"lat,lon\" in decimal degrees, e.g. \"25.7617,-80.1918\". Returns alerts covering that point. Provide point OR area, not both.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "area",
+            "in": "query",
+            "required": false,
+            "description": "2-letter US state / territory or NWS marine area code, e.g. \"FL\", \"TX\", \"PK\". Returns all active alerts for that area. Provide point OR area, not both.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "severity",
+            "in": "query",
+            "required": false,
+            "description": "Filter to a single severity level.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Extreme",
+                "Severe",
+                "Moderate",
+                "Minor",
+                "Unknown"
+              ]
+            }
+          },
+          {
+            "name": "urgency",
+            "in": "query",
+            "required": false,
+            "description": "Filter to a single urgency level.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Immediate",
+                "Expected",
+                "Future",
+                "Past",
+                "Unknown"
+              ]
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Max alerts to return (1-100, default 20). Most-severe first.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 20
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/weather/forecast": {
+      "get": {
+        "tags": [
+          "weather"
+        ],
+        "summary": "Fetch Official US weather forecast for a coordinate (US land",
+        "description": "Official US weather forecast for a coordinate (US land + territories). Pass lat + lon. Returns the National Weather Service forecast as a list of periods — by default ~7 days of day/night periods; pass hourly=true for an hour-by-hour forecast. Each period gives the temperature + unit, wind speed/direction, chance of precipitation, and a short + detailed forecast, plus the resolved city/state and issuing office. Source: US National Weather Service (api.weather.gov), public domain. For active warnings use weather.alerts.",
+        "operationId": "weather_forecast",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = forecast periods (chronological); meta = location + office + count.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "startTime": {
+                                "type": "string"
+                              },
+                              "endTime": {
+                                "type": "string"
+                              },
+                              "isDaytime": {
+                                "type": "boolean"
+                              },
+                              "temperature": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "temperatureUnit": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "windSpeed": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "windDirection": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "precipProbabilityPct": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "shortForecast": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "detailedForecast": {
+                                "type": "string",
+                                "nullable": true
+                              }
+                            },
+                            "required": [
+                              "name",
+                              "startTime",
+                              "endTime",
+                              "isDaytime",
+                              "temperature",
+                              "temperatureUnit",
+                              "windSpeed",
+                              "windDirection",
+                              "precipProbabilityPct",
+                              "shortForecast",
+                              "detailedForecast"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "location": {
+                              "type": "string",
+                              "nullable": true
+                            },
+                            "forecastOffice": {
+                              "type": "string",
+                              "nullable": true
+                            },
+                            "updated": {
+                              "type": "string",
+                              "nullable": true
+                            },
+                            "periods": {
+                              "type": "integer"
+                            }
+                          },
+                          "required": [
+                            "location",
+                            "forecastOffice",
+                            "updated",
+                            "periods"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.00144 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "weather.forecast",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.00144,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001440"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "lat",
+            "in": "query",
+            "required": true,
+            "description": "Latitude in decimal degrees (WGS84).",
+            "schema": {
+              "type": "number",
+              "minimum": -90,
+              "maximum": 90
+            }
+          },
+          {
+            "name": "lon",
+            "in": "query",
+            "required": true,
+            "description": "Longitude in decimal degrees (WGS84).",
+            "schema": {
+              "type": "number",
+              "minimum": -180,
+              "maximum": 180
+            }
+          },
+          {
+            "name": "hourly",
+            "in": "query",
+            "required": false,
+            "description": "Hourly.",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of results to return.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 156
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/weather/history": {
+      "get": {
+        "tags": [
+          "weather"
+        ],
+        "summary": "Fetch Historical daily weather for any coordinate (ERA5...",
+        "description": "Historical daily weather for any coordinate (ERA5 reanalysis, 1940→~5 days ago). Pass lat + lon + start + end (YYYY-MM-DD, range ≤366 days). Returns per-day max/min/mean temperature (°C), precipitation total (mm) + hours, and max wind (km/h). Source: Open-Meteo archive / ECMWF ERA5 (keyless).",
+        "operationId": "weather_history",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = daily history (chronological); total = days.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "date": {
+                                "type": "string"
+                              },
+                              "tempMaxC": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "tempMinC": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "tempMeanC": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "precipMm": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "windMaxKmh": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "precipHours": {
+                                "type": "number",
+                                "nullable": true
+                              }
+                            },
+                            "required": [
+                              "date",
+                              "tempMaxC",
+                              "tempMinC",
+                              "tempMeanC",
+                              "precipMm",
+                              "windMaxKmh",
+                              "precipHours"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.00144 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "weather.history",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.00144,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001440"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "lat",
+            "in": "query",
+            "required": true,
+            "description": "Latitude in decimal degrees (WGS84).",
+            "schema": {
+              "type": "number",
+              "minimum": -90,
+              "maximum": 90
+            }
+          },
+          {
+            "name": "lon",
+            "in": "query",
+            "required": true,
+            "description": "Longitude in decimal degrees (WGS84).",
+            "schema": {
+              "type": "number",
+              "minimum": -180,
+              "maximum": 180
+            }
+          },
+          {
+            "name": "start",
+            "in": "query",
+            "required": true,
+            "description": "Start.",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+            }
+          },
+          {
+            "name": "end",
+            "in": "query",
+            "required": true,
+            "description": "End.",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/weather/marine": {
+      "get": {
+        "tags": [
+          "weather"
+        ],
+        "summary": "Fetch Current marine/sea-state conditions for an ocean",
+        "description": "Current marine/sea-state conditions for an ocean or coastal coordinate. Pass lat + lon. Returns significant wave height (m), wave direction + period, and the wind-wave and swell-wave components. Useful for surf, sailing, and coastal ops. Source: Open-Meteo marine (keyless). Returns 404 for inland points.",
+        "operationId": "weather_marine",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = [current sea state]; total = 1.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "lat": {
+                                "type": "number"
+                              },
+                              "lon": {
+                                "type": "number"
+                              },
+                              "time": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "waveHeightM": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "waveDirectionDeg": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "wavePeriodS": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "windWaveHeightM": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "swellWaveHeightM": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "swellWavePeriodS": {
+                                "type": "number",
+                                "nullable": true
+                              }
+                            },
+                            "required": [
+                              "lat",
+                              "lon",
+                              "time",
+                              "waveHeightM",
+                              "waveDirectionDeg",
+                              "wavePeriodS",
+                              "windWaveHeightM",
+                              "swellWaveHeightM",
+                              "swellWavePeriodS"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "weather.marine",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "lat",
+            "in": "query",
+            "required": true,
+            "description": "Latitude in decimal degrees (WGS84).",
+            "schema": {
+              "type": "number",
+              "minimum": -90,
+              "maximum": 90
+            }
+          },
+          {
+            "name": "lon",
+            "in": "query",
+            "required": true,
+            "description": "Longitude in decimal degrees (WGS84).",
+            "schema": {
+              "type": "number",
+              "minimum": -180,
+              "maximum": 180
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/weather/zip": {
+      "get": {
+        "tags": [
+          "weather"
+        ],
+        "summary": "Fetch Current weather conditions for a US ZIP code",
+        "description": "Current weather conditions for a US ZIP code (temperature, wind, humidity, conditions). Backed by the US National Weather Service (api.weather.gov) — public domain, no rate-limit pressure on commercial use.",
+        "operationId": "weather_zip",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = [{ location, current }] (one ZIP-keyed current-conditions snapshot); total = 1. 404 if the ZIP is unknown.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "location": {
+                                "type": "object",
+                                "properties": {
+                                  "zip": {
+                                    "type": "string"
+                                  },
+                                  "city": {
+                                    "type": "string"
+                                  },
+                                  "state": {
+                                    "type": "string"
+                                  },
+                                  "coords": {
+                                    "type": "object",
+                                    "properties": {
+                                      "lat": {
+                                        "type": "number"
+                                      },
+                                      "lon": {
+                                        "type": "number"
+                                      }
+                                    },
+                                    "required": [
+                                      "lat",
+                                      "lon"
+                                    ],
+                                    "additionalProperties": false
+                                  },
+                                  "timezone": {
+                                    "type": "string",
+                                    "nullable": true
+                                  }
+                                },
+                                "required": [
+                                  "zip",
+                                  "city",
+                                  "state",
+                                  "coords",
+                                  "timezone"
+                                ],
+                                "additionalProperties": false
+                              },
+                              "current": {
+                                "type": "object",
+                                "properties": {
+                                  "temperatureF": {
+                                    "type": "number",
+                                    "nullable": true
+                                  },
+                                  "apparentTemperatureF": {
+                                    "type": "number",
+                                    "nullable": true
+                                  },
+                                  "humidityPct": {
+                                    "type": "number",
+                                    "nullable": true
+                                  },
+                                  "windMph": {
+                                    "type": "number",
+                                    "nullable": true
+                                  },
+                                  "windDirection": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "windDirectionDeg": {
+                                    "type": "number",
+                                    "nullable": true
+                                  },
+                                  "precipProbabilityPct": {
+                                    "type": "number",
+                                    "nullable": true
+                                  },
+                                  "conditions": {
+                                    "type": "string"
+                                  },
+                                  "isDay": {
+                                    "type": "boolean",
+                                    "nullable": true
+                                  },
+                                  "observedAt": {
+                                    "type": "string",
+                                    "nullable": true
+                                  }
+                                },
+                                "required": [
+                                  "temperatureF",
+                                  "apparentTemperatureF",
+                                  "humidityPct",
+                                  "windMph",
+                                  "windDirection",
+                                  "windDirectionDeg",
+                                  "precipProbabilityPct",
+                                  "conditions",
+                                  "isDay",
+                                  "observedAt"
+                                ],
+                                "additionalProperties": false
+                              }
+                            },
+                            "required": [
+                              "location",
+                              "current"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "weather.zip",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "zip",
+            "in": "query",
+            "required": true,
+            "description": "US ZIP code.",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{5}$"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/providers/2s/gov/PAY.md
+++ b/providers/2s/gov/PAY.md
@@ -1,0 +1,17 @@
+---
+name: gov
+title: "2s Gov"
+description: "US government and public-records data: Congress bills/votes/trades, FEC campaign finance, federal regulations, OpenFDA, OSHA/MSHA, USAspending, Census demographics, federal jobs, and NYC property records."
+use_case: "Use for Congressional bills, votes and stock trades, FEC campaign finance, federal regulations and recalls, Census demographics, and property records."
+category: data
+service_url: https://2s.io
+openapi:
+  path: openapi.json
+---
+
+Part of 2s — a unified, agent-native JSON API. Pay per call in USDC on Solana (or Base) via x402; no accounts, no API keys. Add `?trial=1` (or header `X-2s-Trial: 1`) for one free real call per endpoint per hour.
+
+## Spend-aware usage
+
+- Prefer narrow lookups (by id/code) over broad searches; reuse identifiers across calls.
+- Cap result `limit` to the smallest count that answers the task.

--- a/providers/2s/gov/openapi.json
+++ b/providers/2s/gov/openapi.json
@@ -1,0 +1,11256 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "2s",
+    "version": "1",
+    "description": "Unified JSON REST API for AI agents — an ever-expanding catalog of endpoints, pay per call in USDC on Base or Solana via x402, no accounts, no API keys. Fund a wallet on either chain with USDC, hit any endpoint, and your client signs an EIP-3009 authorization (Base) or a partial SPL transfer (Solana) to settle the call. Try before you buy: add ?trial=1 (or header X-2s-Trial: 1) to any endpoint for one free real call per endpoint per hour — no wallet needed — to verify it works before paying. 2s is an open-ended experiment in maximally-comprehensive agent infrastructure — new endpoints land regularly.",
+    "contact": {
+      "name": "2s",
+      "url": "https://2s.io",
+      "email": "alley@2s.io"
+    }
+  },
+  "servers": [
+    {
+      "url": "https://2s.io"
+    }
+  ],
+  "components": {
+    "parameters": {
+      "TrialMode": {
+        "name": "trial",
+        "in": "query",
+        "required": false,
+        "description": "Try before you buy. Set to 1 for one free real call per endpoint per hour — no wallet or payment needed — to verify the endpoint before paying. Equivalent to sending the \"X-2s-Trial: 1\" request header. Works on every endpoint.",
+        "schema": {
+          "type": "integer",
+          "enum": [
+            1
+          ]
+        }
+      }
+    },
+    "securitySchemes": {
+      "x402Payment": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "PAYMENT-SIGNATURE",
+        "description": "x402 protocol v2: base64-encoded PaymentPayload. Call any paid endpoint without auth to receive a 402 with a multi-network PaymentRequirements envelope. Sign for either rail: EIP-3009 transferWithAuthorization (Base USDC) OR a partial SPL token transfer (Solana USDC). Retry with PAYMENT-SIGNATURE header. X-PAYMENT is also accepted for v1 buyer clients. See https://x402.org."
+      }
+    },
+    "schemas": {
+      "X402PaymentRequiredV2": {
+        "type": "object",
+        "description": "x402 v2 PaymentRequired envelope. Pick any entry from accepts[], sign for that rail, retry with the PAYMENT-SIGNATURE header.",
+        "required": [
+          "x402Version",
+          "accepts"
+        ],
+        "properties": {
+          "x402Version": {
+            "type": "integer",
+            "const": 2
+          },
+          "error": {
+            "type": "string",
+            "description": "Human-readable reason payment is required."
+          },
+          "resource": {
+            "type": "string",
+            "description": "The resource URL being purchased."
+          },
+          "accepts": {
+            "type": "array",
+            "description": "Payment requirement options, one per supported network (Base USDC, Solana USDC).",
+            "items": {
+              "type": "object",
+              "required": [
+                "scheme",
+                "network",
+                "amount",
+                "asset",
+                "payTo",
+                "maxTimeoutSeconds"
+              ],
+              "properties": {
+                "scheme": {
+                  "type": "string",
+                  "enum": [
+                    "exact"
+                  ]
+                },
+                "network": {
+                  "type": "string",
+                  "description": "CAIP-2 network id, e.g. \"eip155:8453\" (Base) or \"solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp\"."
+                },
+                "amount": {
+                  "type": "string",
+                  "description": "Price in atomic asset units (USDC has 6 decimals)."
+                },
+                "asset": {
+                  "type": "string",
+                  "description": "Asset contract address / mint."
+                },
+                "payTo": {
+                  "type": "string",
+                  "description": "Treasury address to pay."
+                },
+                "maxTimeoutSeconds": {
+                  "type": "integer"
+                },
+                "extra": {
+                  "type": "object",
+                  "description": "Rail-specific extras (EVM: EIP-712 domain name/version; Solana: feePayer).",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "extensions": {
+            "type": "object",
+            "description": "Optional discovery metadata (e.g. bazaar input/output schemas).",
+            "additionalProperties": true
+          }
+        }
+      }
+    }
+  },
+  "paths": {
+    "/api/census/zipcode": {
+      "get": {
+        "tags": [
+          "census"
+        ],
+        "summary": "Fetch US Census ACS 5-year demographics for a ZIP code (ZCTA).",
+        "description": "US Census ACS 5-year demographics for a ZIP code (ZCTA). Returns population, median age, median household income, poverty rate, household composition, race + ethnicity breakdown, education attainment, workforce (with computed unemployment rate), and housing (with computed owner-occupancy rate and median rent/home value). Backed by ~33k ZCTAs pre-ingested from api.census.gov; refreshed annually. Public-domain US government data.",
+        "operationId": "census_zipcode",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = [demographics] (one ZCTA: population, age, income, poverty, households, race/ethnicity, education, workforce, housing — with computed rates); total = 1. 404 if the ZIP has no ZCTA coverage.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.001 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "census.zipcode",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.001,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "zip",
+            "in": "query",
+            "required": true,
+            "description": "US ZIP code.",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{5}$"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/gov/bill-summaries": {
+      "get": {
+        "tags": [
+          "gov"
+        ],
+        "summary": "Fetch Stream the latest US Congressional bill summaries via...",
+        "description": "Stream the latest US Congressional bill summaries via Congress.gov. Each row is a CRS-authored summary attached to a specific version of a bill (Introduced, Reported to House, Engrossed in Senate, Public Law, etc.). Filter by congress + bill type. Returns the underlying bill metadata + summary text + version code + action date. Use this for change-detection on bills you care about, or to power agent-side \"what did Congress just pass\" feeds.",
+        "operationId": "gov_bill-summaries",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = CRS bill summaries (bill metadata + summary text + version code + action date); total = upstream match count.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "actionDate": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "actionDesc": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "bill": {
+                                "type": "object",
+                                "additionalProperties": {},
+                                "nullable": true
+                              },
+                              "currentChamber": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "currentChamberCode": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "lastSummaryUpdateDate": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "text": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "updateDate": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "versionCode": {
+                                "type": "string",
+                                "nullable": true
+                              }
+                            },
+                            "required": [
+                              "actionDate",
+                              "actionDesc",
+                              "bill",
+                              "currentChamber",
+                              "currentChamberCode",
+                              "lastSummaryUpdateDate",
+                              "text",
+                              "updateDate",
+                              "versionCode"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "gov.bill-summaries",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "congress",
+            "in": "query",
+            "required": false,
+            "description": "US Congress number (e.g. 118 for the 2023–2025 Congress).",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 200
+            }
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "required": false,
+            "description": "Filter results by type.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "hr",
+                "s",
+                "hjres",
+                "sjres",
+                "hconres",
+                "sconres",
+                "hres",
+                "sres"
+              ]
+            }
+          },
+          {
+            "name": "fromDate",
+            "in": "query",
+            "required": false,
+            "description": "From date.",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+            }
+          },
+          {
+            "name": "toDate",
+            "in": "query",
+            "required": false,
+            "description": "To date.",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+            }
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "required": false,
+            "description": "Field to sort results by.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "updateDate+desc",
+                "updateDate+asc"
+              ],
+              "default": "updateDate+desc"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of results to return.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 250,
+              "default": 25
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "description": "Number of results to skip before returning (pagination offset).",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/gov/congress-amendment": {
+      "get": {
+        "tags": [
+          "gov"
+        ],
+        "summary": "Look up or list US Congressional amendments via Congress.gov.",
+        "description": "Look up or list US Congressional amendments via Congress.gov. Pass congress + type + number to fetch a single amendment with full sponsor + action history. Or filter list by congress + type + date range. Amendment types: hamdt=House Amendment, samdt=Senate Amendment, suamdt=Senate Unprinted Amendment.",
+        "operationId": "gov_congress-amendment",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = [amendment] (lookup mode, total 1) or the amendment list (list mode, total = upstream match count); meta.mode flags which.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "mode": {
+                              "type": "string",
+                              "enum": [
+                                "lookup",
+                                "list"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "mode"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "gov.congress-amendment",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "congress",
+            "in": "query",
+            "required": false,
+            "description": "US Congress number (e.g. 118 for the 2023–2025 Congress).",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 200
+            }
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "required": false,
+            "description": "Filter results by type.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "hamdt",
+                "samdt",
+                "suamdt"
+              ]
+            }
+          },
+          {
+            "name": "number",
+            "in": "query",
+            "required": false,
+            "description": "Item number or identifier.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
+          },
+          {
+            "name": "fromDate",
+            "in": "query",
+            "required": false,
+            "description": "From date.",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+            }
+          },
+          {
+            "name": "toDate",
+            "in": "query",
+            "required": false,
+            "description": "To date.",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of results to return.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 250,
+              "default": 25
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "description": "Number of results to skip before returning (pagination offset).",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/gov/congress-bill": {
+      "get": {
+        "tags": [
+          "gov"
+        ],
+        "summary": "Look up or search US Congressional bills via the Library of...",
+        "description": "Look up or search US Congressional bills via the Library of Congress Congress.gov API. Pass congress + type + number to fetch a specific bill (title, sponsors, latest action, action/amendment/committee counts, policy area, congress.gov URL). Or omit number to list bills filtered by congress, bill type (hr | s | hjres | sjres | hconres | sconres | hres | sres), date range, with pagination + sort. Bill type semantics: hr=House Bill, s=Senate Bill, hjres/sjres=joint resolution, hconres/sconres=concurrent resolution, hres/sres=simple resolution.",
+        "operationId": "gov_congress-bill",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = [bill] (lookup mode, total 1) or the bill list (list mode, total = upstream match count); meta.mode flags which.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "mode": {
+                              "type": "string",
+                              "enum": [
+                                "lookup",
+                                "list"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "mode"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "gov.congress-bill",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "congress",
+            "in": "query",
+            "required": false,
+            "description": "US Congress number (e.g. 118 for the 2023–2025 Congress).",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 200
+            }
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "required": false,
+            "description": "Filter results by type.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "hr",
+                "s",
+                "hjres",
+                "sjres",
+                "hconres",
+                "sconres",
+                "hres",
+                "sres"
+              ]
+            }
+          },
+          {
+            "name": "number",
+            "in": "query",
+            "required": false,
+            "description": "Item number or identifier.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
+          },
+          {
+            "name": "fromDate",
+            "in": "query",
+            "required": false,
+            "description": "From date.",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+            }
+          },
+          {
+            "name": "toDate",
+            "in": "query",
+            "required": false,
+            "description": "To date.",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+            }
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "required": false,
+            "description": "Field to sort results by.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "updateDate+desc",
+                "updateDate+asc"
+              ],
+              "default": "updateDate+desc"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of results to return.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 250,
+              "default": 20
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "description": "Number of results to skip before returning (pagination offset).",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/gov/congress-committee": {
+      "get": {
+        "tags": [
+          "gov"
+        ],
+        "summary": "List or look up US Congressional committees (Library of...",
+        "description": "List or look up US Congressional committees (Library of Congress Congress.gov). Pass systemCode (e.g. \"hspw00\") to fetch a single committee with full detail (members, subcommittees, history, hearings, jurisdiction). Or filter list by congress + chamber (house | senate | joint). Standard system codes follow chamber prefix + abbreviation + suffix convention.",
+        "operationId": "gov_congress-committee",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = [committee] (lookup mode, total 1) or the committee list (list mode, total = upstream match count); meta.mode flags which.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "mode": {
+                              "type": "string",
+                              "enum": [
+                                "lookup",
+                                "list"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "mode"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "gov.congress-committee",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "congress",
+            "in": "query",
+            "required": false,
+            "description": "US Congress number (e.g. 118 for the 2023–2025 Congress).",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 200
+            }
+          },
+          {
+            "name": "chamber",
+            "in": "query",
+            "required": false,
+            "description": "Legislative chamber: house or senate.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "house",
+                "senate",
+                "joint"
+              ]
+            }
+          },
+          {
+            "name": "systemCode",
+            "in": "query",
+            "required": false,
+            "description": "System code.",
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-z]{2,8}\\d{2,4}$"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of results to return.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 250,
+              "default": 25
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "description": "Number of results to skip before returning (pagination offset).",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/gov/congress-filings": {
+      "get": {
+        "tags": [
+          "gov"
+        ],
+        "summary": "Fetch Track US House members' financial-disclosure filings...",
+        "description": "Track US House members' financial-disclosure filings — including Periodic Transaction Reports (PTRs), the STOCK Act filings where members must disclose their stock trades within 45 days. Defaults to PTRs; pass type=annual|candidate|amendment|all to see other disclosure kinds. Filter by member name (q), 2-letter state, filing year, or filing-date range (dateFrom/dateTo). Each result gives the member, state + district, filing type (with a readable label), the filing/disclosure date, and a direct link to the source document (docUrl). The envelope total is the full count matching your filter — so q=Pelosi or year=2026 answers 'how many PTRs did they file'. Covers 2008→present (~8,200 PTRs), refreshed daily so new filings appear within ~a day. Note: by law trades are disclosed up to 45 days after they happen — this is current-to-the-filing, not real-time. Data: US House Clerk (public domain).",
+        "operationId": "gov_congress-filings",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = matching filings (newest first); total = full count matching the filter.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "docId": {
+                                "type": "string"
+                              },
+                              "chamber": {
+                                "type": "string"
+                              },
+                              "memberName": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "state": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "district": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "filingType": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "filingTypeLabel": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "filingYear": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "filingDate": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "docUrl": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "tradesParsed": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "docId",
+                              "chamber",
+                              "memberName",
+                              "state",
+                              "district",
+                              "filingType",
+                              "filingTypeLabel",
+                              "filingYear",
+                              "filingDate",
+                              "docUrl",
+                              "tradesParsed"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "gov.congress-filings",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": false,
+            "description": "Free-text search query.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 80
+            }
+          },
+          {
+            "name": "state",
+            "in": "query",
+            "required": false,
+            "description": "US state — two-letter postal abbreviation (e.g. CA) or full name.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 2
+            }
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "required": false,
+            "description": "Filter results by type.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 40
+            }
+          },
+          {
+            "name": "chamber",
+            "in": "query",
+            "required": false,
+            "description": "Legislative chamber: house or senate.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "house",
+                "senate"
+              ]
+            }
+          },
+          {
+            "name": "year",
+            "in": "query",
+            "required": false,
+            "description": "Four-digit calendar year.",
+            "schema": {
+              "type": "integer",
+              "minimum": 2008,
+              "maximum": 2100
+            }
+          },
+          {
+            "name": "dateFrom",
+            "in": "query",
+            "required": false,
+            "description": "Date from.",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+            }
+          },
+          {
+            "name": "dateTo",
+            "in": "query",
+            "required": false,
+            "description": "Date to.",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of results to return.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 25
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "description": "Number of results to skip before returning (pagination offset).",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 100000,
+              "default": 0
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/gov/congress-hearing": {
+      "get": {
+        "tags": [
+          "gov"
+        ],
+        "summary": "Look up or list US Congressional hearings via Congress.gov.",
+        "description": "Look up or list US Congressional hearings via Congress.gov. Pass congress + chamber + jacketNumber to fetch a single hearing with full detail (title, dates, committee, transcripts/recordings if available). Or filter list by congress + chamber, with optional date range. Hearings cover committee testimony from the executive branch, subject experts, and stakeholders — primary-source material for oversight + policy research.",
+        "operationId": "gov_congress-hearing",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = [hearing] (lookup mode, total 1) or the hearing list (list mode, total = upstream match count); meta.mode flags which.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "mode": {
+                              "type": "string",
+                              "enum": [
+                                "lookup",
+                                "list"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "mode"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "gov.congress-hearing",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "congress",
+            "in": "query",
+            "required": false,
+            "description": "US Congress number (e.g. 118 for the 2023–2025 Congress).",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 200
+            }
+          },
+          {
+            "name": "chamber",
+            "in": "query",
+            "required": false,
+            "description": "Legislative chamber: house or senate.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "house",
+                "senate"
+              ]
+            }
+          },
+          {
+            "name": "jacketNumber",
+            "in": "query",
+            "required": false,
+            "description": "Jacket number.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
+          },
+          {
+            "name": "fromDate",
+            "in": "query",
+            "required": false,
+            "description": "From date.",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+            }
+          },
+          {
+            "name": "toDate",
+            "in": "query",
+            "required": false,
+            "description": "To date.",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of results to return.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 250,
+              "default": 25
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "description": "Number of results to skip before returning (pagination offset).",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/gov/congress-member": {
+      "get": {
+        "tags": [
+          "gov"
+        ],
+        "summary": "Look up or search members of the US Congress via Library of...",
+        "description": "Look up or search members of the US Congress via Library of Congress Congress.gov API. Pass bioguideId (e.g. M001190) to fetch one member (full bio, terms, party history, leadership roles, sponsored + cosponsored legislation counts, official website, address). Or filter by congress + state + district, with currentMember=true to limit to seated members. Bioguide IDs are stable across history and are the canonical Congress-member identifier.",
+        "operationId": "gov_congress-member",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = [member] (lookup mode, total 1) or the member list (list mode, total = upstream match count); meta.mode flags which.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "mode": {
+                              "type": "string",
+                              "enum": [
+                                "lookup",
+                                "list"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "mode"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "gov.congress-member",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "bioguideId",
+            "in": "query",
+            "required": false,
+            "description": "Bioguide ID.",
+            "schema": {
+              "type": "string",
+              "pattern": "^[A-Z]\\d{6}$"
+            }
+          },
+          {
+            "name": "congress",
+            "in": "query",
+            "required": false,
+            "description": "US Congress number (e.g. 118 for the 2023–2025 Congress).",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 200
+            }
+          },
+          {
+            "name": "state",
+            "in": "query",
+            "required": false,
+            "description": "US state — two-letter postal abbreviation (e.g. CA) or full name.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 2,
+              "pattern": "^[A-Za-z]{2}$"
+            }
+          },
+          {
+            "name": "district",
+            "in": "query",
+            "required": false,
+            "description": "District.",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 60
+            }
+          },
+          {
+            "name": "currentMember",
+            "in": "query",
+            "required": false,
+            "description": "Current member.",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of results to return.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 250,
+              "default": 25
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "description": "Number of results to skip before returning (pagination offset).",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/gov/congress-nomination": {
+      "get": {
+        "tags": [
+          "gov"
+        ],
+        "summary": "Look up or list US presidential nominations (cabinet...",
+        "description": "Look up or list US presidential nominations (cabinet, judicial, executive) sent to the Senate for confirmation via Congress.gov. Pass congress + number for a single nomination with full action history. Or filter list by congress + date range. Each row carries: citation (PN###-#), description (nominee + position), receivedDate, nominationType (civilian / military / etc.), organization, latest action (committee referral, hearing, confirmation, withdrawal). Essential for confirmation-tracking + judicial-vetting agents.",
+        "operationId": "gov_congress-nomination",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = [nomination] (lookup mode, total 1) or the nomination list (list mode, total = upstream match count); meta.mode flags which.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "mode": {
+                              "type": "string",
+                              "enum": [
+                                "lookup",
+                                "list"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "mode"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "gov.congress-nomination",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "congress",
+            "in": "query",
+            "required": false,
+            "description": "US Congress number (e.g. 118 for the 2023–2025 Congress).",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 200
+            }
+          },
+          {
+            "name": "number",
+            "in": "query",
+            "required": false,
+            "description": "Item number or identifier.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
+          },
+          {
+            "name": "fromDate",
+            "in": "query",
+            "required": false,
+            "description": "From date.",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+            }
+          },
+          {
+            "name": "toDate",
+            "in": "query",
+            "required": false,
+            "description": "To date.",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of results to return.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 250,
+              "default": 25
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "description": "Number of results to skip before returning (pagination offset).",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/gov/congress-record": {
+      "get": {
+        "tags": [
+          "gov"
+        ],
+        "summary": "List daily Congressional Record issues via Congress.gov...",
+        "description": "List daily Congressional Record issues via Congress.gov — the official transcripts and proceedings of the US House and Senate, daily. Filter by year + month + day to narrow to a specific date or month. Each issue carries volume, issue number, publish date, and links to per-section content (Daily Digest, Senate, House, Extensions of Remarks) with PDF + sub-section URLs. Primary source for what was said on the floor.",
+        "operationId": "gov_congress-record",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = Congressional Record issues (id, congress, session, issue, volume, publishDate, links); total = null (upstream paginates without a true count).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "gov.congress-record",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "year",
+            "in": "query",
+            "required": false,
+            "description": "Four-digit calendar year.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1873,
+              "maximum": 2100
+            }
+          },
+          {
+            "name": "month",
+            "in": "query",
+            "required": false,
+            "description": "Calendar month (1–12).",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 12
+            }
+          },
+          {
+            "name": "day",
+            "in": "query",
+            "required": false,
+            "description": "Day of the month (1–31).",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 31
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "description": "Number of results to skip before returning (pagination offset).",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/gov/congress-trades": {
+      "get": {
+        "tags": [
+          "gov"
+        ],
+        "summary": "Search individual US Congress member stock trades, parsed...",
+        "description": "Search individual US Congress member stock trades, parsed from STOCK Act Periodic Transaction Reports into clean rows. Filter by member name (q, e.g. \"Pelosi\"), ticker (e.g. NVDA), transaction type (purchase | sale | exchange | partial_sale), 2-letter state, chamber, or transaction-date range (dateFrom/dateTo). Each trade returns the member + state/district, owner (self/spouse/joint/dependent), ticker + asset description, buy/sell, the disclosed dollar RANGE (amountMin/amountMax — disclosures are ranges, not exact), the transaction date, the disclosure date, days-to-disclose (compliance lag), and a link to the source filing PDF. The envelope total is the full count matching your filter — so ticker=NVDA&type=purchase counts who bought NVIDIA. Amounts are ranges by law; trades are disclosed up to 45 days after they happen (current-to-the-filing). Coverage: US House + Senate e-filed PTRs; scanned/handwritten reports are parsed separately. Data: US House Clerk / US Senate eFD (public domain). Cross-ref /api/gov/congress-filings for the raw filing index.",
+        "operationId": "gov_congress-trades",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = matching trades (newest transaction first); total = full count matching the filter.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "member": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "chamber": {
+                                "type": "string"
+                              },
+                              "state": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "district": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "owner": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "ticker": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "assetDescription": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "assetType": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "transactionType": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "amountMin": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "amountMax": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "transactionDate": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "disclosureDate": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "daysToDisclose": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "docUrl": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "source": {
+                                "type": "string",
+                                "nullable": true
+                              }
+                            },
+                            "required": [
+                              "member",
+                              "chamber",
+                              "state",
+                              "district",
+                              "owner",
+                              "ticker",
+                              "assetDescription",
+                              "assetType",
+                              "transactionType",
+                              "amountMin",
+                              "amountMax",
+                              "transactionDate",
+                              "disclosureDate",
+                              "daysToDisclose",
+                              "docUrl",
+                              "source"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "gov.congress-trades",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": false,
+            "description": "Free-text search query.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 80
+            }
+          },
+          {
+            "name": "ticker",
+            "in": "query",
+            "required": false,
+            "description": "Ticker.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 10
+            }
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "required": false,
+            "description": "Filter results by type.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 20
+            }
+          },
+          {
+            "name": "chamber",
+            "in": "query",
+            "required": false,
+            "description": "Legislative chamber: house or senate.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "house",
+                "senate"
+              ]
+            }
+          },
+          {
+            "name": "state",
+            "in": "query",
+            "required": false,
+            "description": "US state — two-letter postal abbreviation (e.g. CA) or full name.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 2
+            }
+          },
+          {
+            "name": "dateFrom",
+            "in": "query",
+            "required": false,
+            "description": "Date from.",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+            }
+          },
+          {
+            "name": "dateTo",
+            "in": "query",
+            "required": false,
+            "description": "Date to.",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of results to return.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 25
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "description": "Number of results to skip before returning (pagination offset).",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 100000,
+              "default": 0
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/gov/congress-treaty": {
+      "get": {
+        "tags": [
+          "gov"
+        ],
+        "summary": "Look up or list international treaties transmitted to the...",
+        "description": "Look up or list international treaties transmitted to the US Senate for advice and consent via Congress.gov. Pass congress + number (optionally + suffix for partitioned treaties) to fetch a single treaty with parties, topic, transmittal date, and consideration status. Or list by congress. Returns the congress the treaty was received in, the congress that considered it (if any), partial-treaty suffix, topic, transmitted date, and count of parties.",
+        "operationId": "gov_congress-treaty",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = [treaty] (lookup mode, total 1) or the treaty list (list mode, total = upstream match count); meta.mode flags which.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "mode": {
+                              "type": "string",
+                              "enum": [
+                                "lookup",
+                                "list"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "mode"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "gov.congress-treaty",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "congress",
+            "in": "query",
+            "required": false,
+            "description": "US Congress number (e.g. 118 for the 2023–2025 Congress).",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 200
+            }
+          },
+          {
+            "name": "number",
+            "in": "query",
+            "required": false,
+            "description": "Item number or identifier.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
+          },
+          {
+            "name": "suffix",
+            "in": "query",
+            "required": false,
+            "description": "Suffix.",
+            "schema": {
+              "type": "string",
+              "pattern": "^[A-Za-z]$"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of results to return.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 250,
+              "default": 25
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "description": "Number of results to skip before returning (pagination offset).",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/gov/epa-facilities": {
+      "get": {
+        "tags": [
+          "gov"
+        ],
+        "summary": "Fetch EPA Facility Registry Service (FRS) - every regulated...",
+        "description": "EPA Facility Registry Service (FRS) — every regulated facility known to the EPA across all programs (RCRA hazardous waste, NPDES water discharge, SDWA drinking water, TRI toxic release, CAA Clean Air, Superfund, etc.). Filter by state (required), facility name prefix, and EPA program acronym. Each record includes registry ID, primary name, address, city/state/county/zip, EPA region, program system + ID, source-of-data system. Public-domain US government records.",
+        "operationId": "gov_epa-facilities",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = EPA-regulated facilities (state/name/program filtered); total = null (Envirofacts does not report a match count); meta.query echoes the search.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "registryId": {
+                                "type": "string"
+                              },
+                              "primaryName": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "locationAddress": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "city": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "state": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "postalCode": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "county": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "epaRegion": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "programSystem": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "pgmSysId": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "sourceOfData": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "publicIndicator": {
+                                "type": "string",
+                                "nullable": true
+                              }
+                            },
+                            "required": [
+                              "registryId",
+                              "primaryName",
+                              "locationAddress",
+                              "city",
+                              "state",
+                              "postalCode",
+                              "county",
+                              "epaRegion",
+                              "programSystem",
+                              "pgmSysId",
+                              "sourceOfData",
+                              "publicIndicator"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "query": {
+                              "type": "object",
+                              "properties": {
+                                "state": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "program": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "limit": {
+                                  "type": "integer"
+                                },
+                                "offset": {
+                                  "type": "integer"
+                                }
+                              },
+                              "required": [
+                                "state",
+                                "name",
+                                "program",
+                                "limit",
+                                "offset"
+                              ],
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "query"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0024 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "gov.epa-facilities",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0024,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.002400"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "state",
+            "in": "query",
+            "required": true,
+            "description": "2-letter US state code. Required. Example: \"CA\", \"TX\", \"NY\".",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 2,
+              "pattern": "^[A-Za-z]{2}$"
+            }
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "description": "Facility-name prefix match (case-insensitive). Example: \"TESLA\", \"BOEING\", \"AMAZON\".",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 80
+            }
+          },
+          {
+            "name": "program",
+            "in": "query",
+            "required": false,
+            "description": "Program system acronym. Examples: RCRA (hazardous waste), NPDES (water discharge), TRI (toxic release), AIR (Clean Air), SDWA (drinking water).",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 10,
+              "pattern": "^[A-Za-z0-9]+$"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Max facilities to return (1-100). Default 25.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 25
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "description": "Offset for pagination. Default 0.",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 10000,
+              "default": 0
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/gov/fda-animalvet-events": {
+      "get": {
+        "tags": [
+          "gov"
+        ],
+        "summary": "Fetch FDA animal and veterinary adverse event reports, newest",
+        "description": "FDA animal and veterinary adverse event reports, newest first. All filters optional. Each record includes AER ID, dates, animal species/gender/breed/age/weight, reactions (VeDDRA-coded), drugs (brand + active ingredients + administration), primary reporter (Veterinarian/Owner/Other). Use cases: veterinary practice safety research, pet food adverse events, livestock drug surveillance. Backed by OpenFDA's /animalandveterinary/event endpoint; public-domain US government records.",
+        "operationId": "gov_fda-animalvet-events",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = FDA animal/veterinary adverse event reports, newest first; total = upstream match count; meta.query echoes the search.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "aerId": {
+                                "type": "string"
+                              },
+                              "originalReceiveDate": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "onsetDate": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "numberAffected": {
+                                "type": "integer",
+                                "nullable": true
+                              },
+                              "numberTreated": {
+                                "type": "integer",
+                                "nullable": true
+                              },
+                              "animal": {
+                                "type": "object",
+                                "properties": {
+                                  "species": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "gender": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "breed": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "ageValue": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "ageUnit": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "weightValue": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "weightUnit": {
+                                    "type": "string",
+                                    "nullable": true
+                                  }
+                                },
+                                "required": [
+                                  "species",
+                                  "gender",
+                                  "breed",
+                                  "ageValue",
+                                  "ageUnit",
+                                  "weightValue",
+                                  "weightUnit"
+                                ],
+                                "additionalProperties": false
+                              },
+                              "reactions": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "term": {
+                                      "type": "string"
+                                    },
+                                    "veddraCode": {
+                                      "type": "string",
+                                      "nullable": true
+                                    }
+                                  },
+                                  "required": [
+                                    "term",
+                                    "veddraCode"
+                                  ],
+                                  "additionalProperties": false
+                                }
+                              },
+                              "drugs": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "brandName": {
+                                      "type": "string",
+                                      "nullable": true
+                                    },
+                                    "activeIngredients": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "administeredBy": {
+                                      "type": "string",
+                                      "nullable": true
+                                    },
+                                    "route": {
+                                      "type": "string",
+                                      "nullable": true
+                                    }
+                                  },
+                                  "required": [
+                                    "brandName",
+                                    "activeIngredients",
+                                    "administeredBy",
+                                    "route"
+                                  ],
+                                  "additionalProperties": false
+                                }
+                              },
+                              "primaryReporter": {
+                                "type": "string",
+                                "nullable": true
+                              }
+                            },
+                            "required": [
+                              "aerId",
+                              "originalReceiveDate",
+                              "onsetDate",
+                              "numberAffected",
+                              "numberTreated",
+                              "animal",
+                              "reactions",
+                              "drugs",
+                              "primaryReporter"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "query": {
+                              "type": "object",
+                              "properties": {
+                                "drug": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "species": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "reaction": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "limit": {
+                                  "type": "integer"
+                                }
+                              },
+                              "required": [
+                                "drug",
+                                "species",
+                                "reaction",
+                                "limit"
+                              ],
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "query"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0024 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "gov.fda-animalvet-events",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0024,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.002400"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "drug",
+            "in": "query",
+            "required": false,
+            "description": "Drug name substring across brand + active ingredients. Examples: \"Heartgard\", \"Bravecto\", \"Apoquel\".",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 100
+            }
+          },
+          {
+            "name": "species",
+            "in": "query",
+            "required": false,
+            "description": "Animal species. Examples: \"Dog\", \"Cat\", \"Horse\", \"Cattle\", \"Chicken\".",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 60
+            }
+          },
+          {
+            "name": "reaction",
+            "in": "query",
+            "required": false,
+            "description": "Reaction (VeDDRA preferred term) substring. Examples: \"Vomiting\", \"Lethargy\", \"Death\".",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 100
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Max events (1-100). Default 20.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 20
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/gov/fda-device-events": {
+      "get": {
+        "tags": [
+          "gov"
+        ],
+        "summary": "Fetch FDA medical device adverse event reports (MAUDE)",
+        "description": "FDA medical device adverse event reports (MAUDE), newest first by date received. All filters optional. Each record includes report number, event type, dates received + of event, manufacturer, brand/generic device name, model + catalog numbers, listed device problems, patient outcomes, and primary narrative text. Backed by OpenFDA's /device/event endpoint; public-domain US government records.",
+        "operationId": "gov_fda-device-events",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = FDA MAUDE device adverse event reports; total = upstream match count; meta.query echoes the search.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "reportNumber": {
+                                "type": "string"
+                              },
+                              "eventType": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "dateReceived": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "dateOfEvent": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "manufacturerName": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "brandName": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "genericName": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "modelNumber": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "catalogNumber": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "deviceProblems": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "patientOutcome": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "eventDescription": {
+                                "type": "string",
+                                "nullable": true
+                              }
+                            },
+                            "required": [
+                              "reportNumber",
+                              "eventType",
+                              "dateReceived",
+                              "dateOfEvent",
+                              "manufacturerName",
+                              "brandName",
+                              "genericName",
+                              "modelNumber",
+                              "catalogNumber",
+                              "deviceProblems",
+                              "patientOutcome",
+                              "eventDescription"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "query": {
+                              "type": "object",
+                              "properties": {
+                                "device": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "manufacturer": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "problem": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "limit": {
+                                  "type": "integer"
+                                }
+                              },
+                              "required": [
+                                "device",
+                                "manufacturer",
+                                "problem",
+                                "limit"
+                              ],
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "query"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0024 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "gov.fda-device-events",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0024,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.002400"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "device",
+            "in": "query",
+            "required": false,
+            "description": "Device-name substring across brand_name + generic_name. Examples: \"pacemaker\", \"insulin pump\", \"DePuy hip\".",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 100
+            }
+          },
+          {
+            "name": "manufacturer",
+            "in": "query",
+            "required": false,
+            "description": "Manufacturer-name substring. Examples: \"medtronic\", \"boston scientific\", \"abbott\".",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 100
+            }
+          },
+          {
+            "name": "problem",
+            "in": "query",
+            "required": false,
+            "description": "FDA device product code substring (advanced filter; most users want device or manufacturer).",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 100
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Max events (1-100). Default 20.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 20
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/gov/fda-drug-events": {
+      "get": {
+        "tags": [
+          "gov"
+        ],
+        "summary": "Fetch Adverse drug event reports from FDA's Adverse Event...",
+        "description": "Adverse drug event reports from FDA's Adverse Event Reporting System (FAERS) — 9M+ records since 1968 covering serious adverse events, hospitalizations, deaths, and disabilities. Search by drug name (brand/generic/substance, all OR-matched) and optionally filter by MedDRA reaction term. Returns report ID, received date, seriousness flags, patient demographics, MedDRA-coded reactions, implicated drugs (up to 5 per report), and reporting country. Backed by OpenFDA; data is public-domain US government records.",
+        "operationId": "gov_fda-drug-events",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = FDA FAERS adverse drug event reports; total = upstream match count; meta.query echoes the search.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "safetyReportId": {
+                                "type": "string"
+                              },
+                              "receivedDate": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "serious": {
+                                "type": "boolean"
+                              },
+                              "hospitalization": {
+                                "type": "boolean"
+                              },
+                              "death": {
+                                "type": "boolean"
+                              },
+                              "disabling": {
+                                "type": "boolean"
+                              },
+                              "lifeThreatening": {
+                                "type": "boolean"
+                              },
+                              "patientSex": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "patientAge": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "reactions": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "drugs": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "medicinalProduct": {
+                                      "type": "string",
+                                      "nullable": true
+                                    },
+                                    "brandName": {
+                                      "type": "string",
+                                      "nullable": true
+                                    },
+                                    "indication": {
+                                      "type": "string",
+                                      "nullable": true
+                                    },
+                                    "dosageText": {
+                                      "type": "string",
+                                      "nullable": true
+                                    }
+                                  },
+                                  "required": [
+                                    "medicinalProduct",
+                                    "brandName",
+                                    "indication",
+                                    "dosageText"
+                                  ],
+                                  "additionalProperties": false
+                                }
+                              },
+                              "occurCountry": {
+                                "type": "string",
+                                "nullable": true
+                              }
+                            },
+                            "required": [
+                              "safetyReportId",
+                              "receivedDate",
+                              "serious",
+                              "hospitalization",
+                              "death",
+                              "disabling",
+                              "lifeThreatening",
+                              "patientSex",
+                              "patientAge",
+                              "reactions",
+                              "drugs",
+                              "occurCountry"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "query": {
+                              "type": "object",
+                              "properties": {
+                                "drug": {
+                                  "type": "string"
+                                },
+                                "reaction": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "limit": {
+                                  "type": "integer"
+                                }
+                              },
+                              "required": [
+                                "drug",
+                                "reaction",
+                                "limit"
+                              ],
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "query"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0024 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "gov.fda-drug-events",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0024,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.002400"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "drug",
+            "in": "query",
+            "required": true,
+            "description": "Drug name (brand, generic, or substance). Examples: \"tylenol\", \"metformin\", \"lisinopril\". Case-insensitive.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 100
+            }
+          },
+          {
+            "name": "reaction",
+            "in": "query",
+            "required": false,
+            "description": "Optional MedDRA preferred-term reaction filter. Examples: \"headache\", \"nausea\", \"anaphylaxis\".",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 100
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Max reports to return (1-100). Default 10.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 10
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/gov/fda-food-recalls": {
+      "get": {
+        "tags": [
+          "gov"
+        ],
+        "summary": "Fetch FDA food recall enforcement reports, newest first",
+        "description": "FDA food recall enforcement reports, newest first by report date. All filters optional. Each record includes recall number, status (Ongoing/Completed/Terminated/Pending), classification (Class I/II/III), product description, reason for recall, initial-notification mechanism, voluntary-vs-mandated, recalling firm + city/state/country, distribution pattern, and recall + report dates. Backed by OpenFDA's /food/enforcement endpoint; public-domain US government records.",
+        "operationId": "gov_fda-food-recalls",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = FDA food recall enforcement reports, newest first; total = upstream match count; meta.query echoes the search.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "recallNumber": {
+                                "type": "string"
+                              },
+                              "status": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "classification": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "productType": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "productDescription": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "reasonForRecall": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "initialNotification": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "voluntaryMandated": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "recallingFirm": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "city": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "state": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "country": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "distributionPattern": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "recallInitiationDate": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "reportDate": {
+                                "type": "string",
+                                "nullable": true
+                              }
+                            },
+                            "required": [
+                              "recallNumber",
+                              "status",
+                              "classification",
+                              "productType",
+                              "productDescription",
+                              "reasonForRecall",
+                              "initialNotification",
+                              "voluntaryMandated",
+                              "recallingFirm",
+                              "city",
+                              "state",
+                              "country",
+                              "distributionPattern",
+                              "recallInitiationDate",
+                              "reportDate"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "query": {
+                              "type": "object",
+                              "properties": {
+                                "product": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "classification": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "status": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "state": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "limit": {
+                                  "type": "integer"
+                                }
+                              },
+                              "required": [
+                                "product",
+                                "classification",
+                                "status",
+                                "state",
+                                "limit"
+                              ],
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "query"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0024 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "gov.fda-food-recalls",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0024,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.002400"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "product",
+            "in": "query",
+            "required": false,
+            "description": "Product-name substring match on the recall description. Examples: \"spinach\", \"peanut butter\", \"infant formula\".",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 100
+            }
+          },
+          {
+            "name": "classification",
+            "in": "query",
+            "required": false,
+            "description": "Optional class filter. I = life-threatening (e.g., Listeria, undeclared major allergen), II = temporary/reversible health risk, III = unlikely to cause harm (e.g., minor labeling).",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "I",
+                "II",
+                "III"
+              ]
+            }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "description": "Optional status filter.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Ongoing",
+                "Completed",
+                "Terminated",
+                "Pending"
+              ]
+            }
+          },
+          {
+            "name": "state",
+            "in": "query",
+            "required": false,
+            "description": "Optional 2-letter US state of the recalling firm (e.g., \"CA\", \"TX\").",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 2,
+              "pattern": "^[A-Za-z]{2}$"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Max recalls (1-100). Default 20.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 20
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/gov/fda-recalls": {
+      "get": {
+        "tags": [
+          "gov"
+        ],
+        "summary": "Fetch FDA drug recall enforcement reports, newest first.",
+        "description": "FDA drug recall enforcement reports, newest first. All filters optional. Each record includes recall number, status (Ongoing/Completed/Terminated/Pending), classification (Class I/II/III), product description, reason for recall, initial-notification mechanism, voluntary-vs-mandated flag, recalling firm name + city/state/country, distribution pattern, and recall + report dates. Backed by OpenFDA's /drug/enforcement endpoint; data is public-domain US government records.",
+        "operationId": "gov_fda-recalls",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = FDA drug recall enforcement reports, newest first; total = upstream match count; meta.query echoes the search.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "recallNumber": {
+                                "type": "string"
+                              },
+                              "status": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "classification": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "productType": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "productDescription": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "reasonForRecall": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "initialNotification": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "voluntaryMandated": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "recallingFirm": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "city": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "state": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "country": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "distributionPattern": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "recallInitiationDate": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "reportDate": {
+                                "type": "string",
+                                "nullable": true
+                              }
+                            },
+                            "required": [
+                              "recallNumber",
+                              "status",
+                              "classification",
+                              "productType",
+                              "productDescription",
+                              "reasonForRecall",
+                              "initialNotification",
+                              "voluntaryMandated",
+                              "recallingFirm",
+                              "city",
+                              "state",
+                              "country",
+                              "distributionPattern",
+                              "recallInitiationDate",
+                              "reportDate"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "query": {
+                              "type": "object",
+                              "properties": {
+                                "drug": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "classification": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "status": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "limit": {
+                                  "type": "integer"
+                                }
+                              },
+                              "required": [
+                                "drug",
+                                "classification",
+                                "status",
+                                "limit"
+                              ],
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "query"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0024 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "gov.fda-recalls",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0024,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.002400"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "drug",
+            "in": "query",
+            "required": false,
+            "description": "Optional drug-name substring match on the recall product description. Examples: \"sanitizer\", \"metformin\", \"valsartan\".",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 100
+            }
+          },
+          {
+            "name": "classification",
+            "in": "query",
+            "required": false,
+            "description": "Optional class filter. I = life-threatening, II = temporary/reversible health risk, III = unlikely to cause harm.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "I",
+                "II",
+                "III"
+              ]
+            }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "description": "Optional status filter.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Ongoing",
+                "Completed",
+                "Terminated",
+                "Pending"
+              ]
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Max recalls to return (1-100). Default 20.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 20
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/gov/fec-candidate": {
+      "get": {
+        "tags": [
+          "gov"
+        ],
+        "summary": "Search US federal political candidates via the OpenFEC API.",
+        "description": "Search US federal political candidates via the OpenFEC API. Filter by free-text q (name match), candidate ID (e.g. H0VA01076), state, district, party (DEM, REP, IND, LIB, GRE, etc.), office (P=President | S=Senate | H=House), election cycle (even years), election year, and hasRaised (only candidates with reported receipts). Returns FEC candidate ID, name, party, office, state/district, incumbency status, active-through cycle, first/last file dates, cycles, principal committee linkage. Use the candidate ID returned here to fetch their committees with /api/gov/fec-committee.",
+        "operationId": "gov_fec-candidate",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = FEC candidate records; total = upstream match count (OpenFEC pagination.count); page = pagination block.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "page": {
+                          "type": "object",
+                          "properties": {
+                            "number": {
+                              "type": "integer"
+                            },
+                            "size": {
+                              "type": "integer"
+                            },
+                            "pages": {
+                              "type": "integer",
+                              "nullable": true
+                            }
+                          },
+                          "required": [
+                            "number",
+                            "size",
+                            "pages"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "gov.fec-candidate",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": false,
+            "description": "Free-text search query.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 120
+            }
+          },
+          {
+            "name": "candidateId",
+            "in": "query",
+            "required": false,
+            "description": "Candidate ID.",
+            "schema": {
+              "type": "string",
+              "pattern": "^[A-Z]\\d[A-Z0-9]{7}$"
+            }
+          },
+          {
+            "name": "state",
+            "in": "query",
+            "required": false,
+            "description": "US state — two-letter postal abbreviation (e.g. CA) or full name.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 2,
+              "pattern": "^[A-Za-z]{2}$"
+            }
+          },
+          {
+            "name": "district",
+            "in": "query",
+            "required": false,
+            "description": "District.",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{2}$"
+            }
+          },
+          {
+            "name": "party",
+            "in": "query",
+            "required": false,
+            "description": "Party.",
+            "schema": {
+              "type": "string",
+              "pattern": "^[A-Za-z]{3,4}$"
+            }
+          },
+          {
+            "name": "office",
+            "in": "query",
+            "required": false,
+            "description": "Office.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "P",
+                "S",
+                "H"
+              ]
+            }
+          },
+          {
+            "name": "cycle",
+            "in": "query",
+            "required": false,
+            "description": "Two-year US election cycle, given as the even-numbered end year (e.g. 2024).",
+            "schema": {
+              "type": "integer",
+              "minimum": 1980,
+              "maximum": 2100
+            }
+          },
+          {
+            "name": "electionYear",
+            "in": "query",
+            "required": false,
+            "description": "Election year.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1980,
+              "maximum": 2100
+            }
+          },
+          {
+            "name": "hasRaised",
+            "in": "query",
+            "required": false,
+            "description": "Has raised.",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "perPage",
+            "in": "query",
+            "required": false,
+            "description": "Number of results to return per page.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 25
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "description": "Page number (1-based) for paginated results.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 1
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/gov/fec-committee": {
+      "get": {
+        "tags": [
+          "gov"
+        ],
+        "summary": "Search US federal political committees (PACs, super PACs...",
+        "description": "Search US federal political committees (PACs, super PACs, party committees, candidate principal committees, leadership PACs, etc.) via the OpenFEC API. Filter by q (name match), committee ID, candidate ID (returns committees linked to that candidate), committee type (P=Presidential | S=Senate | H=House | X=Independent expenditure-only | Y=Party | Z=National Party non-federal), designation (A=Authorized | J=Joint fundraising | P=Principal | U=Unauthorized | B=Lobbyist/Registrant PAC), state, party, cycle, organization type (C=Corporation | L=Labor | M=Membership | T=Trade | V=Cooperative | W=Corp without stock). Returns FEC committee ID, name, type/designation/organization labels, state, party, treasurer, linked candidate IDs, cycles, affiliated-committee names, first/last file dates.",
+        "operationId": "gov_fec-committee",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = FEC committee records; total = upstream match count (OpenFEC pagination.count); page = pagination block.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "page": {
+                          "type": "object",
+                          "properties": {
+                            "number": {
+                              "type": "integer"
+                            },
+                            "size": {
+                              "type": "integer"
+                            },
+                            "pages": {
+                              "type": "integer",
+                              "nullable": true
+                            }
+                          },
+                          "required": [
+                            "number",
+                            "size",
+                            "pages"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "gov.fec-committee",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": false,
+            "description": "Free-text search query.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 120
+            }
+          },
+          {
+            "name": "committeeId",
+            "in": "query",
+            "required": false,
+            "description": "Committee ID.",
+            "schema": {
+              "type": "string",
+              "pattern": "^C\\d{8}$"
+            }
+          },
+          {
+            "name": "candidateId",
+            "in": "query",
+            "required": false,
+            "description": "Candidate ID.",
+            "schema": {
+              "type": "string",
+              "pattern": "^[A-Z]\\d[A-Z0-9]{7}$"
+            }
+          },
+          {
+            "name": "committeeType",
+            "in": "query",
+            "required": false,
+            "description": "Committee type.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "P",
+                "S",
+                "H",
+                "X",
+                "Y",
+                "Z",
+                "N",
+                "I",
+                "O",
+                "Q",
+                "U",
+                "V",
+                "W",
+                "D",
+                "E"
+              ]
+            }
+          },
+          {
+            "name": "designation",
+            "in": "query",
+            "required": false,
+            "description": "Designation.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "A",
+                "J",
+                "P",
+                "U",
+                "B",
+                "D"
+              ]
+            }
+          },
+          {
+            "name": "state",
+            "in": "query",
+            "required": false,
+            "description": "US state — two-letter postal abbreviation (e.g. CA) or full name.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 2,
+              "pattern": "^[A-Za-z]{2}$"
+            }
+          },
+          {
+            "name": "party",
+            "in": "query",
+            "required": false,
+            "description": "Party.",
+            "schema": {
+              "type": "string",
+              "pattern": "^[A-Za-z]{3,4}$"
+            }
+          },
+          {
+            "name": "cycle",
+            "in": "query",
+            "required": false,
+            "description": "Two-year US election cycle, given as the even-numbered end year (e.g. 2024).",
+            "schema": {
+              "type": "integer",
+              "minimum": 1980,
+              "maximum": 2100
+            }
+          },
+          {
+            "name": "organizationType",
+            "in": "query",
+            "required": false,
+            "description": "Organization type.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "C",
+                "L",
+                "M",
+                "T",
+                "V",
+                "W"
+              ]
+            }
+          },
+          {
+            "name": "perPage",
+            "in": "query",
+            "required": false,
+            "description": "Number of results to return per page.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 25
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "description": "Page number (1-based) for paginated results.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 1
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/gov/fec-contributions": {
+      "get": {
+        "tags": [
+          "gov"
+        ],
+        "summary": "Search FEC Schedule A - every itemized contribution to a...",
+        "description": "Search FEC Schedule A — every itemized contribution to a federal political committee (>264M rows across all cycles). Filter by recipient committeeId or candidateId, contributor name / city / state / zip / employer / occupation, amount range, cycle (twoYearTransactionPeriod e.g. 2024), date range, isIndividual (true = individuals only; false = committee-to-committee). Sort by contribution date or amount, asc/desc. The investigative-journalism + political-research goldmine: who gives, how much, when, working where, doing what. Each row carries the contribution receipt date, amount, contributor aggregate YTD, receipt type, memo, entity type, and link to the underlying PDF filing.",
+        "operationId": "gov_fec-contributions",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = FEC Schedule A itemized contributions; total = upstream match count (OpenFEC pagination.count, null on deep keyset pages); page = pagination block.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "page": {
+                          "type": "object",
+                          "properties": {
+                            "number": {
+                              "type": "integer"
+                            },
+                            "size": {
+                              "type": "integer"
+                            },
+                            "pages": {
+                              "type": "integer",
+                              "nullable": true
+                            }
+                          },
+                          "required": [
+                            "number",
+                            "size",
+                            "pages"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "gov.fec-contributions",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "committeeId",
+            "in": "query",
+            "required": false,
+            "description": "Committee ID.",
+            "schema": {
+              "type": "string",
+              "pattern": "^C\\d{8}$"
+            }
+          },
+          {
+            "name": "candidateId",
+            "in": "query",
+            "required": false,
+            "description": "Candidate ID.",
+            "schema": {
+              "type": "string",
+              "pattern": "^[A-Z]\\d[A-Z0-9]{7}$"
+            }
+          },
+          {
+            "name": "contributorName",
+            "in": "query",
+            "required": false,
+            "description": "Contributor name.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 120
+            }
+          },
+          {
+            "name": "contributorCity",
+            "in": "query",
+            "required": false,
+            "description": "Contributor city.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 80
+            }
+          },
+          {
+            "name": "contributorState",
+            "in": "query",
+            "required": false,
+            "description": "Contributor state.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 2,
+              "pattern": "^[A-Za-z]{2}$"
+            }
+          },
+          {
+            "name": "contributorZip",
+            "in": "query",
+            "required": false,
+            "description": "Contributor ZIP.",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{5}(\\d{4})?$"
+            }
+          },
+          {
+            "name": "contributorEmployer",
+            "in": "query",
+            "required": false,
+            "description": "Contributor employer.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 120
+            }
+          },
+          {
+            "name": "contributorOccupation",
+            "in": "query",
+            "required": false,
+            "description": "Contributor occupation.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 120
+            }
+          },
+          {
+            "name": "minAmount",
+            "in": "query",
+            "required": false,
+            "description": "Minimum amount to include (USD).",
+            "schema": {
+              "type": "number",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "maxAmount",
+            "in": "query",
+            "required": false,
+            "description": "Maximum amount to include (USD).",
+            "schema": {
+              "type": "number",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "twoYearTransactionPeriod",
+            "in": "query",
+            "required": false,
+            "description": "Two year transaction period.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1980,
+              "maximum": 2100
+            }
+          },
+          {
+            "name": "minDate",
+            "in": "query",
+            "required": false,
+            "description": "Min date.",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+            }
+          },
+          {
+            "name": "maxDate",
+            "in": "query",
+            "required": false,
+            "description": "Max date.",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+            }
+          },
+          {
+            "name": "isIndividual",
+            "in": "query",
+            "required": false,
+            "description": "Is individual.",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "perPage",
+            "in": "query",
+            "required": false,
+            "description": "Number of results to return per page.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 25
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "description": "Page number (1-based) for paginated results.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 1
+            }
+          },
+          {
+            "name": "sortField",
+            "in": "query",
+            "required": false,
+            "description": "Sort field.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "contribution_receipt_date",
+                "contribution_receipt_amount"
+              ]
+            }
+          },
+          {
+            "name": "sortDirection",
+            "in": "query",
+            "required": false,
+            "description": "Sort direction.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "asc",
+                "desc"
+              ]
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/gov/fec-expenditures": {
+      "get": {
+        "tags": [
+          "gov"
+        ],
+        "summary": "Search FEC Schedule B - every itemized disbursement (spend...",
+        "description": "Search FEC Schedule B — every itemized disbursement (spend, vendor payment, operating expenditure, contribution out, transfer) made by a federal political committee (>157M rows). Filter by committeeId, recipient name / city / state, disbursement purpose category (Administrative / Fundraising / Media / Polling / Salary / Travel / Operating / Contribution / Loan / etc.), description text, amount range, cycle, date range. Sort by date or amount. Every row carries: who got paid, when, how much, for what, with link to underlying PDF. The natural pair with /api/gov/fec-contributions for following the money on both sides of any federal committee.",
+        "operationId": "gov_fec-expenditures",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = FEC Schedule B itemized disbursements; total = upstream match count (OpenFEC pagination.count, null when upstream omits it); page = pagination block.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "page": {
+                          "type": "object",
+                          "properties": {
+                            "number": {
+                              "type": "integer"
+                            },
+                            "size": {
+                              "type": "integer"
+                            },
+                            "pages": {
+                              "type": "integer",
+                              "nullable": true
+                            }
+                          },
+                          "required": [
+                            "number",
+                            "size",
+                            "pages"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "gov.fec-expenditures",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "committeeId",
+            "in": "query",
+            "required": false,
+            "description": "Committee ID.",
+            "schema": {
+              "type": "string",
+              "pattern": "^C\\d{8}$"
+            }
+          },
+          {
+            "name": "recipientName",
+            "in": "query",
+            "required": false,
+            "description": "Recipient name.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 120
+            }
+          },
+          {
+            "name": "recipientCity",
+            "in": "query",
+            "required": false,
+            "description": "Recipient city.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 80
+            }
+          },
+          {
+            "name": "recipientState",
+            "in": "query",
+            "required": false,
+            "description": "Recipient state.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 2,
+              "pattern": "^[A-Za-z]{2}$"
+            }
+          },
+          {
+            "name": "disbursementPurposeCategory",
+            "in": "query",
+            "required": false,
+            "description": "Disbursement purpose category.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 80
+            }
+          },
+          {
+            "name": "disbursementDescription",
+            "in": "query",
+            "required": false,
+            "description": "Disbursement description.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 160
+            }
+          },
+          {
+            "name": "minAmount",
+            "in": "query",
+            "required": false,
+            "description": "Minimum amount to include (USD).",
+            "schema": {
+              "type": "number",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "maxAmount",
+            "in": "query",
+            "required": false,
+            "description": "Maximum amount to include (USD).",
+            "schema": {
+              "type": "number",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "twoYearTransactionPeriod",
+            "in": "query",
+            "required": false,
+            "description": "Two year transaction period.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1980,
+              "maximum": 2100
+            }
+          },
+          {
+            "name": "minDate",
+            "in": "query",
+            "required": false,
+            "description": "Min date.",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+            }
+          },
+          {
+            "name": "maxDate",
+            "in": "query",
+            "required": false,
+            "description": "Max date.",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+            }
+          },
+          {
+            "name": "perPage",
+            "in": "query",
+            "required": false,
+            "description": "Number of results to return per page.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 25
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "description": "Page number (1-based) for paginated results.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 1
+            }
+          },
+          {
+            "name": "sortField",
+            "in": "query",
+            "required": false,
+            "description": "Sort field.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "disbursement_date",
+                "disbursement_amount"
+              ]
+            }
+          },
+          {
+            "name": "sortDirection",
+            "in": "query",
+            "required": false,
+            "description": "Sort direction.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "asc",
+                "desc"
+              ]
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/gov/fec-totals": {
+      "get": {
+        "tags": [
+          "gov"
+        ],
+        "summary": "Fetch Aggregate financial summaries (receipts, disbursements...",
+        "description": "Aggregate financial summaries (receipts, disbursements, cash-on-hand, debt, transfers, refunds, contributions by source, etc.) per cycle for federal candidates (scope=candidates) or committees (scope=committees). Filter by candidateId / committeeId, cycle, office (P/S/H), party, state, district. For candidates, electionFull=true rolls all cycles of a single election into one row (e.g. a presidential cycle spans 4 years). Use this for top-line \"how much did they raise/spend\" answers without paging through millions of itemized transactions.",
+        "operationId": "gov_fec-totals",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = per-cycle FEC financial summary rows; total = upstream match count (OpenFEC pagination.count); page = pagination block; meta.scope echoes candidates/committees.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "page": {
+                          "type": "object",
+                          "properties": {
+                            "number": {
+                              "type": "integer"
+                            },
+                            "size": {
+                              "type": "integer"
+                            },
+                            "pages": {
+                              "type": "integer",
+                              "nullable": true
+                            }
+                          },
+                          "required": [
+                            "number",
+                            "size",
+                            "pages"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "scope": {
+                              "type": "string",
+                              "enum": [
+                                "candidates",
+                                "committees"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "scope"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "gov.fec-totals",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "scope",
+            "in": "query",
+            "required": true,
+            "description": "Scope.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "candidates",
+                "committees"
+              ]
+            }
+          },
+          {
+            "name": "candidateId",
+            "in": "query",
+            "required": false,
+            "description": "Candidate ID.",
+            "schema": {
+              "type": "string",
+              "pattern": "^[A-Z]\\d[A-Z0-9]{7}$"
+            }
+          },
+          {
+            "name": "committeeId",
+            "in": "query",
+            "required": false,
+            "description": "Committee ID.",
+            "schema": {
+              "type": "string",
+              "pattern": "^C\\d{8}$"
+            }
+          },
+          {
+            "name": "cycle",
+            "in": "query",
+            "required": false,
+            "description": "Two-year US election cycle, given as the even-numbered end year (e.g. 2024).",
+            "schema": {
+              "type": "integer",
+              "minimum": 1980,
+              "maximum": 2100
+            }
+          },
+          {
+            "name": "office",
+            "in": "query",
+            "required": false,
+            "description": "Office.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "P",
+                "S",
+                "H"
+              ]
+            }
+          },
+          {
+            "name": "party",
+            "in": "query",
+            "required": false,
+            "description": "Party.",
+            "schema": {
+              "type": "string",
+              "pattern": "^[A-Za-z]{3,4}$"
+            }
+          },
+          {
+            "name": "state",
+            "in": "query",
+            "required": false,
+            "description": "US state — two-letter postal abbreviation (e.g. CA) or full name.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 2,
+              "pattern": "^[A-Za-z]{2}$"
+            }
+          },
+          {
+            "name": "district",
+            "in": "query",
+            "required": false,
+            "description": "District.",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{2}$"
+            }
+          },
+          {
+            "name": "electionFull",
+            "in": "query",
+            "required": false,
+            "description": "Election full.",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "perPage",
+            "in": "query",
+            "required": false,
+            "description": "Number of results to return per page.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 25
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "description": "Page number (1-based) for paginated results.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 1
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/gov/federal-register-recent": {
+      "get": {
+        "tags": [
+          "gov"
+        ],
+        "summary": "Fetch Newest Federal Register documents by publication date...",
+        "description": "Newest Federal Register documents by publication date — chronological feed for compliance change-detection. Filter by document type (RULE / PRORULE / NOTICE / PRESDOCU), agency name, and publication date range. Each record includes document number, type, title, abstract, publication date, effective date, agencies, citations (CFR/USC), HTML + PDF URLs. Defaults to last 7 days of final rules. Free public-domain data from federalregister.gov.",
+        "operationId": "gov_federal-register-recent",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = recent Federal Register documents in chronological order; total = upstream match count; meta.hasNext signals more pages, meta.query echoes the search.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "documentNumber": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "title": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "abstract": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "publicationDate": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "effectiveOn": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "agencies": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "citations": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "htmlUrl": {
+                                "type": "string",
+                                "format": "uri",
+                                "nullable": true
+                              },
+                              "pdfUrl": {
+                                "type": "string",
+                                "format": "uri",
+                                "nullable": true
+                              }
+                            },
+                            "required": [
+                              "documentNumber",
+                              "type",
+                              "title",
+                              "abstract",
+                              "publicationDate",
+                              "effectiveOn",
+                              "agencies",
+                              "citations",
+                              "htmlUrl",
+                              "pdfUrl"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "query": {
+                              "type": "object",
+                              "properties": {
+                                "type": {
+                                  "type": "string"
+                                },
+                                "agency": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "since": {
+                                  "type": "string"
+                                },
+                                "until": {
+                                  "type": "string"
+                                },
+                                "limit": {
+                                  "type": "integer"
+                                },
+                                "page": {
+                                  "type": "integer"
+                                }
+                              },
+                              "required": [
+                                "type",
+                                "agency",
+                                "since",
+                                "until",
+                                "limit",
+                                "page"
+                              ],
+                              "additionalProperties": false
+                            },
+                            "hasNext": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "query",
+                            "hasNext"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0024 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "gov.federal-register-recent",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0024,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.002400"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "type",
+            "in": "query",
+            "required": false,
+            "description": "Document type: RULE = final rules, PRORULE = proposed rules, NOTICE = notices, PRESDOCU = presidential docs.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "RULE",
+                "PRORULE",
+                "NOTICE",
+                "PRESDOCU"
+              ],
+              "default": "RULE"
+            }
+          },
+          {
+            "name": "agency",
+            "in": "query",
+            "required": false,
+            "description": "Agency slug or name (e.g., \"environmental-protection-agency\", \"federal-trade-commission\").",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 80
+            }
+          },
+          {
+            "name": "since",
+            "in": "query",
+            "required": false,
+            "description": "Earliest publication date (YYYY-MM-DD). Default = 7 days ago.",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+            }
+          },
+          {
+            "name": "until",
+            "in": "query",
+            "required": false,
+            "description": "Latest publication date (YYYY-MM-DD). Default = today.",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Max results (1-100). Default 25.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 25
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "description": "Page number (1-based). Default 1.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 1000,
+              "default": 1
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/gov/house-votes": {
+      "get": {
+        "tags": [
+          "gov"
+        ],
+        "summary": "Fetch US House of Representatives roll-call votes, newest",
+        "description": "US House of Representatives roll-call votes, newest first by action date. Each record includes year + roll number, congress/session, vote question + type + result, action date/time, bill reference (legis_num), description, grand totals (yea/nay/present/not-voting), AND per-party breakdown (Republican/Democratic/Independent yea/nay/present/not-voting counts). Filters (all optional, AND-combined): year, congress, result substring, bill substring (legis_num ILIKE), since/until (action_date), limit + offset. Locally aggregated from clerk.house.gov XML feeds (refreshed daily by cron). Public-domain US government records.",
+        "operationId": "gov_house-votes",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = US House roll-call votes with per-party totals; total = matching rows; meta carries the query echo + nextOffset/previousOffset.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "year": {
+                                "type": "integer"
+                              },
+                              "roll": {
+                                "type": "integer"
+                              },
+                              "congress": {
+                                "type": "integer",
+                                "nullable": true
+                              },
+                              "session": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "voteQuestion": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "voteType": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "voteResult": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "actionDate": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "actionTime": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "legisNum": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "voteDesc": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "totals": {
+                                "type": "object",
+                                "properties": {
+                                  "yea": {
+                                    "type": "integer"
+                                  },
+                                  "nay": {
+                                    "type": "integer"
+                                  },
+                                  "present": {
+                                    "type": "integer"
+                                  },
+                                  "notVoting": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "required": [
+                                  "yea",
+                                  "nay",
+                                  "present",
+                                  "notVoting"
+                                ],
+                                "additionalProperties": false
+                              },
+                              "totalsByParty": {
+                                "type": "object",
+                                "additionalProperties": {
+                                  "type": "object",
+                                  "properties": {
+                                    "yea": {
+                                      "type": "integer"
+                                    },
+                                    "nay": {
+                                      "type": "integer"
+                                    },
+                                    "present": {
+                                      "type": "integer"
+                                    },
+                                    "not_voting": {
+                                      "type": "integer"
+                                    }
+                                  },
+                                  "required": [
+                                    "yea",
+                                    "nay",
+                                    "present",
+                                    "not_voting"
+                                  ],
+                                  "additionalProperties": false
+                                }
+                              },
+                              "sourceXmlUrl": {
+                                "type": "string",
+                                "format": "uri"
+                              }
+                            },
+                            "required": [
+                              "year",
+                              "roll",
+                              "congress",
+                              "session",
+                              "voteQuestion",
+                              "voteType",
+                              "voteResult",
+                              "actionDate",
+                              "actionTime",
+                              "legisNum",
+                              "voteDesc",
+                              "totals",
+                              "totalsByParty",
+                              "sourceXmlUrl"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "query": {
+                              "type": "object",
+                              "properties": {
+                                "year": {
+                                  "type": "number",
+                                  "nullable": true
+                                },
+                                "congress": {
+                                  "type": "number",
+                                  "nullable": true
+                                },
+                                "result": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "bill": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "since": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "until": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "limit": {
+                                  "type": "integer"
+                                },
+                                "offset": {
+                                  "type": "integer"
+                                }
+                              },
+                              "required": [
+                                "year",
+                                "congress",
+                                "result",
+                                "bill",
+                                "since",
+                                "until",
+                                "limit",
+                                "offset"
+                              ],
+                              "additionalProperties": false
+                            },
+                            "nextOffset": {
+                              "type": "integer",
+                              "nullable": true
+                            },
+                            "previousOffset": {
+                              "type": "integer",
+                              "nullable": true
+                            }
+                          },
+                          "required": [
+                            "query",
+                            "nextOffset",
+                            "previousOffset"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0024 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "gov.house-votes",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0024,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.002400"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "year",
+            "in": "query",
+            "required": false,
+            "description": "Filter by year. Example: 2025.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1990,
+              "maximum": 2099
+            }
+          },
+          {
+            "name": "congress",
+            "in": "query",
+            "required": false,
+            "description": "Filter by Congress number. The 119th Congress = 2025-2026.",
+            "schema": {
+              "type": "integer",
+              "minimum": 100,
+              "maximum": 200
+            }
+          },
+          {
+            "name": "result",
+            "in": "query",
+            "required": false,
+            "description": "Filter by vote result (case-insensitive substring). Examples: \"Passed\", \"Failed\", \"Agreed\".",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 40
+            }
+          },
+          {
+            "name": "bill",
+            "in": "query",
+            "required": false,
+            "description": "Filter by bill reference (case-insensitive substring on legis_num). Examples: \"H R 498\", \"H R 49\", \"S 1\".",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 40
+            }
+          },
+          {
+            "name": "since",
+            "in": "query",
+            "required": false,
+            "description": "Earliest action date (YYYY-MM-DD).",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+            }
+          },
+          {
+            "name": "until",
+            "in": "query",
+            "required": false,
+            "description": "Latest action date (YYYY-MM-DD).",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Max records (1-100). Default 25.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 25
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "description": "Offset for pagination. Default 0.",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 100000,
+              "default": 0
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/gov/inmate-locator": {
+      "get": {
+        "tags": [
+          "gov"
+        ],
+        "summary": "Search the Federal Bureau of Prisons inmate locator...",
+        "description": "Search the Federal Bureau of Prisons inmate locator — federal inmates from 1982 to present, both currently incarcerated and released. Search by lastName (+ optional firstName/middleName, age, sex, race) or by exact BOP register number (inmateNumber, e.g. \"12345-678\"). Each match: full name, register number, sex, race, age, current facility (code/name/type), projected release date, actual release date (when released). KYC, due-diligence, journalism, and background-research staple. Federal public data.",
+        "operationId": "gov_inmate-locator",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = matched federal inmates; total = match count (null when BOP capped the list); meta.capped flags truncation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "type": "object",
+                                "properties": {
+                                  "first": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "middle": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "last": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "suffix": {
+                                    "type": "string",
+                                    "nullable": true
+                                  }
+                                },
+                                "required": [
+                                  "first",
+                                  "middle",
+                                  "last",
+                                  "suffix"
+                                ],
+                                "additionalProperties": false
+                              },
+                              "inmateNumber": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "sex": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "race": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "age": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "facility": {
+                                "type": "object",
+                                "properties": {
+                                  "code": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "name": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "type": {
+                                    "type": "string",
+                                    "nullable": true
+                                  }
+                                },
+                                "required": [
+                                  "code",
+                                  "name",
+                                  "type"
+                                ],
+                                "additionalProperties": false,
+                                "nullable": true
+                              },
+                              "projectedReleaseDate": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "actualReleaseDate": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "releaseCode": {
+                                "type": "string",
+                                "nullable": true
+                              }
+                            },
+                            "required": [
+                              "name",
+                              "inmateNumber",
+                              "sex",
+                              "race",
+                              "age",
+                              "facility",
+                              "projectedReleaseDate",
+                              "actualReleaseDate",
+                              "releaseCode"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "capped": {
+                              "type": "boolean",
+                              "description": "True when BOP truncated the match list; total is null in that case."
+                            }
+                          },
+                          "required": [
+                            "capped"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0024 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "gov.inmate-locator",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0024,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.002400"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "lastName",
+            "in": "query",
+            "required": false,
+            "description": "Last name to filter by.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 80
+            }
+          },
+          {
+            "name": "firstName",
+            "in": "query",
+            "required": false,
+            "description": "First name to filter by.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 80
+            }
+          },
+          {
+            "name": "middleName",
+            "in": "query",
+            "required": false,
+            "description": "Middle name.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 80
+            }
+          },
+          {
+            "name": "inmateNumber",
+            "in": "query",
+            "required": false,
+            "description": "Inmate number.",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{5}-\\d{3}$"
+            }
+          },
+          {
+            "name": "age",
+            "in": "query",
+            "required": false,
+            "description": "Age.",
+            "schema": {
+              "type": "integer",
+              "minimum": 18,
+              "maximum": 120
+            }
+          },
+          {
+            "name": "sex",
+            "in": "query",
+            "required": false,
+            "description": "Sex.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Male",
+                "Female"
+              ]
+            }
+          },
+          {
+            "name": "race",
+            "in": "query",
+            "required": false,
+            "description": "Race.",
+            "schema": {
+              "type": "string",
+              "maxLength": 40
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/gov/lobbying-filings": {
+      "get": {
+        "tags": [
+          "gov"
+        ],
+        "summary": "Search US federal lobbying disclosures (Senate LDA filings)...",
+        "description": "Search US federal lobbying disclosures (Senate LDA filings) — who lobbies for whom, on what issues, for how much. Filter by registrant (lobbying firm name), client (organization being represented), lobbyist (individual name), year, period (first_quarter|second_quarter|third_quarter|fourth_quarter|mid_year|year_end), and type (e.g. RR=registration, Q1-Q4=quarterly reports). Each filing: type, year/period, reported income or expenses (USD), registrant + client (id/name/description/state), lobbying issues (code + description), lobbyist count, official document URL, posted timestamp. Money-in-politics, journalism, and policy-intelligence staple. Public federal data.",
+        "operationId": "gov_lobbying-filings",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = LDA lobbying filings (registrant, client, issues, income/expenses); total = upstream match count.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "filingUuid": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "typeDisplay": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "year": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "period": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "periodDisplay": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "income": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "expenses": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "registrant": {
+                                "type": "object",
+                                "properties": {
+                                  "id": {
+                                    "type": "number",
+                                    "nullable": true
+                                  },
+                                  "name": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "description": {
+                                    "type": "string",
+                                    "nullable": true
+                                  }
+                                },
+                                "required": [
+                                  "id",
+                                  "name",
+                                  "description"
+                                ],
+                                "additionalProperties": false,
+                                "nullable": true
+                              },
+                              "client": {
+                                "type": "object",
+                                "properties": {
+                                  "id": {
+                                    "type": "number",
+                                    "nullable": true
+                                  },
+                                  "name": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "description": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "state": {
+                                    "type": "string",
+                                    "nullable": true
+                                  }
+                                },
+                                "required": [
+                                  "id",
+                                  "name",
+                                  "description",
+                                  "state"
+                                ],
+                                "additionalProperties": false,
+                                "nullable": true
+                              },
+                              "issues": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "code": {
+                                      "type": "string",
+                                      "nullable": true
+                                    },
+                                    "description": {
+                                      "type": "string",
+                                      "nullable": true
+                                    }
+                                  },
+                                  "required": [
+                                    "code",
+                                    "description"
+                                  ],
+                                  "additionalProperties": false
+                                }
+                              },
+                              "lobbyistCount": {
+                                "type": "number"
+                              },
+                              "documentUrl": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "postedAt": {
+                                "type": "string",
+                                "nullable": true
+                              }
+                            },
+                            "required": [
+                              "filingUuid",
+                              "type",
+                              "typeDisplay",
+                              "year",
+                              "period",
+                              "periodDisplay",
+                              "income",
+                              "expenses",
+                              "registrant",
+                              "client",
+                              "issues",
+                              "lobbyistCount",
+                              "documentUrl",
+                              "postedAt"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.00288 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "gov.lobbying-filings",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.00288,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.002880"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "registrant",
+            "in": "query",
+            "required": false,
+            "description": "Registrant.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 120
+            }
+          },
+          {
+            "name": "client",
+            "in": "query",
+            "required": false,
+            "description": "Client.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 120
+            }
+          },
+          {
+            "name": "lobbyist",
+            "in": "query",
+            "required": false,
+            "description": "Lobbyist.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 120
+            }
+          },
+          {
+            "name": "year",
+            "in": "query",
+            "required": false,
+            "description": "Four-digit calendar year.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1999,
+              "maximum": 2030
+            }
+          },
+          {
+            "name": "period",
+            "in": "query",
+            "required": false,
+            "description": "Period.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "first_quarter",
+                "second_quarter",
+                "third_quarter",
+                "fourth_quarter",
+                "mid_year",
+                "year_end"
+              ]
+            }
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "required": false,
+            "description": "Filter results by type.",
+            "schema": {
+              "type": "string",
+              "maxLength": 8
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "description": "Page number (1-based) for paginated results.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 1
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "description": "Number of results to return per page.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 25,
+              "default": 10
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/gov/msha-accidents": {
+      "get": {
+        "tags": [
+          "gov"
+        ],
+        "summary": "Search MSHA mine safety accident records via US Department...",
+        "description": "Search MSHA mine safety accident records via US Department of Labor Open Data Portal (~738k accidents at US mines). Each row carries mine id, contractor id, mine subunit (underground/surface/mill/etc.), FIPS state code, accident date, classification, narrative, injury degree + nature + body-part, occupation code, experience, schooling, sex, age. Filter by mine id, contractor id, FIPS state code, subunit code, accident date range, classification code. Source of truth for fatalities + injuries at every US coal + metal/nonmetal mine since 2000.",
+        "operationId": "gov_msha-accidents",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = MSHA mine safety accident records.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "nextOffset": {
+                              "type": "integer",
+                              "nullable": true
+                            }
+                          },
+                          "required": [
+                            "nextOffset"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "gov.msha-accidents",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "mineId",
+            "in": "query",
+            "required": false,
+            "description": "Mine ID.",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4,8}$"
+            }
+          },
+          {
+            "name": "contractorId",
+            "in": "query",
+            "required": false,
+            "description": "Contractor ID.",
+            "schema": {
+              "type": "string",
+              "pattern": "^[A-Z0-9]{3,10}$"
+            }
+          },
+          {
+            "name": "state",
+            "in": "query",
+            "required": false,
+            "description": "US state — two-letter postal abbreviation (e.g. CA) or full name.",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{2}$"
+            }
+          },
+          {
+            "name": "subunit",
+            "in": "query",
+            "required": false,
+            "description": "Subunit.",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{2}$"
+            }
+          },
+          {
+            "name": "accidentDateMin",
+            "in": "query",
+            "required": false,
+            "description": "Accident date min.",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+            }
+          },
+          {
+            "name": "accidentDateMax",
+            "in": "query",
+            "required": false,
+            "description": "Accident date max.",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+            }
+          },
+          {
+            "name": "classification",
+            "in": "query",
+            "required": false,
+            "description": "Classification.",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{2,3}$"
+            }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "required": false,
+            "description": "Fields.",
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-z][a-z0-9_]*(,[a-z][a-z0-9_]*)*$",
+              "maxLength": 400
+            }
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "required": false,
+            "description": "Field to sort results by.",
+            "schema": {
+              "type": "string",
+              "pattern": "^-?[a-z][a-z0-9_]*$",
+              "maxLength": 120
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of results to return.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 25
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "description": "Number of results to skip before returning (pagination offset).",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/gov/osha-accidents": {
+      "get": {
+        "tags": [
+          "gov"
+        ],
+        "summary": "Search OSHA-investigated workplace accident reports via US...",
+        "description": "Search OSHA-investigated workplace accident reports via US Department of Labor Open Data Portal (~165k accidents). Each row carries summary number, related inspection number, report id, event date, narrative, nature of injury, body part affected, source of injury, occupation, age, sex, degree of injury (1 = fatality, 2 = hospitalized, 3 = no lost time, etc.). Filter by event date range, nature of injury code, fatality flag. Pair with /api/gov/osha-inspections + /api/gov/osha-violations to follow injury → investigation → citations.",
+        "operationId": "gov_osha-accidents",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = OSHA workplace accident reports.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "nextOffset": {
+                              "type": "integer",
+                              "nullable": true
+                            }
+                          },
+                          "required": [
+                            "nextOffset"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "gov.osha-accidents",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "summaryNr",
+            "in": "query",
+            "required": false,
+            "description": "Summary nr.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
+          },
+          {
+            "name": "activityNr",
+            "in": "query",
+            "required": false,
+            "description": "Activity nr.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
+          },
+          {
+            "name": "reportId",
+            "in": "query",
+            "required": false,
+            "description": "Report ID.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 40
+            }
+          },
+          {
+            "name": "eventDateMin",
+            "in": "query",
+            "required": false,
+            "description": "Event date min.",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+            }
+          },
+          {
+            "name": "eventDateMax",
+            "in": "query",
+            "required": false,
+            "description": "Event date max.",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+            }
+          },
+          {
+            "name": "natureOfInj",
+            "in": "query",
+            "required": false,
+            "description": "Nature of inj.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 20
+            }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "required": false,
+            "description": "Fields.",
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-z][a-z0-9_]*(,[a-z][a-z0-9_]*)*$",
+              "maxLength": 400
+            }
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "required": false,
+            "description": "Field to sort results by.",
+            "schema": {
+              "type": "string",
+              "pattern": "^-?[a-z][a-z0-9_]*$",
+              "maxLength": 120
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of results to return.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 25
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "description": "Number of results to skip before returning (pagination offset).",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/gov/osha-inspections": {
+      "get": {
+        "tags": [
+          "gov"
+        ],
+        "summary": "Search OSHA inspection records via the US Department of...",
+        "description": "Search OSHA inspection records via the US Department of Labor Open Data Portal (~5M historical inspections). Filter by US state (2-letter), city, zip, or establishment-name substring (estabName, case-insensitive). Optional `filter` accepts raw OData-style clauses (joined with AND); `fields` selects columns; `sort` sorts (prefix with `-` for desc). Each row carries activity number, reporting id, establishment name + full site address, owner type/code, advance-notice flag, safety/health type, SIC + NAICS industry codes, open + close dates, host establishment number, union status. Backbone of workplace-safety + investigative-journalism agents.",
+        "operationId": "gov_osha-inspections",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = OSHA inspection records.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "nextOffset": {
+                              "type": "integer",
+                              "nullable": true
+                            }
+                          },
+                          "required": [
+                            "nextOffset"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "gov.osha-inspections",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "state",
+            "in": "query",
+            "required": false,
+            "description": "US state — two-letter postal abbreviation (e.g. CA) or full name.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 2,
+              "pattern": "^[A-Za-z]{2}$"
+            }
+          },
+          {
+            "name": "city",
+            "in": "query",
+            "required": false,
+            "description": "City name to filter by.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 80
+            }
+          },
+          {
+            "name": "zip",
+            "in": "query",
+            "required": false,
+            "description": "US ZIP code.",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{5}$"
+            }
+          },
+          {
+            "name": "estabName",
+            "in": "query",
+            "required": false,
+            "description": "Estab name.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 120
+            }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "required": false,
+            "description": "Fields.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 400
+            }
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "description": "Filter.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 600
+            }
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "required": false,
+            "description": "Field to sort results by.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 120
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of results to return.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 25
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "description": "Number of results to skip before returning (pagination offset).",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/gov/osha-violations": {
+      "get": {
+        "tags": [
+          "gov"
+        ],
+        "summary": "Search OSHA citation / violation records via US Department...",
+        "description": "Search OSHA citation / violation records via US Department of Labor Open Data Portal (~13.2M citations). Each citation links to an inspection via `activityNr` — pair with /api/gov/osha-inspections to follow site → inspection → violations. Filter by activityNr, citationId, standard (29 CFR section, e.g. \"19100132\" for PPE general requirements), issuance date range, initial-penalty min/max, emphasis program code.",
+        "operationId": "gov_osha-violations",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = OSHA violation records.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "nextOffset": {
+                              "type": "integer",
+                              "nullable": true
+                            }
+                          },
+                          "required": [
+                            "nextOffset"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "gov.osha-violations",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "activityNr",
+            "in": "query",
+            "required": false,
+            "description": "Activity nr.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
+          },
+          {
+            "name": "citationId",
+            "in": "query",
+            "required": false,
+            "description": "Citation ID.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 40
+            }
+          },
+          {
+            "name": "standard",
+            "in": "query",
+            "required": false,
+            "description": "Standard.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 40
+            }
+          },
+          {
+            "name": "issuanceDateMin",
+            "in": "query",
+            "required": false,
+            "description": "Issuance date min.",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+            }
+          },
+          {
+            "name": "issuanceDateMax",
+            "in": "query",
+            "required": false,
+            "description": "Issuance date max.",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+            }
+          },
+          {
+            "name": "initialPenalty",
+            "in": "query",
+            "required": false,
+            "description": "Initial penalty.",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "min": {
+                  "type": "number",
+                  "minimum": 0
+                },
+                "max": {
+                  "type": "number",
+                  "minimum": 0
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          {
+            "name": "emphasis",
+            "in": "query",
+            "required": false,
+            "description": "Emphasis.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 40
+            }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "required": false,
+            "description": "Fields.",
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-z][a-z0-9_]*(,[a-z][a-z0-9_]*)*$",
+              "maxLength": 400
+            }
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "required": false,
+            "description": "Field to sort results by.",
+            "schema": {
+              "type": "string",
+              "pattern": "^-?[a-z][a-z0-9_]*$",
+              "maxLength": 120
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of results to return.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 25
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "description": "Number of results to skip before returning (pagination offset).",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/gov/senate-votes": {
+      "get": {
+        "tags": [
+          "gov"
+        ],
+        "summary": "Fetch US Senate roll-call votes, newest first by vote date.",
+        "description": "US Senate roll-call votes, newest first by vote date. Each record includes congress + session + vote_number, vote question + result + title + majority requirement, vote date/time, document name (e.g., S. 5, H.R. 4499), document title, grand totals (yeas/nays/present/absent), AND per-party breakdown (D/R/I yea/nay/present/absent counts derived from member-level vote_cast). Filters (all optional, AND-combined): congress, session (1 or 2), result substring, document substring (e.g., 'S. 5'), since/until (vote_date), limit + offset. Locally aggregated from senate.gov XML feeds (refreshed daily). Public-domain US government records.",
+        "operationId": "gov_senate-votes",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = US Senate roll-call votes with per-party totals; total = matching rows; meta carries the query echo + nextOffset/previousOffset.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "congress": {
+                                "type": "integer"
+                              },
+                              "session": {
+                                "type": "integer"
+                              },
+                              "voteNumber": {
+                                "type": "integer"
+                              },
+                              "congressYear": {
+                                "type": "integer",
+                                "nullable": true
+                              },
+                              "voteDate": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "voteTime": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "voteQuestion": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "voteResult": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "voteResultText": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "voteTitle": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "majorityRequirement": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "documentName": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "documentTitle": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "totals": {
+                                "type": "object",
+                                "properties": {
+                                  "yeas": {
+                                    "type": "integer"
+                                  },
+                                  "nays": {
+                                    "type": "integer"
+                                  },
+                                  "present": {
+                                    "type": "integer"
+                                  },
+                                  "absent": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "required": [
+                                  "yeas",
+                                  "nays",
+                                  "present",
+                                  "absent"
+                                ],
+                                "additionalProperties": false
+                              },
+                              "totalsByParty": {
+                                "type": "object",
+                                "additionalProperties": {
+                                  "type": "object",
+                                  "properties": {
+                                    "yea": {
+                                      "type": "integer"
+                                    },
+                                    "nay": {
+                                      "type": "integer"
+                                    },
+                                    "present": {
+                                      "type": "integer"
+                                    },
+                                    "absent": {
+                                      "type": "integer"
+                                    }
+                                  },
+                                  "required": [
+                                    "yea",
+                                    "nay",
+                                    "present",
+                                    "absent"
+                                  ],
+                                  "additionalProperties": false
+                                }
+                              },
+                              "sourceXmlUrl": {
+                                "type": "string",
+                                "format": "uri"
+                              }
+                            },
+                            "required": [
+                              "congress",
+                              "session",
+                              "voteNumber",
+                              "congressYear",
+                              "voteDate",
+                              "voteTime",
+                              "voteQuestion",
+                              "voteResult",
+                              "voteResultText",
+                              "voteTitle",
+                              "majorityRequirement",
+                              "documentName",
+                              "documentTitle",
+                              "totals",
+                              "totalsByParty",
+                              "sourceXmlUrl"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "query": {
+                              "type": "object",
+                              "properties": {
+                                "congress": {
+                                  "type": "number",
+                                  "nullable": true
+                                },
+                                "session": {
+                                  "type": "number",
+                                  "nullable": true
+                                },
+                                "result": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "document": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "since": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "until": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "limit": {
+                                  "type": "integer"
+                                },
+                                "offset": {
+                                  "type": "integer"
+                                }
+                              },
+                              "required": [
+                                "congress",
+                                "session",
+                                "result",
+                                "document",
+                                "since",
+                                "until",
+                                "limit",
+                                "offset"
+                              ],
+                              "additionalProperties": false
+                            },
+                            "nextOffset": {
+                              "type": "integer",
+                              "nullable": true
+                            },
+                            "previousOffset": {
+                              "type": "integer",
+                              "nullable": true
+                            }
+                          },
+                          "required": [
+                            "query",
+                            "nextOffset",
+                            "previousOffset"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0024 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "gov.senate-votes",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0024,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.002400"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "congress",
+            "in": "query",
+            "required": false,
+            "description": "Filter by Congress number. The 119th Congress = 2025-2026.",
+            "schema": {
+              "type": "integer",
+              "minimum": 100,
+              "maximum": 200
+            }
+          },
+          {
+            "name": "session",
+            "in": "query",
+            "required": false,
+            "description": "Filter by session (1 = odd year, 2 = even year of a Congress).",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "result",
+            "in": "query",
+            "required": false,
+            "description": "Filter by vote result (case-insensitive substring). Examples: \"Agreed\", \"Rejected\", \"Cloture\".",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 60
+            }
+          },
+          {
+            "name": "document",
+            "in": "query",
+            "required": false,
+            "description": "Filter by document name substring (case-insensitive on document_name). Examples: \"S. 5\", \"H.R. 4499\", \"H.R.\".",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 40
+            }
+          },
+          {
+            "name": "since",
+            "in": "query",
+            "required": false,
+            "description": "Earliest vote date (YYYY-MM-DD).",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+            }
+          },
+          {
+            "name": "until",
+            "in": "query",
+            "required": false,
+            "description": "Latest vote date (YYYY-MM-DD).",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Max records (1-100). Default 25.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 25
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "description": "Offset for pagination. Default 0.",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 100000,
+              "default": 0
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/gov/usaspending-awards": {
+      "get": {
+        "tags": [
+          "gov"
+        ],
+        "summary": "Search federal awards (contracts, grants, loans, direct...",
+        "description": "Search federal awards (contracts, grants, loans, direct payments) from USAspending.gov. Largest amount first within the date window. Each record includes award ID, recipient name, dollar amount, award type, awarding agency + sub-agency, start + end dates, description, and a permalink to the usaspending.gov detail page. Filter by recipient name, awarding agency name, recipient state, award type group, and date range. Backed by USAspending.gov's spending_by_award API; public-domain US government records.",
+        "operationId": "gov_usaspending-awards",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = federal awards (contracts, grants, loans, direct payments); total = null (USAspending does not report a match count on this search); meta.hasNext signals more pages, meta.query echoes the search.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "awardId": {
+                                "type": "string"
+                              },
+                              "recipientName": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "amount": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "awardType": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "awardingAgency": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "awardingSubAgency": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "startDate": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "endDate": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "description": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "usaspendingUrl": {
+                                "type": "string",
+                                "format": "uri",
+                                "nullable": true
+                              }
+                            },
+                            "required": [
+                              "awardId",
+                              "recipientName",
+                              "amount",
+                              "awardType",
+                              "awardingAgency",
+                              "awardingSubAgency",
+                              "startDate",
+                              "endDate",
+                              "description",
+                              "usaspendingUrl"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "query": {
+                              "type": "object",
+                              "properties": {
+                                "recipient": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "agency": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "recipientState": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "awardType": {
+                                  "type": "string"
+                                },
+                                "since": {
+                                  "type": "string"
+                                },
+                                "until": {
+                                  "type": "string"
+                                },
+                                "limit": {
+                                  "type": "integer"
+                                },
+                                "page": {
+                                  "type": "integer"
+                                }
+                              },
+                              "required": [
+                                "recipient",
+                                "agency",
+                                "recipientState",
+                                "awardType",
+                                "since",
+                                "until",
+                                "limit",
+                                "page"
+                              ],
+                              "additionalProperties": false
+                            },
+                            "hasNext": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "query",
+                            "hasNext"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0024 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "gov.usaspending-awards",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0024,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.002400"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "recipient",
+            "in": "query",
+            "required": false,
+            "description": "Recipient (vendor/grantee) name substring. Examples: \"Microsoft\", \"Lockheed Martin\", \"Stanford University\".",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 120
+            }
+          },
+          {
+            "name": "agency",
+            "in": "query",
+            "required": false,
+            "description": "Awarding top-tier agency name. Examples: \"Department of Defense\", \"National Institutes of Health\", \"Department of Energy\".",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 120
+            }
+          },
+          {
+            "name": "recipientState",
+            "in": "query",
+            "required": false,
+            "description": "2-letter US state of the recipient (e.g., \"CA\", \"VA\").",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 2,
+              "pattern": "^[A-Za-z]{2}$"
+            }
+          },
+          {
+            "name": "awardType",
+            "in": "query",
+            "required": false,
+            "description": "Award type group. contracts = A/B/C/D; grants = 02/03/04/05; loans = 07/08; direct_payments = 06/10; other = 11. Default contracts.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "contracts",
+                "grants",
+                "loans",
+                "direct_payments",
+                "other"
+              ],
+              "default": "contracts"
+            }
+          },
+          {
+            "name": "since",
+            "in": "query",
+            "required": false,
+            "description": "Earliest action date (YYYY-MM-DD). Default = 5 years ago.",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+            }
+          },
+          {
+            "name": "until",
+            "in": "query",
+            "required": false,
+            "description": "Latest action date (YYYY-MM-DD). Default = today.",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Records per page (1-100). Default 25.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 25
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "description": "Page number (1-based). Default 1.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 1000,
+              "default": 1
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/gov/usgs-water": {
+      "get": {
+        "tags": [
+          "gov"
+        ],
+        "summary": "Fetch Real-time water data from USGS NWIS stream / river /...",
+        "description": "Real-time water data from USGS NWIS stream / river / groundwater gauges within a bounding box around lat/lon. Returns each site's latest reading per requested variable: streamflow (00060, ft³/s), gage height (00065, ft), water temperature (00010, °C), precipitation (00045, in), and others. Each reading: site code + name, lat/lon, variable name + description + unit, value (or null if no data / sentinel), qualifier codes (e.g., 'P' = provisional, 'A' = approved), observed timestamp. Free public-domain data from waterservices.usgs.gov.",
+        "operationId": "gov_usgs-water",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = latest USGS gauge readings (one per site+variable) in the bounding box; total = null (NWIS reports no match count); meta.query + meta.bbox echo the search window.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "siteCode": {
+                                "type": "string"
+                              },
+                              "siteName": {
+                                "type": "string"
+                              },
+                              "agencyCode": {
+                                "type": "string"
+                              },
+                              "latitude": {
+                                "type": "number"
+                              },
+                              "longitude": {
+                                "type": "number"
+                              },
+                              "variableCode": {
+                                "type": "string"
+                              },
+                              "variableName": {
+                                "type": "string"
+                              },
+                              "variableDescription": {
+                                "type": "string"
+                              },
+                              "unit": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "qualifiers": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "observedAt": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "noDataValue": {
+                                "type": "number",
+                                "nullable": true
+                              }
+                            },
+                            "required": [
+                              "siteCode",
+                              "siteName",
+                              "agencyCode",
+                              "latitude",
+                              "longitude",
+                              "variableCode",
+                              "variableName",
+                              "variableDescription",
+                              "unit",
+                              "value",
+                              "qualifiers",
+                              "observedAt",
+                              "noDataValue"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "query": {
+                              "type": "object",
+                              "properties": {
+                                "lat": {
+                                  "type": "number"
+                                },
+                                "lon": {
+                                  "type": "number"
+                                },
+                                "radiusDegrees": {
+                                  "type": "number"
+                                },
+                                "variables": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                },
+                                "limit": {
+                                  "type": "integer"
+                                }
+                              },
+                              "required": [
+                                "lat",
+                                "lon",
+                                "radiusDegrees",
+                                "variables",
+                                "limit"
+                              ],
+                              "additionalProperties": false
+                            },
+                            "bbox": {
+                              "type": "object",
+                              "properties": {
+                                "west": {
+                                  "type": "number"
+                                },
+                                "south": {
+                                  "type": "number"
+                                },
+                                "east": {
+                                  "type": "number"
+                                },
+                                "north": {
+                                  "type": "number"
+                                }
+                              },
+                              "required": [
+                                "west",
+                                "south",
+                                "east",
+                                "north"
+                              ],
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "query",
+                            "bbox"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0024 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "gov.usgs-water",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0024,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.002400"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "lat",
+            "in": "query",
+            "required": true,
+            "description": "Center latitude (decimal degrees).",
+            "schema": {
+              "type": "number",
+              "minimum": -90,
+              "maximum": 90
+            }
+          },
+          {
+            "name": "lon",
+            "in": "query",
+            "required": true,
+            "description": "Center longitude (decimal degrees).",
+            "schema": {
+              "type": "number",
+              "minimum": -180,
+              "maximum": 180
+            }
+          },
+          {
+            "name": "radius",
+            "in": "query",
+            "required": false,
+            "description": "Half-side of bounding box, in decimal degrees. Default 0.5 (~35 mi).",
+            "schema": {
+              "type": "number",
+              "minimum": 0.05,
+              "maximum": 2,
+              "default": 0.5
+            }
+          },
+          {
+            "name": "variables",
+            "in": "query",
+            "required": false,
+            "description": "Comma-separated USGS parameter codes (5-digit). Default \"00060,00065,00010\" (streamflow, gage height, water temp).",
+            "schema": {
+              "type": "string",
+              "pattern": "^(\\d{5})(,\\d{5})*$"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Max readings to return (1-100). Default 25.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 25
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/job/federal-codes": {
+      "get": {
+        "tags": [
+          "job"
+        ],
+        "summary": "Fetch a USAJobs reference codelist (lookup tables behind...",
+        "description": "Fetch a USAJobs reference codelist (lookup tables behind every federal job posting). Pass name to pick which list: agencysubelements (every agency + sub-element), occupationalseries (2210 IT, 0301 Misc Admin, 0801 Engineer, etc.), paygrades, payplans (GS, SES, ES, WG, etc.), hiringpaths (veteran, military spouse, native American, etc.), securityclearances, locationcodes, countries, countrysubdivisions, ethnicities, racecodes, militarystatuscodes, languagecodes, positionscheduletypecodes (full-time/part-time/seasonal), travelpercentages, missioncriticalcodes, cyberworkroles, etc. (33 lists total). Use the returned codes as filter inputs to /api/job/federal-search.",
+        "operationId": "job_federal-codes",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = the requested USAJobs reference codelist entries; total = entry count; meta.name + meta.dateGenerated identify the list.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "name": {
+                              "type": "string",
+                              "enum": [
+                                "academichonors",
+                                "agencysubelements",
+                                "announcementclosingtypes",
+                                "applicantsuppliers",
+                                "cyberworkroles",
+                                "countries",
+                                "countrysubdivisions",
+                                "degreetypecodes",
+                                "documentations",
+                                "ethnicities",
+                                "federalemploymentstatuses",
+                                "geoloccodes",
+                                "hiringpaths",
+                                "languagecodes",
+                                "languageproficiencies",
+                                "locationcodes",
+                                "militarystatuscodes",
+                                "missioncriticalcodes",
+                                "occupationalseries",
+                                "paygrades",
+                                "payplans",
+                                "positionofferingtypecodes",
+                                "positionopeningstatuses",
+                                "positionscheduletypecodes",
+                                "racecodes",
+                                "refereetypecodes",
+                                "remunerationrateintervalcodes",
+                                "requiredstandarddocuments",
+                                "securityclearances",
+                                "servicetypes",
+                                "specialhirings",
+                                "travelpercentages",
+                                "whomayapply"
+                              ]
+                            },
+                            "dateGenerated": {
+                              "type": "string",
+                              "nullable": true
+                            }
+                          },
+                          "required": [
+                            "name",
+                            "dateGenerated"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "job.federal-codes",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "name",
+            "in": "query",
+            "required": true,
+            "description": "Name to search for.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "academichonors",
+                "agencysubelements",
+                "announcementclosingtypes",
+                "applicantsuppliers",
+                "cyberworkroles",
+                "countries",
+                "countrysubdivisions",
+                "degreetypecodes",
+                "documentations",
+                "ethnicities",
+                "federalemploymentstatuses",
+                "geoloccodes",
+                "hiringpaths",
+                "languagecodes",
+                "languageproficiencies",
+                "locationcodes",
+                "militarystatuscodes",
+                "missioncriticalcodes",
+                "occupationalseries",
+                "paygrades",
+                "payplans",
+                "positionofferingtypecodes",
+                "positionopeningstatuses",
+                "positionscheduletypecodes",
+                "racecodes",
+                "refereetypecodes",
+                "remunerationrateintervalcodes",
+                "requiredstandarddocuments",
+                "securityclearances",
+                "servicetypes",
+                "specialhirings",
+                "travelpercentages",
+                "whomayapply"
+              ]
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/job/federal-search": {
+      "get": {
+        "tags": [
+          "job"
+        ],
+        "summary": "Search current US federal job postings via the USAJobs API.",
+        "description": "Search current US federal job postings via the USAJobs API. Filter by keyword, positionTitle, locationName (\"Washington, DC\" or city/zip), remote (telework-eligible), pay grade range (e.g. payGradeLow=GS09 + payGradeHigh=GS13), jobCategoryCode (occupational series, e.g. 2210 for IT), organization (agency sub-element code, e.g. TR40 for IRS), whoMayApply (all/public/status). Returns per-posting: control number, position ID, title, USAJobs URL + apply URL, organization + department, locations, schedule, offering type, pay scales (min/max + interval), publication start + application close, qualification summary, job category + grade. Use sortField + sortDirection to sort. Pagination via resultsPerPage + page.",
+        "operationId": "job_federal-search",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = matched federal job postings; total = upstream total match count; meta.count = postings on this page.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "controlNumber": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "positionId": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "title": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "uri": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "applyUri": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "organization": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "department": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "locations": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "additionalProperties": {}
+                                }
+                              },
+                              "remote": {
+                                "type": "boolean"
+                              },
+                              "schedule": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "additionalProperties": {}
+                                }
+                              },
+                              "offeringType": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "additionalProperties": {}
+                                }
+                              },
+                              "payScales": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "min": {
+                                      "type": "number",
+                                      "nullable": true
+                                    },
+                                    "max": {
+                                      "type": "number",
+                                      "nullable": true
+                                    },
+                                    "interval": {
+                                      "type": "string",
+                                      "nullable": true
+                                    }
+                                  },
+                                  "required": [
+                                    "min",
+                                    "max",
+                                    "interval"
+                                  ],
+                                  "additionalProperties": false
+                                }
+                              },
+                              "publicationStart": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "applicationClose": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "qualificationSummary": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "jobCategory": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "additionalProperties": {}
+                                }
+                              },
+                              "jobGrade": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "additionalProperties": {}
+                                }
+                              }
+                            },
+                            "required": [
+                              "controlNumber",
+                              "positionId",
+                              "title",
+                              "uri",
+                              "applyUri",
+                              "organization",
+                              "department",
+                              "locations",
+                              "remote",
+                              "schedule",
+                              "offeringType",
+                              "payScales",
+                              "publicationStart",
+                              "applicationClose",
+                              "qualificationSummary",
+                              "jobCategory",
+                              "jobGrade"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "count": {
+                              "type": "integer",
+                              "description": "Postings returned on this page."
+                            }
+                          },
+                          "required": [
+                            "count"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "job.federal-search",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "keyword",
+            "in": "query",
+            "required": false,
+            "description": "Keyword.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 120
+            }
+          },
+          {
+            "name": "positionTitle",
+            "in": "query",
+            "required": false,
+            "description": "Position title.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 120
+            }
+          },
+          {
+            "name": "locationName",
+            "in": "query",
+            "required": false,
+            "description": "Location name.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 120
+            }
+          },
+          {
+            "name": "remote",
+            "in": "query",
+            "required": false,
+            "description": "Remote.",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "payGradeLow",
+            "in": "query",
+            "required": false,
+            "description": "Pay grade low.",
+            "schema": {
+              "type": "string",
+              "pattern": "^[A-Z]{2}\\d{2}$"
+            }
+          },
+          {
+            "name": "payGradeHigh",
+            "in": "query",
+            "required": false,
+            "description": "Pay grade high.",
+            "schema": {
+              "type": "string",
+              "pattern": "^[A-Z]{2}\\d{2}$"
+            }
+          },
+          {
+            "name": "jobCategoryCode",
+            "in": "query",
+            "required": false,
+            "description": "Job category code.",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{3,4}$"
+            }
+          },
+          {
+            "name": "organization",
+            "in": "query",
+            "required": false,
+            "description": "Organization.",
+            "schema": {
+              "type": "string",
+              "pattern": "^[A-Z0-9]{2,6}$"
+            }
+          },
+          {
+            "name": "whoMayApply",
+            "in": "query",
+            "required": false,
+            "description": "Who may apply.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "all",
+                "public",
+                "status"
+              ]
+            }
+          },
+          {
+            "name": "resultsPerPage",
+            "in": "query",
+            "required": false,
+            "description": "Results per page.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 500,
+              "default": 25
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "description": "Page number (1-based) for paginated results.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 1
+            }
+          },
+          {
+            "name": "sortField",
+            "in": "query",
+            "required": false,
+            "description": "Sort field.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "OpenDate",
+                "CloseDate",
+                "PositionTitle",
+                "Salary"
+              ]
+            }
+          },
+          {
+            "name": "sortDirection",
+            "in": "query",
+            "required": false,
+            "description": "Sort direction.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Asc",
+                "Desc"
+              ]
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/property/nyc-deed-history": {
+      "get": {
+        "tags": [
+          "property"
+        ],
+        "summary": "Fetch NYC deed + mortgage history for a tax lot via ACRIS...",
+        "description": "NYC deed + mortgage history for a tax lot via ACRIS (Automated City Register Information System) legals dataset, keyed by BBL. Each row carries a unique documentId you can use to drill into the ACRIS master dataset (the master URL pattern is included in the response) for full details: parties, consideration amount, document type (DEED, MORTGAGE, ASSIGNMENT OF MORTGAGE, etc.). Use `property.nyc-parcel-lookup` first to convert an address to a BBL. Returns most-recent records first.",
+        "operationId": "property_nyc-deed-history",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = ACRIS legals records for the BBL.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "bbl": {
+                              "type": "string"
+                            },
+                            "masterDatasetForDocIds": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "bbl",
+                            "masterDatasetForDocIds"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "property.nyc-deed-history",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "bbl",
+            "in": "query",
+            "required": true,
+            "description": "Bbl.",
+            "schema": {
+              "type": "string",
+              "pattern": "^[1-5][- 0-9]{9,19}$"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of results to return.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 200,
+              "default": 25
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "description": "Number of results to skip before returning (pagination offset).",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/property/nyc-parcel-lookup": {
+      "get": {
+        "tags": [
+          "property"
+        ],
+        "summary": "Fetch NYC tax-lot lookup via PLUTO (Primary Land Use Tax Lot...",
+        "description": "NYC tax-lot lookup via PLUTO (Primary Land Use Tax Lot Output) — every tax lot in the city with owner, zoning, lot/building area, year built, classification, lat/lon, community + school + council + police districts. Pass `bbl` (10-digit Borough-Block-Lot composite, e.g. 1010110001 for the Empire State Building) for an exact lookup, OR pass `address` (partial-match) optionally constrained by `borough` (name or 2-letter code MN/BX/BK/QN/SI). The BBL returned here is the universal join key for all other property.nyc-* endpoints — fetch parcels first, then chain into deed-history, permits, or violations.",
+        "operationId": "property_nyc-parcel-lookup",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = NYC parcels.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "property.nyc-parcel-lookup",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "bbl",
+            "in": "query",
+            "required": false,
+            "description": "Bbl.",
+            "schema": {
+              "type": "string",
+              "pattern": "^[1-5][- 0-9]{9,19}$"
+            }
+          },
+          {
+            "name": "address",
+            "in": "query",
+            "required": false,
+            "description": "Street address or full address string.",
+            "schema": {
+              "type": "string",
+              "minLength": 3,
+              "maxLength": 120
+            }
+          },
+          {
+            "name": "borough",
+            "in": "query",
+            "required": false,
+            "description": "Borough.",
+            "schema": {
+              "type": "string",
+              "pattern": "^([A-Za-z ]{2,15})$"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/property/nyc-permits": {
+      "get": {
+        "tags": [
+          "property"
+        ],
+        "summary": "Fetch NYC Department of Buildings permit issuance - every...",
+        "description": "NYC Department of Buildings permit issuance — every construction, alteration, or demolition permit ever issued. Search by `bbl` (10-digit) or `address` (street_name substring). Filter by jobType (A1=Major Alteration, A2=Minor Alteration, A3=Minor Cosmetic, NB=New Building, DM=Demolition, etc.) or permitStatus (ISSUED, IN PROCESS, RE-ISSUED, REVOKED, etc.). Each row carries job + permit numbers, work type, building type, residential flag, filing/issuance/expiration dates, estimated fee. Use for construction-history agents, code-enforcement research, and zoning compliance checks.",
+        "operationId": "property_nyc-permits",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = nyc dob permit records.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "property.nyc-permits",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "bbl",
+            "in": "query",
+            "required": false,
+            "description": "Bbl.",
+            "schema": {
+              "type": "string",
+              "pattern": "^[1-5][- 0-9]{9,19}$"
+            }
+          },
+          {
+            "name": "address",
+            "in": "query",
+            "required": false,
+            "description": "Street address or full address string.",
+            "schema": {
+              "type": "string",
+              "minLength": 3,
+              "maxLength": 120
+            }
+          },
+          {
+            "name": "jobType",
+            "in": "query",
+            "required": false,
+            "description": "Job type.",
+            "schema": {
+              "type": "string",
+              "pattern": "^[A-Za-z0-9]{1,5}$"
+            }
+          },
+          {
+            "name": "permitStatus",
+            "in": "query",
+            "required": false,
+            "description": "Permit status.",
+            "schema": {
+              "type": "string",
+              "pattern": "^[A-Za-z _-]{2,30}$"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of results to return.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 200,
+              "default": 25
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "description": "Number of results to skip before returning (pagination offset).",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/property/nyc-violations": {
+      "get": {
+        "tags": [
+          "property"
+        ],
+        "summary": "Fetch NYC Housing Preservation & Development (HPD)",
+        "description": "NYC Housing Preservation & Development (HPD) violations — every notice of violation issued at a multi-family building. Search by `bbl` (10-digit) or `address` (street_name substring). Filter by `classCode` (A=least severe, B=hazardous, C=immediately hazardous) and `currentStatusOnly=true` to limit to open violations. Each row carries violation id, building id, full address + apartment + story, inspection + approved + certify-by + correct-by dates, current status + status date, and the narrative NOV description. Use for landlord-history, code-enforcement, and tenant-rights agents.",
+        "operationId": "property_nyc-violations",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = nyc hpd violation records.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "property.nyc-violations",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "bbl",
+            "in": "query",
+            "required": false,
+            "description": "Bbl.",
+            "schema": {
+              "type": "string",
+              "pattern": "^[1-5][- 0-9]{9,19}$"
+            }
+          },
+          {
+            "name": "address",
+            "in": "query",
+            "required": false,
+            "description": "Street address or full address string.",
+            "schema": {
+              "type": "string",
+              "minLength": 3,
+              "maxLength": 120
+            }
+          },
+          {
+            "name": "classCode",
+            "in": "query",
+            "required": false,
+            "description": "Class code.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "A",
+                "B",
+                "C"
+              ]
+            }
+          },
+          {
+            "name": "currentStatusOnly",
+            "in": "query",
+            "required": false,
+            "description": "Current status only.",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of results to return.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 200,
+              "default": 25
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "description": "Number of results to skip before returning (pagination offset).",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/providers/2s/health/PAY.md
+++ b/providers/2s/health/PAY.md
@@ -1,0 +1,17 @@
+---
+name: health
+title: "2s Health"
+description: "Healthcare reference data: ICD-10 and RxNorm code verification, Medicare provider + Open Payments, hospital quality, NPI provider profiles, clinical-trial search, and USDA/Open Food Facts nutrition."
+use_case: "Use for verifying ICD-10 and drug codes, looking up providers and hospitals, searching clinical trials, and fetching nutrition facts."
+category: data
+service_url: https://2s.io
+openapi:
+  path: openapi.json
+---
+
+Part of 2s — a unified, agent-native JSON API. Pay per call in USDC on Solana (or Base) via x402; no accounts, no API keys. Add `?trial=1` (or header `X-2s-Trial: 1`) for one free real call per endpoint per hour.
+
+## Spend-aware usage
+
+- Prefer narrow lookups (by id/code) over broad searches; reuse identifiers across calls.
+- Cap result `limit` to the smallest count that answers the task.

--- a/providers/2s/health/openapi.json
+++ b/providers/2s/health/openapi.json
@@ -1,0 +1,3329 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "2s",
+    "version": "1",
+    "description": "Unified JSON REST API for AI agents — an ever-expanding catalog of endpoints, pay per call in USDC on Base or Solana via x402, no accounts, no API keys. Fund a wallet on either chain with USDC, hit any endpoint, and your client signs an EIP-3009 authorization (Base) or a partial SPL transfer (Solana) to settle the call. Try before you buy: add ?trial=1 (or header X-2s-Trial: 1) to any endpoint for one free real call per endpoint per hour — no wallet needed — to verify it works before paying. 2s is an open-ended experiment in maximally-comprehensive agent infrastructure — new endpoints land regularly.",
+    "contact": {
+      "name": "2s",
+      "url": "https://2s.io",
+      "email": "alley@2s.io"
+    }
+  },
+  "servers": [
+    {
+      "url": "https://2s.io"
+    }
+  ],
+  "components": {
+    "parameters": {
+      "TrialMode": {
+        "name": "trial",
+        "in": "query",
+        "required": false,
+        "description": "Try before you buy. Set to 1 for one free real call per endpoint per hour — no wallet or payment needed — to verify the endpoint before paying. Equivalent to sending the \"X-2s-Trial: 1\" request header. Works on every endpoint.",
+        "schema": {
+          "type": "integer",
+          "enum": [
+            1
+          ]
+        }
+      }
+    },
+    "securitySchemes": {
+      "x402Payment": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "PAYMENT-SIGNATURE",
+        "description": "x402 protocol v2: base64-encoded PaymentPayload. Call any paid endpoint without auth to receive a 402 with a multi-network PaymentRequirements envelope. Sign for either rail: EIP-3009 transferWithAuthorization (Base USDC) OR a partial SPL token transfer (Solana USDC). Retry with PAYMENT-SIGNATURE header. X-PAYMENT is also accepted for v1 buyer clients. See https://x402.org."
+      }
+    },
+    "schemas": {
+      "X402PaymentRequiredV2": {
+        "type": "object",
+        "description": "x402 v2 PaymentRequired envelope. Pick any entry from accepts[], sign for that rail, retry with the PAYMENT-SIGNATURE header.",
+        "required": [
+          "x402Version",
+          "accepts"
+        ],
+        "properties": {
+          "x402Version": {
+            "type": "integer",
+            "const": 2
+          },
+          "error": {
+            "type": "string",
+            "description": "Human-readable reason payment is required."
+          },
+          "resource": {
+            "type": "string",
+            "description": "The resource URL being purchased."
+          },
+          "accepts": {
+            "type": "array",
+            "description": "Payment requirement options, one per supported network (Base USDC, Solana USDC).",
+            "items": {
+              "type": "object",
+              "required": [
+                "scheme",
+                "network",
+                "amount",
+                "asset",
+                "payTo",
+                "maxTimeoutSeconds"
+              ],
+              "properties": {
+                "scheme": {
+                  "type": "string",
+                  "enum": [
+                    "exact"
+                  ]
+                },
+                "network": {
+                  "type": "string",
+                  "description": "CAIP-2 network id, e.g. \"eip155:8453\" (Base) or \"solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp\"."
+                },
+                "amount": {
+                  "type": "string",
+                  "description": "Price in atomic asset units (USDC has 6 decimals)."
+                },
+                "asset": {
+                  "type": "string",
+                  "description": "Asset contract address / mint."
+                },
+                "payTo": {
+                  "type": "string",
+                  "description": "Treasury address to pay."
+                },
+                "maxTimeoutSeconds": {
+                  "type": "integer"
+                },
+                "extra": {
+                  "type": "object",
+                  "description": "Rail-specific extras (EVM: EIP-712 domain name/version; Solana: feePayer).",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "extensions": {
+            "type": "object",
+            "description": "Optional discovery metadata (e.g. bazaar input/output schemas).",
+            "additionalProperties": true
+          }
+        }
+      }
+    }
+  },
+  "paths": {
+    "/api/clinical/trial-search": {
+      "get": {
+        "tags": [
+          "clinical"
+        ],
+        "summary": "Search ClinicalTrials.gov - every registered US (and many...",
+        "description": "Search ClinicalTrials.gov — every registered US (and many international) clinical study (~500k trials). Free-text query matches title + condition + intervention; or direct lookup by NCT ID. Optional filters: recruitment status, lead sponsor, phase (PHASE1..PHASE4), country. Each record includes NCT ID, brief + official title, status, phases, study type, conditions list, interventions (with type + name), enrollment count + type, key dates (start / primary completion / completion / first posted / last update), lead sponsor + class (INDUSTRY/NIH/OTHER), hasResults flag, brief summary, and canonical clinicaltrials.gov URL. Public-domain NIH NLM data.",
+        "operationId": "clinical_trial-search",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = ClinicalTrials.gov studies; total = null (upstream paginates by opaque token, no true count); meta.nextPageToken for the next page; meta.query echoes the search.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "nctId": {
+                                "type": "string"
+                              },
+                              "briefTitle": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "officialTitle": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "status": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "phases": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "studyType": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "conditions": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "interventions": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "nullable": true
+                                    },
+                                    "name": {
+                                      "type": "string",
+                                      "nullable": true
+                                    }
+                                  },
+                                  "required": [
+                                    "type",
+                                    "name"
+                                  ],
+                                  "additionalProperties": false
+                                }
+                              },
+                              "enrollmentCount": {
+                                "type": "integer",
+                                "nullable": true
+                              },
+                              "enrollmentType": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "startDate": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "primaryCompletionDate": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "completionDate": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "leadSponsor": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "leadSponsorClass": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "hasResults": {
+                                "type": "boolean"
+                              },
+                              "studyFirstPostedDate": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "lastUpdatePostedDate": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "briefSummary": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "url": {
+                                "type": "string",
+                                "format": "uri"
+                              }
+                            },
+                            "required": [
+                              "nctId",
+                              "briefTitle",
+                              "officialTitle",
+                              "status",
+                              "phases",
+                              "studyType",
+                              "conditions",
+                              "interventions",
+                              "enrollmentCount",
+                              "enrollmentType",
+                              "startDate",
+                              "primaryCompletionDate",
+                              "completionDate",
+                              "leadSponsor",
+                              "leadSponsorClass",
+                              "hasResults",
+                              "studyFirstPostedDate",
+                              "lastUpdatePostedDate",
+                              "briefSummary",
+                              "url"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "query": {
+                              "type": "object",
+                              "properties": {
+                                "query": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "nctId": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "status": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "sponsor": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "phase": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "country": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "pageSize": {
+                                  "type": "integer"
+                                }
+                              },
+                              "required": [
+                                "query",
+                                "nctId",
+                                "status",
+                                "sponsor",
+                                "phase",
+                                "country",
+                                "pageSize"
+                              ],
+                              "additionalProperties": false
+                            },
+                            "nextPageToken": {
+                              "type": "string",
+                              "nullable": true
+                            }
+                          },
+                          "required": [
+                            "query",
+                            "nextPageToken"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "clinical.trial-search",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "query",
+            "in": "query",
+            "required": false,
+            "description": "Free-text search query.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 300
+            }
+          },
+          {
+            "name": "nctId",
+            "in": "query",
+            "required": false,
+            "description": "Nct ID.",
+            "schema": {
+              "type": "string",
+              "pattern": "^NCT\\d{8}$"
+            }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "description": "Filter results by status.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "RECRUITING",
+                "ACTIVE_NOT_RECRUITING",
+                "COMPLETED",
+                "TERMINATED",
+                "WITHDRAWN",
+                "NOT_YET_RECRUITING",
+                "SUSPENDED"
+              ]
+            }
+          },
+          {
+            "name": "sponsor",
+            "in": "query",
+            "required": false,
+            "description": "Sponsor.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 200
+            }
+          },
+          {
+            "name": "phase",
+            "in": "query",
+            "required": false,
+            "description": "Phase.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 40
+            }
+          },
+          {
+            "name": "country",
+            "in": "query",
+            "required": false,
+            "description": "Country name or ISO country code.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 80
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "description": "Number of results to return per page.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 10
+            }
+          },
+          {
+            "name": "pageToken",
+            "in": "query",
+            "required": false,
+            "description": "Page token.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 500
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/food/barcode-lookup": {
+      "get": {
+        "tags": [
+          "food"
+        ],
+        "summary": "Resolve a food product barcode (UPC, EAN-13, EAN-8, etc.)...",
+        "description": "Resolve a food product barcode (UPC, EAN-13, EAN-8, etc.) to structured product metadata via Open Food Facts — the CC0 community-maintained database of >3M food products. Returns product name, brand, ingredient list, allergens, nutriments (per-100g + per-serving), Nutri-Score grade (a-e), NOVA processing classification (1-4), Eco-Score, categories, manufacturing origin, packaging, and product image URLs.",
+        "operationId": "food_barcode-lookup",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = [product] when the barcode resolves (total 1), else [] (total 0); meta.found flags whether Open Food Facts had the product.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "barcode": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "brands": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "categories": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "quantity": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "servingSize": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "ingredientsText": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "allergens": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "imageUrl": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "nutriscoreGrade": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "novaGroup": {
+                                "type": "integer",
+                                "nullable": true
+                              },
+                              "ecoscoreGrade": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "nutrientLevels": {
+                                "type": "object",
+                                "additionalProperties": {
+                                  "type": "string"
+                                }
+                              },
+                              "nutriments": {
+                                "type": "object",
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "number"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ]
+                                }
+                              },
+                              "countries": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "labels": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "manufacturingPlaces": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "origins": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "packaging": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "required": [
+                              "barcode",
+                              "name",
+                              "brands",
+                              "categories",
+                              "quantity",
+                              "servingSize",
+                              "ingredientsText",
+                              "allergens",
+                              "imageUrl",
+                              "nutriscoreGrade",
+                              "novaGroup",
+                              "ecoscoreGrade",
+                              "nutrientLevels",
+                              "nutriments",
+                              "countries",
+                              "labels",
+                              "manufacturingPlaces",
+                              "origins",
+                              "packaging"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "found": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "found"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "food.barcode-lookup",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "barcode",
+            "in": "query",
+            "required": true,
+            "description": "Barcode.",
+            "schema": {
+              "type": "string",
+              "pattern": "^[0-9]{6,14}$"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/health/hospital-lookup": {
+      "get": {
+        "tags": [
+          "health"
+        ],
+        "summary": "Fetch CMS Care Compare lookup for every CMS-certified US",
+        "description": "CMS Care Compare lookup for every CMS-certified US hospital (~5k). Lookup by 6-digit CMS Facility ID for direct match, or fuzzy by name + state + city + hospital type, with optional minimum overall rating (1-5) filter. Each record includes facility ID, name, full address, phone, hospital type (Acute Care / Critical Access / Psychiatric / etc.), ownership category, emergency services flag, birthing-friendly designation, CMS overall star rating, and per-measure-group counts (mortality, safety, readmission, patient experience, effectiveness, timeliness, medical imaging). Public-domain federal data.",
+        "operationId": "health_hospital-lookup",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = CMS-certified hospital records; total = upstream match count; meta.query echoes the search.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "facilityId": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "address": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "city": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "state": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "zipcode": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "county": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "phone": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "hospitalType": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "ownership": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "hasEmergencyServices": {
+                                "type": "boolean",
+                                "nullable": true
+                              },
+                              "meetsBirthingFriendlyCriteria": {
+                                "type": "boolean",
+                                "nullable": true
+                              },
+                              "overallRating": {
+                                "type": "integer",
+                                "nullable": true
+                              },
+                              "mortalityGroupCount": {
+                                "type": "integer",
+                                "nullable": true
+                              },
+                              "safetyGroupCount": {
+                                "type": "integer",
+                                "nullable": true
+                              },
+                              "readmissionGroupCount": {
+                                "type": "integer",
+                                "nullable": true
+                              },
+                              "experienceGroupCount": {
+                                "type": "integer",
+                                "nullable": true
+                              },
+                              "effectivenessGroupCount": {
+                                "type": "integer",
+                                "nullable": true
+                              },
+                              "timelinessGroupCount": {
+                                "type": "integer",
+                                "nullable": true
+                              },
+                              "imagingGroupCount": {
+                                "type": "integer",
+                                "nullable": true
+                              }
+                            },
+                            "required": [
+                              "facilityId",
+                              "name",
+                              "address",
+                              "city",
+                              "state",
+                              "zipcode",
+                              "county",
+                              "phone",
+                              "hospitalType",
+                              "ownership",
+                              "hasEmergencyServices",
+                              "meetsBirthingFriendlyCriteria",
+                              "overallRating",
+                              "mortalityGroupCount",
+                              "safetyGroupCount",
+                              "readmissionGroupCount",
+                              "experienceGroupCount",
+                              "effectivenessGroupCount",
+                              "timelinessGroupCount",
+                              "imagingGroupCount"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "query": {
+                              "type": "object",
+                              "properties": {
+                                "facilityId": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "name": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "city": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "state": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "hospitalType": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "minRating": {
+                                  "type": "integer",
+                                  "nullable": true
+                                },
+                                "limit": {
+                                  "type": "integer"
+                                },
+                                "offset": {
+                                  "type": "integer"
+                                }
+                              },
+                              "required": [
+                                "facilityId",
+                                "name",
+                                "city",
+                                "state",
+                                "hospitalType",
+                                "minRating",
+                                "limit",
+                                "offset"
+                              ],
+                              "additionalProperties": false
+                            },
+                            "returned": {
+                              "type": "integer"
+                            }
+                          },
+                          "required": [
+                            "query",
+                            "returned"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "health.hospital-lookup",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "facilityId",
+            "in": "query",
+            "required": false,
+            "description": "Facility ID.",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{6}$"
+            }
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "description": "Name to search for.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 200
+            }
+          },
+          {
+            "name": "city",
+            "in": "query",
+            "required": false,
+            "description": "City name to filter by.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 100
+            }
+          },
+          {
+            "name": "state",
+            "in": "query",
+            "required": false,
+            "description": "US state — two-letter postal abbreviation (e.g. CA) or full name.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 2,
+              "pattern": "^[A-Za-z]{2}$"
+            }
+          },
+          {
+            "name": "hospitalType",
+            "in": "query",
+            "required": false,
+            "description": "Hospital type.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 80
+            }
+          },
+          {
+            "name": "minRating",
+            "in": "query",
+            "required": false,
+            "description": "Min rating.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 5
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of results to return.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 20
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "description": "Number of results to skip before returning (pagination offset).",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 10000,
+              "default": 0
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/health/hospital-quality": {
+      "get": {
+        "tags": [
+          "health"
+        ],
+        "summary": "Fetch CMS Care Compare hospital quality ratings - the data",
+        "description": "CMS Care Compare hospital quality ratings — the data behind medicare.gov hospital ratings, for all ~5,300 Medicare-certified US hospitals. Look up by facilityId (CMS certification number), or filter by state, city, and name (partial match). Each row: facility id/name/address/phone, hospital type + ownership, emergency services, overall star rating (1-5), and per-domain measure summaries (mortality, safety of care, readmission, patient experience, timeliness, effectiveness) showing whether the hospital performs better/same/worse than the national average. Rows returned with CMS's documented column names. Public-domain federal data.",
+        "operationId": "health_hospital-quality",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = CMS Care Compare hospital rows (CMS's documented column names, incl. hospital_overall_rating); total = upstream match count (null if CMS omits it).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.00288 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "health.hospital-quality",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.00288,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.002880"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "facilityId",
+            "in": "query",
+            "required": false,
+            "description": "Facility ID.",
+            "schema": {
+              "type": "string",
+              "pattern": "^[0-9A-Za-z]{6}$"
+            }
+          },
+          {
+            "name": "state",
+            "in": "query",
+            "required": false,
+            "description": "US state — two-letter postal abbreviation (e.g. CA) or full name.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 2
+            }
+          },
+          {
+            "name": "city",
+            "in": "query",
+            "required": false,
+            "description": "City name to filter by.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 60
+            }
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "description": "Name to search for.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 120
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of results to return.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 10
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "description": "Number of results to skip before returning (pagination offset).",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/health/medicare-provider": {
+      "get": {
+        "tags": [
+          "health"
+        ],
+        "summary": "Fetch Medicare utilization + payments by provider (CMS",
+        "description": "Medicare utilization + payments by provider (CMS 'Physician & Other Practitioners - by Provider' annual dataset). Look up by npi, or filter by lastName (exact last/organization name) + state. Each row: provider NPI, name, credentials, entity type, full address, provider type/specialty, Medicare participation, beneficiary counts, total services, submitted charges, Medicare allowed/payment amounts, plus beneficiary demographic + chronic-condition aggregates — CMS's documented column names (Rndrng_NPI, Tot_Srvcs, Tot_Mdcr_Pymt_Amt, etc). Complements /api/health/open-payments (industry payments to the same NPIs). KYC, healthcare-fraud research, and provider due diligence. For a provider 360 (identity + industry payments + this) by NPI in one call, see /api/health/provider-profile. Public-domain federal data.",
+        "operationId": "health_medicare-provider",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = CMS Medicare provider utilization rows (CMS's documented column names: Rndrng_NPI, Tot_Srvcs, Tot_Mdcr_Pymt_Amt, …); total = null (CMS data-api returns no match count).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.00288 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "health.medicare-provider",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.00288,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.002880"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "npi",
+            "in": "query",
+            "required": false,
+            "description": "NPI.",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{10}$"
+            }
+          },
+          {
+            "name": "lastName",
+            "in": "query",
+            "required": false,
+            "description": "Last name to filter by.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 80
+            }
+          },
+          {
+            "name": "state",
+            "in": "query",
+            "required": false,
+            "description": "US state — two-letter postal abbreviation (e.g. CA) or full name.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 2
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of results to return.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 10
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "description": "Number of results to skip before returning (pagination offset).",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/health/mortality-stats": {
+      "get": {
+        "tags": [
+          "health"
+        ],
+        "summary": "Fetch US mortality statistics from CDC NCHS.",
+        "description": "US mortality statistics from CDC NCHS. dataset=leading-causes (default): annual deaths + age-adjusted death rate per 100k by state and top-10 cause of death, 1999-2017 — filter by state (full name, e.g. \"California\", or \"United States\"), year, cause (e.g. \"Heart disease\", \"Cancer\", \"Suicide\"). dataset=weekly-counts: provisional weekly death counts by jurisdiction with per-cause columns (all-cause, natural, COVID-19, heart disease, cancer, etc.), 2020-2023 — filter by state and mmwrYear. Rows returned raw from CDC with documented column names. Public-domain federal data.",
+        "operationId": "health_mortality-stats",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = raw CDC NCHS rows (documented column names); total = null (Socrata page, no upstream count); meta.dataset echoes which dataset was queried.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "dataset": {
+                              "type": "string",
+                              "enum": [
+                                "leading-causes",
+                                "weekly-counts"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "dataset"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0024 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "health.mortality-stats",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0024,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.002400"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "dataset",
+            "in": "query",
+            "required": false,
+            "description": "Dataset.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "leading-causes",
+                "weekly-counts"
+              ],
+              "default": "leading-causes"
+            }
+          },
+          {
+            "name": "state",
+            "in": "query",
+            "required": false,
+            "description": "US state — two-letter postal abbreviation (e.g. CA) or full name.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 40
+            }
+          },
+          {
+            "name": "year",
+            "in": "query",
+            "required": false,
+            "description": "Four-digit calendar year.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1999,
+              "maximum": 2023
+            }
+          },
+          {
+            "name": "cause",
+            "in": "query",
+            "required": false,
+            "description": "Cause.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 80
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of results to return.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 200,
+              "default": 25
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "description": "Number of results to skip before returning (pagination offset).",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/health/open-payments": {
+      "get": {
+        "tags": [
+          "health"
+        ],
+        "summary": "Search CMS Open Payments - every payment from a drug/device...",
+        "description": "Search CMS Open Payments — every payment from a drug/device manufacturer or GPO to a US physician or teaching hospital under the Sunshine Act (~10M records per year). Lookup by 10-digit NPI for the recipient (most precise), by last/first name + state, or by payer (manufacturer) name. Each record includes recipient (NPI, name, specialty, location), payer (manufacturer name + state/country), payment (amount USD, date, nature of payment such as 'Consulting Fee'/'Food and Beverage'/'Travel'/'Royalty', form of payment), and associated product (drug/device name + therapeutic area). Investigative journalism + KYC + healthcare conflict-of-interest research. Public-domain federal data.",
+        "operationId": "health_open-payments",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = CMS Open Payments records matching the query; total = upstream match count; meta carries the query echo + program year. For a provider 360 (identity + this + Medicare billing) by NPI in one call, see /api/health/provider-profile.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "recordId": {
+                                "type": "string"
+                              },
+                              "recipient": {
+                                "type": "object",
+                                "properties": {
+                                  "npi": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "firstName": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "lastName": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "type": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "primarySpecialty": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "city": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "state": {
+                                    "type": "string",
+                                    "nullable": true
+                                  }
+                                },
+                                "required": [
+                                  "npi",
+                                  "firstName",
+                                  "lastName",
+                                  "type",
+                                  "primarySpecialty",
+                                  "city",
+                                  "state"
+                                ],
+                                "additionalProperties": false
+                              },
+                              "payer": {
+                                "type": "object",
+                                "properties": {
+                                  "name": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "state": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "country": {
+                                    "type": "string",
+                                    "nullable": true
+                                  }
+                                },
+                                "required": [
+                                  "name",
+                                  "state",
+                                  "country"
+                                ],
+                                "additionalProperties": false
+                              },
+                              "payment": {
+                                "type": "object",
+                                "properties": {
+                                  "amountUsd": {
+                                    "type": "number",
+                                    "nullable": true
+                                  },
+                                  "date": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "natureOfPayment": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "formOfPayment": {
+                                    "type": "string",
+                                    "nullable": true
+                                  }
+                                },
+                                "required": [
+                                  "amountUsd",
+                                  "date",
+                                  "natureOfPayment",
+                                  "formOfPayment"
+                                ],
+                                "additionalProperties": false
+                              },
+                              "associatedProduct": {
+                                "type": "object",
+                                "properties": {
+                                  "type": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "name": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "therapeuticArea": {
+                                    "type": "string",
+                                    "nullable": true
+                                  }
+                                },
+                                "required": [
+                                  "type",
+                                  "name",
+                                  "therapeuticArea"
+                                ],
+                                "additionalProperties": false
+                              },
+                              "programYear": {
+                                "type": "string",
+                                "nullable": true
+                              }
+                            },
+                            "required": [
+                              "recordId",
+                              "recipient",
+                              "payer",
+                              "payment",
+                              "associatedProduct",
+                              "programYear"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "query": {
+                              "type": "object",
+                              "properties": {
+                                "npi": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "lastName": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "firstName": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "payerName": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "state": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "minAmount": {
+                                  "type": "number",
+                                  "nullable": true
+                                },
+                                "limit": {
+                                  "type": "integer"
+                                },
+                                "offset": {
+                                  "type": "integer"
+                                }
+                              },
+                              "required": [
+                                "npi",
+                                "lastName",
+                                "firstName",
+                                "payerName",
+                                "state",
+                                "minAmount",
+                                "limit",
+                                "offset"
+                              ],
+                              "additionalProperties": false
+                            },
+                            "programYear": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "query",
+                            "programYear"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "health.open-payments",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "npi",
+            "in": "query",
+            "required": false,
+            "description": "NPI.",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{10}$"
+            }
+          },
+          {
+            "name": "firstName",
+            "in": "query",
+            "required": false,
+            "description": "First name to filter by.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 80
+            }
+          },
+          {
+            "name": "lastName",
+            "in": "query",
+            "required": false,
+            "description": "Last name to filter by.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 80
+            }
+          },
+          {
+            "name": "payerName",
+            "in": "query",
+            "required": false,
+            "description": "Payer name.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 200
+            }
+          },
+          {
+            "name": "state",
+            "in": "query",
+            "required": false,
+            "description": "US state — two-letter postal abbreviation (e.g. CA) or full name.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 2,
+              "pattern": "^[A-Za-z]{2}$"
+            }
+          },
+          {
+            "name": "minAmount",
+            "in": "query",
+            "required": false,
+            "description": "Minimum amount to include (USD).",
+            "schema": {
+              "type": "number",
+              "minimum": 0,
+              "maximum": 10000000
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of results to return.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 20
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "description": "Number of results to skip before returning (pagination offset).",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 100000,
+              "default": 0
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/health/provider-profile": {
+      "get": {
+        "tags": [
+          "health"
+        ],
+        "summary": "Fetch Provider 360 - everything we know about a US",
+        "description": "Provider 360 — everything we know about a US healthcare provider, merged on their 10-digit NPI in one call. Combines three federal datasets: identity (NPPES registry: name, specialty/taxonomy, practice address, licenses), industry payments (CMS Open Payments: what drug & device makers paid them), and Medicare billing (CMS Physician & Other Practitioners: services, charges, and Medicare payment amounts). Each section reports found/error independently — a provider with no Open Payments or Medicare record still returns identity. KYC, healthcare-fraud research, investigative journalism, provider due diligence. Pass npi (required). For the individual sources see /api/license/medical, /api/health/open-payments, /api/health/medicare-provider.",
+        "operationId": "health_provider-profile",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "npi": {
+                          "type": "string"
+                        },
+                        "identity": {
+                          "type": "object",
+                          "properties": {
+                            "found": {
+                              "type": "boolean"
+                            },
+                            "error": {
+                              "type": "string",
+                              "nullable": true
+                            },
+                            "provider": {
+                              "type": "object",
+                              "additionalProperties": {},
+                              "nullable": true
+                            }
+                          },
+                          "required": [
+                            "found",
+                            "error",
+                            "provider"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "openPayments": {
+                          "type": "object",
+                          "properties": {
+                            "found": {
+                              "type": "boolean"
+                            },
+                            "error": {
+                              "type": "string",
+                              "nullable": true
+                            },
+                            "totalCount": {
+                              "type": "number",
+                              "nullable": true
+                            },
+                            "payments": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "additionalProperties": {}
+                              }
+                            }
+                          },
+                          "required": [
+                            "found",
+                            "error",
+                            "totalCount",
+                            "payments"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "medicare": {
+                          "type": "object",
+                          "properties": {
+                            "found": {
+                              "type": "boolean"
+                            },
+                            "error": {
+                              "type": "string",
+                              "nullable": true
+                            },
+                            "record": {
+                              "type": "object",
+                              "additionalProperties": {},
+                              "nullable": true
+                            }
+                          },
+                          "required": [
+                            "found",
+                            "error",
+                            "record"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "sources": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
+                        }
+                      },
+                      "required": [
+                        "npi",
+                        "identity",
+                        "openPayments",
+                        "medicare",
+                        "sources"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.00576 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "health.provider-profile",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.00576,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "legacy",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.005760"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "npi",
+            "in": "query",
+            "required": true,
+            "description": "NPI.",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{10}$"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/medical/icd10": {
+      "get": {
+        "tags": [
+          "medical"
+        ],
+        "summary": "Verify and search ICD-10-CM diagnosis codes against the...",
+        "description": "Verify and search ICD-10-CM diagnosis codes against the official US code set (FY2026, ~98k entries). Pass code (with or without the dot, e.g. E11.9 or E119) to confirm the code exists and list its more-specific child codes, or q to keyword-search code descriptions (e.g. \"type 2 diabetes neuropathy\"). Optional billable_only=true restricts results to codes valid for claim submission; limit caps results (1-50, default 10). Returns a verified flag, the exact match if any, and matched codes with billable status plus short and long descriptions. Data: CMS/NCHS ICD-10-CM (public domain), refreshed each US fiscal year. Use to confirm diagnosis codes are real and current before placing them in claims, prior authorizations, or clinical documents.",
+        "operationId": "medical_icd10",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = matched ICD-10-CM codes (verify mode: the exact code + child codes; keyword mode: billable matches first); total = 1 when an exact code is verified, else null. meta.mode flags verify vs keyword and carries verified/exactMatch.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "Storage form without the dot, e.g. E119."
+                              },
+                              "codeDotted": {
+                                "type": "string",
+                                "description": "Conventional display form, e.g. E11.9."
+                              },
+                              "billable": {
+                                "type": "boolean",
+                                "description": "True when valid for claim submission (leaf code); false for category headers."
+                              },
+                              "shortDescription": {
+                                "type": "string"
+                              },
+                              "longDescription": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "codeDotted",
+                              "billable",
+                              "shortDescription",
+                              "longDescription"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "mode": {
+                              "type": "string",
+                              "enum": [
+                                "verify",
+                                "keyword"
+                              ],
+                              "description": "verify = code lookup; keyword = q search."
+                            },
+                            "query": {
+                              "type": "object",
+                              "properties": {
+                                "code": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "q": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "billableOnly": {
+                                  "type": "boolean"
+                                },
+                                "limit": {
+                                  "type": "integer"
+                                }
+                              },
+                              "required": [
+                                "code",
+                                "q",
+                                "billableOnly",
+                                "limit"
+                              ],
+                              "additionalProperties": false
+                            },
+                            "verified": {
+                              "type": "boolean",
+                              "nullable": true,
+                              "description": "Verify mode: true iff the exact code exists in the official set. null in keyword mode."
+                            },
+                            "exactMatch": {
+                              "type": "object",
+                              "properties": {
+                                "code": {
+                                  "type": "string",
+                                  "description": "Storage form without the dot, e.g. E119."
+                                },
+                                "codeDotted": {
+                                  "type": "string",
+                                  "description": "Conventional display form, e.g. E11.9."
+                                },
+                                "billable": {
+                                  "type": "boolean",
+                                  "description": "True when valid for claim submission (leaf code); false for category headers."
+                                },
+                                "shortDescription": {
+                                  "type": "string"
+                                },
+                                "longDescription": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "code",
+                                "codeDotted",
+                                "billable",
+                                "shortDescription",
+                                "longDescription"
+                              ],
+                              "additionalProperties": false,
+                              "nullable": true,
+                              "description": "The exact code when verified, else null."
+                            },
+                            "fiscalYear": {
+                              "type": "integer",
+                              "description": "US fiscal year of the loaded code set."
+                            }
+                          },
+                          "required": [
+                            "mode",
+                            "query",
+                            "verified",
+                            "exactMatch",
+                            "fiscalYear"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.001 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "medical.icd10",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.001,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "code",
+            "in": "query",
+            "required": false,
+            "description": "ICD-10-CM code to verify, with or without the dot (e.g. E11.9 or E119). Returns the exact match plus more-specific child codes. Provide either code or q, not both.",
+            "schema": {
+              "type": "string",
+              "minLength": 3,
+              "maxLength": 9,
+              "pattern": "^[A-Za-z][0-9][0-9A-Za-z](\\.?[0-9A-Za-z]{0,4})$"
+            }
+          },
+          {
+            "name": "q",
+            "in": "query",
+            "required": false,
+            "description": "Keyword search over official code descriptions (e.g. \"type 2 diabetes neuropathy\"). Every word must match. Provide either code or q, not both.",
+            "schema": {
+              "type": "string",
+              "minLength": 3,
+              "maxLength": 120
+            }
+          },
+          {
+            "name": "billable_only",
+            "in": "query",
+            "required": false,
+            "description": "When true, only return codes valid for claim submission (excludes category headers).",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Maximum codes returned (1-50, default 10).",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 50
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/medical/rxnorm": {
+      "get": {
+        "tags": [
+          "medical"
+        ],
+        "summary": "Parse and verify drug names against RxNorm, the...",
+        "description": "Normalize and verify drug names against RxNorm, the canonical US drug vocabulary from the NIH. Two modes: term (\"tylenol 500mg\", brand or generic, typos tolerated) returns ranked RxCUI candidates with normalized names and match scores; rxcui returns the canonical concept (name, term type like IN=ingredient / SBD=branded drug / SCD=clinical drug, suppression flag) plus related concepts — active ingredients, brand names, and available dose forms. Use before writing prescriptions data, drug interactions queries, or pharmacy integrations: verify the drug exists and get its stable identifier instead of trusting model memory. Sibling: /api/medical/icd10 (diagnosis codes). Public-domain NIH data.",
+        "operationId": "medical_rxnorm",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = ranked RxCUI candidates (term/search mode) or [the one canonical concept] (rxcui/detail mode); total = null in search mode, 1 or 0 in detail mode. meta.mode flags search vs detail; meta.concept + meta.related carry detail-mode extras.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "mode": {
+                              "type": "string",
+                              "enum": [
+                                "search",
+                                "detail"
+                              ]
+                            },
+                            "concept": {
+                              "type": "object",
+                              "properties": {
+                                "rxcui": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "synonym": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "termType": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "description": "IN=ingredient, BN=brand, SBD=branded drug, SCD=clinical drug, …"
+                                },
+                                "suppressed": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "rxcui",
+                                "name",
+                                "synonym",
+                                "termType",
+                                "suppressed"
+                              ],
+                              "additionalProperties": false,
+                              "nullable": true,
+                              "description": "Canonical concept (detail mode). Null when the rxcui does not exist."
+                            },
+                            "related": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "termType": {
+                                    "type": "string"
+                                  },
+                                  "concepts": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "rxcui": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "rxcui",
+                                        "name"
+                                      ],
+                                      "additionalProperties": false
+                                    }
+                                  }
+                                },
+                                "required": [
+                                  "termType",
+                                  "concepts"
+                                ],
+                                "additionalProperties": false
+                              },
+                              "nullable": true,
+                              "description": "Related concepts by term type: IN (ingredients), BN (brands), DF (dose forms). Detail mode only."
+                            }
+                          },
+                          "required": [
+                            "mode",
+                            "concept",
+                            "related"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "medical.rxnorm",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "term",
+            "in": "query",
+            "required": false,
+            "description": "Free-text drug name. Provide term or rxcui, not both.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 200
+            }
+          },
+          {
+            "name": "rxcui",
+            "in": "query",
+            "required": false,
+            "description": "RXCUI.",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{1,8}$"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of results to return.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 20,
+              "default": 5
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/nutrition/food": {
+      "get": {
+        "tags": [
+          "nutrition"
+        ],
+        "summary": "Fetch USDA FoodData Central nutrition lookup.",
+        "description": "USDA FoodData Central nutrition lookup. Two modes: search (query=cheddar cheese) returns matching foods with fdcId, description, data type, category, and brand; detail (fdcId=328637) returns the full analyzed nutrient profile — energy, protein, fats, carbohydrates, vitamins, minerals — with USDA nutrient numbers, amounts, and units (per 100 g/ml unless serving fields indicate otherwise), plus ingredients for branded foods. Filter search by dataType: Foundation and SR Legacy are lab-analyzed generic foods, Branded is the packaged-food label corpus, Survey (FNDDS) is as-consumed dishes. Authoritative USDA data covering ~400k foods — use real analyzed values instead of model-estimated nutrition facts.",
+        "operationId": "nutrition_food",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = food search hits (meta.mode=\"search\", total = totalHits) OR one food’s full nutrient profile (meta.mode=\"detail\", total = 1) from USDA FoodData Central.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "anyOf": [
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "fdcId": {
+                                    "type": "number"
+                                  },
+                                  "description": {
+                                    "type": "string"
+                                  },
+                                  "dataType": {
+                                    "type": "string"
+                                  },
+                                  "foodCategory": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "brandOwner": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "brandName": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "servingSize": {
+                                    "type": "number",
+                                    "nullable": true
+                                  },
+                                  "servingSizeUnit": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "publishedDate": {
+                                    "type": "string",
+                                    "nullable": true
+                                  }
+                                },
+                                "required": [
+                                  "fdcId",
+                                  "description",
+                                  "dataType",
+                                  "foodCategory",
+                                  "brandOwner",
+                                  "brandName",
+                                  "servingSize",
+                                  "servingSizeUnit",
+                                  "publishedDate"
+                                ],
+                                "additionalProperties": false,
+                                "description": "Search-mode hit (meta.mode = \"search\")."
+                              },
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "fdcId": {
+                                    "type": "number"
+                                  },
+                                  "description": {
+                                    "type": "string"
+                                  },
+                                  "dataType": {
+                                    "type": "string"
+                                  },
+                                  "foodCategory": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "brandOwner": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "ingredients": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "servingSize": {
+                                    "type": "number",
+                                    "nullable": true
+                                  },
+                                  "servingSizeUnit": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "publicationDate": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "nutrients": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "number": {
+                                          "type": "string",
+                                          "description": "USDA nutrient number, e.g. \"208\" = Energy (kcal)."
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "amount": {
+                                          "type": "number"
+                                        },
+                                        "unitName": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "number",
+                                        "name",
+                                        "amount",
+                                        "unitName"
+                                      ],
+                                      "additionalProperties": false
+                                    }
+                                  }
+                                },
+                                "required": [
+                                  "fdcId",
+                                  "description",
+                                  "dataType",
+                                  "foodCategory",
+                                  "brandOwner",
+                                  "ingredients",
+                                  "servingSize",
+                                  "servingSizeUnit",
+                                  "publicationDate",
+                                  "nutrients"
+                                ],
+                                "additionalProperties": false,
+                                "description": "Detail-mode full nutrient profile (meta.mode = \"detail\"). Values per 100 g/ml unless serving fields indicate otherwise."
+                              }
+                            ]
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "mode": {
+                              "type": "string",
+                              "enum": [
+                                "search",
+                                "detail"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "mode"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "nutrition.food",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "query",
+            "in": "query",
+            "required": false,
+            "description": "Food name to search, e.g. \"cheddar cheese\". Provide query or fdcId, not both.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 120
+            }
+          },
+          {
+            "name": "fdcId",
+            "in": "query",
+            "required": false,
+            "description": "FDC food id — returns the full nutrient profile.",
+            "schema": {
+              "type": "integer",
+              "exclusiveMinimum": true,
+              "minimum": 0
+            }
+          },
+          {
+            "name": "dataType",
+            "in": "query",
+            "required": false,
+            "description": "Restrict search to one data type. Foundation/SR Legacy = analyzed generic foods, Branded = packaged labels, Survey (FNDDS) = as-consumed dishes.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Foundation",
+                "SR Legacy",
+                "Survey (FNDDS)",
+                "Branded"
+              ]
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of results to return.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 50,
+              "default": 10
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "description": "Page number (1-based) for paginated results.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 1
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/providers/2s/identity/PAY.md
+++ b/providers/2s/identity/PAY.md
@@ -1,0 +1,17 @@
+---
+name: identity
+title: "2s Identity"
+description: "Entity and identifier verification: validate IBAN, BIC, CUSIP, ISIN, LEI, GTIN, ABA and more; GLEIF business identity, NAICS, Secretary-of-State entity search, professional-license lookups, and nonprofit screening."
+use_case: "Use for validating financial and product identifiers, verifying a business or LEI, checking professional licenses, and screening people or nonprofits."
+category: identity
+service_url: https://2s.io
+openapi:
+  path: openapi.json
+---
+
+Part of 2s — a unified, agent-native JSON API. Pay per call in USDC on Solana (or Base) via x402; no accounts, no API keys. Add `?trial=1` (or header `X-2s-Trial: 1`) for one free real call per endpoint per hour.
+
+## Spend-aware usage
+
+- Prefer narrow lookups (by id/code) over broad searches; reuse identifiers across calls.
+- Cap result `limit` to the smallest count that answers the task.

--- a/providers/2s/identity/openapi.json
+++ b/providers/2s/identity/openapi.json
@@ -1,0 +1,5299 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "2s",
+    "version": "1",
+    "description": "Unified JSON REST API for AI agents — an ever-expanding catalog of endpoints, pay per call in USDC on Base or Solana via x402, no accounts, no API keys. Fund a wallet on either chain with USDC, hit any endpoint, and your client signs an EIP-3009 authorization (Base) or a partial SPL transfer (Solana) to settle the call. Try before you buy: add ?trial=1 (or header X-2s-Trial: 1) to any endpoint for one free real call per endpoint per hour — no wallet needed — to verify it works before paying. 2s is an open-ended experiment in maximally-comprehensive agent infrastructure — new endpoints land regularly.",
+    "contact": {
+      "name": "2s",
+      "url": "https://2s.io",
+      "email": "alley@2s.io"
+    }
+  },
+  "servers": [
+    {
+      "url": "https://2s.io"
+    }
+  ],
+  "components": {
+    "parameters": {
+      "TrialMode": {
+        "name": "trial",
+        "in": "query",
+        "required": false,
+        "description": "Try before you buy. Set to 1 for one free real call per endpoint per hour — no wallet or payment needed — to verify the endpoint before paying. Equivalent to sending the \"X-2s-Trial: 1\" request header. Works on every endpoint.",
+        "schema": {
+          "type": "integer",
+          "enum": [
+            1
+          ]
+        }
+      }
+    },
+    "securitySchemes": {
+      "x402Payment": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "PAYMENT-SIGNATURE",
+        "description": "x402 protocol v2: base64-encoded PaymentPayload. Call any paid endpoint without auth to receive a 402 with a multi-network PaymentRequirements envelope. Sign for either rail: EIP-3009 transferWithAuthorization (Base USDC) OR a partial SPL token transfer (Solana USDC). Retry with PAYMENT-SIGNATURE header. X-PAYMENT is also accepted for v1 buyer clients. See https://x402.org."
+      }
+    },
+    "schemas": {
+      "X402PaymentRequiredV2": {
+        "type": "object",
+        "description": "x402 v2 PaymentRequired envelope. Pick any entry from accepts[], sign for that rail, retry with the PAYMENT-SIGNATURE header.",
+        "required": [
+          "x402Version",
+          "accepts"
+        ],
+        "properties": {
+          "x402Version": {
+            "type": "integer",
+            "const": 2
+          },
+          "error": {
+            "type": "string",
+            "description": "Human-readable reason payment is required."
+          },
+          "resource": {
+            "type": "string",
+            "description": "The resource URL being purchased."
+          },
+          "accepts": {
+            "type": "array",
+            "description": "Payment requirement options, one per supported network (Base USDC, Solana USDC).",
+            "items": {
+              "type": "object",
+              "required": [
+                "scheme",
+                "network",
+                "amount",
+                "asset",
+                "payTo",
+                "maxTimeoutSeconds"
+              ],
+              "properties": {
+                "scheme": {
+                  "type": "string",
+                  "enum": [
+                    "exact"
+                  ]
+                },
+                "network": {
+                  "type": "string",
+                  "description": "CAIP-2 network id, e.g. \"eip155:8453\" (Base) or \"solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp\"."
+                },
+                "amount": {
+                  "type": "string",
+                  "description": "Price in atomic asset units (USDC has 6 decimals)."
+                },
+                "asset": {
+                  "type": "string",
+                  "description": "Asset contract address / mint."
+                },
+                "payTo": {
+                  "type": "string",
+                  "description": "Treasury address to pay."
+                },
+                "maxTimeoutSeconds": {
+                  "type": "integer"
+                },
+                "extra": {
+                  "type": "object",
+                  "description": "Rail-specific extras (EVM: EIP-712 domain name/version; Solana: feePayer).",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "extensions": {
+            "type": "object",
+            "description": "Optional discovery metadata (e.g. bazaar input/output schemas).",
+            "additionalProperties": true
+          }
+        }
+      }
+    }
+  },
+  "paths": {
+    "/api/business/entity-screen": {
+      "get": {
+        "tags": [
+          "business"
+        ],
+        "summary": "Fetch KYC in one call: look up a business in a US state",
+        "description": "KYC in one call: look up a business in a US state registry (NY, CO, CT) AND screen it against the OFAC sanctions list. Give a state and a name (or exact entityId). Returns the matched registered entities (id, type, status, jurisdiction, address, registered agent) and, for each, a sanctions screen of the entity name AND its registered agent against OFAC SDN — with fuzzy-match confidence and a flagged boolean. Counterparty due-diligence, vendor onboarding, AML. Composition of /api/business/sos-search + /api/law/sanctions-check (each section reports found/error independently). Note: sanctions screening is name-based and probabilistic — review flagged matches manually.",
+        "operationId": "business_entity-screen",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "state": {
+                          "type": "string"
+                        },
+                        "count": {
+                          "type": "number"
+                        },
+                        "entities": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "entity": {
+                                "type": "object",
+                                "additionalProperties": {}
+                              },
+                              "sanctions": {
+                                "type": "object",
+                                "properties": {
+                                  "found": {
+                                    "type": "boolean"
+                                  },
+                                  "error": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "flagged": {
+                                    "type": "boolean"
+                                  },
+                                  "entityMatchCount": {
+                                    "type": "number"
+                                  },
+                                  "agentMatchCount": {
+                                    "type": "number"
+                                  },
+                                  "matches": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "additionalProperties": {}
+                                    }
+                                  }
+                                },
+                                "required": [
+                                  "found",
+                                  "error",
+                                  "flagged",
+                                  "entityMatchCount",
+                                  "agentMatchCount",
+                                  "matches"
+                                ],
+                                "additionalProperties": false
+                              }
+                            },
+                            "required": [
+                              "entity",
+                              "sanctions"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "sources": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
+                        }
+                      },
+                      "required": [
+                        "state",
+                        "count",
+                        "entities",
+                        "sources"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.00576 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "business.entity-screen",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.00576,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "legacy",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.005760"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "state",
+            "in": "query",
+            "required": true,
+            "description": "US state — two-letter postal abbreviation (e.g. CA) or full name.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "NY",
+                "CO",
+                "CT"
+              ]
+            }
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "description": "Name to search for.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 120
+            }
+          },
+          {
+            "name": "entityId",
+            "in": "query",
+            "required": false,
+            "description": "Entity ID.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 30
+            }
+          },
+          {
+            "name": "threshold",
+            "in": "query",
+            "required": false,
+            "description": "Minimum score/threshold required to include a result.",
+            "schema": {
+              "type": "number",
+              "minimum": 0.1,
+              "maximum": 1,
+              "default": 0.5
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of results to return.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 10,
+              "default": 5
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/business/lei": {
+      "get": {
+        "tags": [
+          "business"
+        ],
+        "summary": "Look up or search the global LEI (Legal Entity Identifier)...",
+        "description": "Look up or search the global LEI (Legal Entity Identifier) registry — the authoritative ISO 17442 directory of ~2.6M legal entities worldwide. Pass `lei` for an exact 20-character LEI, or `query` to search by legal/other name (ranked best-match first). Filter name search by `country` (ISO 2-letter, HQ country) and `status` (active = currently active entities only; all = default). Each result returns the LEI, legal name, an alternate/other name, legal jurisdiction, entity category (GENERAL/FUND/BRANCH/…), ISO 20275 legal-form code, entity status (ACTIVE/INACTIVE), LEI registration status (ISSUED/LAPSED/RETIRED/…), headquarters city/region/country/postal code, the initial registration + last update + next renewal dates, and the managing LOU. Use this to canonicalize a company name to its LEI, resolve a counterparty, or enrich a vendor master. Data: GLEIF Golden Copy (CC0, public domain).",
+        "operationId": "business_lei",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = matching entities (bm25-ranked for name search; ≤1 for exact LEI lookup); total = match count; page = pagination block.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "lei": {
+                                "type": "string"
+                              },
+                              "legalName": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "otherName": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "First alternate/other registered name, if any."
+                              },
+                              "jurisdiction": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "Legal jurisdiction (ISO country or subdivision)."
+                              },
+                              "category": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "Entity category: GENERAL | FUND | BRANCH | SOLE_PROPRIETOR | …"
+                              },
+                              "legalForm": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "ISO 20275 Entity Legal Form (ELF) code."
+                              },
+                              "entityStatus": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "ACTIVE | INACTIVE."
+                              },
+                              "registrationStatus": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "LEI registration status: ISSUED | LAPSED | RETIRED | ANNULLED | …"
+                              },
+                              "headquarters": {
+                                "type": "object",
+                                "properties": {
+                                  "city": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "region": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "country": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "postalCode": {
+                                    "type": "string",
+                                    "nullable": true
+                                  }
+                                },
+                                "required": [
+                                  "city",
+                                  "region",
+                                  "country",
+                                  "postalCode"
+                                ],
+                                "additionalProperties": false
+                              },
+                              "initialRegistrationDate": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "lastUpdateDate": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "nextRenewalDate": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "managingLou": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "LEI of the Local Operating Unit that maintains this record."
+                              }
+                            },
+                            "required": [
+                              "lei",
+                              "legalName",
+                              "otherName",
+                              "jurisdiction",
+                              "category",
+                              "legalForm",
+                              "entityStatus",
+                              "registrationStatus",
+                              "headquarters",
+                              "initialRegistrationDate",
+                              "lastUpdateDate",
+                              "nextRenewalDate",
+                              "managingLou"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "page": {
+                          "type": "object",
+                          "properties": {
+                            "number": {
+                              "type": "integer"
+                            },
+                            "size": {
+                              "type": "integer"
+                            },
+                            "pages": {
+                              "type": "integer",
+                              "nullable": true
+                            }
+                          },
+                          "required": [
+                            "number",
+                            "size",
+                            "pages"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "business.lei",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "lei",
+            "in": "query",
+            "required": false,
+            "description": "LEI.",
+            "schema": {
+              "type": "string",
+              "pattern": "^[A-Za-z0-9]{20}$"
+            }
+          },
+          {
+            "name": "query",
+            "in": "query",
+            "required": false,
+            "description": "Free-text search query.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 200
+            }
+          },
+          {
+            "name": "country",
+            "in": "query",
+            "required": false,
+            "description": "Country name or ISO country code.",
+            "schema": {
+              "type": "string",
+              "pattern": "^[A-Za-z]{2}$"
+            }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "description": "Filter results by status.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "active",
+                "all"
+              ]
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of results to return.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "description": "Number of results to skip before returning (pagination offset).",
+            "schema": {
+              "type": "integer",
+              "minimum": 0
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/business/naics": {
+      "get": {
+        "tags": [
+          "business"
+        ],
+        "summary": "Look up or search NAICS 2022 industry classification codes...",
+        "description": "Look up or search NAICS 2022 industry classification codes (US Census Bureau, public domain). Pass `code` for an exact NAICS code — 2–6 digits or a combined sector like 31-33 — and get its official title, hierarchy path, full official description, activity index terms, and direct child codes. Or pass `query` for free-text search (e.g. 'software publishers', 'coffee shop') over titles plus the official ~20k-entry activity index → ranked candidate codes, optionally filtered by `level` (2=sector … 6=national industry). Ground truth for industry coding in KYC, business registration, government filings, and ERP vendor/customer setup.",
+        "operationId": "business_naics",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = NAICS codes (exact match first followed by its direct children, or ranked search candidates); total = match count.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "description": "NAICS 2022 code (sectors may be ranges like 31-33)."
+                              },
+                              "level": {
+                                "type": "number",
+                                "description": "Hierarchy level: 2=sector, 3=subsector, 4=industry group, 5=NAICS industry, 6=national industry."
+                              },
+                              "title": {
+                                "type": "string",
+                                "description": "Official NAICS title."
+                              },
+                              "heading": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "Ancestor path (sector > subsector > …), excludes the code itself."
+                              },
+                              "description": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "Official Census description. Full text on the exactly-matched code; truncated elsewhere."
+                              },
+                              "indexTerms": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "nullable": true,
+                                "description": "Official activity index entries cross-referenced to this code (6-digit codes; capped)."
+                              }
+                            },
+                            "required": [
+                              "code",
+                              "level",
+                              "title",
+                              "heading",
+                              "description",
+                              "indexTerms"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "page": {
+                          "type": "object",
+                          "properties": {
+                            "number": {
+                              "type": "integer"
+                            },
+                            "size": {
+                              "type": "integer"
+                            },
+                            "pages": {
+                              "type": "integer",
+                              "nullable": true
+                            }
+                          },
+                          "required": [
+                            "number",
+                            "size",
+                            "pages"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.001 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "business.naics",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.001,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "code",
+            "in": "query",
+            "required": false,
+            "description": "Exact NAICS code (2–6 digits, or a combined sector range like 31-33). XOR with query.",
+            "schema": {
+              "type": "string",
+              "pattern": "^(\\d{2}-\\d{2}|\\d{2,6})$"
+            }
+          },
+          {
+            "name": "query",
+            "in": "query",
+            "required": false,
+            "description": "Free-text industry or activity description to search. XOR with code.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 120
+            }
+          },
+          {
+            "name": "level",
+            "in": "query",
+            "required": false,
+            "description": "Search mode only: restrict results to one hierarchy level (2=sector … 6=national industry).",
+            "schema": {
+              "type": "integer",
+              "minimum": 2,
+              "maximum": 6
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Search mode only: max results, 1–50, default 20.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 50
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/business/sos-search": {
+      "get": {
+        "tags": [
+          "business"
+        ],
+        "summary": "Search state Secretary-of-State business registries...",
+        "description": "Search state Secretary-of-State business registries, normalized to one schema across states. Currently supported: NY (active corporations + LLCs), CO (all entities incl. status), and CT (Business Registry Master incl. type, status, NAICS). Query by name (partial, case-insensitive) or exact entityId; results: state, entity id, name, type, status, formation jurisdiction, formation date, principal/registered address, registered agent. KYC, vendor due-diligence, and counterparty-verification staple. Each state sourced from its official open-data portal.",
+        "operationId": "business_sos-search",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = matching business entities (normalized across states); total = null (capped state-portal search); meta = {state}.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "state": {
+                                "type": "string"
+                              },
+                              "entityId": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "name": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "type": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "status": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "jurisdiction": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "formedDate": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "address": {
+                                "type": "object",
+                                "properties": {
+                                  "street": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "city": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "state": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "zip": {
+                                    "type": "string",
+                                    "nullable": true
+                                  }
+                                },
+                                "required": [
+                                  "street",
+                                  "city",
+                                  "state",
+                                  "zip"
+                                ],
+                                "additionalProperties": false,
+                                "nullable": true
+                              },
+                              "agent": {
+                                "type": "string",
+                                "nullable": true
+                              }
+                            },
+                            "required": [
+                              "state",
+                              "entityId",
+                              "name",
+                              "type",
+                              "status",
+                              "jurisdiction",
+                              "formedDate",
+                              "address",
+                              "agent"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "state": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "state"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.00288 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "business.sos-search",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.00288,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.002880"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "state",
+            "in": "query",
+            "required": true,
+            "description": "US state — two-letter postal abbreviation (e.g. CA) or full name.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "NY",
+                "CO",
+                "CT"
+              ]
+            }
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "description": "Name to search for.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 120
+            }
+          },
+          {
+            "name": "entityId",
+            "in": "query",
+            "required": false,
+            "description": "Entity ID.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 30
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of results to return.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 10
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "description": "Number of results to skip before returning (pagination offset).",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/license/broker": {
+      "get": {
+        "tags": [
+          "license"
+        ],
+        "summary": "Fetch FINRA BrokerCheck lookup - every US registered broker",
+        "description": "FINRA BrokerCheck lookup — every US registered broker / investment advisor (~620k current + former). Search by free-text query (name + firm) or by CRD number for a direct individual record. Each result includes CRD ID, name (with any 'doing business as' aliases), broker-check + IA scope (Active/Inactive), a hasDisclosures flag (yes/no for complaints, settlements, terminations on file), industry-start date, FINRA registration count, and current + previous employments (firm name, branch city/state, registration dates). Public per FINRA's investor-protection BrokerCheck program; pair with /api/finance/sec-filings for cross-reference.",
+        "operationId": "license_broker",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = FINRA BrokerCheck records; total = upstream match count; meta.query echoes the search.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "crd": {
+                                "type": "string"
+                              },
+                              "firstName": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "middleName": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "lastName": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "otherNames": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "bcScope": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "iaScope": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "hasDisclosures": {
+                                "type": "boolean"
+                              },
+                              "yearsInIndustryStart": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "finraRegistrationCount": {
+                                "type": "integer"
+                              },
+                              "employmentCount": {
+                                "type": "integer"
+                              },
+                              "currentEmployments": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "firmId": {
+                                      "type": "string"
+                                    },
+                                    "firmName": {
+                                      "type": "string"
+                                    },
+                                    "branchCity": {
+                                      "type": "string",
+                                      "nullable": true
+                                    },
+                                    "branchState": {
+                                      "type": "string",
+                                      "nullable": true
+                                    },
+                                    "registrationBeginDate": {
+                                      "type": "string",
+                                      "nullable": true
+                                    }
+                                  },
+                                  "required": [
+                                    "firmId",
+                                    "firmName",
+                                    "branchCity",
+                                    "branchState",
+                                    "registrationBeginDate"
+                                  ],
+                                  "additionalProperties": false
+                                }
+                              },
+                              "previousEmployments": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "firmId": {
+                                      "type": "string"
+                                    },
+                                    "firmName": {
+                                      "type": "string"
+                                    },
+                                    "registrationBeginDate": {
+                                      "type": "string",
+                                      "nullable": true
+                                    },
+                                    "registrationEndDate": {
+                                      "type": "string",
+                                      "nullable": true
+                                    }
+                                  },
+                                  "required": [
+                                    "firmId",
+                                    "firmName",
+                                    "registrationBeginDate",
+                                    "registrationEndDate"
+                                  ],
+                                  "additionalProperties": false
+                                }
+                              }
+                            },
+                            "required": [
+                              "crd",
+                              "firstName",
+                              "middleName",
+                              "lastName",
+                              "otherNames",
+                              "bcScope",
+                              "iaScope",
+                              "hasDisclosures",
+                              "yearsInIndustryStart",
+                              "finraRegistrationCount",
+                              "employmentCount",
+                              "currentEmployments",
+                              "previousEmployments"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "query": {
+                              "type": "object",
+                              "properties": {
+                                "query": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "crd": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "limit": {
+                                  "type": "integer"
+                                },
+                                "offset": {
+                                  "type": "integer"
+                                }
+                              },
+                              "required": [
+                                "query",
+                                "crd",
+                                "limit",
+                                "offset"
+                              ],
+                              "additionalProperties": false
+                            },
+                            "returned": {
+                              "type": "integer"
+                            }
+                          },
+                          "required": [
+                            "query",
+                            "returned"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "license.broker",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "query",
+            "in": "query",
+            "required": false,
+            "description": "Free-text search query.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 200
+            }
+          },
+          {
+            "name": "crd",
+            "in": "query",
+            "required": false,
+            "description": "Crd.",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{1,9}$"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of results to return.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 50,
+              "default": 10
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "description": "Number of results to skip before returning (pagination offset).",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 10000,
+              "default": 0
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/license/medical": {
+      "get": {
+        "tags": [
+          "license"
+        ],
+        "summary": "Fetch US healthcare provider lookup (NPPES NPI Registry).",
+        "description": "US healthcare provider lookup (NPPES NPI Registry). Every US doctor, nurse, dentist, hospital, lab, pharmacy has an NPI — this returns the canonical record. Lookup by 10-digit NPI for a precise match, or by firstName + lastName + state for fuzzy search. Each record includes name + credentials, status, enumeration date, primary + secondary specialty taxonomies (with state license numbers), practice + mailing addresses, phone, and any cross-issuer identifiers (Medicaid, Medicare, etc.). Public-domain CMS data, free. For all three NPI datasets merged (identity + industry payments + Medicare billing) in one call, see /api/health/provider-profile.",
+        "operationId": "license_medical",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = NPPES provider records; total = null (NPPES caps results without a true count); meta.query echoes the search.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "npi": {
+                                "type": "string"
+                              },
+                              "enumerationType": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "object",
+                                "properties": {
+                                  "first": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "last": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "middle": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "credential": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "organizationName": {
+                                    "type": "string",
+                                    "nullable": true
+                                  }
+                                },
+                                "required": [
+                                  "first",
+                                  "last",
+                                  "middle",
+                                  "credential",
+                                  "organizationName"
+                                ],
+                                "additionalProperties": false
+                              },
+                              "status": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "enumerationDate": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "lastUpdated": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "taxonomies": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "code": {
+                                      "type": "string"
+                                    },
+                                    "desc": {
+                                      "type": "string"
+                                    },
+                                    "primary": {
+                                      "type": "boolean"
+                                    },
+                                    "licenseNumber": {
+                                      "type": "string",
+                                      "nullable": true
+                                    },
+                                    "licenseState": {
+                                      "type": "string",
+                                      "nullable": true
+                                    }
+                                  },
+                                  "required": [
+                                    "code",
+                                    "desc",
+                                    "primary",
+                                    "licenseNumber",
+                                    "licenseState"
+                                  ],
+                                  "additionalProperties": false
+                                }
+                              },
+                              "addresses": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "purpose": {
+                                      "type": "string"
+                                    },
+                                    "address1": {
+                                      "type": "string",
+                                      "nullable": true
+                                    },
+                                    "address2": {
+                                      "type": "string",
+                                      "nullable": true
+                                    },
+                                    "city": {
+                                      "type": "string",
+                                      "nullable": true
+                                    },
+                                    "state": {
+                                      "type": "string",
+                                      "nullable": true
+                                    },
+                                    "postalCode": {
+                                      "type": "string",
+                                      "nullable": true
+                                    },
+                                    "country": {
+                                      "type": "string",
+                                      "nullable": true
+                                    },
+                                    "telephone": {
+                                      "type": "string",
+                                      "nullable": true
+                                    },
+                                    "fax": {
+                                      "type": "string",
+                                      "nullable": true
+                                    }
+                                  },
+                                  "required": [
+                                    "purpose",
+                                    "address1",
+                                    "address2",
+                                    "city",
+                                    "state",
+                                    "postalCode",
+                                    "country",
+                                    "telephone",
+                                    "fax"
+                                  ],
+                                  "additionalProperties": false
+                                }
+                              },
+                              "identifiers": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "code": {
+                                      "type": "string"
+                                    },
+                                    "desc": {
+                                      "type": "string"
+                                    },
+                                    "issuer": {
+                                      "type": "string",
+                                      "nullable": true
+                                    },
+                                    "identifier": {
+                                      "type": "string"
+                                    },
+                                    "state": {
+                                      "type": "string",
+                                      "nullable": true
+                                    }
+                                  },
+                                  "required": [
+                                    "code",
+                                    "desc",
+                                    "issuer",
+                                    "identifier",
+                                    "state"
+                                  ],
+                                  "additionalProperties": false
+                                }
+                              }
+                            },
+                            "required": [
+                              "npi",
+                              "enumerationType",
+                              "name",
+                              "status",
+                              "enumerationDate",
+                              "lastUpdated",
+                              "taxonomies",
+                              "addresses",
+                              "identifiers"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "query": {
+                              "type": "object",
+                              "properties": {
+                                "npi": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "name": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "firstName": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "lastName": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "state": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "enumerationType": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "limit": {
+                                  "type": "integer"
+                                },
+                                "skip": {
+                                  "type": "integer"
+                                }
+                              },
+                              "required": [
+                                "npi",
+                                "name",
+                                "firstName",
+                                "lastName",
+                                "state",
+                                "enumerationType",
+                                "limit",
+                                "skip"
+                              ],
+                              "additionalProperties": false
+                            },
+                            "returned": {
+                              "type": "integer"
+                            }
+                          },
+                          "required": [
+                            "query",
+                            "returned"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "license.medical",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "npi",
+            "in": "query",
+            "required": false,
+            "description": "NPI.",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{10}$"
+            }
+          },
+          {
+            "name": "firstName",
+            "in": "query",
+            "required": false,
+            "description": "First name to filter by.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 80
+            }
+          },
+          {
+            "name": "lastName",
+            "in": "query",
+            "required": false,
+            "description": "Last name to filter by.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 120
+            }
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "description": "Name to search for.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 120
+            }
+          },
+          {
+            "name": "state",
+            "in": "query",
+            "required": false,
+            "description": "US state — two-letter postal abbreviation (e.g. CA) or full name.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 2,
+              "pattern": "^[A-Za-z]{2}$"
+            }
+          },
+          {
+            "name": "enumerationType",
+            "in": "query",
+            "required": false,
+            "description": "Enumeration type.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "1",
+                "2"
+              ]
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of results to return.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 200,
+              "default": 10
+            }
+          },
+          {
+            "name": "skip",
+            "in": "query",
+            "required": false,
+            "description": "Skip.",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 10000,
+              "default": 0
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/license/real-estate": {
+      "get": {
+        "tags": [
+          "license"
+        ],
+        "summary": "Verify US real-estate licenses (brokers, sales agents...",
+        "description": "Verify US real-estate licenses (brokers, sales agents, broker companies). Currently supported state: TX (Texas Real Estate Commission license holders). Search by name (license holder, partial), licenseNumber (exact), licenseType (partial, e.g. \"Broker\", \"Sales Agent\"), status (e.g. \"Active\"). Each license: type, number, holder name, status, original license date, expiration date, and the related supervising broker (type/number/name) where applicable. Agent/broker due-diligence and KYC. Siblings: /api/license/medical, /api/license/broker, /api/license/trades. Official state open data.",
+        "operationId": "license_real-estate",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = real-estate licenses; total = null (capped state-portal search); meta = {state, query}.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "licenseType": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "licenseNumber": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "name": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "status": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "originalLicenseDate": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "expires": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "supervisor": {
+                                "type": "object",
+                                "properties": {
+                                  "type": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "number": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "name": {
+                                    "type": "string",
+                                    "nullable": true
+                                  }
+                                },
+                                "required": [
+                                  "type",
+                                  "number",
+                                  "name"
+                                ],
+                                "additionalProperties": false,
+                                "nullable": true
+                              }
+                            },
+                            "required": [
+                              "licenseType",
+                              "licenseNumber",
+                              "name",
+                              "status",
+                              "originalLicenseDate",
+                              "expires",
+                              "supervisor"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "state": {
+                              "type": "string"
+                            },
+                            "query": {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "licenseNumber": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "licenseType": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "status": {
+                                  "type": "string",
+                                  "nullable": true
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "licenseNumber",
+                                "licenseType",
+                                "status"
+                              ],
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "state",
+                            "query"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.00288 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "license.real-estate",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.00288,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.002880"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "state",
+            "in": "query",
+            "required": true,
+            "description": "US state — two-letter postal abbreviation (e.g. CA) or full name.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "TX"
+              ]
+            }
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "description": "Name to search for.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 120
+            }
+          },
+          {
+            "name": "licenseNumber",
+            "in": "query",
+            "required": false,
+            "description": "License number.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 20
+            }
+          },
+          {
+            "name": "licenseType",
+            "in": "query",
+            "required": false,
+            "description": "License type.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 60
+            }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "description": "Filter results by status.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 40
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of results to return.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 10
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "description": "Number of results to skip before returning (pagination offset).",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/license/trades": {
+      "get": {
+        "tags": [
+          "license"
+        ],
+        "summary": "Verify US trade / occupational licenses (electricians, A/C...",
+        "description": "Verify US trade / occupational licenses (electricians, A/C technicians, cosmetologists, tow operators, and other state-regulated trades). Currently supported state: TX (Texas Department of Licensing & Regulation, all active licenses). Search by name (matches owner or business name, partial), licenseNumber (exact), licenseType (partial, e.g. \"Electrician\"), county. Each license: type + subtype, number, business + owner name, county, expiration date, continuing-education flag. Contractor due-diligence and KYC. Siblings: /api/license/medical (NPI), /api/license/broker (FINRA). Official state open data.",
+        "operationId": "license_trades",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = trade/occupational licenses; total = null (capped state-portal search); meta = {state, query}.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "licenseType": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "licenseSubtype": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "licenseNumber": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "businessName": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "ownerName": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "county": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "expires": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "continuingEducation": {
+                                "type": "boolean",
+                                "nullable": true
+                              }
+                            },
+                            "required": [
+                              "licenseType",
+                              "licenseSubtype",
+                              "licenseNumber",
+                              "businessName",
+                              "ownerName",
+                              "county",
+                              "expires",
+                              "continuingEducation"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "state": {
+                              "type": "string"
+                            },
+                            "query": {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "licenseNumber": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "licenseType": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "county": {
+                                  "type": "string",
+                                  "nullable": true
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "licenseNumber",
+                                "licenseType",
+                                "county"
+                              ],
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "state",
+                            "query"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.00288 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "license.trades",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.00288,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.002880"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "state",
+            "in": "query",
+            "required": true,
+            "description": "US state — two-letter postal abbreviation (e.g. CA) or full name.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "TX"
+              ]
+            }
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "description": "Name to search for.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 120
+            }
+          },
+          {
+            "name": "licenseNumber",
+            "in": "query",
+            "required": false,
+            "description": "License number.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 20
+            }
+          },
+          {
+            "name": "licenseType",
+            "in": "query",
+            "required": false,
+            "description": "License type.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 60
+            }
+          },
+          {
+            "name": "county",
+            "in": "query",
+            "required": false,
+            "description": "County name to filter by.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 40
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of results to return.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 10
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "description": "Number of results to skip before returning (pagination offset).",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/nonprofit/screen": {
+      "get": {
+        "tags": [
+          "nonprofit"
+        ],
+        "summary": "Look up US 501(c) nonprofits and screen each result against...",
+        "description": "Look up US 501(c) nonprofits and screen each result against the OFAC sanctions list in one call. Pass q (organization name) or ein; each matched organization returns its registry record (EIN, name, location, NTEE code, subsection) plus a sanctions block — flagged status, match count, and the matching SDN entries with confidence scores. Grant-making due diligence, donation compliance, and charity-fraud triage. Components also standalone: /api/nonprofit/search (registry only) and /api/law/sanctions-check (screen any name). Same composition family as /api/business/entity-screen.",
+        "operationId": "nonprofit_screen",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Nonprofits with a per-org OFAC sanctions block (flagged, matches, confidence).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "query": {
+                          "type": "string"
+                        },
+                        "count": {
+                          "type": "number"
+                        },
+                        "organizations": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "org": {
+                                "type": "object",
+                                "additionalProperties": {},
+                                "description": "Nonprofit registry record (EIN, name, location, NTEE)."
+                              },
+                              "sanctions": {
+                                "type": "object",
+                                "properties": {
+                                  "found": {
+                                    "type": "boolean",
+                                    "description": "True when the screen ran successfully."
+                                  },
+                                  "error": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "flagged": {
+                                    "type": "boolean",
+                                    "description": "True when a high-confidence OFAC match exists."
+                                  },
+                                  "matchCount": {
+                                    "type": "number"
+                                  },
+                                  "matches": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "additionalProperties": {}
+                                    }
+                                  }
+                                },
+                                "required": [
+                                  "found",
+                                  "error",
+                                  "flagged",
+                                  "matchCount",
+                                  "matches"
+                                ],
+                                "additionalProperties": false
+                              }
+                            },
+                            "required": [
+                              "org",
+                              "sanctions"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "sources": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "provider": {
+                                "type": "string"
+                              },
+                              "url": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "provider",
+                              "url"
+                            ],
+                            "additionalProperties": false
+                          }
+                        }
+                      },
+                      "required": [
+                        "query",
+                        "count",
+                        "organizations",
+                        "sources"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.00504 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "nonprofit.screen",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.00504,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "legacy",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.005040"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": false,
+            "description": "Organization name. Provide q or ein, not both.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 120
+            }
+          },
+          {
+            "name": "ein",
+            "in": "query",
+            "required": false,
+            "description": "EIN.",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{9}$"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of results to return.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 10,
+              "default": 5
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/nonprofit/search": {
+      "get": {
+        "tags": [
+          "nonprofit"
+        ],
+        "summary": "Search US 501(c) nonprofit organizations",
+        "description": "US 501(c) nonprofit organization search. Lookup by 9-digit EIN (with or without hyphen), free-text name, 2-letter state, NTEE category code (e.g. 'B99' for education), or IRS subsection code (3 = 501(c)(3), 4 = 501(c)(4), etc.). Each record includes EIN, name, city/state, NTEE code, subsection code + human-readable subsection description (e.g. '501(c)(3) Charitable / Religious / Educational'), and relevance score. Sourced from ProPublica Nonprofit Explorer, which aggregates IRS Form 990 + BMF data; underlying IRS data is public domain.",
+        "operationId": "nonprofit_search",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = matching nonprofit organizations; total = upstream match count; page = 0-indexed pagination (100/page); meta.query echoes the search.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "ein": {
+                                "type": "string"
+                              },
+                              "einFormatted": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "subName": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "city": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "state": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "nteeCode": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "subsectionCode": {
+                                "type": "integer",
+                                "nullable": true
+                              },
+                              "subsectionDesc": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "score": {
+                                "type": "number",
+                                "nullable": true
+                              }
+                            },
+                            "required": [
+                              "ein",
+                              "einFormatted",
+                              "name",
+                              "subName",
+                              "city",
+                              "state",
+                              "nteeCode",
+                              "subsectionCode",
+                              "subsectionDesc",
+                              "score"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "page": {
+                          "type": "object",
+                          "properties": {
+                            "number": {
+                              "type": "integer"
+                            },
+                            "size": {
+                              "type": "integer"
+                            },
+                            "pages": {
+                              "type": "integer",
+                              "nullable": true
+                            }
+                          },
+                          "required": [
+                            "number",
+                            "size",
+                            "pages"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "query": {
+                              "type": "object",
+                              "properties": {
+                                "q": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "ein": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "state": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "nteeCode": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "subsectionCode": {
+                                  "type": "integer",
+                                  "nullable": true
+                                },
+                                "page": {
+                                  "type": "integer"
+                                }
+                              },
+                              "required": [
+                                "q",
+                                "ein",
+                                "state",
+                                "nteeCode",
+                                "subsectionCode",
+                                "page"
+                              ],
+                              "additionalProperties": false
+                            },
+                            "returned": {
+                              "type": "integer"
+                            }
+                          },
+                          "required": [
+                            "query",
+                            "returned"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "nonprofit.search",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": false,
+            "description": "Free-text search query.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 200
+            }
+          },
+          {
+            "name": "ein",
+            "in": "query",
+            "required": false,
+            "description": "EIN.",
+            "schema": {
+              "type": "string",
+              "minLength": 9,
+              "maxLength": 11,
+              "pattern": "^\\d{2}-?\\d{7}$"
+            }
+          },
+          {
+            "name": "state",
+            "in": "query",
+            "required": false,
+            "description": "US state — two-letter postal abbreviation (e.g. CA) or full name.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 2,
+              "pattern": "^[A-Za-z]{2}$"
+            }
+          },
+          {
+            "name": "nteeCode",
+            "in": "query",
+            "required": false,
+            "description": "Ntee code.",
+            "schema": {
+              "type": "string",
+              "pattern": "^[A-Za-z][0-9]{1,3}$"
+            }
+          },
+          {
+            "name": "subsectionCode",
+            "in": "query",
+            "required": false,
+            "description": "Subsection code.",
+            "schema": {
+              "type": "integer",
+              "minimum": 2,
+              "maximum": 92
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "description": "Page number (1-based) for paginated results.",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 99,
+              "default": 0
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/person/cross-registry": {
+      "get": {
+        "tags": [
+          "person"
+        ],
+        "summary": "Search a person's name across five US public registries in...",
+        "description": "Sweep a person's name across five US public registries in one call: FINRA securities brokers, federal-court attorneys (CourtListener), federal inmates (BOP), Texas trade licenses (TDLR), and Texas real-estate licenses (TREC). Returns one block per registry with found/error status, match count, and the matching records — name-matched CANDIDATES, deliberately not merged into one identity (same name does not mean same person; verify with each registry's identifier before acting). Due-diligence, KYC screening triage, and background-research staple. Each registry is also a standalone endpoint (/api/license/broker, /api/law/attorney-lookup, /api/gov/inmate-locator, /api/license/trades, /api/license/real-estate) for follow-up by identifier.",
+        "operationId": "person_cross-registry",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Per-registry candidate blocks (found/error/count/matches) for one person name across 5 registries.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "note": {
+                          "type": "string",
+                          "description": "Identity-resolution disclaimer — matches are candidates, not confirmed identities."
+                        },
+                        "brokers": {
+                          "type": "object",
+                          "properties": {
+                            "found": {
+                              "type": "boolean"
+                            },
+                            "error": {
+                              "type": "string",
+                              "nullable": true
+                            },
+                            "count": {
+                              "type": "number"
+                            },
+                            "matches": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "additionalProperties": {}
+                              }
+                            }
+                          },
+                          "required": [
+                            "found",
+                            "error",
+                            "count",
+                            "matches"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "attorneys": {
+                          "type": "object",
+                          "properties": {
+                            "found": {
+                              "type": "boolean"
+                            },
+                            "error": {
+                              "type": "string",
+                              "nullable": true
+                            },
+                            "count": {
+                              "type": "number"
+                            },
+                            "matches": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "additionalProperties": {}
+                              }
+                            }
+                          },
+                          "required": [
+                            "found",
+                            "error",
+                            "count",
+                            "matches"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "inmates": {
+                          "type": "object",
+                          "properties": {
+                            "found": {
+                              "type": "boolean"
+                            },
+                            "error": {
+                              "type": "string",
+                              "nullable": true
+                            },
+                            "count": {
+                              "type": "number"
+                            },
+                            "matches": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "additionalProperties": {}
+                              }
+                            }
+                          },
+                          "required": [
+                            "found",
+                            "error",
+                            "count",
+                            "matches"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "txTrades": {
+                          "type": "object",
+                          "properties": {
+                            "found": {
+                              "type": "boolean"
+                            },
+                            "error": {
+                              "type": "string",
+                              "nullable": true
+                            },
+                            "count": {
+                              "type": "number"
+                            },
+                            "matches": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "additionalProperties": {}
+                              }
+                            }
+                          },
+                          "required": [
+                            "found",
+                            "error",
+                            "count",
+                            "matches"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "txRealEstate": {
+                          "type": "object",
+                          "properties": {
+                            "found": {
+                              "type": "boolean"
+                            },
+                            "error": {
+                              "type": "string",
+                              "nullable": true
+                            },
+                            "count": {
+                              "type": "number"
+                            },
+                            "matches": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "additionalProperties": {}
+                              }
+                            }
+                          },
+                          "required": [
+                            "found",
+                            "error",
+                            "count",
+                            "matches"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "sources": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "provider": {
+                                "type": "string"
+                              },
+                              "url": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "provider",
+                              "url"
+                            ],
+                            "additionalProperties": false
+                          }
+                        }
+                      },
+                      "required": [
+                        "name",
+                        "note",
+                        "brokers",
+                        "attorneys",
+                        "inmates",
+                        "txTrades",
+                        "txRealEstate",
+                        "sources"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0072 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "person.cross-registry",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0072,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "legacy",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.007200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "name",
+            "in": "query",
+            "required": true,
+            "description": "Person full name. \"First Last\" works best (the inmate registry needs split names).",
+            "schema": {
+              "type": "string",
+              "minLength": 3,
+              "maxLength": 120,
+              "pattern": "^[\\p{L}][\\p{L} .,'-]+$"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of results to return.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 10,
+              "default": 5
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/validate/aba": {
+      "get": {
+        "tags": [
+          "validate"
+        ],
+        "summary": "Validate a US bank ABA routing number with the Federal...",
+        "description": "Validate a US bank ABA routing number with the Federal Reserve weighted mod-10 checksum (3-7-1) — not just a 9-digit regex. Returns {valid, routingNumber, district (routing-symbol class), reason}. Catches transposed digits in ACH/wire setup that a length check misses. Structure + checksum only; not a bank-directory existence lookup.",
+        "operationId": "validate_aba",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = [validation result]; total = 1.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "input": {
+                                "type": "string"
+                              },
+                              "valid": {
+                                "type": "boolean"
+                              },
+                              "routingNumber": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "district": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "Routing-symbol class (Federal Reserve, thrift, electronic, traveler check)."
+                              },
+                              "reason": {
+                                "type": "string",
+                                "nullable": true
+                              }
+                            },
+                            "required": [
+                              "input",
+                              "valid",
+                              "routingNumber",
+                              "district",
+                              "reason"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.001 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "validate.aba",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.001,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "routingNumber",
+            "in": "query",
+            "required": true,
+            "description": "Routing number.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 20
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/validate/batch": {
+      "post": {
+        "tags": [
+          "validate"
+        ],
+        "summary": "Validate up to 100 identifiers of mixed kinds in a single...",
+        "description": "Validate up to 100 identifiers of mixed kinds in a single deterministic call. Pass items=[{type,value}] where type is one of: iban, gtin, aba, lei, bic, gln, sscc, isin, cusip. Each result (returned in input order, with its index and type) carries {valid, reason} plus the same type-specific fields the single-identifier endpoints return (e.g. gtin14, countryCode, district). One unsupported type or one bad value degrades to that item's valid:false — it never fails the batch. meta carries validCount/invalidCount. This collapses a record's worth of per-field checksum checks (IBAN + BIC + GTIN + LEI + …) into one round-trip instead of one LLM/HTTP hop per field.",
+        "operationId": "validate_batch",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = per-identifier results in input order (index, type, valid, reason + type-specific fields); total = items.length; meta carries validCount/invalidCount.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "validCount": {
+                              "type": "integer"
+                            },
+                            "invalidCount": {
+                              "type": "integer"
+                            }
+                          },
+                          "required": [
+                            "validCount",
+                            "invalidCount"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "validate.batch",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "items": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "minLength": 1,
+                          "maxLength": 32,
+                          "description": "Filter results by type."
+                        },
+                        "value": {
+                          "type": "string",
+                          "minLength": 1,
+                          "maxLength": 64,
+                          "description": "Value."
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "value"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "minItems": 1,
+                    "maxItems": 100,
+                    "description": "Items."
+                  }
+                },
+                "required": [
+                  "items"
+                ],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/validate/bic": {
+      "get": {
+        "tags": [
+          "validate"
+        ],
+        "summary": "Validate a SWIFT/BIC code (ISO 9362): 8 or 11 characters =...",
+        "description": "Validate a SWIFT/BIC code (ISO 9362): 8 or 11 characters = 4-letter institution + 2-letter ISO country + 2-char location + optional 3-char branch, with the country position checked against ISO 3166. Returns {valid, bic, institution, country, location, branch, reason}. Structure validation only — not a SWIFT-directory existence lookup.",
+        "operationId": "validate_bic",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = [validation result]; total = 1.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "input": {
+                                "type": "string"
+                              },
+                              "valid": {
+                                "type": "boolean"
+                              },
+                              "bic": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "institution": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "country": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "location": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "branch": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "reason": {
+                                "type": "string",
+                                "nullable": true
+                              }
+                            },
+                            "required": [
+                              "input",
+                              "valid",
+                              "bic",
+                              "institution",
+                              "country",
+                              "location",
+                              "branch",
+                              "reason"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.001 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "validate.bic",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.001,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "bic",
+            "in": "query",
+            "required": true,
+            "description": "BIC.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 20
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/validate/cusip": {
+      "get": {
+        "tags": [
+          "validate"
+        ],
+        "summary": "Validate a CUSIP (9-character US/Canada securities...",
+        "description": "Validate a CUSIP (9-character US/Canada securities identifier) with its mod-10 weighted check digit. Returns {valid, cusip, checkDigit, reason}. Catches transposed characters in security master / holdings data that a length check misses. Structure + checksum only.",
+        "operationId": "validate_cusip",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = [validation result]; total = 1.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "input": {
+                                "type": "string"
+                              },
+                              "valid": {
+                                "type": "boolean"
+                              },
+                              "cusip": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "checkDigit": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "reason": {
+                                "type": "string",
+                                "nullable": true
+                              }
+                            },
+                            "required": [
+                              "input",
+                              "valid",
+                              "cusip",
+                              "checkDigit",
+                              "reason"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.001 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "validate.cusip",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.001,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "cusip",
+            "in": "query",
+            "required": true,
+            "description": "CUSIP.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 12
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/validate/gln": {
+      "get": {
+        "tags": [
+          "validate"
+        ],
+        "summary": "Validate a GS1 GLN (Global Location Number) - 13 digits...",
+        "description": "Validate a GS1 GLN (Global Location Number) — 13 digits with the GS1 mod-10 check digit. GLNs identify trading parties and physical locations (ship-to, bill-to, warehouse) across CPG supply chains and EDI. Returns {valid, gln, checkDigit, reason}. Catches transposed digits a length check misses.",
+        "operationId": "validate_gln",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = [validation result]; total = 1.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "input": {
+                                "type": "string"
+                              },
+                              "valid": {
+                                "type": "boolean"
+                              },
+                              "gln": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "checkDigit": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "reason": {
+                                "type": "string",
+                                "nullable": true
+                              }
+                            },
+                            "required": [
+                              "input",
+                              "valid",
+                              "gln",
+                              "checkDigit",
+                              "reason"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.001 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "validate.gln",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.001,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "gln",
+            "in": "query",
+            "required": true,
+            "description": "GLN.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 20
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/validate/gtin": {
+      "get": {
+        "tags": [
+          "validate"
+        ],
+        "summary": "Validate a product barcode - GTIN-8/12/13/14, UPC-A...",
+        "description": "Validate a product barcode — GTIN-8/12/13/14, UPC-A, EAN-13, or ISBN-10/13 — with the GS1 mod-10 check digit (ISBN-10 uses mod-11). Returns {valid, type, gtin14 (canonical 14-digit form, left-padded), checkDigit, reason}. Normalizes every product identifier to one GTIN-14 key so a product-master/ETL pipeline can dedupe and validate SKUs in one deterministic call instead of doing checksum math in an LLM.",
+        "operationId": "validate_gtin",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = [validation result]; total = 1.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "input": {
+                                "type": "string"
+                              },
+                              "valid": {
+                                "type": "boolean"
+                              },
+                              "type": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "GTIN-8 | GTIN-12 | GTIN-13 | GTIN-14 | ISBN-10"
+                              },
+                              "gtin14": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "Canonical 14-digit GTIN (left-padded) when valid."
+                              },
+                              "checkDigit": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "reason": {
+                                "type": "string",
+                                "nullable": true
+                              }
+                            },
+                            "required": [
+                              "input",
+                              "valid",
+                              "type",
+                              "gtin14",
+                              "checkDigit",
+                              "reason"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.001 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "validate.gtin",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.001,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "gtin",
+            "in": "query",
+            "required": true,
+            "description": "GTIN.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 32
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/validate/iban": {
+      "get": {
+        "tags": [
+          "validate"
+        ],
+        "summary": "Validate an International Bank Account Number (IBAN) with...",
+        "description": "Validate an International Bank Account Number (IBAN) with full ISO 13616 checks: country-specific length and the ISO 7064 mod-97 checksum (not just a regex). Returns {valid, iban (normalized), formatted (4-char groups), countryCode, checkDigits, bban, reason}. Catches transposed digits and wrong-length accounts that a format check misses, and returns the canonical form so a glue/ETL pipeline can validate AND normalize bank details in one deterministic call. ~85 countries. No bank directory lookup — structure + checksum only.",
+        "operationId": "validate_iban",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = [validation result]; total = 1.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "input": {
+                                "type": "string"
+                              },
+                              "valid": {
+                                "type": "boolean"
+                              },
+                              "iban": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "Normalized (spaces removed, uppercased) when valid."
+                              },
+                              "formatted": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "IBAN grouped in 4-character blocks."
+                              },
+                              "countryCode": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "checkDigits": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "bban": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "Basic Bank Account Number (everything after the check digits)."
+                              },
+                              "reason": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "Why it failed, when valid is false."
+                              }
+                            },
+                            "required": [
+                              "input",
+                              "valid",
+                              "iban",
+                              "formatted",
+                              "countryCode",
+                              "checkDigits",
+                              "bban",
+                              "reason"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.001 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "validate.iban",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.001,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "iban",
+            "in": "query",
+            "required": true,
+            "description": "IBAN.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 64
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/validate/isin": {
+      "get": {
+        "tags": [
+          "validate"
+        ],
+        "summary": "Validate an ISIN (International Securities Identification...",
+        "description": "Validate an ISIN (International Securities Identification Number, ISO 6166): 2-letter country prefix + 9-char NSIN + Luhn check digit. Returns {valid, isin, country, nsin, embeddedCusip (for US/CA), checkDigit, reason}. Catches transposed characters in security master data that a regex misses. Structure + checksum only.",
+        "operationId": "validate_isin",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = [validation result]; total = 1.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "input": {
+                                "type": "string"
+                              },
+                              "valid": {
+                                "type": "boolean"
+                              },
+                              "isin": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "country": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "nsin": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "embeddedCusip": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "The CUSIP for US/CA ISINs."
+                              },
+                              "checkDigit": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "reason": {
+                                "type": "string",
+                                "nullable": true
+                              }
+                            },
+                            "required": [
+                              "input",
+                              "valid",
+                              "isin",
+                              "country",
+                              "nsin",
+                              "embeddedCusip",
+                              "checkDigit",
+                              "reason"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.001 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "validate.isin",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.001,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "isin",
+            "in": "query",
+            "required": true,
+            "description": "ISIN.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 20
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/validate/lei": {
+      "get": {
+        "tags": [
+          "validate"
+        ],
+        "summary": "Validate a Legal Entity Identifier (LEI, ISO 17442) with...",
+        "description": "Validate a Legal Entity Identifier (LEI, ISO 17442) with the ISO 7064 mod-97-10 check digits — not just a 20-character regex. Returns {valid, lei (normalized), louPrefix (issuing LOU), checkDigits, reason}. Confirms a counterparty/vendor LEI is well-formed before lookup; pairs with GLEIF data for name + ownership resolution. Structure + checksum only.",
+        "operationId": "validate_lei",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = [validation result]; total = 1.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "input": {
+                                "type": "string"
+                              },
+                              "valid": {
+                                "type": "boolean"
+                              },
+                              "lei": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "louPrefix": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "First 4 chars — the issuing Local Operating Unit."
+                              },
+                              "checkDigits": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "reason": {
+                                "type": "string",
+                                "nullable": true
+                              }
+                            },
+                            "required": [
+                              "input",
+                              "valid",
+                              "lei",
+                              "louPrefix",
+                              "checkDigits",
+                              "reason"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.001 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "validate.lei",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.001,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "lei",
+            "in": "query",
+            "required": true,
+            "description": "LEI.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 32
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/validate/sscc": {
+      "get": {
+        "tags": [
+          "validate"
+        ],
+        "summary": "Validate a GS1 SSCC (Serial Shipping Container Code) - 18...",
+        "description": "Validate a GS1 SSCC (Serial Shipping Container Code) — 18 digits with the GS1 mod-10 check digit. SSCCs identify individual logistic units (pallets, cases) and are the key field in shipping/ASN (EDI 856) flows. Returns {valid, sscc, extensionDigit, checkDigit, reason}.",
+        "operationId": "validate_sscc",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = [validation result]; total = 1.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "input": {
+                                "type": "string"
+                              },
+                              "valid": {
+                                "type": "boolean"
+                              },
+                              "sscc": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "extensionDigit": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "checkDigit": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "reason": {
+                                "type": "string",
+                                "nullable": true
+                              }
+                            },
+                            "required": [
+                              "input",
+                              "valid",
+                              "sscc",
+                              "extensionDigit",
+                              "checkDigit",
+                              "reason"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.001 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "validate.sscc",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.001,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "sscc",
+            "in": "query",
+            "required": true,
+            "description": "SSCC.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 24
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/providers/2s/legal/PAY.md
+++ b/providers/2s/legal/PAY.md
@@ -1,0 +1,17 @@
+---
+name: legal
+title: "2s Legal"
+description: "US legal-reference data: verify case citations, statutes (USC) and regulations (CFR), search court opinions and dockets, look up attorneys and judges, trademark search/status, and OFAC sanctions screening."
+use_case: "Use for verifying legal citations, fetching statute and regulation text, searching court opinions and dockets, trademark lookups, and sanctions screening."
+category: other
+service_url: https://2s.io
+openapi:
+  path: openapi.json
+---
+
+Part of 2s — a unified, agent-native JSON API. Pay per call in USDC on Solana (or Base) via x402; no accounts, no API keys. Add `?trial=1` (or header `X-2s-Trial: 1`) for one free real call per endpoint per hour.
+
+## Spend-aware usage
+
+- Prefer narrow lookups (by id/code) over broad searches; reuse identifiers across calls.
+- Cap result `limit` to the smallest count that answers the task.

--- a/providers/2s/legal/openapi.json
+++ b/providers/2s/legal/openapi.json
@@ -1,0 +1,3436 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "2s",
+    "version": "1",
+    "description": "Unified JSON REST API for AI agents — an ever-expanding catalog of endpoints, pay per call in USDC on Base or Solana via x402, no accounts, no API keys. Fund a wallet on either chain with USDC, hit any endpoint, and your client signs an EIP-3009 authorization (Base) or a partial SPL transfer (Solana) to settle the call. Try before you buy: add ?trial=1 (or header X-2s-Trial: 1) to any endpoint for one free real call per endpoint per hour — no wallet needed — to verify it works before paying. 2s is an open-ended experiment in maximally-comprehensive agent infrastructure — new endpoints land regularly.",
+    "contact": {
+      "name": "2s",
+      "url": "https://2s.io",
+      "email": "alley@2s.io"
+    }
+  },
+  "servers": [
+    {
+      "url": "https://2s.io"
+    }
+  ],
+  "components": {
+    "parameters": {
+      "TrialMode": {
+        "name": "trial",
+        "in": "query",
+        "required": false,
+        "description": "Try before you buy. Set to 1 for one free real call per endpoint per hour — no wallet or payment needed — to verify the endpoint before paying. Equivalent to sending the \"X-2s-Trial: 1\" request header. Works on every endpoint.",
+        "schema": {
+          "type": "integer",
+          "enum": [
+            1
+          ]
+        }
+      }
+    },
+    "securitySchemes": {
+      "x402Payment": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "PAYMENT-SIGNATURE",
+        "description": "x402 protocol v2: base64-encoded PaymentPayload. Call any paid endpoint without auth to receive a 402 with a multi-network PaymentRequirements envelope. Sign for either rail: EIP-3009 transferWithAuthorization (Base USDC) OR a partial SPL token transfer (Solana USDC). Retry with PAYMENT-SIGNATURE header. X-PAYMENT is also accepted for v1 buyer clients. See https://x402.org."
+      }
+    },
+    "schemas": {
+      "X402PaymentRequiredV2": {
+        "type": "object",
+        "description": "x402 v2 PaymentRequired envelope. Pick any entry from accepts[], sign for that rail, retry with the PAYMENT-SIGNATURE header.",
+        "required": [
+          "x402Version",
+          "accepts"
+        ],
+        "properties": {
+          "x402Version": {
+            "type": "integer",
+            "const": 2
+          },
+          "error": {
+            "type": "string",
+            "description": "Human-readable reason payment is required."
+          },
+          "resource": {
+            "type": "string",
+            "description": "The resource URL being purchased."
+          },
+          "accepts": {
+            "type": "array",
+            "description": "Payment requirement options, one per supported network (Base USDC, Solana USDC).",
+            "items": {
+              "type": "object",
+              "required": [
+                "scheme",
+                "network",
+                "amount",
+                "asset",
+                "payTo",
+                "maxTimeoutSeconds"
+              ],
+              "properties": {
+                "scheme": {
+                  "type": "string",
+                  "enum": [
+                    "exact"
+                  ]
+                },
+                "network": {
+                  "type": "string",
+                  "description": "CAIP-2 network id, e.g. \"eip155:8453\" (Base) or \"solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp\"."
+                },
+                "amount": {
+                  "type": "string",
+                  "description": "Price in atomic asset units (USDC has 6 decimals)."
+                },
+                "asset": {
+                  "type": "string",
+                  "description": "Asset contract address / mint."
+                },
+                "payTo": {
+                  "type": "string",
+                  "description": "Treasury address to pay."
+                },
+                "maxTimeoutSeconds": {
+                  "type": "integer"
+                },
+                "extra": {
+                  "type": "object",
+                  "description": "Rail-specific extras (EVM: EIP-712 domain name/version; Solana: feePayer).",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "extensions": {
+            "type": "object",
+            "description": "Optional discovery metadata (e.g. bazaar input/output schemas).",
+            "additionalProperties": true
+          }
+        }
+      }
+    }
+  },
+  "paths": {
+    "/api/law/attorney-lookup": {
+      "get": {
+        "tags": [
+          "law"
+        ],
+        "summary": "Find US attorneys by name in CourtListener's RECAP corpus...",
+        "description": "Find US attorneys by name in CourtListener's RECAP corpus (PACER-derived attorney directory). Query by name (case-insensitive prefix match: \"Jennifer Lee\" matches \"Jennifer Lee Pasquarella\" but not \"Sara Jennifer Lee\"), optional firm/contact-text contains filter, and limit (1-50, default 10). Returns id, normalized name, parsed firm + mailing address, phone, email, fax, count of known (docket, party) appearances, and canonical CourtListener URL per match. Use for opposing-counsel research, conflict checks, and \"who has filed this type of motion in this district\" queries. Underlying data is public domain (PACER filings); the directory itself is maintained by Free Law Project.",
+        "operationId": "law_attorney-lookup",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = matched attorneys with parsed contact info, case-appearance count, and canonical CourtListener URLs; total = null (upstream does not report a match count); meta.query echoes the search.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "integer"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "firm": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "address": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "phone": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "email": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "fax": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "caseCount": {
+                                "type": "integer"
+                              },
+                              "url": {
+                                "type": "string",
+                                "format": "uri"
+                              },
+                              "dateModified": {
+                                "type": "string",
+                                "nullable": true
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "name",
+                              "firm",
+                              "address",
+                              "phone",
+                              "email",
+                              "fax",
+                              "caseCount",
+                              "url",
+                              "dateModified"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "query": {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "firm": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "limit": {
+                                  "type": "number"
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "firm",
+                                "limit"
+                              ],
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "query"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0036 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "law.attorney-lookup",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0036,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.003600"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "name",
+            "in": "query",
+            "required": true,
+            "description": "Attorney name (or name prefix) to search. Case-insensitive prefix match — \"Jennifer Lee\" finds \"Jennifer Lee Pasquarella\" but not \"Sara Jennifer Lee\".",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 200
+            }
+          },
+          {
+            "name": "firm",
+            "in": "query",
+            "required": false,
+            "description": "Optional contains filter on the firm / contact block (e.g. \"Skadden\").",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 200
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Max attorney records to return (1-50). Default 10.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 50,
+              "default": 10
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/law/case-search": {
+      "get": {
+        "tags": [
+          "law"
+        ],
+        "summary": "Search US court opinions (SCOTUS, federal circuits, state...",
+        "description": "Search US court opinions (SCOTUS, federal circuits, state appellate/supreme — ~9M opinions). Query by free-text (party names, keywords, docket #, citation). Filter by court slug (e.g., \"scotus\", \"ca9\", \"nysupct\"), filing date range, and order (relevance/dateFiled-desc/dateFiled-asc/citeCount-desc). Returns clusterId, caseName, court, year, docket, reporter citations, citationCount, snippet, canonical URL. Discovery-side complement to case-verify. Backed by CourtListener (Free Law Project); underlying opinions are public domain.",
+        "operationId": "law_case-search",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = matched court opinions (clusterId, caseName, court, year, citations, url); total = upstream match count; meta.query echoes the search.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "query": {
+                              "type": "object",
+                              "properties": {
+                                "q": {
+                                  "type": "string"
+                                },
+                                "court": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "filedAfter": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "filedBefore": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "order": {
+                                  "type": "string"
+                                },
+                                "limit": {
+                                  "type": "number"
+                                }
+                              },
+                              "required": [
+                                "q",
+                                "court",
+                                "filedAfter",
+                                "filedBefore",
+                                "order",
+                                "limit"
+                              ],
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "query"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0036 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "law.case-search",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0036,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.003600"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": true,
+            "description": "Free-text search query.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 500
+            }
+          },
+          {
+            "name": "court",
+            "in": "query",
+            "required": false,
+            "description": "Court.",
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-z0-9-]{2,40}(,[a-z0-9-]{2,40}){0,9}$"
+            }
+          },
+          {
+            "name": "filedAfter",
+            "in": "query",
+            "required": false,
+            "description": "Filed after.",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+            }
+          },
+          {
+            "name": "filedBefore",
+            "in": "query",
+            "required": false,
+            "description": "Filed before.",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+            }
+          },
+          {
+            "name": "order",
+            "in": "query",
+            "required": false,
+            "description": "Sort direction: asc or desc.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "relevance",
+                "dateFiled-desc",
+                "dateFiled-asc",
+                "citeCount-desc"
+              ]
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of results to return.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 20,
+              "default": 10
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/law/case-verify": {
+      "post": {
+        "tags": [
+          "law"
+        ],
+        "summary": "Verify US legal case citations in a passage of text.",
+        "description": "Verify US legal case citations in a passage of text. POST { text } where text contains one or more citations (e.g. \"Marbury v. Madison, 5 U.S. 137 (1803)\"). Returns per-citation results with canonical case name, court, year, docket, citationCount, and a public CourtListener URL — or flags the citation as unverified. Anti-hallucination check for legal LLM output. Underlying opinions are public domain; CourtListener (Free Law Project) is the corpus.",
+        "operationId": "law_case-verify",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = per-citation verification results (one element per citation found in the text); total = citations checked; meta = input echo + verified/unverified counts.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "input": {
+                              "type": "string",
+                              "description": "Echo of the checked text (truncated past 200 chars)."
+                            },
+                            "verified": {
+                              "type": "integer"
+                            },
+                            "unverified": {
+                              "type": "integer"
+                            }
+                          },
+                          "required": [
+                            "input",
+                            "verified",
+                            "unverified"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.006 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "law.case-verify",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.006,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.006000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "text": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 30000,
+                    "description": "Text."
+                  }
+                },
+                "required": [
+                  "text"
+                ],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/law/cfr-section": {
+      "get": {
+        "tags": [
+          "law"
+        ],
+        "summary": "Fetch the authoritative text of any section of the US Code...",
+        "description": "Fetch the authoritative text of any section of the US Code of Federal Regulations by title and section number — for example title 12, section 1026.43 returns Regulation Z’s ability-to-repay standards. Returns the canonical citation, section heading, full plain text, Federal Register source credit, the as-of date, and a link to the official eCFR page. An optional date parameter (YYYY-MM-DD) retrieves the historical text in force on that date, back to 2017. Data from the Electronic Code of Federal Regulations (US GPO / Office of the Federal Register), public domain, updated daily — verify regulatory citations against the authoritative source instead of relying on model memory.",
+        "operationId": "law_cfr-section",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = [section] (one CFR section: citation, heading, full plain text, source credit, as-of date, official link); total = 1.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "citation": {
+                                "type": "string",
+                                "description": "Canonical citation, e.g. \"12 CFR 1026.43\"."
+                              },
+                              "title": {
+                                "type": "integer",
+                                "description": "CFR title number."
+                              },
+                              "part": {
+                                "type": "string",
+                                "description": "Part identifier (digits before the dot)."
+                              },
+                              "section": {
+                                "type": "string",
+                                "description": "Full section identifier."
+                              },
+                              "heading": {
+                                "type": "string",
+                                "description": "Official section heading."
+                              },
+                              "text": {
+                                "type": "string",
+                                "description": "Plain-text body of the section."
+                              },
+                              "sourceCredit": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "Federal Register source credit (citation history), when present."
+                              },
+                              "asOfDate": {
+                                "type": "string",
+                                "description": "Date (yyyy-mm-dd) the returned text reflects."
+                              },
+                              "truncated": {
+                                "type": "boolean",
+                                "description": "True if text was cut at the response cap (rare, giant sections only)."
+                              },
+                              "url": {
+                                "type": "string",
+                                "description": "Official eCFR page for the section."
+                              }
+                            },
+                            "required": [
+                              "citation",
+                              "title",
+                              "part",
+                              "section",
+                              "heading",
+                              "text",
+                              "sourceCredit",
+                              "asOfDate",
+                              "truncated",
+                              "url"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0018 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "law.cfr-section",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0018,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001800"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "title",
+            "in": "query",
+            "required": true,
+            "description": "CFR title number, 1-50 (e.g. 12 for Banks and Banking, 40 for Protection of Environment).",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 50
+            }
+          },
+          {
+            "name": "section",
+            "in": "query",
+            "required": true,
+            "description": "Section identifier as \"part.section\", e.g. \"1026.43\" or \"240.10b-5\". The part is the digits before the dot.",
+            "schema": {
+              "type": "string",
+              "pattern": "^[0-9]{1,4}[a-zA-Z]{0,2}\\.[0-9a-zA-Z][0-9a-zA-Z.\\-]{0,18}$"
+            }
+          },
+          {
+            "name": "date",
+            "in": "query",
+            "required": false,
+            "description": "Optional point-in-time date (YYYY-MM-DD). Returns the text in force on that date; coverage starts 2017-01-03. Defaults to the latest available text.",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/law/citation-check": {
+      "post": {
+        "tags": [
+          "law"
+        ],
+        "summary": "Verify legal citations against real case law",
+        "description": "Anti-hallucination checker for legal references — verify that cited cases, US Code sections, and CFR regulations in a passage actually EXIST, and (deterministically) that an attributed QUOTE actually appears in the cited opinion. POST { text } to scan a brief/passage: every case citation (via CourtListener), 'N U.S.C. § X', and 'N C.F.R. § X' is checked for existence with canonical metadata + a source URL, or flagged unverified. POST { quotes: [{ citation, quote }] } to verify specific quotations: each citation is resolved and its opinion full text is checked for the quote (ellipsis-aware), returning quote.present true/false. Pass both. Returns per-reference results + a summary (verified/unverified, quotesPresent/quotesMissing). Catches fabricated cases AND fabricated quotations — the LLM legal-output failure mode that gets attorneys sanctioned. Note: this checks existence + quote presence (facts), NOT whether a case legally supports a proposition. Sources: CourtListener (Free Law Project), US OLRC, eCFR (public domain).",
+        "operationId": "law_citation-check",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = per-reference results (existence + optional quote check); total = references checked; meta.summary = aggregate counts.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "type": {
+                                "type": "string",
+                                "enum": [
+                                  "case",
+                                  "usc",
+                                  "cfr"
+                                ]
+                              },
+                              "citation": {
+                                "type": "string"
+                              },
+                              "exists": {
+                                "type": "boolean"
+                              },
+                              "title": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "detail": {
+                                "type": "object",
+                                "properties": {
+                                  "court": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "year": {
+                                    "type": "number",
+                                    "nullable": true
+                                  },
+                                  "docketNumber": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "citationCount": {
+                                    "type": "number",
+                                    "nullable": true
+                                  }
+                                },
+                                "required": [
+                                  "court",
+                                  "year",
+                                  "docketNumber",
+                                  "citationCount"
+                                ],
+                                "additionalProperties": false,
+                                "nullable": true
+                              },
+                              "url": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "error": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "quote": {
+                                "type": "object",
+                                "properties": {
+                                  "checked": {
+                                    "type": "boolean"
+                                  },
+                                  "present": {
+                                    "type": "boolean"
+                                  },
+                                  "note": {
+                                    "type": "string",
+                                    "nullable": true
+                                  }
+                                },
+                                "required": [
+                                  "checked",
+                                  "present",
+                                  "note"
+                                ],
+                                "additionalProperties": false,
+                                "nullable": true
+                              }
+                            },
+                            "required": [
+                              "type",
+                              "citation",
+                              "exists",
+                              "title",
+                              "detail",
+                              "url",
+                              "error",
+                              "quote"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "summary": {
+                              "type": "object",
+                              "properties": {
+                                "total": {
+                                  "type": "integer"
+                                },
+                                "verified": {
+                                  "type": "integer"
+                                },
+                                "unverified": {
+                                  "type": "integer"
+                                },
+                                "quotesChecked": {
+                                  "type": "integer"
+                                },
+                                "quotesPresent": {
+                                  "type": "integer"
+                                },
+                                "quotesMissing": {
+                                  "type": "integer"
+                                }
+                              },
+                              "required": [
+                                "total",
+                                "verified",
+                                "unverified",
+                                "quotesChecked",
+                                "quotesPresent",
+                                "quotesMissing"
+                              ],
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "summary"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0072 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "law.citation-check",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0072,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.007200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "text": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 50000,
+                    "description": "Text."
+                  },
+                  "quotes": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "citation": {
+                          "type": "string",
+                          "minLength": 2,
+                          "maxLength": 400,
+                          "description": "Citation."
+                        },
+                        "quote": {
+                          "type": "string",
+                          "minLength": 4,
+                          "maxLength": 4000,
+                          "description": "Quote."
+                        }
+                      },
+                      "required": [
+                        "citation",
+                        "quote"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "maxItems": 10,
+                    "description": "Quotes."
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/law/docket-search": {
+      "get": {
+        "tags": [
+          "law"
+        ],
+        "summary": "Search US federal court dockets - civil and criminal - from...",
+        "description": "Search US federal court dockets — civil and criminal — from the RECAP/PACER archive. Full-text q (case name, party, e.g. \"United States v. Bankman-Fried\"), optional court (CourtListener court id like \"cand\", \"nysd\", \"ca9\"), filedAfter/filedBefore (YYYY-MM-DD), page. Or pass docketNumber (+ court) for exact lookup. Each docket: id, case name, court, docket number, date filed/terminated, nature of suit, assigned judge, public docket URL. Criminal-case research, litigation monitoring, KYC/due-diligence. Sibling endpoints: /api/law/case-search (opinions full-text), /api/law/opinion (full opinion text).",
+        "operationId": "law_docket-search",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = matched federal court dockets; total = upstream match count (null when unknown).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "docketId": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "caseName": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "court": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "courtId": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "docketNumber": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "dateFiled": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "dateTerminated": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "natureOfSuit": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "assignedTo": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "url": {
+                                "type": "string",
+                                "nullable": true
+                              }
+                            },
+                            "required": [
+                              "docketId",
+                              "caseName",
+                              "court",
+                              "courtId",
+                              "docketNumber",
+                              "dateFiled",
+                              "dateTerminated",
+                              "natureOfSuit",
+                              "assignedTo",
+                              "url"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0048 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "law.docket-search",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0048,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.004800"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": false,
+            "description": "Free-text search query.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 300
+            }
+          },
+          {
+            "name": "court",
+            "in": "query",
+            "required": false,
+            "description": "Court.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 15
+            }
+          },
+          {
+            "name": "docketNumber",
+            "in": "query",
+            "required": false,
+            "description": "Docket number.",
+            "schema": {
+              "type": "string",
+              "minLength": 3,
+              "maxLength": 40
+            }
+          },
+          {
+            "name": "filedAfter",
+            "in": "query",
+            "required": false,
+            "description": "Filed after.",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+            }
+          },
+          {
+            "name": "filedBefore",
+            "in": "query",
+            "required": false,
+            "description": "Filed before.",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "description": "Page number (1-based) for paginated results.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 1
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/law/federal-register": {
+      "get": {
+        "tags": [
+          "law"
+        ],
+        "summary": "Search the US Federal Register - proposed rules, final...",
+        "description": "Search the US Federal Register — proposed rules, final rules, notices, and presidential documents. Filter by free-text term, document type (RULE/PRORULE/NOTICE/PRESDOCU), agency slug (e.g., epa, fda, sec), and publication date range. Returns document_number, type, title, abstract, FR citation, agencies, publication_date, effective_on, comments_close_on, htmlUrl, pdfUrl, rawTextUrl. Public-domain US government data. Real-time — published daily, past LLM training cutoff.",
+        "operationId": "law_federal-register",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = matched Federal Register documents; total = upstream match count; meta.query echoes the search.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "query": {
+                              "type": "object",
+                              "properties": {
+                                "term": {
+                                  "type": "string"
+                                },
+                                "type": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "agency": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "since": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "until": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "limit": {
+                                  "type": "number"
+                                }
+                              },
+                              "required": [
+                                "term",
+                                "type",
+                                "agency",
+                                "since",
+                                "until",
+                                "limit"
+                              ],
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "query"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.001 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "law.federal-register",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.001,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": true,
+            "description": "Free-text search query.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 500
+            }
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "required": false,
+            "description": "Filter results by type.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "RULE",
+                "PRORULE",
+                "NOTICE",
+                "PRESDOCU"
+              ]
+            }
+          },
+          {
+            "name": "agency",
+            "in": "query",
+            "required": false,
+            "description": "Agency.",
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-z0-9-]{2,60}$"
+            }
+          },
+          {
+            "name": "since",
+            "in": "query",
+            "required": false,
+            "description": "Since.",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+            }
+          },
+          {
+            "name": "until",
+            "in": "query",
+            "required": false,
+            "description": "Until.",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of results to return.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 20,
+              "default": 10
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/law/judge-lookup": {
+      "get": {
+        "tags": [
+          "law"
+        ],
+        "summary": "Find US federal + state appellate judges by name in...",
+        "description": "Find US federal + state appellate judges by name in CourtListener's People DB. Query by firstName (case-insensitive prefix), lastName (case-insensitive prefix), or both — at least one required. Returns id, full name + components, dates of birth/death, gender, education (school, degree level, year), political affiliations (party + appointing executive period), count of distinct judicial positions, and canonical CourtListener URL per match. Pairs with law.case-search + law.attorney-lookup to complete the WHO graph of a legal research workflow. Backed by CourtListener (Free Law Project); underlying data is public domain.",
+        "operationId": "law_judge-lookup",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = matched judges with bio, education, political affiliations, position count, and canonical CourtListener URLs; total = null (upstream does not report a match count); meta.query echoes the search.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "integer"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "firstName": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "middleName": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "lastName": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "suffix": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "dateOfBirth": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "dateOfDeath": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "gender": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "isJudge": {
+                                "type": "boolean"
+                              },
+                              "education": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "school": {
+                                      "type": "string",
+                                      "nullable": true
+                                    },
+                                    "degreeLevel": {
+                                      "type": "string",
+                                      "nullable": true
+                                    },
+                                    "degreeYear": {
+                                      "type": "integer",
+                                      "nullable": true
+                                    }
+                                  },
+                                  "required": [
+                                    "school",
+                                    "degreeLevel",
+                                    "degreeYear"
+                                  ],
+                                  "additionalProperties": false
+                                }
+                              },
+                              "politicalAffiliations": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "party": {
+                                      "type": "string",
+                                      "nullable": true
+                                    },
+                                    "source": {
+                                      "type": "string",
+                                      "nullable": true
+                                    },
+                                    "startDate": {
+                                      "type": "string",
+                                      "nullable": true
+                                    },
+                                    "endDate": {
+                                      "type": "string",
+                                      "nullable": true
+                                    }
+                                  },
+                                  "required": [
+                                    "party",
+                                    "source",
+                                    "startDate",
+                                    "endDate"
+                                  ],
+                                  "additionalProperties": false
+                                }
+                              },
+                              "positionCount": {
+                                "type": "integer"
+                              },
+                              "url": {
+                                "type": "string",
+                                "format": "uri"
+                              },
+                              "dateModified": {
+                                "type": "string",
+                                "nullable": true
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "name",
+                              "firstName",
+                              "middleName",
+                              "lastName",
+                              "suffix",
+                              "dateOfBirth",
+                              "dateOfDeath",
+                              "gender",
+                              "isJudge",
+                              "education",
+                              "politicalAffiliations",
+                              "positionCount",
+                              "url",
+                              "dateModified"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "query": {
+                              "type": "object",
+                              "properties": {
+                                "firstName": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "lastName": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "limit": {
+                                  "type": "number"
+                                }
+                              },
+                              "required": [
+                                "firstName",
+                                "lastName",
+                                "limit"
+                              ],
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "query"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0036 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "law.judge-lookup",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0036,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.003600"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "firstName",
+            "in": "query",
+            "required": false,
+            "description": "First-name prefix to search (case-insensitive). \"Son\" matches \"Sonia\". Optional, but at least one of firstName/lastName required.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 100
+            }
+          },
+          {
+            "name": "lastName",
+            "in": "query",
+            "required": false,
+            "description": "Last-name prefix to search (case-insensitive). \"Soto\" matches \"Sotomayor\". Optional, but at least one of firstName/lastName required.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 100
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Max judge records to return (1-50). Default 10.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 50,
+              "default": 10
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/law/opinion": {
+      "post": {
+        "tags": [
+          "law"
+        ],
+        "summary": "Fetch the full text of a US court opinion by CourtListener...",
+        "description": "Fetch the full text of a US court opinion by CourtListener opinion ID OR by citation. Returns plain text (preferred), HTML fallback, case metadata (case name, court, year, docket, citation), opinion type (lead/concurrence/dissent), author, and a list of alternate opinions in the same cluster. POST { opinionId?: number, citation?: string } — exactly one required. Anti-hallucination follow-up to case-verify: once you confirm the citation exists, fetch the text. Backed by CourtListener (public-domain underlying corpus).",
+        "operationId": "law_opinion",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = [opinion] (single document: full text, case metadata, alternate opinions in cluster); total = 1; meta.query echoes the lookup.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "query": {
+                              "type": "object",
+                              "properties": {
+                                "opinionId": {
+                                  "type": "number",
+                                  "nullable": true
+                                },
+                                "citation": {
+                                  "type": "string",
+                                  "nullable": true
+                                }
+                              },
+                              "required": [
+                                "opinionId",
+                                "citation"
+                              ],
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "query"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0048 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "law.opinion",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0048,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.004800"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "opinionId": {
+                    "type": "integer",
+                    "exclusiveMinimum": true,
+                    "minimum": 0,
+                    "description": "Opinion ID."
+                  },
+                  "citation": {
+                    "type": "string",
+                    "minLength": 2,
+                    "maxLength": 500,
+                    "description": "Citation."
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/law/sanctions-check": {
+      "post": {
+        "tags": [
+          "law"
+        ],
+        "summary": "Check a name against sanctions lists (fuzzy match)",
+        "description": "Fuzzy-match a name (person, company, vessel, aircraft) against the US Treasury OFAC Specially Designated Nationals list. POST { query, threshold?, limit?, sourceList? }. Returns ranked matches with similarity scores, entity type, sanctions programs, aliases, and remarks. Threshold default 0.4; scores ≥ 0.85 flagged as hasHighConfidenceMatch. List refreshed daily from public US Treasury data.",
+        "operationId": "law_sanctions-check",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = ranked OFAC SDN matches with similarity scores; total = match count; meta = query echo, threshold, hasHighConfidenceMatch flag.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "query": {
+                              "type": "string"
+                            },
+                            "threshold": {
+                              "type": "number"
+                            },
+                            "hasHighConfidenceMatch": {
+                              "type": "boolean",
+                              "description": "True when any match scored ≥ 0.85."
+                            },
+                            "list": {
+                              "type": "string"
+                            },
+                            "refreshCadence": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "query",
+                            "threshold",
+                            "hasHighConfidenceMatch",
+                            "list",
+                            "refreshCadence"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0048 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "law.sanctions-check",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0048,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.004800"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "query": {
+                    "type": "string",
+                    "minLength": 2,
+                    "maxLength": 500,
+                    "description": "Free-text search query."
+                  },
+                  "threshold": {
+                    "type": "number",
+                    "minimum": 0.1,
+                    "maximum": 1,
+                    "description": "Minimum score/threshold required to include a result."
+                  },
+                  "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 100,
+                    "description": "Maximum number of results to return."
+                  },
+                  "sourceList": {
+                    "type": "string",
+                    "maxLength": 64,
+                    "description": "Source list."
+                  }
+                },
+                "required": [
+                  "query"
+                ],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/law/trademark-search": {
+      "get": {
+        "tags": [
+          "law"
+        ],
+        "summary": "Search US trademarks by wordmark text, owner name, or...",
+        "description": "Search US trademarks by wordmark text, owner name, or goods/services — the text search the USPTO offers no public API for. Pass `query` for full-text search (ranked best-match first), or `serial` / `registrationNumber` for an exact record. Filter with `field` (mark|owner|all), `status` (live=registered+pending only, default; all=includes dead/abandoned), and `intlClass` (Nice class, e.g. 9). Returns each mark's wordmark, serial, registration number, status (+ live flag), filing/registration/abandonment dates, owner, international classes, and goods/services. Corpus: USPTO full trademark register (public domain). Use law.trademark-status for live USPTO prosecution detail on a known serial.",
+        "operationId": "law_trademark-search",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = matching trademarks (bm25-ranked for text search; ≤1 for exact serial/reg lookup); total = match count; page = pagination block.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "serialNumber": {
+                                "type": "string"
+                              },
+                              "registrationNumber": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "markText": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "The wordmark / literal element."
+                              },
+                              "status": {
+                                "type": "object",
+                                "properties": {
+                                  "code": {
+                                    "type": "string",
+                                    "nullable": true,
+                                    "description": "USPTO TRAM status code (e.g. 700)."
+                                  },
+                                  "label": {
+                                    "type": "string",
+                                    "nullable": true,
+                                    "description": "Human-readable status, e.g. \"Registered\", \"Abandoned-Failure to Respond\"."
+                                  },
+                                  "date": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "live": {
+                                    "type": "boolean",
+                                    "description": "False for abandoned/cancelled/expired marks; true for registered or in-prosecution."
+                                  }
+                                },
+                                "required": [
+                                  "code",
+                                  "label",
+                                  "date",
+                                  "live"
+                                ],
+                                "additionalProperties": false
+                              },
+                              "filingDate": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "registrationDate": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "abandonmentDate": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "cancellationDate": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "renewalDate": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "owner": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "Primary current owner / applicant."
+                              },
+                              "intlClasses": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "description": "Nice international class codes, zero-padded."
+                              },
+                              "goodsServices": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "Goods/services description (truncated to ~4k chars)."
+                              },
+                              "markDrawingCode": {
+                                "type": "string",
+                                "nullable": true
+                              }
+                            },
+                            "required": [
+                              "serialNumber",
+                              "registrationNumber",
+                              "markText",
+                              "status",
+                              "filingDate",
+                              "registrationDate",
+                              "abandonmentDate",
+                              "cancellationDate",
+                              "renewalDate",
+                              "owner",
+                              "intlClasses",
+                              "goodsServices",
+                              "markDrawingCode"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "page": {
+                          "type": "object",
+                          "properties": {
+                            "number": {
+                              "type": "integer"
+                            },
+                            "size": {
+                              "type": "integer"
+                            },
+                            "pages": {
+                              "type": "integer",
+                              "nullable": true
+                            }
+                          },
+                          "required": [
+                            "number",
+                            "size",
+                            "pages"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0024 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "law.trademark-search",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0024,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.002400"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "query",
+            "in": "query",
+            "required": false,
+            "description": "Free-text search query.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 200
+            }
+          },
+          {
+            "name": "serial",
+            "in": "query",
+            "required": false,
+            "description": "Serial.",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{6,9}$"
+            }
+          },
+          {
+            "name": "registrationNumber",
+            "in": "query",
+            "required": false,
+            "description": "Registration number.",
+            "schema": {
+              "type": "string",
+              "pattern": "^[0-9 ]{1,10}$"
+            }
+          },
+          {
+            "name": "field",
+            "in": "query",
+            "required": false,
+            "description": "Field.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "mark",
+                "owner",
+                "all"
+              ]
+            }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "description": "Filter results by status.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "live",
+                "all"
+              ]
+            }
+          },
+          {
+            "name": "intlClass",
+            "in": "query",
+            "required": false,
+            "description": "Intl class.",
+            "schema": {
+              "type": "string",
+              "pattern": "^0*\\d{1,3}$"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of results to return.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "description": "Number of results to skip before returning (pagination offset).",
+            "schema": {
+              "type": "integer",
+              "minimum": 0
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/law/trademark-status": {
+      "get": {
+        "tags": [
+          "law"
+        ],
+        "summary": "Verify a US trademark by USPTO serial number (8 digits) or...",
+        "description": "Verify a US trademark by USPTO serial number (8 digits) or registration number. Returns the word mark, LIVE/DEAD status with the detailed status description and date, filing and registration dates, current owner (name, entity type, citizenship), mark type (trademark / service mark / certification mark), standard-character flag, abandonment date when applicable, and the international classes covered with their descriptions. Authoritative real-time USPTO data — confirm a mark exists and is active before relying on it for clearance, licensing, or due-diligence work. Lookup is by number only (no text search); siblings: /api/patents/search, /api/law/case-verify.",
+        "operationId": "law_trademark-status",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = [trademark] (one trademark: mark text, LIVE/DEAD status, owner, dates, classes, official TSDR link); total = 1.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "serialNumber": {
+                                "type": "string"
+                              },
+                              "registrationNumber": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "registrationDate": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "filingDate": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "mark": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "Word mark text; null for design-only marks."
+                              },
+                              "live": {
+                                "type": "boolean",
+                                "description": "True when the mark is LIVE (active application or registration)."
+                              },
+                              "statusCode": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "statusDescription": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "TM5 status family, e.g. \"LIVE/REGISTRATION/Issued and Active\"."
+                              },
+                              "statusDetail": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "statusDate": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "dateAbandoned": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "markType": {
+                                "type": "string"
+                              },
+                              "standardCharacterMark": {
+                                "type": "boolean"
+                              },
+                              "supplementalRegister": {
+                                "type": "boolean"
+                              },
+                              "owner": {
+                                "type": "object",
+                                "properties": {
+                                  "name": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "entityType": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "partyType": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "citizenship": {
+                                    "type": "string",
+                                    "nullable": true
+                                  }
+                                },
+                                "required": [
+                                  "name",
+                                  "entityType",
+                                  "partyType",
+                                  "citizenship"
+                                ],
+                                "additionalProperties": false,
+                                "nullable": true
+                              },
+                              "classes": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "internationalCode": {
+                                      "type": "string",
+                                      "nullable": true
+                                    },
+                                    "description": {
+                                      "type": "string",
+                                      "nullable": true
+                                    },
+                                    "status": {
+                                      "type": "string",
+                                      "nullable": true
+                                    }
+                                  },
+                                  "required": [
+                                    "internationalCode",
+                                    "description",
+                                    "status"
+                                  ],
+                                  "additionalProperties": false
+                                }
+                              },
+                              "url": {
+                                "type": "string",
+                                "description": "Official TSDR page for human review."
+                              }
+                            },
+                            "required": [
+                              "serialNumber",
+                              "registrationNumber",
+                              "registrationDate",
+                              "filingDate",
+                              "mark",
+                              "live",
+                              "statusCode",
+                              "statusDescription",
+                              "statusDetail",
+                              "statusDate",
+                              "dateAbandoned",
+                              "markType",
+                              "standardCharacterMark",
+                              "supplementalRegister",
+                              "owner",
+                              "classes",
+                              "url"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0018 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "law.trademark-status",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0018,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001800"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "serialNumber",
+            "in": "query",
+            "required": false,
+            "description": "Serial number.",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{8}$"
+            }
+          },
+          {
+            "name": "registrationNumber",
+            "in": "query",
+            "required": false,
+            "description": "Registration number.",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{6,8}$"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/law/usc-section": {
+      "get": {
+        "tags": [
+          "law"
+        ],
+        "summary": "Fetch the authoritative current text of any United States...",
+        "description": "Fetch the authoritative current text of any United States Code section by title and section number — for example title 17, section 107 returns the fair-use statute. Returns the canonical citation, heading, hierarchy context (title/chapter), full statutory plain text, the Statutes-at-Large source credit, and a link to the official OLRC page; set includeNotes=true to also get editorial notes (amendment history, effective dates). Hyphenated and lettered sections like 1395w-4 or 78j work. Data from the Office of the Law Revision Counsel current (\"prelim\") edition, public domain — verify statutory citations against the authoritative source instead of relying on model memory. For federal regulations see /api/law/cfr-section; for case law see /api/law/case-verify.",
+        "operationId": "law_usc-section",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = [section] (one USC section: citation, heading, context, full statutory text, source credit, optional notes, official link); total = 1.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "citation": {
+                                "type": "string",
+                                "description": "Canonical citation, e.g. \"17 U.S.C. § 107\"."
+                              },
+                              "title": {
+                                "type": "integer",
+                                "description": "USC title number."
+                              },
+                              "section": {
+                                "type": "string",
+                                "description": "Section number as requested."
+                              },
+                              "heading": {
+                                "type": "string",
+                                "description": "Official section heading."
+                              },
+                              "context": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "Hierarchy breadcrumb (title › chapter › …)."
+                              },
+                              "text": {
+                                "type": "string",
+                                "description": "Plain-text statutory body (no editorial notes)."
+                              },
+                              "sourceCredit": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "Statutes-at-Large credit (enactment + amendment cites)."
+                              },
+                              "notes": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "Editorial notes, only when includeNotes=true."
+                              },
+                              "truncated": {
+                                "type": "boolean",
+                                "description": "True if a block was cut at the response cap (rare)."
+                              },
+                              "edition": {
+                                "type": "string",
+                                "description": "USC edition served (\"prelim\" = current law)."
+                              },
+                              "url": {
+                                "type": "string",
+                                "description": "Official uscode.house.gov page for the section."
+                              }
+                            },
+                            "required": [
+                              "citation",
+                              "title",
+                              "section",
+                              "heading",
+                              "context",
+                              "text",
+                              "sourceCredit",
+                              "notes",
+                              "truncated",
+                              "edition",
+                              "url"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0018 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "law.usc-section",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0018,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001800"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "title",
+            "in": "query",
+            "required": true,
+            "description": "USC title number, 1-54 (e.g. 17 for Copyrights, 26 for Internal Revenue Code, 42 for Public Health and Welfare).",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 54
+            }
+          },
+          {
+            "name": "section",
+            "in": "query",
+            "required": true,
+            "description": "Section number, e.g. \"107\", \"78j\", or \"1395w-4\".",
+            "schema": {
+              "type": "string",
+              "pattern": "^[0-9]{1,5}[a-zA-Z]{0,3}(-[0-9a-zA-Z]{1,8})?$"
+            }
+          },
+          {
+            "name": "includeNotes",
+            "in": "query",
+            "required": false,
+            "description": "Include editorial notes (amendment history, effective dates, cross-references). Default false — notes can be long.",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/providers/2s/science/PAY.md
+++ b/providers/2s/science/PAY.md
@@ -1,0 +1,17 @@
+---
+name: science
+title: "2s Science"
+description: "Science and knowledge data: satellites and space objects, genomics/proteins/species, chemical compounds, academic papers (arXiv/PubMed), patents, books, schools, dictionary/thesaurus, and Wikipedia/Wikidata entities."
+use_case: "Use for satellite and space data, gene/protein/compound lookups, searching academic papers and patents, and dictionary or encyclopedia entries."
+category: data
+service_url: https://2s.io
+openapi:
+  path: openapi.json
+---
+
+Part of 2s — a unified, agent-native JSON API. Pay per call in USDC on Solana (or Base) via x402; no accounts, no API keys. Add `?trial=1` (or header `X-2s-Trial: 1`) for one free real call per endpoint per hour.
+
+## Spend-aware usage
+
+- Prefer narrow lookups (by id/code) over broad searches; reuse identifiers across calls.
+- Cap result `limit` to the smallest count that answers the task.

--- a/providers/2s/science/openapi.json
+++ b/providers/2s/science/openapi.json
@@ -1,0 +1,7315 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "2s",
+    "version": "1",
+    "description": "Unified JSON REST API for AI agents — an ever-expanding catalog of endpoints, pay per call in USDC on Base or Solana via x402, no accounts, no API keys. Fund a wallet on either chain with USDC, hit any endpoint, and your client signs an EIP-3009 authorization (Base) or a partial SPL transfer (Solana) to settle the call. Try before you buy: add ?trial=1 (or header X-2s-Trial: 1) to any endpoint for one free real call per endpoint per hour — no wallet needed — to verify it works before paying. 2s is an open-ended experiment in maximally-comprehensive agent infrastructure — new endpoints land regularly.",
+    "contact": {
+      "name": "2s",
+      "url": "https://2s.io",
+      "email": "alley@2s.io"
+    }
+  },
+  "servers": [
+    {
+      "url": "https://2s.io"
+    }
+  ],
+  "components": {
+    "parameters": {
+      "TrialMode": {
+        "name": "trial",
+        "in": "query",
+        "required": false,
+        "description": "Try before you buy. Set to 1 for one free real call per endpoint per hour — no wallet or payment needed — to verify the endpoint before paying. Equivalent to sending the \"X-2s-Trial: 1\" request header. Works on every endpoint.",
+        "schema": {
+          "type": "integer",
+          "enum": [
+            1
+          ]
+        }
+      }
+    },
+    "securitySchemes": {
+      "x402Payment": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "PAYMENT-SIGNATURE",
+        "description": "x402 protocol v2: base64-encoded PaymentPayload. Call any paid endpoint without auth to receive a 402 with a multi-network PaymentRequirements envelope. Sign for either rail: EIP-3009 transferWithAuthorization (Base USDC) OR a partial SPL token transfer (Solana USDC). Retry with PAYMENT-SIGNATURE header. X-PAYMENT is also accepted for v1 buyer clients. See https://x402.org."
+      }
+    },
+    "schemas": {
+      "X402PaymentRequiredV2": {
+        "type": "object",
+        "description": "x402 v2 PaymentRequired envelope. Pick any entry from accepts[], sign for that rail, retry with the PAYMENT-SIGNATURE header.",
+        "required": [
+          "x402Version",
+          "accepts"
+        ],
+        "properties": {
+          "x402Version": {
+            "type": "integer",
+            "const": 2
+          },
+          "error": {
+            "type": "string",
+            "description": "Human-readable reason payment is required."
+          },
+          "resource": {
+            "type": "string",
+            "description": "The resource URL being purchased."
+          },
+          "accepts": {
+            "type": "array",
+            "description": "Payment requirement options, one per supported network (Base USDC, Solana USDC).",
+            "items": {
+              "type": "object",
+              "required": [
+                "scheme",
+                "network",
+                "amount",
+                "asset",
+                "payTo",
+                "maxTimeoutSeconds"
+              ],
+              "properties": {
+                "scheme": {
+                  "type": "string",
+                  "enum": [
+                    "exact"
+                  ]
+                },
+                "network": {
+                  "type": "string",
+                  "description": "CAIP-2 network id, e.g. \"eip155:8453\" (Base) or \"solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp\"."
+                },
+                "amount": {
+                  "type": "string",
+                  "description": "Price in atomic asset units (USDC has 6 decimals)."
+                },
+                "asset": {
+                  "type": "string",
+                  "description": "Asset contract address / mint."
+                },
+                "payTo": {
+                  "type": "string",
+                  "description": "Treasury address to pay."
+                },
+                "maxTimeoutSeconds": {
+                  "type": "integer"
+                },
+                "extra": {
+                  "type": "object",
+                  "description": "Rail-specific extras (EVM: EIP-712 domain name/version; Solana: feePayer).",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "extensions": {
+            "type": "object",
+            "description": "Optional discovery metadata (e.g. bazaar input/output schemas).",
+            "additionalProperties": true
+          }
+        }
+      }
+    }
+  },
+  "paths": {
+    "/api/bio/gene": {
+      "get": {
+        "tags": [
+          "bio"
+        ],
+        "summary": "Look up a gene by its official symbol (e.g.",
+        "description": "Look up a gene by its official symbol (e.g. \"TP53\", \"BRCA1\", \"CFTR\") and organism (taxid, default 9606 = human), merging NCBI Gene with UniProt. Returns the gene symbol, NCBI Gene ID, full description, organism, chromosome + cytogenetic map location, alias symbols, and the curated RefSeq function summary; plus the reviewed protein from UniProt — accession, entry id, recommended protein name, length in amino acids, and the curated function description. NCBI + UniProt links. Bioinformatics, clinical-genetics research, education. Public-domain NCBI + CC-BY UniProt data. Common organism taxids: human 9606, mouse 10090, zebrafish 7955, fruit fly 7227, yeast 559292.",
+        "operationId": "bio_gene",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = [{ gene }] (one gene; the best-effort UniProt protein sub-block stays inside the item); total = 1; meta.sources lists both NCBI Gene + UniProt attributions (envelope source is the primary, NCBI Gene).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "gene": {
+                                "type": "object",
+                                "properties": {
+                                  "symbol": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "ncbiGeneId": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "description": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "organism": {
+                                    "type": "object",
+                                    "properties": {
+                                      "scientificName": {
+                                        "type": "string",
+                                        "nullable": true
+                                      },
+                                      "commonName": {
+                                        "type": "string",
+                                        "nullable": true
+                                      },
+                                      "taxid": {
+                                        "type": "number",
+                                        "nullable": true
+                                      }
+                                    },
+                                    "required": [
+                                      "scientificName",
+                                      "commonName",
+                                      "taxid"
+                                    ],
+                                    "additionalProperties": false,
+                                    "nullable": true
+                                  },
+                                  "chromosome": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "mapLocation": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "aliases": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "summary": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "protein": {
+                                    "type": "object",
+                                    "properties": {
+                                      "found": {
+                                        "type": "boolean"
+                                      },
+                                      "uniprotAccession": {
+                                        "type": "string",
+                                        "nullable": true
+                                      },
+                                      "uniprotId": {
+                                        "type": "string",
+                                        "nullable": true
+                                      },
+                                      "name": {
+                                        "type": "string",
+                                        "nullable": true
+                                      },
+                                      "lengthAa": {
+                                        "type": "number",
+                                        "nullable": true
+                                      },
+                                      "function": {
+                                        "type": "string",
+                                        "nullable": true
+                                      }
+                                    },
+                                    "required": [
+                                      "found",
+                                      "uniprotAccession",
+                                      "uniprotId",
+                                      "name",
+                                      "lengthAa",
+                                      "function"
+                                    ],
+                                    "additionalProperties": false
+                                  },
+                                  "ncbiUrl": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "uniprotUrl": {
+                                    "type": "string",
+                                    "nullable": true
+                                  }
+                                },
+                                "required": [
+                                  "symbol",
+                                  "ncbiGeneId",
+                                  "description",
+                                  "organism",
+                                  "chromosome",
+                                  "mapLocation",
+                                  "aliases",
+                                  "summary",
+                                  "protein",
+                                  "ncbiUrl",
+                                  "uniprotUrl"
+                                ],
+                                "additionalProperties": false
+                              }
+                            },
+                            "required": [
+                              "gene"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "sources": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "provider": {
+                                    "type": "string"
+                                  },
+                                  "url": {
+                                    "type": "string"
+                                  },
+                                  "license": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "provider",
+                                  "url",
+                                  "license"
+                                ],
+                                "additionalProperties": false
+                              }
+                            }
+                          },
+                          "required": [
+                            "sources"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.00192 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "bio.gene",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.00192,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001920"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "symbol",
+            "in": "query",
+            "required": true,
+            "description": "Symbol.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 30
+            }
+          },
+          {
+            "name": "taxid",
+            "in": "query",
+            "required": false,
+            "description": "Taxid.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 9999999,
+              "default": 9606
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/bio/protein": {
+      "get": {
+        "tags": [
+          "bio"
+        ],
+        "summary": "Look up a protein in UniProtKB by accession (e.g.",
+        "description": "Look up a protein in UniProtKB by accession (e.g. \"P04637\", \"Q9Y6K9\", \"P0DTC2\"). Returns the entry id, reviewed (Swiss-Prot) flag, recommended + alternative protein names, gene names, organism + taxid, sequence length and molecular weight, the curated function description, subcellular locations, Gene Ontology terms (id + term + aspect: biological_process / molecular_function / cellular_component), PDB structure ids, and keywords. Bioinformatics, structural biology, drug-target research, education. Gene-centric sibling: /api/bio/gene. CC-BY UniProt data.",
+        "operationId": "bio_protein",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = [{ protein }] (one UniProtKB entry: names, organism, sequence, function, GO terms, PDB ids); total = 1.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "protein": {
+                                "type": "object",
+                                "properties": {
+                                  "accession": {
+                                    "type": "string"
+                                  },
+                                  "entryId": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "reviewed": {
+                                    "type": "boolean"
+                                  },
+                                  "proteinName": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "alternativeNames": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "genes": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "organism": {
+                                    "type": "object",
+                                    "properties": {
+                                      "scientificName": {
+                                        "type": "string",
+                                        "nullable": true
+                                      },
+                                      "commonName": {
+                                        "type": "string",
+                                        "nullable": true
+                                      },
+                                      "taxid": {
+                                        "type": "number",
+                                        "nullable": true
+                                      }
+                                    },
+                                    "required": [
+                                      "scientificName",
+                                      "commonName",
+                                      "taxid"
+                                    ],
+                                    "additionalProperties": false,
+                                    "nullable": true
+                                  },
+                                  "lengthAa": {
+                                    "type": "number",
+                                    "nullable": true
+                                  },
+                                  "molecularWeightDa": {
+                                    "type": "number",
+                                    "nullable": true
+                                  },
+                                  "function": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "subcellularLocations": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "goTerms": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "id": {
+                                          "type": "string"
+                                        },
+                                        "term": {
+                                          "type": "string"
+                                        },
+                                        "aspect": {
+                                          "type": "string",
+                                          "nullable": true
+                                        }
+                                      },
+                                      "required": [
+                                        "id",
+                                        "term",
+                                        "aspect"
+                                      ],
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "pdbStructures": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "keywords": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "uniprotUrl": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "accession",
+                                  "entryId",
+                                  "reviewed",
+                                  "proteinName",
+                                  "alternativeNames",
+                                  "genes",
+                                  "organism",
+                                  "lengthAa",
+                                  "molecularWeightDa",
+                                  "function",
+                                  "subcellularLocations",
+                                  "goTerms",
+                                  "pdbStructures",
+                                  "keywords",
+                                  "uniprotUrl"
+                                ],
+                                "additionalProperties": false
+                              }
+                            },
+                            "required": [
+                              "protein"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.00144 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "bio.protein",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.00144,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001440"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "accession",
+            "in": "query",
+            "required": true,
+            "description": "Accession.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 20,
+              "pattern": "^[A-Za-z0-9]+$"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/bio/species": {
+      "get": {
+        "tags": [
+          "bio"
+        ],
+        "summary": "Resolve any organism by scientific or common name to the...",
+        "description": "Resolve any organism by scientific or common name to the GBIF taxonomic backbone — the canonical free reference for life on Earth. Returns the accepted scientific name + canonical name, taxonomic rank and status, the match type/confidence, the full classification (kingdom → phylum → class → order → family → genus → species), up to 8 English vernacular (common) names, the count of recorded occurrences worldwide, and the GBIF species URL. Biodiversity, ecology, education, and as a taxonomy normalizer for other pipelines. Fuzzy-matches misspellings. CC-BY GBIF data.",
+        "operationId": "bio_species",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = [{ species }] (one resolved taxon; classification + vernacular + occurrence sub-blocks stay inside the item, best-effort); total = 1.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "species": {
+                                "type": "object",
+                                "properties": {
+                                  "usageKey": {
+                                    "type": "number",
+                                    "nullable": true
+                                  },
+                                  "scientificName": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "canonicalName": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "rank": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "taxonomicStatus": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "matchType": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "matchConfidence": {
+                                    "type": "number",
+                                    "nullable": true
+                                  },
+                                  "classification": {
+                                    "type": "object",
+                                    "properties": {
+                                      "kingdom": {
+                                        "type": "string",
+                                        "nullable": true
+                                      },
+                                      "phylum": {
+                                        "type": "string",
+                                        "nullable": true
+                                      },
+                                      "class": {
+                                        "type": "string",
+                                        "nullable": true
+                                      },
+                                      "order": {
+                                        "type": "string",
+                                        "nullable": true
+                                      },
+                                      "family": {
+                                        "type": "string",
+                                        "nullable": true
+                                      },
+                                      "genus": {
+                                        "type": "string",
+                                        "nullable": true
+                                      },
+                                      "species": {
+                                        "type": "string",
+                                        "nullable": true
+                                      }
+                                    },
+                                    "required": [
+                                      "kingdom",
+                                      "phylum",
+                                      "class",
+                                      "order",
+                                      "family",
+                                      "genus",
+                                      "species"
+                                    ],
+                                    "additionalProperties": false
+                                  },
+                                  "vernacularNames": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "occurrenceCount": {
+                                    "type": "number",
+                                    "nullable": true
+                                  },
+                                  "gbifUrl": {
+                                    "type": "string",
+                                    "nullable": true
+                                  }
+                                },
+                                "required": [
+                                  "usageKey",
+                                  "scientificName",
+                                  "canonicalName",
+                                  "rank",
+                                  "taxonomicStatus",
+                                  "matchType",
+                                  "matchConfidence",
+                                  "classification",
+                                  "vernacularNames",
+                                  "occurrenceCount",
+                                  "gbifUrl"
+                                ],
+                                "additionalProperties": false
+                              }
+                            },
+                            "required": [
+                              "species"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.00144 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "bio.species",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.00144,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001440"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "name",
+            "in": "query",
+            "required": true,
+            "description": "Name to search for.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 120
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/book/search": {
+      "get": {
+        "tags": [
+          "book"
+        ],
+        "summary": "Search Open Library book metadata",
+        "description": "Open Library book metadata search. Lookup by free-text query (matches title + author), or by individual title / author / ISBN (10 or 13 digit). Each record includes Open Library work key, title, author names + Open Library author keys, first publish year, edition count, cover image URL, sample ISBNs, publishers, languages, subject tags, fulltext flag, ebook access tier (public/borrowable/printdisabled/no_ebook), and canonical openlibrary.org URL. CC0 public-domain metadata.",
+        "operationId": "book_search",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = Open Library book records; total = upstream match count (numFound); page = current page; meta.query echoes the search.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "workKey": {
+                                "type": "string"
+                              },
+                              "title": {
+                                "type": "string"
+                              },
+                              "authorNames": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "authorKeys": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "firstPublishYear": {
+                                "type": "integer",
+                                "nullable": true
+                              },
+                              "editionCount": {
+                                "type": "integer",
+                                "nullable": true
+                              },
+                              "coverEditionKey": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "coverImageUrl": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "isbns": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "publishers": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "languages": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "subjectTags": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "hasFulltext": {
+                                "type": "boolean"
+                              },
+                              "ebookAccess": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "openlibraryUrl": {
+                                "type": "string",
+                                "format": "uri"
+                              }
+                            },
+                            "required": [
+                              "workKey",
+                              "title",
+                              "authorNames",
+                              "authorKeys",
+                              "firstPublishYear",
+                              "editionCount",
+                              "coverEditionKey",
+                              "coverImageUrl",
+                              "isbns",
+                              "publishers",
+                              "languages",
+                              "subjectTags",
+                              "hasFulltext",
+                              "ebookAccess",
+                              "openlibraryUrl"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "page": {
+                          "type": "object",
+                          "properties": {
+                            "number": {
+                              "type": "integer"
+                            },
+                            "size": {
+                              "type": "integer"
+                            },
+                            "pages": {
+                              "type": "integer",
+                              "nullable": true
+                            }
+                          },
+                          "required": [
+                            "number",
+                            "size",
+                            "pages"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "query": {
+                              "type": "object",
+                              "properties": {
+                                "q": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "title": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "author": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "isbn": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "limit": {
+                                  "type": "integer"
+                                },
+                                "page": {
+                                  "type": "integer"
+                                }
+                              },
+                              "required": [
+                                "q",
+                                "title",
+                                "author",
+                                "isbn",
+                                "limit",
+                                "page"
+                              ],
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "query"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "book.search",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": false,
+            "description": "Free-text search query.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 200
+            }
+          },
+          {
+            "name": "title",
+            "in": "query",
+            "required": false,
+            "description": "Title to search for.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 200
+            }
+          },
+          {
+            "name": "author",
+            "in": "query",
+            "required": false,
+            "description": "Author.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 200
+            }
+          },
+          {
+            "name": "isbn",
+            "in": "query",
+            "required": false,
+            "description": "ISBN.",
+            "schema": {
+              "type": "string",
+              "minLength": 9,
+              "maxLength": 17
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of results to return.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 50,
+              "default": 10
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "description": "Page number (1-based) for paginated results.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 1
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/chem/compound": {
+      "get": {
+        "tags": [
+          "chem"
+        ],
+        "summary": "Look up a chemical compound by CID, common/IUPAC name...",
+        "description": "Look up a chemical compound by CID, common/IUPAC name, SMILES, or InChIKey. Returns CID, preferred name, IUPAC name, molecular formula, molecular weight, exact mass, SMILES, connectivity SMILES, InChI, InChIKey, XLogP, formal charge, the 10 most-common synonyms, a PubChem permalink, and source attribution. Data is sourced from NIH PubChem (public domain). Provide exactly one of cid, name, smiles, or inchikey.",
+        "operationId": "chem_compound",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = [compound] (CID, names, formula, weights, SMILES/InChI, XLogP, synonyms, PubChem URL); total = 1; meta.query echoes the resolved namespace + value.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "query": {
+                              "type": "object",
+                              "properties": {
+                                "namespace": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "namespace",
+                                "value"
+                              ],
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "query"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.001 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "chem.compound",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.001,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "cid",
+            "in": "query",
+            "required": false,
+            "description": "PubChem Compound ID (CID), e.g. 2244 for aspirin.",
+            "schema": {
+              "type": "integer",
+              "exclusiveMinimum": true,
+              "minimum": 0,
+              "maximum": 2500000000
+            }
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "description": "Common, trade, or IUPAC name, e.g. \"aspirin\" or \"ibuprofen\".",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 200
+            }
+          },
+          {
+            "name": "smiles",
+            "in": "query",
+            "required": false,
+            "description": "SMILES structural notation, e.g. \"CC(=O)Oc1ccccc1C(=O)O\".",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 500
+            }
+          },
+          {
+            "name": "inchikey",
+            "in": "query",
+            "required": false,
+            "description": "InChIKey (27-char hashed identifier), e.g. \"BSYNRYMUTXBXSQ-UHFFFAOYSA-N\".",
+            "schema": {
+              "type": "string",
+              "pattern": "^[A-Z]{14}-[A-Z]{10}-[A-Z]$"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/edu/college-scorecard": {
+      "get": {
+        "tags": [
+          "edu"
+        ],
+        "summary": "Search US colleges + universities via the Department of...",
+        "description": "Search US colleges + universities via the Department of Education College Scorecard API. Filter by free-text name (q), OPE/IPEDS school id, state, city, zip, ownership (1=Public | 2=Private nonprofit | 3=Private for-profit), predominant degree level (0=Not classified | 1=Certificate | 2=Associate | 3=Bachelor | 4=Graduate), enrollment range. Returns a curated field set per school: identity (name, alias, URL, location), classification (Carnegie, locale, religious affiliation, minority-serving designation), latest admissions (admit rate, SAT/ACT midpoints), cost (in-state + out-of-state tuition, total cost of attendance), aid (median debt, federal-loan rate, Pell rate), completion rate, 10-year median earnings, repayment rate, lat/lon. Every accredited US institution. Use perPage + page for pagination; page is 0-indexed.",
+        "operationId": "edu_college-scorecard",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = College Scorecard school rows (dotted field names like 'school.name', 'latest.student.size'); total = upstream match count; page = 0-indexed page block.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "page": {
+                          "type": "object",
+                          "properties": {
+                            "number": {
+                              "type": "integer"
+                            },
+                            "size": {
+                              "type": "integer"
+                            },
+                            "pages": {
+                              "type": "integer",
+                              "nullable": true
+                            }
+                          },
+                          "required": [
+                            "number",
+                            "size",
+                            "pages"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "edu.college-scorecard",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": false,
+            "description": "Free-text search query.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 120
+            }
+          },
+          {
+            "name": "schoolId",
+            "in": "query",
+            "required": false,
+            "description": "School ID.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
+          },
+          {
+            "name": "state",
+            "in": "query",
+            "required": false,
+            "description": "US state — two-letter postal abbreviation (e.g. CA) or full name.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 2,
+              "pattern": "^[A-Za-z]{2}$"
+            }
+          },
+          {
+            "name": "city",
+            "in": "query",
+            "required": false,
+            "description": "City name to filter by.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 80
+            }
+          },
+          {
+            "name": "zip",
+            "in": "query",
+            "required": false,
+            "description": "US ZIP code.",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{5}$"
+            }
+          },
+          {
+            "name": "ownership",
+            "in": "query",
+            "required": false,
+            "description": "Ownership.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "degreePredominant",
+            "in": "query",
+            "required": false,
+            "description": "Degree predominant.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "minEnrollment",
+            "in": "query",
+            "required": false,
+            "description": "Min enrollment.",
+            "schema": {
+              "type": "integer",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "maxEnrollment",
+            "in": "query",
+            "required": false,
+            "description": "Max enrollment.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
+          },
+          {
+            "name": "perPage",
+            "in": "query",
+            "required": false,
+            "description": "Number of results to return per page.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 20
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "description": "Page number (1-based) for paginated results.",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0
+            }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "required": false,
+            "description": "Fields.",
+            "schema": {
+              "type": "string",
+              "maxLength": 2000
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/edu/school-lookup": {
+      "get": {
+        "tags": [
+          "edu"
+        ],
+        "summary": "Look up any US public K-12 school (~102k, NCES Common Core...",
+        "description": "Look up any US public K-12 school (~102k, NCES Common Core of Data). Search by name (partial), district (LEA name, partial), state (2-letter), city, zip, or exact ncessch (12-digit NCES id). Each school: NCES id, name, district + LEA id, address, phone, lat/lon, school level (1=primary 2=middle 3=high 4=other) and type (1=regular 2=special-ed 3=vocational 4=alternative), charter/magnet/virtual flags, enrollment, teacher FTE, grade span, CCD year. Results ordered by enrollment. Higher-ed sibling: /api/edu/college-scorecard. Public-domain federal data.",
+        "operationId": "edu_school-lookup",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = US public K-12 schools (NCES CCD rows, enrollment-ordered); total = null (LIKE search returns a capped page, no full match count).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "ncessch": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "district": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "leaid": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "state": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "city": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "street": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "zip": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "phone": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "latitude": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "longitude": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "schoolLevel": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "schoolType": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "charter": {
+                                "type": "boolean",
+                                "nullable": true
+                              },
+                              "magnet": {
+                                "type": "boolean",
+                                "nullable": true
+                              },
+                              "virtual": {
+                                "type": "boolean",
+                                "nullable": true
+                              },
+                              "enrollment": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "teachersFte": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "lowestGrade": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "highestGrade": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "year": {
+                                "type": "number",
+                                "nullable": true
+                              }
+                            },
+                            "required": [
+                              "ncessch",
+                              "name",
+                              "district",
+                              "leaid",
+                              "state",
+                              "city",
+                              "street",
+                              "zip",
+                              "phone",
+                              "latitude",
+                              "longitude",
+                              "schoolLevel",
+                              "schoolType",
+                              "charter",
+                              "magnet",
+                              "virtual",
+                              "enrollment",
+                              "teachersFte",
+                              "lowestGrade",
+                              "highestGrade",
+                              "year"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.00144 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "edu.school-lookup",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.00144,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001440"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "description": "Name to search for.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 120
+            }
+          },
+          {
+            "name": "district",
+            "in": "query",
+            "required": false,
+            "description": "District.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 120
+            }
+          },
+          {
+            "name": "state",
+            "in": "query",
+            "required": false,
+            "description": "US state — two-letter postal abbreviation (e.g. CA) or full name.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 2
+            }
+          },
+          {
+            "name": "city",
+            "in": "query",
+            "required": false,
+            "description": "City name to filter by.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 60
+            }
+          },
+          {
+            "name": "zip",
+            "in": "query",
+            "required": false,
+            "description": "US ZIP code.",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{5}$"
+            }
+          },
+          {
+            "name": "ncessch",
+            "in": "query",
+            "required": false,
+            "description": "Ncessch.",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{12}$"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of results to return.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 10
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "description": "Number of results to skip before returning (pagination offset).",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/paper/doi-lookup": {
+      "get": {
+        "tags": [
+          "paper"
+        ],
+        "summary": "Resolve a DOI to authoritative bibliographic metadata via...",
+        "description": "Resolve a DOI to authoritative bibliographic metadata via Crossref. Accepts bare DOI (10.1038/nature12373) or full DOI URL (https://doi.org/10.1038/nature12373). Returns work type, title, container (journal/conference), publisher, issued/published dates, abstract, authors (with ORCID + affiliations), page range, volume/issue, ISBN + ISSN lists, canonical URL, reference + citation counts, license blocks, and subject classifications. ~160M works in Crossref. Best authoritative DOI → bibliographic resolver. Metadata is CC0.",
+        "operationId": "paper_doi-lookup",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = [Crossref bibliographic record] for the DOI; total = 1.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "doi": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "title": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "containerTitle": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "publisher": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "issued": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "publishedPrint": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "publishedOnline": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "abstract": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "authors": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "given": {
+                                      "type": "string",
+                                      "nullable": true
+                                    },
+                                    "family": {
+                                      "type": "string",
+                                      "nullable": true
+                                    },
+                                    "orcid": {
+                                      "type": "string",
+                                      "nullable": true
+                                    },
+                                    "affiliation": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "required": [
+                                    "given",
+                                    "family",
+                                    "orcid",
+                                    "affiliation"
+                                  ],
+                                  "additionalProperties": false
+                                }
+                              },
+                              "pageRange": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "volume": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "issue": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "isbn": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "issn": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "url": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "referenceCount": {
+                                "type": "integer",
+                                "nullable": true
+                              },
+                              "isReferencedByCount": {
+                                "type": "integer",
+                                "nullable": true
+                              },
+                              "license": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "url": {
+                                      "type": "string"
+                                    },
+                                    "contentVersion": {
+                                      "type": "string",
+                                      "nullable": true
+                                    }
+                                  },
+                                  "required": [
+                                    "url",
+                                    "contentVersion"
+                                  ],
+                                  "additionalProperties": false
+                                }
+                              },
+                              "subjects": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "required": [
+                              "doi",
+                              "type",
+                              "title",
+                              "containerTitle",
+                              "publisher",
+                              "issued",
+                              "publishedPrint",
+                              "publishedOnline",
+                              "abstract",
+                              "authors",
+                              "pageRange",
+                              "volume",
+                              "issue",
+                              "isbn",
+                              "issn",
+                              "url",
+                              "referenceCount",
+                              "isReferencedByCount",
+                              "license",
+                              "subjects"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "paper.doi-lookup",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "doi",
+            "in": "query",
+            "required": true,
+            "description": "DOI.",
+            "schema": {
+              "type": "string",
+              "minLength": 7,
+              "maxLength": 300
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/papers/search": {
+      "get": {
+        "tags": [
+          "papers"
+        ],
+        "summary": "Fetch Unified scientific literature search across arXiv...",
+        "description": "Unified scientific literature search across arXiv (preprints), PubMed (biomedical), and Semantic Scholar (cross-field, with citation counts). Returns a flat array of papers with stable schema: source, sourceId, doi, title, authors, abstract, year, publishedAt, citationCount, url, pdfUrl. Partial failures surface in the errors array rather than failing the whole call. Optional filters: since (YYYY-MM-DD), sources (subset), limit (max 20 per source).",
+        "operationId": "papers_search",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = papers (flat array across arXiv + PubMed + Semantic Scholar; source, sourceId, doi, title, authors, abstract, year, citationCount, url, pdfUrl); total = count returned across sources; meta.errors = degraded sources; meta.sources/attribution describe per-source coverage.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "query": {
+                              "type": "string",
+                              "description": "Echo of the free-text query."
+                            },
+                            "sources": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              },
+                              "description": "Sources actually queried (after filtering)."
+                            },
+                            "errors": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "source": {
+                                    "type": "string"
+                                  },
+                                  "message": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "source",
+                                  "message"
+                                ],
+                                "additionalProperties": false
+                              },
+                              "description": "Per-source failures; empty when all sources succeeded."
+                            },
+                            "attribution": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "source": {
+                                    "type": "string"
+                                  },
+                                  "license": {
+                                    "type": "string"
+                                  },
+                                  "url": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "source",
+                                  "license",
+                                  "url"
+                                ],
+                                "additionalProperties": false
+                              },
+                              "description": "Per-source license + terms."
+                            }
+                          },
+                          "required": [
+                            "query",
+                            "sources",
+                            "errors",
+                            "attribution"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0024 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "papers.search",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0024,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.002400"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": true,
+            "description": "Free-text search query.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 500
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of results to return.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 20,
+              "default": 10
+            }
+          },
+          {
+            "name": "since",
+            "in": "query",
+            "required": false,
+            "description": "Since.",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+            }
+          },
+          {
+            "name": "sources",
+            "in": "query",
+            "required": false,
+            "description": "Sources.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/patents/detail": {
+      "get": {
+        "tags": [
+          "patents"
+        ],
+        "summary": "Fetch Full US patent application file-wrapper detail by...",
+        "description": "Full US patent application file-wrapper detail by application number. Returns bibliographic data (title, inventors, applicants, dates, status, examiner, art unit, docket #, confirmation #) plus the file-wrapper event timeline (filing, IDS, Office Actions, allowance, abandonment, …), continuity chain (parent / continuation / divisional / national stage), recorded assignments (assignor → assignee with reel/frame + conveyance text), and foreign priority claims under 35 USC § 119. Application number is the 6-10 digit USPTO ID (e.g. 18566276).",
+        "operationId": "patents_detail",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = [the one patent application file-wrapper record] (bibliography, status timeline, continuity, assignments, foreign priority); total = 1.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0018 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "patents.detail",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0018,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001800"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "applicationNumber",
+            "in": "query",
+            "required": true,
+            "description": "Application number.",
+            "schema": {
+              "type": "string",
+              "pattern": "^[0-9]{6,10}$"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/patents/documents": {
+      "get": {
+        "tags": [
+          "patents"
+        ],
+        "summary": "List every document in the file wrapper for a US patent...",
+        "description": "List every document in the file wrapper for a US patent application. Returns each document with its USPTO code (e.g. CTNF non-final OA, CTFR final OA, IDS, WCLM claims worksheet, NOA notice of allowance), human-readable description, official date, direction (INTERNAL/INCOMING/OUTGOING), and available formats with page counts. Includes patentCenterUrl pointing at the public USPTO Patent Center documents page for direct PDF download. Application number is the 6-10 digit USPTO ID.",
+        "operationId": "patents_documents",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = file-wrapper documents (code, description, date, direction, formats); total = upstream document count; meta.applicationNumber + meta.patentCenterUrl identify the application.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "applicationNumber": {
+                              "type": "string"
+                            },
+                            "patentCenterUrl": {
+                              "type": "string",
+                              "description": "Public USPTO Patent Center documents page for direct PDF download."
+                            }
+                          },
+                          "required": [
+                            "applicationNumber",
+                            "patentCenterUrl"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0018 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "patents.documents",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0018,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001800"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "applicationNumber",
+            "in": "query",
+            "required": true,
+            "description": "Application number.",
+            "schema": {
+              "type": "string",
+              "pattern": "^[0-9]{6,10}$"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/patents/search": {
+      "get": {
+        "tags": [
+          "patents"
+        ],
+        "summary": "Search US patent applications and grants via the USPTO Open...",
+        "description": "Search US patent applications and grants via the USPTO Open Data Portal. Query: q (required, 2+ chars), yearFrom / yearTo (optional filing-year bounds), applicationType (optional: Utility|Design|Plant|Reissue), limit (1-100, default 10), offset (0-based, default 0). Returns { total, returned, offset, limit, hits[{ applicationNumber, title, applicationType, firstInventor, inventors[], applicants[], filingDate, effectiveFilingDate, status:{ code, description, updatedAt }, cpcSymbols[], uspcSymbol, url }] }. URLs link to USPTO Patent Center for the public file wrapper.",
+        "operationId": "patents_search",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = matched patent applications/grants; total = upstream total hit count; meta echoes the query + returned (this page).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "query": {
+                              "type": "object",
+                              "properties": {
+                                "q": {
+                                  "type": "string"
+                                },
+                                "yearFrom": {
+                                  "type": "integer",
+                                  "nullable": true
+                                },
+                                "yearTo": {
+                                  "type": "integer",
+                                  "nullable": true
+                                },
+                                "applicationType": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "offset": {
+                                  "type": "integer"
+                                },
+                                "limit": {
+                                  "type": "integer"
+                                }
+                              },
+                              "required": [
+                                "q",
+                                "yearFrom",
+                                "yearTo",
+                                "applicationType",
+                                "offset",
+                                "limit"
+                              ],
+                              "additionalProperties": false
+                            },
+                            "returned": {
+                              "type": "integer",
+                              "description": "Hits returned on this page."
+                            }
+                          },
+                          "required": [
+                            "query",
+                            "returned"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0018 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "patents.search",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0018,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001800"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": true,
+            "description": "Free-text search query.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 500
+            }
+          },
+          {
+            "name": "yearFrom",
+            "in": "query",
+            "required": false,
+            "description": "Year from.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1790,
+              "maximum": 2100
+            }
+          },
+          {
+            "name": "yearTo",
+            "in": "query",
+            "required": false,
+            "description": "Year to.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1790,
+              "maximum": 2100
+            }
+          },
+          {
+            "name": "applicationType",
+            "in": "query",
+            "required": false,
+            "description": "Application type.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Utility",
+                "Design",
+                "Plant",
+                "Reissue"
+              ]
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of results to return.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 10
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "description": "Number of results to skip before returning (pagination offset).",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 10000,
+              "default": 0
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/space/body": {
+      "get": {
+        "tags": [
+          "space"
+        ],
+        "summary": "Look up any asteroid or comet in NASA JPL's Small-Body...",
+        "description": "Look up any asteroid or comet in NASA JPL's Small-Body Database by designation, number, or name (e.g. \"433\", \"Eros\", \"433 Eros\", \"1P/Halley\", \"2024 YR4\"). Returns full name + kind + orbit class (e.g. Amor, Apollo, Jupiter-family comet), NEO and potentially-hazardous-asteroid flags, physical params (absolute magnitude H, diameter, extent, rotation period, albedo, density, spectral type), and orbital elements (eccentricity, semi-major axis, perihelion/aphelion, inclination, period, Earth MOID, observation arc). Astronomy, planetary-defense, and mission-planning research. Public-domain NASA/JPL data; for a body's near-Earth close approaches see /api/space/close-approaches.",
+        "operationId": "space_body",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = [{ body }] (one small-body: identity, NEO/PHA flags, orbit class, physical + orbital params); total = 1.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "body": {
+                                "type": "object",
+                                "properties": {
+                                  "fullName": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "shortName": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "kind": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "neo": {
+                                    "type": "boolean",
+                                    "nullable": true
+                                  },
+                                  "pha": {
+                                    "type": "boolean",
+                                    "nullable": true
+                                  },
+                                  "orbitClass": {
+                                    "type": "object",
+                                    "properties": {
+                                      "code": {
+                                        "type": "string",
+                                        "nullable": true
+                                      },
+                                      "name": {
+                                        "type": "string",
+                                        "nullable": true
+                                      }
+                                    },
+                                    "required": [
+                                      "code",
+                                      "name"
+                                    ],
+                                    "additionalProperties": false,
+                                    "nullable": true
+                                  },
+                                  "physical": {
+                                    "type": "object",
+                                    "additionalProperties": {}
+                                  },
+                                  "orbit": {
+                                    "type": "object",
+                                    "additionalProperties": {}
+                                  }
+                                },
+                                "required": [
+                                  "fullName",
+                                  "shortName",
+                                  "kind",
+                                  "neo",
+                                  "pha",
+                                  "orbitClass",
+                                  "physical",
+                                  "orbit"
+                                ],
+                                "additionalProperties": false
+                              }
+                            },
+                            "required": [
+                              "body"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.00144 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "space.body",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.00144,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001440"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": true,
+            "description": "Free-text search query.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 60
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/space/close-approaches": {
+      "get": {
+        "tags": [
+          "space"
+        ],
+        "summary": "List near-Earth asteroid/comet close approaches to Earth...",
+        "description": "List near-Earth asteroid/comet close approaches to Earth within a date window and maximum distance, from NASA JPL's Close-Approach Data API. Filter by dateMin / dateMax (YYYY-MM-DD) and distMaxAu (max approach distance in AU; default 0.05 AU ≈ 19.5 lunar distances). Each approach: object designation, close-approach date (UTC), nominal + minimum distance in AU and lunar distances, relative velocity (km/s), and absolute magnitude H (a size proxy). Sorted nearest-first. Planetary-defense, observation planning, and \"what's passing by this month\" queries. Public-domain NASA/JPL data; for full physical/orbital params of a listed object see /api/space/body.",
+        "operationId": "space_close-approaches",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = close approaches (object, date, distance in AU + lunar distances, relative velocity, H); total = upstream match count in the window (before the limit cap).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "designation": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "date": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "julianDate": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "distanceAu": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "distanceMinAu": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "distanceLd": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "relativeVelocityKmS": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "absoluteMagnitudeH": {
+                                "type": "number",
+                                "nullable": true
+                              }
+                            },
+                            "required": [
+                              "designation",
+                              "date",
+                              "julianDate",
+                              "distanceAu",
+                              "distanceMinAu",
+                              "distanceLd",
+                              "relativeVelocityKmS",
+                              "absoluteMagnitudeH"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.00144 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "space.close-approaches",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.00144,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001440"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "dateMin",
+            "in": "query",
+            "required": false,
+            "description": "Date min.",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+            }
+          },
+          {
+            "name": "dateMax",
+            "in": "query",
+            "required": false,
+            "description": "Date max.",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+            }
+          },
+          {
+            "name": "distMaxAu",
+            "in": "query",
+            "required": false,
+            "description": "Dist max au.",
+            "schema": {
+              "type": "number",
+              "minimum": 0.0001,
+              "maximum": 1,
+              "default": 0.05
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of results to return.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 200,
+              "default": 50
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/space/exoplanet": {
+      "get": {
+        "tags": [
+          "space"
+        ],
+        "summary": "Search confirmed exoplanets in the NASA Exoplanet Archive...",
+        "description": "Search confirmed exoplanets in the NASA Exoplanet Archive (~6,000, updated weekly — past any LLM training cutoff). Filter by name (planet, partial), hostStar (partial), discoveryYear, or method (e.g. \"Transit\", \"Radial Velocity\", \"Microlensing\"). Each planet: name, host star + how many stars/planets in the system, discovery method/year/facility, orbital period, semi-major axis, radius (Earth radii), mass (Earth masses), equilibrium temperature, insolation; host-star spectral type/temperature/radius/mass; distance in parsecs + light-years; and RA/dec. Astronomy, habitability research, science education. Public-domain NASA data.",
+        "operationId": "space_exoplanet",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = matched confirmed exoplanets (name, host star, discovery, orbit, radius/mass, distance); total = null (the archive caps rows at limit with no true match total); meta.query echoes the filters.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "query": {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "hostStar": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "discoveryYear": {
+                                  "type": "number",
+                                  "nullable": true
+                                },
+                                "method": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "limit": {
+                                  "type": "number"
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "hostStar",
+                                "discoveryYear",
+                                "method",
+                                "limit"
+                              ],
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "query"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.00144 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "space.exoplanet",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.00144,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001440"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "description": "Name to search for.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 60
+            }
+          },
+          {
+            "name": "hostStar",
+            "in": "query",
+            "required": false,
+            "description": "Host star.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 60
+            }
+          },
+          {
+            "name": "discoveryYear",
+            "in": "query",
+            "required": false,
+            "description": "Discovery year.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1989,
+              "maximum": 2030
+            }
+          },
+          {
+            "name": "method",
+            "in": "query",
+            "required": false,
+            "description": "Method.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 40
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of results to return.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 20
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/space/launches": {
+      "get": {
+        "tags": [
+          "space"
+        ],
+        "summary": "Fetch Upcoming or recent orbital rocket launches from",
+        "description": "Upcoming or recent orbital rocket launches from The Space Devs' Launch Library 2 — the live manifest behind most launch-tracking apps. `when`=upcoming (default) or previous. Optional `search` filters by rocket, provider, or mission text (e.g. \"Starship\", \"SpaceX\", \"Artemis\"). Each launch: name, status (Go/TBD/Success/Failure), NET launch time + window (UTC), launch provider, rocket configuration, pad + location, mission name/type/orbit/description, and whether a webcast is live. Real-time data agents can't get from training. Public CC-BY data (attribute The Space Devs).",
+        "operationId": "space_launches",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = launches (name, status, NET, provider, rocket, pad, mission); total = upstream match count (Launch Library `count`); meta.when echoes upcoming/previous.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "name": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "status": {
+                                "type": "object",
+                                "properties": {
+                                  "abbrev": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "description": {
+                                    "type": "string",
+                                    "nullable": true
+                                  }
+                                },
+                                "required": [
+                                  "abbrev",
+                                  "description"
+                                ],
+                                "additionalProperties": false,
+                                "nullable": true
+                              },
+                              "net": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "windowStart": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "windowEnd": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "provider": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "rocket": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "pad": {
+                                "type": "object",
+                                "properties": {
+                                  "name": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "location": {
+                                    "type": "string",
+                                    "nullable": true
+                                  }
+                                },
+                                "required": [
+                                  "name",
+                                  "location"
+                                ],
+                                "additionalProperties": false,
+                                "nullable": true
+                              },
+                              "mission": {
+                                "type": "object",
+                                "properties": {
+                                  "name": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "type": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "orbit": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "description": {
+                                    "type": "string",
+                                    "nullable": true
+                                  }
+                                },
+                                "required": [
+                                  "name",
+                                  "type",
+                                  "orbit",
+                                  "description"
+                                ],
+                                "additionalProperties": false,
+                                "nullable": true
+                              },
+                              "webcastLive": {
+                                "type": "boolean",
+                                "nullable": true
+                              },
+                              "image": {
+                                "type": "string",
+                                "nullable": true
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "name",
+                              "status",
+                              "net",
+                              "windowStart",
+                              "windowEnd",
+                              "provider",
+                              "rocket",
+                              "pad",
+                              "mission",
+                              "webcastLive",
+                              "image"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "when": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "when"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.00144 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "space.launches",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.00144,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001440"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "when",
+            "in": "query",
+            "required": false,
+            "description": "When.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "upcoming",
+                "previous"
+              ],
+              "default": "upcoming"
+            }
+          },
+          {
+            "name": "search",
+            "in": "query",
+            "required": false,
+            "description": "Free-text search query.",
+            "schema": {
+              "type": "string",
+              "maxLength": 80
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of results to return.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 50,
+              "default": 10
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "description": "Number of results to skip before returning (pagination offset).",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/space/observe": {
+      "get": {
+        "tags": [
+          "space"
+        ],
+        "summary": "Calculate where any asteroid or comet is in the sky and...",
+        "description": "Compute where any asteroid or comet is in the sky and whether you can see it. Give a body (designation/number/name, e.g. \"433 Eros\", \"Ceres\", \"2024 YR4\") and optionally your lat/lon and a time (ISO, default now). Returns the body's identity (NEO/PHA flags, orbit class, absolute magnitude H), its geocentric right ascension + declination, the constellation it's in, geocentric + heliocentric distance (AU), solar phase angle, and its apparent visual magnitude (IAU H-G model — how bright it appears now). With lat/lon it adds altitude/azimuth, whether it's above your horizon, a visible-now flag (up AND sky dark), and the best viewing window in the next 24 hours (when it's highest during darkness). Orbital position is computed locally from JPL elements — VALIDATED against JPL Horizons to <0.1 arcminute. Stargazing, astrophotography planning, occultation/observation prep. For the body's static physical + orbital params see /api/space/body.",
+        "operationId": "space_observe",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = [{ body, at, position, observer }] (one observability snapshot; RA/Dec validated against JPL Horizons; observer block null without lat/lon); total = 1.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "body": {
+                                "type": "object",
+                                "properties": {
+                                  "fullName": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "neo": {
+                                    "type": "boolean",
+                                    "nullable": true
+                                  },
+                                  "pha": {
+                                    "type": "boolean",
+                                    "nullable": true
+                                  },
+                                  "orbitClass": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "absoluteMagnitudeH": {
+                                    "type": "number",
+                                    "nullable": true
+                                  }
+                                },
+                                "required": [
+                                  "fullName",
+                                  "neo",
+                                  "pha",
+                                  "orbitClass",
+                                  "absoluteMagnitudeH"
+                                ],
+                                "additionalProperties": false
+                              },
+                              "at": {
+                                "type": "string"
+                              },
+                              "position": {
+                                "type": "object",
+                                "properties": {
+                                  "rightAscensionHours": {
+                                    "type": "number"
+                                  },
+                                  "declinationDeg": {
+                                    "type": "number"
+                                  },
+                                  "constellation": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "geocentricDistanceAu": {
+                                    "type": "number"
+                                  },
+                                  "heliocentricDistanceAu": {
+                                    "type": "number"
+                                  },
+                                  "phaseAngleDeg": {
+                                    "type": "number"
+                                  },
+                                  "apparentMagnitude": {
+                                    "type": "number",
+                                    "nullable": true
+                                  }
+                                },
+                                "required": [
+                                  "rightAscensionHours",
+                                  "declinationDeg",
+                                  "constellation",
+                                  "geocentricDistanceAu",
+                                  "heliocentricDistanceAu",
+                                  "phaseAngleDeg",
+                                  "apparentMagnitude"
+                                ],
+                                "additionalProperties": false
+                              },
+                              "observer": {
+                                "type": "object",
+                                "properties": {
+                                  "altitudeDeg": {
+                                    "type": "number"
+                                  },
+                                  "azimuthDeg": {
+                                    "type": "number"
+                                  },
+                                  "aboveHorizon": {
+                                    "type": "boolean"
+                                  },
+                                  "visibleNow": {
+                                    "type": "boolean"
+                                  },
+                                  "bestViewing": {
+                                    "type": "object",
+                                    "properties": {
+                                      "at": {
+                                        "type": "string"
+                                      },
+                                      "altitudeDeg": {
+                                        "type": "number"
+                                      }
+                                    },
+                                    "required": [
+                                      "at",
+                                      "altitudeDeg"
+                                    ],
+                                    "additionalProperties": false,
+                                    "nullable": true
+                                  }
+                                },
+                                "required": [
+                                  "altitudeDeg",
+                                  "azimuthDeg",
+                                  "aboveHorizon",
+                                  "visibleNow",
+                                  "bestViewing"
+                                ],
+                                "additionalProperties": false,
+                                "nullable": true
+                              }
+                            },
+                            "required": [
+                              "body",
+                              "at",
+                              "position",
+                              "observer"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.00288 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "space.observe",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.00288,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.002880"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "query",
+            "required": true,
+            "description": "Body.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 60
+            }
+          },
+          {
+            "name": "lat",
+            "in": "query",
+            "required": false,
+            "description": "Latitude in decimal degrees (WGS84).",
+            "schema": {
+              "type": "number",
+              "minimum": -90,
+              "maximum": 90
+            }
+          },
+          {
+            "name": "lon",
+            "in": "query",
+            "required": false,
+            "description": "Longitude in decimal degrees (WGS84).",
+            "schema": {
+              "type": "number",
+              "minimum": -180,
+              "maximum": 180
+            }
+          },
+          {
+            "name": "altKm",
+            "in": "query",
+            "required": false,
+            "description": "Alt km.",
+            "schema": {
+              "type": "number",
+              "minimum": -0.5,
+              "maximum": 9
+            }
+          },
+          {
+            "name": "at",
+            "in": "query",
+            "required": false,
+            "description": "At.",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/space/satellite": {
+      "get": {
+        "tags": [
+          "space"
+        ],
+        "summary": "Calculate the current position of any cataloged...",
+        "description": "Compute the current position of any cataloged Earth-orbiting satellite by NORAD catalog number (e.g. 25544 = ISS, 20580 = Hubble), using fresh Celestrak orbital elements propagated with SGP4. Returns sub-point latitude/longitude, altitude (km), and speed (km/s) for the requested instant (default: now; pass `at` as an ISO timestamp for any time within a few days of the elements' epoch). Supply observer `lat`/`lon` (and optional altKm) to also get look angles — azimuth, elevation, slant range, and whether the satellite is above your horizon — for visual/antenna pointing. Satellite tracking, pass prediction, ground-station planning. Public-domain orbital data; physical/mission metadata is not included.",
+        "operationId": "space_satellite",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = [{ position }] (one satellite sub-point + velocity + optional observer look angles); total = 1.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "position": {
+                                "type": "object",
+                                "properties": {
+                                  "noradId": {
+                                    "type": "number"
+                                  },
+                                  "name": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "internationalDesignator": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "epoch": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "at": {
+                                    "type": "string"
+                                  },
+                                  "geodetic": {
+                                    "type": "object",
+                                    "properties": {
+                                      "latitude": {
+                                        "type": "number"
+                                      },
+                                      "longitude": {
+                                        "type": "number"
+                                      },
+                                      "altitudeKm": {
+                                        "type": "number"
+                                      }
+                                    },
+                                    "required": [
+                                      "latitude",
+                                      "longitude",
+                                      "altitudeKm"
+                                    ],
+                                    "additionalProperties": false
+                                  },
+                                  "velocityKmS": {
+                                    "type": "number"
+                                  },
+                                  "look": {
+                                    "type": "object",
+                                    "properties": {
+                                      "azimuthDeg": {
+                                        "type": "number"
+                                      },
+                                      "elevationDeg": {
+                                        "type": "number"
+                                      },
+                                      "rangeKm": {
+                                        "type": "number"
+                                      },
+                                      "aboveHorizon": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "azimuthDeg",
+                                      "elevationDeg",
+                                      "rangeKm",
+                                      "aboveHorizon"
+                                    ],
+                                    "additionalProperties": false,
+                                    "nullable": true
+                                  }
+                                },
+                                "required": [
+                                  "noradId",
+                                  "name",
+                                  "internationalDesignator",
+                                  "epoch",
+                                  "at",
+                                  "geodetic",
+                                  "velocityKmS",
+                                  "look"
+                                ],
+                                "additionalProperties": false
+                              }
+                            },
+                            "required": [
+                              "position"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.00144 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "space.satellite",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.00144,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001440"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "noradId",
+            "in": "query",
+            "required": true,
+            "description": "Norad ID.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 999999
+            }
+          },
+          {
+            "name": "lat",
+            "in": "query",
+            "required": false,
+            "description": "Latitude in decimal degrees (WGS84).",
+            "schema": {
+              "type": "number",
+              "minimum": -90,
+              "maximum": 90
+            }
+          },
+          {
+            "name": "lon",
+            "in": "query",
+            "required": false,
+            "description": "Longitude in decimal degrees (WGS84).",
+            "schema": {
+              "type": "number",
+              "minimum": -180,
+              "maximum": 180
+            }
+          },
+          {
+            "name": "altKm",
+            "in": "query",
+            "required": false,
+            "description": "Alt km.",
+            "schema": {
+              "type": "number",
+              "minimum": -0.5,
+              "maximum": 9
+            }
+          },
+          {
+            "name": "at",
+            "in": "query",
+            "required": false,
+            "description": "At.",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/space/satellites": {
+      "get": {
+        "tags": [
+          "space"
+        ],
+        "summary": "Search the catalog of every cataloged Earth-orbiting object...",
+        "description": "Search the catalog of every cataloged Earth-orbiting object — ~69,000 satellites, rocket bodies, and debris tracked by US Space Force / 18 SDS (via CelesTrak SATCAT). Filter by name (q, e.g. \"starlink\"), owner/launching country (owner — code like US/PRC/CIS or a name like \"china\"), object type (type = payload | rocket body | debris | unknown), launch-year range (launchYearFrom/launchYearTo), international/COSPAR designator prefix (intlDesignator, e.g. \"2024-\"), on-orbit vs decayed (onOrbit), or exact NORAD number (noradId). Each result carries the NORAD id, name, international designator, object type, owner + resolved country, launch date + site, decay date (null = still in orbit), and orbital parameters (period, inclination, apogee, perigee). The envelope total is the full count matching your filter — so onOrbit=true&type=payload answers \"how many active satellites are up there\", and owner=PRC tells you who launched them. For a satellite's live sub-point position, pass its noradId to /api/space/satellite.",
+        "operationId": "space_satellites",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = matching catalog rows; total = full count matching the filter (use it for \"how many\" queries).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "noradId": {
+                                "type": "number"
+                              },
+                              "name": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "intlDesignator": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "objectType": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "opsStatus": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "owner": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "ownerName": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "launchDate": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "launchSite": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "decayDate": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "onOrbit": {
+                                "type": "boolean"
+                              },
+                              "orbit": {
+                                "type": "object",
+                                "properties": {
+                                  "periodMin": {
+                                    "type": "number",
+                                    "nullable": true
+                                  },
+                                  "inclinationDeg": {
+                                    "type": "number",
+                                    "nullable": true
+                                  },
+                                  "apogeeKm": {
+                                    "type": "number",
+                                    "nullable": true
+                                  },
+                                  "perigeeKm": {
+                                    "type": "number",
+                                    "nullable": true
+                                  },
+                                  "orbitType": {
+                                    "type": "string",
+                                    "nullable": true
+                                  }
+                                },
+                                "required": [
+                                  "periodMin",
+                                  "inclinationDeg",
+                                  "apogeeKm",
+                                  "perigeeKm",
+                                  "orbitType"
+                                ],
+                                "additionalProperties": false
+                              },
+                              "rcsM2": {
+                                "type": "number",
+                                "nullable": true
+                              }
+                            },
+                            "required": [
+                              "noradId",
+                              "name",
+                              "intlDesignator",
+                              "objectType",
+                              "opsStatus",
+                              "owner",
+                              "ownerName",
+                              "launchDate",
+                              "launchSite",
+                              "decayDate",
+                              "onOrbit",
+                              "orbit",
+                              "rcsM2"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "space.satellites",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": false,
+            "description": "Free-text search query.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 120
+            }
+          },
+          {
+            "name": "owner",
+            "in": "query",
+            "required": false,
+            "description": "Owner.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 40
+            }
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "required": false,
+            "description": "Filter results by type.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 20
+            }
+          },
+          {
+            "name": "noradId",
+            "in": "query",
+            "required": false,
+            "description": "Norad ID.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 999999
+            }
+          },
+          {
+            "name": "intlDesignator",
+            "in": "query",
+            "required": false,
+            "description": "Intl designator.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 20
+            }
+          },
+          {
+            "name": "launchYearFrom",
+            "in": "query",
+            "required": false,
+            "description": "Launch year from.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1957,
+              "maximum": 2100
+            }
+          },
+          {
+            "name": "launchYearTo",
+            "in": "query",
+            "required": false,
+            "description": "Launch year to.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1957,
+              "maximum": 2100
+            }
+          },
+          {
+            "name": "onOrbit",
+            "in": "query",
+            "required": false,
+            "description": "On orbit.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "true",
+                "false"
+              ]
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of results to return.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 25
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "description": "Number of results to skip before returning (pagination offset).",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 100000,
+              "default": 0
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/space/sky-tonight": {
+      "get": {
+        "tags": [
+          "space"
+        ],
+        "summary": "Fetch Observer-local sky almanac for any lat/lon and time...",
+        "description": "Observer-local sky almanac for any lat/lon and time (default now). Returns the Sun's next rise/set + current altitude/azimuth; the Moon's rise/set, current alt/az, phase angle, phase name (New → Full → Waning Crescent), illuminated fraction, and next moon quarter; and for all seven non-Earth planets (Mercury→Neptune): altitude, azimuth, RA/dec, distance (AU), apparent magnitude, and whether each is currently above the horizon. Computed from first principles (astronomy-engine, sub-arcminute) — no external service, no key. Stargazing, astrophotography planning, 'what's up right now', is-it-dark-yet. `at` accepts any ISO timestamp.",
+        "operationId": "space_sky-tonight",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = [{ sky }] (one observer-local almanac; the sun/moon/planets blocks live inside this single item); total = 1.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "sky": {
+                                "type": "object",
+                                "properties": {
+                                  "at": {
+                                    "type": "string"
+                                  },
+                                  "observer": {
+                                    "type": "object",
+                                    "properties": {
+                                      "lat": {
+                                        "type": "number"
+                                      },
+                                      "lon": {
+                                        "type": "number"
+                                      },
+                                      "altitudeM": {
+                                        "type": "number"
+                                      }
+                                    },
+                                    "required": [
+                                      "lat",
+                                      "lon",
+                                      "altitudeM"
+                                    ],
+                                    "additionalProperties": false
+                                  },
+                                  "sun": {
+                                    "type": "object",
+                                    "additionalProperties": {}
+                                  },
+                                  "moon": {
+                                    "type": "object",
+                                    "additionalProperties": {}
+                                  },
+                                  "planets": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "additionalProperties": {}
+                                    }
+                                  }
+                                },
+                                "required": [
+                                  "at",
+                                  "observer",
+                                  "sun",
+                                  "moon",
+                                  "planets"
+                                ],
+                                "additionalProperties": false
+                              }
+                            },
+                            "required": [
+                              "sky"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.001 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "space.sky-tonight",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.001,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "lat",
+            "in": "query",
+            "required": true,
+            "description": "Latitude in decimal degrees (WGS84).",
+            "schema": {
+              "type": "number",
+              "minimum": -90,
+              "maximum": 90
+            }
+          },
+          {
+            "name": "lon",
+            "in": "query",
+            "required": true,
+            "description": "Longitude in decimal degrees (WGS84).",
+            "schema": {
+              "type": "number",
+              "minimum": -180,
+              "maximum": 180
+            }
+          },
+          {
+            "name": "altitudeM",
+            "in": "query",
+            "required": false,
+            "description": "Altitude m.",
+            "schema": {
+              "type": "number",
+              "minimum": -500,
+              "maximum": 9000,
+              "default": 0
+            }
+          },
+          {
+            "name": "at",
+            "in": "query",
+            "required": false,
+            "description": "At.",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/space/skywatch": {
+      "get": {
+        "tags": [
+          "space"
+        ],
+        "summary": "Fetch what is notable in your sky now for a lat/lon",
+        "description": "One call → what's notable in YOUR sky right now, for a lat/lon. Synthesizes three sources: (1) the live almanac — sun up/down, moon phase + illumination, and which of the 7 naked-eye planets are currently above your horizon with their altitude/azimuth/magnitude; (2) near-Earth asteroid close approaches over the next 7 days (designation, date, distance in lunar distances); and (3) the ISS — its current sub-point, and whether it is above your horizon right now with look angles. Each section reports found/error independently. The \"is it dark, what's up, anything passing\" digest for stargazers and astrophotographers. For the raw almanac alone see /api/space/sky-tonight.",
+        "operationId": "space_skywatch",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "at": {
+                          "type": "string"
+                        },
+                        "observer": {
+                          "type": "object",
+                          "properties": {
+                            "lat": {
+                              "type": "number"
+                            },
+                            "lon": {
+                              "type": "number"
+                            },
+                            "altitudeM": {
+                              "type": "number"
+                            }
+                          },
+                          "required": [
+                            "lat",
+                            "lon",
+                            "altitudeM"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "sky": {
+                          "type": "object",
+                          "properties": {
+                            "isDark": {
+                              "type": "boolean"
+                            },
+                            "sun": {
+                              "type": "object",
+                              "additionalProperties": {}
+                            },
+                            "moon": {
+                              "type": "object",
+                              "additionalProperties": {}
+                            },
+                            "planetsUp": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "additionalProperties": {}
+                              }
+                            }
+                          },
+                          "required": [
+                            "isDark",
+                            "sun",
+                            "moon",
+                            "planetsUp"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "closeApproaches": {
+                          "type": "object",
+                          "properties": {
+                            "found": {
+                              "type": "boolean"
+                            },
+                            "error": {
+                              "type": "string",
+                              "nullable": true
+                            },
+                            "count": {
+                              "type": "number",
+                              "nullable": true
+                            },
+                            "approaches": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "additionalProperties": {}
+                              }
+                            }
+                          },
+                          "required": [
+                            "found",
+                            "error",
+                            "count",
+                            "approaches"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "iss": {
+                          "type": "object",
+                          "properties": {
+                            "found": {
+                              "type": "boolean"
+                            },
+                            "error": {
+                              "type": "string",
+                              "nullable": true
+                            },
+                            "aboveHorizon": {
+                              "type": "boolean",
+                              "nullable": true
+                            },
+                            "geodetic": {
+                              "type": "object",
+                              "additionalProperties": {},
+                              "nullable": true
+                            },
+                            "look": {
+                              "type": "object",
+                              "additionalProperties": {},
+                              "nullable": true
+                            }
+                          },
+                          "required": [
+                            "found",
+                            "error",
+                            "aboveHorizon",
+                            "geodetic",
+                            "look"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "sources": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
+                        }
+                      },
+                      "required": [
+                        "at",
+                        "observer",
+                        "sky",
+                        "closeApproaches",
+                        "iss",
+                        "sources"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.00288 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "space.skywatch",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.00288,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "legacy",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.002880"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "lat",
+            "in": "query",
+            "required": true,
+            "description": "Latitude in decimal degrees (WGS84).",
+            "schema": {
+              "type": "number",
+              "minimum": -90,
+              "maximum": 90
+            }
+          },
+          {
+            "name": "lon",
+            "in": "query",
+            "required": true,
+            "description": "Longitude in decimal degrees (WGS84).",
+            "schema": {
+              "type": "number",
+              "minimum": -180,
+              "maximum": 180
+            }
+          },
+          {
+            "name": "altitudeM",
+            "in": "query",
+            "required": false,
+            "description": "Altitude m.",
+            "schema": {
+              "type": "number",
+              "minimum": -500,
+              "maximum": 9000,
+              "default": 0
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/space/system": {
+      "get": {
+        "tags": [
+          "space"
+        ],
+        "summary": "Analyze a confirmed exoplanetary system by host-star name (e.g.",
+        "description": "Profile a confirmed exoplanetary system by host-star name (e.g. \"TRAPPIST-1\", \"Kepler-90\", \"TOI-700\"). Groups all the star's known planets into one view, summarizes the host star (spectral type, temperature, radius, mass, distance in light-years), and COMPUTES the star's habitable (\"Goldilocks\") zone — inner and outer boundary in AU, derived from the stellar luminosity (effective temperature + radius vs. the Sun) — then flags which planets orbit within it. Each planet: radius/mass (Earth units), orbital period, semi-major axis, equilibrium temperature, and in-habitable-zone flag. Astronomy, habitability research, education. Built from the NASA Exoplanet Archive (the same data as /api/space/exoplanet) plus the computed HZ. Public-domain NASA data.",
+        "operationId": "space_system",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "system": {
+                          "type": "object",
+                          "properties": {
+                            "hostStar": {
+                              "type": "string"
+                            },
+                            "planetCount": {
+                              "type": "number"
+                            },
+                            "star": {
+                              "type": "object",
+                              "properties": {
+                                "spectralType": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "effectiveTempK": {
+                                  "type": "number",
+                                  "nullable": true
+                                },
+                                "radiusSolar": {
+                                  "type": "number",
+                                  "nullable": true
+                                },
+                                "massSolar": {
+                                  "type": "number",
+                                  "nullable": true
+                                },
+                                "luminositySolar": {
+                                  "type": "number",
+                                  "nullable": true
+                                },
+                                "distanceLightYears": {
+                                  "type": "number",
+                                  "nullable": true
+                                }
+                              },
+                              "required": [
+                                "spectralType",
+                                "effectiveTempK",
+                                "radiusSolar",
+                                "massSolar",
+                                "luminositySolar",
+                                "distanceLightYears"
+                              ],
+                              "additionalProperties": false
+                            },
+                            "habitableZone": {
+                              "type": "object",
+                              "properties": {
+                                "innerAu": {
+                                  "type": "number"
+                                },
+                                "outerAu": {
+                                  "type": "number"
+                                }
+                              },
+                              "required": [
+                                "innerAu",
+                                "outerAu"
+                              ],
+                              "additionalProperties": false,
+                              "nullable": true
+                            },
+                            "planets": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "additionalProperties": {}
+                              }
+                            }
+                          },
+                          "required": [
+                            "hostStar",
+                            "planetCount",
+                            "star",
+                            "habitableZone",
+                            "planets"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "system",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.00288 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "space.system",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.00288,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "legacy",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.002880"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "hostStar",
+            "in": "query",
+            "required": true,
+            "description": "Host star.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 60
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/space/weather": {
+      "get": {
+        "tags": [
+          "space"
+        ],
+        "summary": "Fetch Current space weather from NOAA SWPC public feeds.",
+        "description": "Current space weather from NOAA SWPC public feeds. Returns the latest planetary K-index (3-hour geomagnetic activity), solar wind plasma (density / speed / temperature from ACE/DSCOVR at L1), GOES X-ray flux with NOAA flare class (A/B/C/M/X), and the current NOAA R (radio blackout) / S (solar radiation) / G (geomagnetic storm) scales plus a 24-hour forecast in 6-hour windows. All timestamps are ISO 8601 UTC. No parameters. Useful for aurora forecasting, HF-radio propagation, satellite-operations planning, and GPS-degradation alerts. Data is public domain (NOAA / US government work).",
+        "operationId": "space_weather",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = [{ kp, solarWind, xray, scales }] (one current space-weather snapshot; all four blocks live inside this single item); total = 1.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "kp": {
+                                "type": "object",
+                                "properties": {
+                                  "latest": {
+                                    "type": "object",
+                                    "properties": {
+                                      "time": {
+                                        "type": "string",
+                                        "description": "ISO 8601 UTC timestamp of the 3-hour interval."
+                                      },
+                                      "kp": {
+                                        "type": "number",
+                                        "description": "Planetary K-index, 0..9."
+                                      },
+                                      "gScale": {
+                                        "type": "integer",
+                                        "description": "Derived NOAA G-storm scale (0..5)."
+                                      },
+                                      "gLabel": {
+                                        "type": "string",
+                                        "description": "Plain-English label: none / minor / moderate / strong / severe / extreme."
+                                      }
+                                    },
+                                    "required": [
+                                      "time",
+                                      "kp",
+                                      "gScale",
+                                      "gLabel"
+                                    ],
+                                    "additionalProperties": false
+                                  },
+                                  "recent": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "time": {
+                                          "type": "string"
+                                        },
+                                        "kp": {
+                                          "type": "number"
+                                        },
+                                        "gScale": {
+                                          "type": "integer"
+                                        },
+                                        "gLabel": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "time",
+                                        "kp",
+                                        "gScale",
+                                        "gLabel"
+                                      ],
+                                      "additionalProperties": false
+                                    },
+                                    "description": "Last ~24 hours of Kp samples (up to 8 entries, oldest first)."
+                                  }
+                                },
+                                "required": [
+                                  "latest",
+                                  "recent"
+                                ],
+                                "additionalProperties": false
+                              },
+                              "solarWind": {
+                                "type": "object",
+                                "properties": {
+                                  "time": {
+                                    "type": "string"
+                                  },
+                                  "densityPerCm3": {
+                                    "type": "number",
+                                    "nullable": true,
+                                    "description": "Proton density at L1 (n/cm³)."
+                                  },
+                                  "speedKmPerSec": {
+                                    "type": "number",
+                                    "nullable": true,
+                                    "description": "Bulk speed (km/s). Quiet ~350-450, fast > 600."
+                                  },
+                                  "temperatureK": {
+                                    "type": "number",
+                                    "nullable": true,
+                                    "description": "Proton temperature (K)."
+                                  }
+                                },
+                                "required": [
+                                  "time",
+                                  "densityPerCm3",
+                                  "speedKmPerSec",
+                                  "temperatureK"
+                                ],
+                                "additionalProperties": false
+                              },
+                              "xray": {
+                                "type": "object",
+                                "properties": {
+                                  "time": {
+                                    "type": "string"
+                                  },
+                                  "fluxLongWm2": {
+                                    "type": "number",
+                                    "nullable": true,
+                                    "description": "GOES long-band (0.1-0.8 nm) flux in W/m²."
+                                  },
+                                  "flareClass": {
+                                    "type": "string",
+                                    "nullable": true,
+                                    "description": "NOAA flare class derived from long-band flux (e.g. \"C2.4\", \"M1.0\", \"X9.3\")."
+                                  },
+                                  "satellite": {
+                                    "type": "integer",
+                                    "nullable": true,
+                                    "description": "GOES satellite number reporting this sample."
+                                  }
+                                },
+                                "required": [
+                                  "time",
+                                  "fluxLongWm2",
+                                  "flareClass",
+                                  "satellite"
+                                ],
+                                "additionalProperties": false
+                              },
+                              "scales": {
+                                "type": "object",
+                                "properties": {
+                                  "current": {
+                                    "type": "object",
+                                    "properties": {
+                                      "observedAt": {
+                                        "type": "string"
+                                      },
+                                      "rRadio": {
+                                        "type": "object",
+                                        "properties": {
+                                          "scale": {
+                                            "type": "integer"
+                                          },
+                                          "label": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "scale",
+                                          "label"
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      "sRadiation": {
+                                        "type": "object",
+                                        "properties": {
+                                          "scale": {
+                                            "type": "integer"
+                                          },
+                                          "label": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "scale",
+                                          "label"
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      "gGeomagnetic": {
+                                        "type": "object",
+                                        "properties": {
+                                          "scale": {
+                                            "type": "integer"
+                                          },
+                                          "label": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "scale",
+                                          "label"
+                                        ],
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "required": [
+                                      "observedAt",
+                                      "rRadio",
+                                      "sRadiation",
+                                      "gGeomagnetic"
+                                    ],
+                                    "additionalProperties": false
+                                  },
+                                  "forecast": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "startsAt": {
+                                          "type": "string"
+                                        },
+                                        "rMinorPercent": {
+                                          "type": "number",
+                                          "nullable": true,
+                                          "description": "Probability of R1-R2 radio blackout (0..100)."
+                                        },
+                                        "rMajorPercent": {
+                                          "type": "number",
+                                          "nullable": true,
+                                          "description": "Probability of R3+ radio blackout (0..100)."
+                                        },
+                                        "sPercent": {
+                                          "type": "number",
+                                          "nullable": true,
+                                          "description": "Probability of S1+ solar radiation storm (0..100)."
+                                        },
+                                        "gScale": {
+                                          "type": "integer"
+                                        },
+                                        "gLabel": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "startsAt",
+                                        "rMinorPercent",
+                                        "rMajorPercent",
+                                        "sPercent",
+                                        "gScale",
+                                        "gLabel"
+                                      ],
+                                      "additionalProperties": false
+                                    },
+                                    "description": "Forward forecast in 6-hour windows (up to 4 entries covering the next ~24h)."
+                                  }
+                                },
+                                "required": [
+                                  "current",
+                                  "forecast"
+                                ],
+                                "additionalProperties": false
+                              }
+                            },
+                            "required": [
+                              "kp",
+                              "solarWind",
+                              "xray",
+                              "scales"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.001 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "space.weather",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.001,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/wikidata/entity": {
+      "get": {
+        "tags": [
+          "wikidata"
+        ],
+        "summary": "Fetch a Wikidata entity (Q42, P31, etc.) - structured...",
+        "description": "Fetch a Wikidata entity (Q42, P31, etc.) — structured knowledge-graph record with labels + descriptions + aliases in selectable languages, claims (property → value statements grouped by property ID), sitelinks (Wikipedia article title per language). 110M+ entities. CC0 public domain. Pass languages= as comma-separated codes (default \"en\") to control which language strings are included; pass maxClaimsPerProperty to cap how many statements come back per property (default 10).",
+        "operationId": "wikidata_entity",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = [Wikidata entity record] (labels, descriptions, aliases, claims, sitelinks); total = 1.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              },
+                              "pageId": {
+                                "type": "integer",
+                                "nullable": true
+                              },
+                              "lastModified": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "labels": {
+                                "type": "object",
+                                "additionalProperties": {
+                                  "type": "object",
+                                  "properties": {
+                                    "language": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "language",
+                                    "value"
+                                  ],
+                                  "additionalProperties": false
+                                }
+                              },
+                              "descriptions": {
+                                "type": "object",
+                                "additionalProperties": {
+                                  "type": "object",
+                                  "properties": {
+                                    "language": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "language",
+                                    "value"
+                                  ],
+                                  "additionalProperties": false
+                                }
+                              },
+                              "aliases": {
+                                "type": "object",
+                                "additionalProperties": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "language": {
+                                        "type": "string"
+                                      },
+                                      "value": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "language",
+                                      "value"
+                                    ],
+                                    "additionalProperties": false
+                                  }
+                                }
+                              },
+                              "claimsCount": {
+                                "type": "integer"
+                              },
+                              "claims": {
+                                "type": "object",
+                                "additionalProperties": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "rank": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      },
+                                      "valueType": {
+                                        "type": "string",
+                                        "nullable": true
+                                      },
+                                      "value": {}
+                                    },
+                                    "required": [
+                                      "rank",
+                                      "type",
+                                      "valueType"
+                                    ],
+                                    "additionalProperties": false
+                                  }
+                                }
+                              },
+                              "sitelinksCount": {
+                                "type": "integer"
+                              },
+                              "sitelinks": {
+                                "type": "object",
+                                "additionalProperties": {
+                                  "type": "object",
+                                  "properties": {
+                                    "site": {
+                                      "type": "string"
+                                    },
+                                    "title": {
+                                      "type": "string"
+                                    },
+                                    "url": {
+                                      "type": "string",
+                                      "nullable": true
+                                    }
+                                  },
+                                  "required": [
+                                    "site",
+                                    "title",
+                                    "url"
+                                  ],
+                                  "additionalProperties": false
+                                }
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "type",
+                              "pageId",
+                              "lastModified",
+                              "labels",
+                              "descriptions",
+                              "aliases",
+                              "claimsCount",
+                              "claims",
+                              "sitelinksCount",
+                              "sitelinks"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "wikidata.entity",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "query",
+            "required": true,
+            "description": "Unique identifier of the record to fetch.",
+            "schema": {
+              "type": "string",
+              "pattern": "^[QPLMSqplms]\\d+$"
+            }
+          },
+          {
+            "name": "languages",
+            "in": "query",
+            "required": false,
+            "description": "Languages.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 100,
+              "default": "en"
+            }
+          },
+          {
+            "name": "includeClaims",
+            "in": "query",
+            "required": false,
+            "description": "Include claims.",
+            "schema": {
+              "type": "boolean",
+              "default": true
+            }
+          },
+          {
+            "name": "maxClaimsPerProperty",
+            "in": "query",
+            "required": false,
+            "description": "Max claims per property.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 50,
+              "default": 10
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/wikipedia/summary": {
+      "get": {
+        "tags": [
+          "wikipedia"
+        ],
+        "summary": "Fetch a Wikipedia article summary in any of 30 supported...",
+        "description": "Fetch a Wikipedia article summary in any of 30 supported languages. Returns title, displayTitle, lang, pageId, description, extract (plain text), extractHtml, lead image, canonical URLs, last-modified timestamp, word count, license, and an attribution string. Backed by https://<lang>.wikipedia.org/api/rest_v1/page/summary. Content is CC BY-SA 4.0 with attribution provided.",
+        "operationId": "wikipedia_summary",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = [Wikipedia article summary] (title, extract, extractHtml, leadImage, lastModified, wordCount, attribution); total = 1.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.001 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "wikipedia.summary",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.001,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "title",
+            "in": "query",
+            "required": true,
+            "description": "Title to search for.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 300
+            }
+          },
+          {
+            "name": "lang",
+            "in": "query",
+            "required": false,
+            "description": "Two-letter ISO language code.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "en",
+                "es",
+                "fr",
+                "de",
+                "it",
+                "pt",
+                "ru",
+                "ja",
+                "zh",
+                "ko",
+                "ar",
+                "nl",
+                "pl",
+                "tr",
+                "sv",
+                "cs",
+                "fi",
+                "da",
+                "no",
+                "el",
+                "he",
+                "hi",
+                "th",
+                "vi",
+                "uk",
+                "id",
+                "ms",
+                "ro",
+                "hu",
+                "simple"
+              ],
+              "default": "en"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/word/define": {
+      "get": {
+        "tags": [
+          "word"
+        ],
+        "summary": "Look up an English dictionary definition",
+        "description": "English dictionary lookup via dictionaryapi.dev (Wiktionary-sourced). Returns full entries with IPA phonetic transcription(s), audio pronunciation URLs, and meanings grouped by part of speech. Each meaning carries definitions with usage examples and per-definition synonyms + antonyms. CC BY-SA 3.0/4.0 — attribute when redistributing. Useful for vocabulary agents, writing assistants, language-learning tools.",
+        "operationId": "word_define",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = dictionary entries for the word (phonetics, meanings by part of speech, per-definition synonyms/antonyms); total = number of entries.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "word": {
+                                "type": "string"
+                              },
+                              "phonetic": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "phonetics": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "text": {
+                                      "type": "string",
+                                      "nullable": true
+                                    },
+                                    "audio": {
+                                      "type": "string",
+                                      "nullable": true
+                                    },
+                                    "sourceUrl": {
+                                      "type": "string",
+                                      "nullable": true
+                                    }
+                                  },
+                                  "required": [
+                                    "text",
+                                    "audio",
+                                    "sourceUrl"
+                                  ],
+                                  "additionalProperties": false
+                                }
+                              },
+                              "meanings": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "partOfSpeech": {
+                                      "type": "string"
+                                    },
+                                    "definitions": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "properties": {
+                                          "definition": {
+                                            "type": "string"
+                                          },
+                                          "example": {
+                                            "type": "string",
+                                            "nullable": true
+                                          },
+                                          "synonyms": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "antonyms": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "string"
+                                            }
+                                          }
+                                        },
+                                        "required": [
+                                          "definition",
+                                          "example",
+                                          "synonyms",
+                                          "antonyms"
+                                        ],
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "synonyms": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "antonyms": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "required": [
+                                    "partOfSpeech",
+                                    "definitions",
+                                    "synonyms",
+                                    "antonyms"
+                                  ],
+                                  "additionalProperties": false
+                                }
+                              },
+                              "sourceUrls": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "license": {
+                                "type": "object",
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "url": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name",
+                                  "url"
+                                ],
+                                "additionalProperties": false,
+                                "nullable": true
+                              }
+                            },
+                            "required": [
+                              "word",
+                              "phonetic",
+                              "phonetics",
+                              "meanings",
+                              "sourceUrls",
+                              "license"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "word.define",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "word",
+            "in": "query",
+            "required": true,
+            "description": "Word.",
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-zA-Z][a-zA-Z'.-]{0,49}$"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/word/related": {
+      "get": {
+        "tags": [
+          "word"
+        ],
+        "summary": "Look up related words via Datamuse",
+        "description": "Related-word lookup via Datamuse. Supply a seed word and a relation kind: rhymes, near-rhymes, synonyms, antonyms, means (semantic match), triggers (associated by usage), homophones, sounds-like (phonetic neighbour), spelled-like (typo / wildcard), follows-from (words that come after), preceded-by (words that come before). Returns ranked candidates with relevance score, syllable count, and grammatical tags. Useful for content generation, rhyme/poetry, vocabulary expansion, and naming agents.",
+        "operationId": "word_related",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = ranked related words (word, score, syllables, tags); total = null (Datamuse caps candidates without a true count); meta echoes seed word + relation + fetched count.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "word": {
+                                "type": "string"
+                              },
+                              "score": {
+                                "type": "number"
+                              },
+                              "numSyllables": {
+                                "type": "integer",
+                                "nullable": true
+                              },
+                              "tags": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "required": [
+                              "word",
+                              "score",
+                              "numSyllables",
+                              "tags"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "word": {
+                              "type": "string"
+                            },
+                            "relation": {
+                              "type": "string"
+                            },
+                            "fetched": {
+                              "type": "integer"
+                            }
+                          },
+                          "required": [
+                            "word",
+                            "relation",
+                            "fetched"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "word.related",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "word",
+            "in": "query",
+            "required": true,
+            "description": "Word.",
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-zA-Z][a-zA-Z'.-]{0,49}$"
+            }
+          },
+          {
+            "name": "relation",
+            "in": "query",
+            "required": true,
+            "description": "Relation.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "rhymes",
+                "near-rhymes",
+                "synonyms",
+                "antonyms",
+                "means",
+                "triggers",
+                "homophones",
+                "sounds-like",
+                "spelled-like",
+                "follows-from",
+                "preceded-by"
+              ]
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of results to return.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 25
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/providers/2s/security/PAY.md
+++ b/providers/2s/security/PAY.md
@@ -1,0 +1,17 @@
+---
+name: security
+title: "2s Security"
+description: "Security data: look up a CVE across NVD, the CISA Known Exploited Vulnerabilities catalog, and FIRST.org EPSS exploit-probability scores in a single call for vulnerability triage."
+use_case: "Use for vulnerability triage: resolve a CVE id to its CVSS score, CISA KEV exploited status, and EPSS exploit probability."
+category: security
+service_url: https://2s.io
+openapi:
+  path: openapi.json
+---
+
+Part of 2s — a unified, agent-native JSON API. Pay per call in USDC on Solana (or Base) via x402; no accounts, no API keys. Add `?trial=1` (or header `X-2s-Trial: 1`) for one free real call per endpoint per hour.
+
+## Spend-aware usage
+
+- Prefer narrow lookups (by id/code) over broad searches; reuse identifiers across calls.
+- Cap result `limit` to the smallest count that answers the task.

--- a/providers/2s/security/openapi.json
+++ b/providers/2s/security/openapi.json
@@ -1,0 +1,300 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "2s",
+    "version": "1",
+    "description": "Unified JSON REST API for AI agents — an ever-expanding catalog of endpoints, pay per call in USDC on Base or Solana via x402, no accounts, no API keys. Fund a wallet on either chain with USDC, hit any endpoint, and your client signs an EIP-3009 authorization (Base) or a partial SPL transfer (Solana) to settle the call. Try before you buy: add ?trial=1 (or header X-2s-Trial: 1) to any endpoint for one free real call per endpoint per hour — no wallet needed — to verify it works before paying. 2s is an open-ended experiment in maximally-comprehensive agent infrastructure — new endpoints land regularly.",
+    "contact": {
+      "name": "2s",
+      "url": "https://2s.io",
+      "email": "alley@2s.io"
+    }
+  },
+  "servers": [
+    {
+      "url": "https://2s.io"
+    }
+  ],
+  "components": {
+    "parameters": {
+      "TrialMode": {
+        "name": "trial",
+        "in": "query",
+        "required": false,
+        "description": "Try before you buy. Set to 1 for one free real call per endpoint per hour — no wallet or payment needed — to verify the endpoint before paying. Equivalent to sending the \"X-2s-Trial: 1\" request header. Works on every endpoint.",
+        "schema": {
+          "type": "integer",
+          "enum": [
+            1
+          ]
+        }
+      }
+    },
+    "securitySchemes": {
+      "x402Payment": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "PAYMENT-SIGNATURE",
+        "description": "x402 protocol v2: base64-encoded PaymentPayload. Call any paid endpoint without auth to receive a 402 with a multi-network PaymentRequirements envelope. Sign for either rail: EIP-3009 transferWithAuthorization (Base USDC) OR a partial SPL token transfer (Solana USDC). Retry with PAYMENT-SIGNATURE header. X-PAYMENT is also accepted for v1 buyer clients. See https://x402.org."
+      }
+    },
+    "schemas": {
+      "X402PaymentRequiredV2": {
+        "type": "object",
+        "description": "x402 v2 PaymentRequired envelope. Pick any entry from accepts[], sign for that rail, retry with the PAYMENT-SIGNATURE header.",
+        "required": [
+          "x402Version",
+          "accepts"
+        ],
+        "properties": {
+          "x402Version": {
+            "type": "integer",
+            "const": 2
+          },
+          "error": {
+            "type": "string",
+            "description": "Human-readable reason payment is required."
+          },
+          "resource": {
+            "type": "string",
+            "description": "The resource URL being purchased."
+          },
+          "accepts": {
+            "type": "array",
+            "description": "Payment requirement options, one per supported network (Base USDC, Solana USDC).",
+            "items": {
+              "type": "object",
+              "required": [
+                "scheme",
+                "network",
+                "amount",
+                "asset",
+                "payTo",
+                "maxTimeoutSeconds"
+              ],
+              "properties": {
+                "scheme": {
+                  "type": "string",
+                  "enum": [
+                    "exact"
+                  ]
+                },
+                "network": {
+                  "type": "string",
+                  "description": "CAIP-2 network id, e.g. \"eip155:8453\" (Base) or \"solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp\"."
+                },
+                "amount": {
+                  "type": "string",
+                  "description": "Price in atomic asset units (USDC has 6 decimals)."
+                },
+                "asset": {
+                  "type": "string",
+                  "description": "Asset contract address / mint."
+                },
+                "payTo": {
+                  "type": "string",
+                  "description": "Treasury address to pay."
+                },
+                "maxTimeoutSeconds": {
+                  "type": "integer"
+                },
+                "extra": {
+                  "type": "object",
+                  "description": "Rail-specific extras (EVM: EIP-712 domain name/version; Solana: feePayer).",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "extensions": {
+            "type": "object",
+            "description": "Optional discovery metadata (e.g. bazaar input/output schemas).",
+            "additionalProperties": true
+          }
+        }
+      }
+    }
+  },
+  "paths": {
+    "/api/security/cve": {
+      "get": {
+        "tags": [
+          "security"
+        ],
+        "summary": "Look up a CVE by id (e.g.",
+        "description": "Look up a CVE by id (e.g. CVE-2021-44228) across three authoritative vulnerability feeds in one call. Query: cve (CVE-YYYY-NNNN). Returns the canonical record — description, CVSS base score + severity + vector, CWE weakness ids, published/modified dates, reference links — plus whether it is on the US CISA Known Exploited Vulnerabilities catalog (with remediation due date and known-ransomware flag) and its EPSS exploit-probability score and percentile. The exploited and EPSS sections report independently, so one feed being unavailable does not fail the call. 404 if the CVE id is unknown. For triage, prioritization, and anti-hallucination on vulnerability claims.",
+        "operationId": "security_cve",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "cve": {
+                          "type": "string"
+                        },
+                        "published": {
+                          "type": "string",
+                          "nullable": true
+                        },
+                        "lastModified": {
+                          "type": "string",
+                          "nullable": true
+                        },
+                        "vulnStatus": {
+                          "type": "string",
+                          "nullable": true
+                        },
+                        "description": {
+                          "type": "string",
+                          "nullable": true
+                        },
+                        "cvss": {
+                          "type": "object",
+                          "additionalProperties": {},
+                          "nullable": true
+                        },
+                        "cwes": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "references": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
+                        },
+                        "knownExploited": {
+                          "type": "object",
+                          "additionalProperties": {}
+                        },
+                        "knownExploitedError": {
+                          "type": "string",
+                          "nullable": true
+                        },
+                        "epss": {
+                          "type": "object",
+                          "additionalProperties": {},
+                          "nullable": true
+                        },
+                        "epssError": {
+                          "type": "string",
+                          "nullable": true
+                        },
+                        "sources": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
+                        }
+                      },
+                      "required": [
+                        "cve",
+                        "published",
+                        "lastModified",
+                        "vulnStatus",
+                        "description",
+                        "cvss",
+                        "cwes",
+                        "references",
+                        "knownExploited",
+                        "knownExploitedError",
+                        "epss",
+                        "epssError",
+                        "sources"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0018 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "security.cve",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0018,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "legacy",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001800"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "cve",
+            "in": "query",
+            "required": true,
+            "description": "CVE identifier in the form CVE-YYYY-NNNN (e.g. CVE-2021-44228).",
+            "schema": {
+              "type": "string",
+              "minLength": 6,
+              "maxLength": 40
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/providers/2s/trade/PAY.md
+++ b/providers/2s/trade/PAY.md
@@ -1,0 +1,17 @@
+---
+name: trade
+title: "2s Trade"
+description: "Trade and B2B document data: Harmonized Tariff Schedule (HTS) duty lookups, UN/LOCODE port and location codes, and ANSI X12 EDI parsing plus 997 functional-acknowledgment generation."
+use_case: "Use for tariff/HTS duty rates, UN/LOCODE port codes, and parsing or acknowledging EDI X12 documents (850, 810, 856, 997)."
+category: data
+service_url: https://2s.io
+openapi:
+  path: openapi.json
+---
+
+Part of 2s — a unified, agent-native JSON API. Pay per call in USDC on Solana (or Base) via x402; no accounts, no API keys. Add `?trial=1` (or header `X-2s-Trial: 1`) for one free real call per endpoint per hour.
+
+## Spend-aware usage
+
+- Prefer narrow lookups (by id/code) over broad searches; reuse identifiers across calls.
+- Cap result `limit` to the smallest count that answers the task.

--- a/providers/2s/trade/openapi.json
+++ b/providers/2s/trade/openapi.json
@@ -1,0 +1,1292 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "2s",
+    "version": "1",
+    "description": "Unified JSON REST API for AI agents — an ever-expanding catalog of endpoints, pay per call in USDC on Base or Solana via x402, no accounts, no API keys. Fund a wallet on either chain with USDC, hit any endpoint, and your client signs an EIP-3009 authorization (Base) or a partial SPL transfer (Solana) to settle the call. Try before you buy: add ?trial=1 (or header X-2s-Trial: 1) to any endpoint for one free real call per endpoint per hour — no wallet needed — to verify it works before paying. 2s is an open-ended experiment in maximally-comprehensive agent infrastructure — new endpoints land regularly.",
+    "contact": {
+      "name": "2s",
+      "url": "https://2s.io",
+      "email": "alley@2s.io"
+    }
+  },
+  "servers": [
+    {
+      "url": "https://2s.io"
+    }
+  ],
+  "components": {
+    "parameters": {
+      "TrialMode": {
+        "name": "trial",
+        "in": "query",
+        "required": false,
+        "description": "Try before you buy. Set to 1 for one free real call per endpoint per hour — no wallet or payment needed — to verify the endpoint before paying. Equivalent to sending the \"X-2s-Trial: 1\" request header. Works on every endpoint.",
+        "schema": {
+          "type": "integer",
+          "enum": [
+            1
+          ]
+        }
+      }
+    },
+    "securitySchemes": {
+      "x402Payment": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "PAYMENT-SIGNATURE",
+        "description": "x402 protocol v2: base64-encoded PaymentPayload. Call any paid endpoint without auth to receive a 402 with a multi-network PaymentRequirements envelope. Sign for either rail: EIP-3009 transferWithAuthorization (Base USDC) OR a partial SPL token transfer (Solana USDC). Retry with PAYMENT-SIGNATURE header. X-PAYMENT is also accepted for v1 buyer clients. See https://x402.org."
+      }
+    },
+    "schemas": {
+      "X402PaymentRequiredV2": {
+        "type": "object",
+        "description": "x402 v2 PaymentRequired envelope. Pick any entry from accepts[], sign for that rail, retry with the PAYMENT-SIGNATURE header.",
+        "required": [
+          "x402Version",
+          "accepts"
+        ],
+        "properties": {
+          "x402Version": {
+            "type": "integer",
+            "const": 2
+          },
+          "error": {
+            "type": "string",
+            "description": "Human-readable reason payment is required."
+          },
+          "resource": {
+            "type": "string",
+            "description": "The resource URL being purchased."
+          },
+          "accepts": {
+            "type": "array",
+            "description": "Payment requirement options, one per supported network (Base USDC, Solana USDC).",
+            "items": {
+              "type": "object",
+              "required": [
+                "scheme",
+                "network",
+                "amount",
+                "asset",
+                "payTo",
+                "maxTimeoutSeconds"
+              ],
+              "properties": {
+                "scheme": {
+                  "type": "string",
+                  "enum": [
+                    "exact"
+                  ]
+                },
+                "network": {
+                  "type": "string",
+                  "description": "CAIP-2 network id, e.g. \"eip155:8453\" (Base) or \"solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp\"."
+                },
+                "amount": {
+                  "type": "string",
+                  "description": "Price in atomic asset units (USDC has 6 decimals)."
+                },
+                "asset": {
+                  "type": "string",
+                  "description": "Asset contract address / mint."
+                },
+                "payTo": {
+                  "type": "string",
+                  "description": "Treasury address to pay."
+                },
+                "maxTimeoutSeconds": {
+                  "type": "integer"
+                },
+                "extra": {
+                  "type": "object",
+                  "description": "Rail-specific extras (EVM: EIP-712 domain name/version; Solana: feePayer).",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "extensions": {
+            "type": "object",
+            "description": "Optional discovery metadata (e.g. bazaar input/output schemas).",
+            "additionalProperties": true
+          }
+        }
+      }
+    }
+  },
+  "paths": {
+    "/api/edi/ack": {
+      "post": {
+        "tags": [
+          "edi"
+        ],
+        "summary": "Generate the ANSI ASC X12 997 Functional Acknowledgment for...",
+        "description": "Generate the ANSI ASC X12 997 Functional Acknowledgment for a received EDI interchange. POST { edi } with the raw inbound interchange text (the 850/810/856/etc. you received); returns the ready-to-send 997 in meta.ack — sender/receiver mirrored back, delimiters echoed, one ST(997) per inbound functional group with correct AK1 (functional id + group control number), AK2/AK5 per transaction set, and AK9 with accurate included/received/accepted counts. Set status to control the response: A=Accepted (default), E=Accepted with errors, P=Partially accepted, R=Rejected, M/W/X=authentication/security rejection. Deterministic, no external calls. This is the reply leg of EDI: every transaction set you receive is supposed to be acknowledged, and assembling a valid 997 (especially the AK9 counts) is exactly the fiddly envelope bookkeeping agents shouldn't hand-roll.",
+        "operationId": "edi_ack",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: meta.ack = the generated 997 text; items = per functional group acknowledged (status + AK9 counts + per-transaction-set response).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "acknowledgedFunctionalGroup": {
+                                "type": "string"
+                              },
+                              "acknowledgedGroupControlNumber": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "status": {
+                                "type": "string"
+                              },
+                              "transactionSetsIncluded": {
+                                "type": "integer"
+                              },
+                              "transactionSetsReceived": {
+                                "type": "integer"
+                              },
+                              "transactionSetsAccepted": {
+                                "type": "integer"
+                              },
+                              "transactionSets": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string"
+                                    },
+                                    "controlNumber": {
+                                      "type": "string",
+                                      "nullable": true
+                                    },
+                                    "response": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "type",
+                                    "controlNumber",
+                                    "response"
+                                  ],
+                                  "additionalProperties": false
+                                }
+                              }
+                            },
+                            "required": [
+                              "acknowledgedFunctionalGroup",
+                              "acknowledgedGroupControlNumber",
+                              "status",
+                              "transactionSetsIncluded",
+                              "transactionSetsReceived",
+                              "transactionSetsAccepted",
+                              "transactionSets"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "ack": {
+                              "type": "string",
+                              "description": "The ready-to-send 997 interchange text."
+                            },
+                            "controlNumber": {
+                              "type": "string"
+                            },
+                            "acknowledges": {
+                              "type": "object",
+                              "properties": {
+                                "senderId": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "receiverId": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "interchangeControlNumber": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "functionalGroupCount": {
+                                  "type": "integer"
+                                },
+                                "transactionSetCount": {
+                                  "type": "integer"
+                                }
+                              },
+                              "required": [
+                                "senderId",
+                                "receiverId",
+                                "interchangeControlNumber",
+                                "functionalGroupCount",
+                                "transactionSetCount"
+                              ],
+                              "additionalProperties": false
+                            },
+                            "delimiters": {
+                              "type": "object",
+                              "properties": {
+                                "element": {
+                                  "type": "string"
+                                },
+                                "component": {
+                                  "type": "string"
+                                },
+                                "segment": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "element",
+                                "component",
+                                "segment"
+                              ],
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "ack",
+                            "controlNumber",
+                            "acknowledges",
+                            "delimiters"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0018 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "edi.ack",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0018,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001800"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "edi": {
+                    "type": "string",
+                    "minLength": 106,
+                    "maxLength": 500000,
+                    "description": "Edi."
+                  },
+                  "status": {
+                    "type": "string",
+                    "enum": [
+                      "A",
+                      "E",
+                      "P",
+                      "R",
+                      "M",
+                      "W",
+                      "X"
+                    ],
+                    "description": "Filter results by status."
+                  },
+                  "controlNumber": {
+                    "type": "string",
+                    "maxLength": 15,
+                    "description": "Control number."
+                  }
+                },
+                "required": [
+                  "edi"
+                ],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/edi/parse": {
+      "post": {
+        "tags": [
+          "edi"
+        ],
+        "summary": "Parse a raw ANSI ASC X12 EDI document (the format used for...",
+        "description": "Parse a raw ANSI ASC X12 EDI document (the format used for B2B purchase orders, invoices, ship notices, etc.) into clean, structured JSON. POST { edi } with the raw interchange text. Auto-detects the delimiters from the ISA envelope, then returns the interchange metadata (sender/receiver/date/control number/test-or-production), each functional group, and each transaction set with its type decoded (e.g. 850 = Purchase Order, 810 = Invoice, 856 = Ship Notice/ASN, 855 = PO Acknowledgment, 997 = Functional Acknowledgment), every segment named (BEG, N1, PO1, …), and a semantic summary — for a PO that's the PO number, dates, parties (ship-to/vendor with address), and line items (qty/uom/price/product id); for an invoice the invoice + PO numbers and total; for an ASN the shipment id and carrier; for a 997 the acknowledged group + status. Deterministic, no external calls. Turns opaque EDI into something an agent can actually use without hand-rolling an X12 parser.",
+        "operationId": "edi_parse",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = transaction sets (each decoded + summarized); meta = interchange envelope + detected delimiters + counts.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "functionalCode": {
+                                "type": "string"
+                              },
+                              "functionalName": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              },
+                              "typeName": {
+                                "type": "string"
+                              },
+                              "controlNumber": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "segmentCount": {
+                                "type": "integer"
+                              },
+                              "summary": {
+                                "type": "object",
+                                "additionalProperties": {},
+                                "description": "Type-specific semantic summary (PO number, parties, line items, totals, etc.)."
+                              },
+                              "segments": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "tag": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "elements": {
+                                      "type": "array",
+                                      "items": {
+                                        "anyOf": [
+                                          {
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "string"
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  "required": [
+                                    "tag",
+                                    "name",
+                                    "elements"
+                                  ],
+                                  "additionalProperties": false
+                                }
+                              }
+                            },
+                            "required": [
+                              "functionalCode",
+                              "functionalName",
+                              "type",
+                              "typeName",
+                              "controlNumber",
+                              "segmentCount",
+                              "summary",
+                              "segments"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "interchange": {
+                              "type": "object",
+                              "additionalProperties": {}
+                            },
+                            "delimiters": {
+                              "type": "object",
+                              "properties": {
+                                "element": {
+                                  "type": "string"
+                                },
+                                "component": {
+                                  "type": "string"
+                                },
+                                "segment": {
+                                  "type": "string"
+                                },
+                                "repetition": {
+                                  "type": "string",
+                                  "nullable": true
+                                }
+                              },
+                              "required": [
+                                "element",
+                                "component",
+                                "segment",
+                                "repetition"
+                              ],
+                              "additionalProperties": false
+                            },
+                            "functionalGroupCount": {
+                              "type": "integer"
+                            },
+                            "transactionSetCount": {
+                              "type": "integer"
+                            },
+                            "segmentCount": {
+                              "type": "integer"
+                            }
+                          },
+                          "required": [
+                            "interchange",
+                            "delimiters",
+                            "functionalGroupCount",
+                            "transactionSetCount",
+                            "segmentCount"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0018 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "edi.parse",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0018,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001800"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "edi": {
+                    "type": "string",
+                    "minLength": 106,
+                    "maxLength": 500000,
+                    "description": "Edi."
+                  }
+                },
+                "required": [
+                  "edi"
+                ],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/trade/locode": {
+      "get": {
+        "tags": [
+          "trade"
+        ],
+        "summary": "Look up or search UN/LOCODE - the United Nations Code for...",
+        "description": "Look up or search UN/LOCODE — the United Nations Code for Trade and Transport Locations (~116k locations, all countries). Pass `locode` for an exact code (e.g. USNYC or 'US NYC'). Or pass `query` to search location names, optionally filtered by `country` (ISO 3166 alpha-2) and `function` (port, rail, road, airport, postal, multimodal, fixed, border). Each result: locode, name, country, subdivision, transport functions, entry status, IATA code where it differs, and coordinates. UN/LOCODE is the standard location identifier in shipping schedules, EDI messages, and customs documents.",
+        "operationId": "trade_locode",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = UN/LOCODE entries (single exact match, or ranked name-search results); total = match count.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "locode": {
+                                "type": "string",
+                                "description": "5-character UN/LOCODE (country + location)."
+                              },
+                              "country": {
+                                "type": "string",
+                                "description": "ISO 3166 alpha-2 country code."
+                              },
+                              "location": {
+                                "type": "string",
+                                "description": "3-character location part of the code."
+                              },
+                              "name": {
+                                "type": "string",
+                                "description": "Place name (with diacritics)."
+                              },
+                              "nameAscii": {
+                                "type": "string",
+                                "description": "Place name without diacritics."
+                              },
+                              "subdivision": {
+                                "type": "object",
+                                "properties": {
+                                  "code": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string",
+                                    "nullable": true
+                                  }
+                                },
+                                "required": [
+                                  "code",
+                                  "name"
+                                ],
+                                "additionalProperties": false,
+                                "nullable": true,
+                                "description": "ISO 3166-2 subdivision (state/province), when assigned."
+                              },
+                              "functions": {
+                                "type": "object",
+                                "properties": {
+                                  "raw": {
+                                    "type": "string",
+                                    "description": "Raw 8-position UN/LOCODE function classifier."
+                                  },
+                                  "list": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "description": "Decoded transport functions (port, rail terminal, airport, …)."
+                                  }
+                                },
+                                "required": [
+                                  "raw",
+                                  "list"
+                                ],
+                                "additionalProperties": false
+                              },
+                              "status": {
+                                "type": "object",
+                                "properties": {
+                                  "code": {
+                                    "type": "string"
+                                  },
+                                  "meaning": {
+                                    "type": "string",
+                                    "nullable": true
+                                  }
+                                },
+                                "required": [
+                                  "code",
+                                  "meaning"
+                                ],
+                                "additionalProperties": false,
+                                "nullable": true,
+                                "description": "Entry status code + meaning (e.g. AA = approved by national agency)."
+                              },
+                              "iata": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "IATA code, only when it differs from the location part."
+                              },
+                              "coordinates": {
+                                "type": "object",
+                                "properties": {
+                                  "lat": {
+                                    "type": "number"
+                                  },
+                                  "lon": {
+                                    "type": "number"
+                                  }
+                                },
+                                "required": [
+                                  "lat",
+                                  "lon"
+                                ],
+                                "additionalProperties": false,
+                                "nullable": true
+                              },
+                              "updated": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "Last-change marker from the source list (YYMM)."
+                              }
+                            },
+                            "required": [
+                              "locode",
+                              "country",
+                              "location",
+                              "name",
+                              "nameAscii",
+                              "subdivision",
+                              "functions",
+                              "status",
+                              "iata",
+                              "coordinates",
+                              "updated"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "page": {
+                          "type": "object",
+                          "properties": {
+                            "number": {
+                              "type": "integer"
+                            },
+                            "size": {
+                              "type": "integer"
+                            },
+                            "pages": {
+                              "type": "integer",
+                              "nullable": true
+                            }
+                          },
+                          "required": [
+                            "number",
+                            "size",
+                            "pages"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.001 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "trade.locode",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.001,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "locode",
+            "in": "query",
+            "required": false,
+            "description": "Exact UN/LOCODE to look up (e.g. USNYC or 'US NYC'). Pass this OR query.",
+            "schema": {
+              "type": "string",
+              "pattern": "^[A-Za-z]{2}[\\s-]?[A-Za-z0-9]{3}$"
+            }
+          },
+          {
+            "name": "query",
+            "in": "query",
+            "required": false,
+            "description": "Location name to search (e.g. Rotterdam). Pass this OR locode.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 120
+            }
+          },
+          {
+            "name": "country",
+            "in": "query",
+            "required": false,
+            "description": "Restrict query-mode results to one country (ISO 3166 alpha-2, e.g. NL).",
+            "schema": {
+              "type": "string",
+              "pattern": "^[A-Za-z]{2}$"
+            }
+          },
+          {
+            "name": "function",
+            "in": "query",
+            "required": false,
+            "description": "Restrict query-mode results to locations with this transport function.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "port",
+                "rail",
+                "road",
+                "airport",
+                "postal",
+                "multimodal",
+                "fixed",
+                "border"
+              ]
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Max query-mode results, 1–50 (default 10).",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 50
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/trade/tariff": {
+      "get": {
+        "tags": [
+          "trade"
+        ],
+        "summary": "Look up or search the US Harmonized Tariff Schedule (HTS /...",
+        "description": "Look up or search the US Harmonized Tariff Schedule (HTS / HS codes). Pass `code` for an exact HTS number (dots optional) — returns that line plus its 10-digit statistical suffixes with duty rates. Or pass `query` for free-text search (e.g. 'electric toothbrush', 'roasted coffee') → ranked candidate HS codes by hierarchical heading. Each result: htsno, chapter, description, full heading path, units, and duty rates (general/MFN, special/FTA, column-2). ~29.6k lines, public-domain USITC data. The deterministic backbone for tariff classification in import/export and ERP item setup.",
+        "operationId": "trade_tariff",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = HTS lines (exact match + suffixes, or ranked search candidates); total = match count.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "htsno": {
+                                "type": "string"
+                              },
+                              "chapter": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "description": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "heading": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "Full hierarchical heading path (ancestors > leaf)."
+                              },
+                              "units": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "nullable": true
+                              },
+                              "duty": {
+                                "type": "object",
+                                "properties": {
+                                  "general": {
+                                    "type": "string",
+                                    "nullable": true,
+                                    "description": "General (MFN) duty rate."
+                                  },
+                                  "special": {
+                                    "type": "string",
+                                    "nullable": true,
+                                    "description": "Special (FTA / preference) rate."
+                                  },
+                                  "other": {
+                                    "type": "string",
+                                    "nullable": true,
+                                    "description": "Column 2 rate."
+                                  }
+                                },
+                                "required": [
+                                  "general",
+                                  "special",
+                                  "other"
+                                ],
+                                "additionalProperties": false
+                              }
+                            },
+                            "required": [
+                              "htsno",
+                              "chapter",
+                              "description",
+                              "heading",
+                              "units",
+                              "duty"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "page": {
+                          "type": "object",
+                          "properties": {
+                            "number": {
+                              "type": "integer"
+                            },
+                            "size": {
+                              "type": "integer"
+                            },
+                            "pages": {
+                              "type": "integer",
+                              "nullable": true
+                            }
+                          },
+                          "required": [
+                            "number",
+                            "size",
+                            "pages"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0018 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "trade.tariff",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0018,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001800"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "code",
+            "in": "query",
+            "required": false,
+            "description": "Code to look up.",
+            "schema": {
+              "type": "string",
+              "pattern": "^[0-9.\\s]{4,14}$"
+            }
+          },
+          {
+            "name": "query",
+            "in": "query",
+            "required": false,
+            "description": "Free-text search query.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 120
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of results to return.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 50
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/providers/2s/vehicle/PAY.md
+++ b/providers/2s/vehicle/PAY.md
@@ -1,0 +1,17 @@
+---
+name: vehicle
+title: "2s Vehicle"
+description: "Vehicle and aviation data: NHTSA VIN decode, recalls, complaints and investigations; aircraft registration lookups, airport directory, METAR/TAF aviation weather, and flight status."
+use_case: "Use for decoding a VIN, checking vehicle recalls, looking up aircraft or airports, and fetching aviation weather or flight status."
+category: data
+service_url: https://2s.io
+openapi:
+  path: openapi.json
+---
+
+Part of 2s — a unified, agent-native JSON API. Pay per call in USDC on Solana (or Base) via x402; no accounts, no API keys. Add `?trial=1` (or header `X-2s-Trial: 1`) for one free real call per endpoint per hour.
+
+## Spend-aware usage
+
+- Prefer narrow lookups (by id/code) over broad searches; reuse identifiers across calls.
+- Cap result `limit` to the smallest count that answers the task.

--- a/providers/2s/vehicle/openapi.json
+++ b/providers/2s/vehicle/openapi.json
@@ -1,0 +1,3812 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "2s",
+    "version": "1",
+    "description": "Unified JSON REST API for AI agents — an ever-expanding catalog of endpoints, pay per call in USDC on Base or Solana via x402, no accounts, no API keys. Fund a wallet on either chain with USDC, hit any endpoint, and your client signs an EIP-3009 authorization (Base) or a partial SPL transfer (Solana) to settle the call. Try before you buy: add ?trial=1 (or header X-2s-Trial: 1) to any endpoint for one free real call per endpoint per hour — no wallet needed — to verify it works before paying. 2s is an open-ended experiment in maximally-comprehensive agent infrastructure — new endpoints land regularly.",
+    "contact": {
+      "name": "2s",
+      "url": "https://2s.io",
+      "email": "alley@2s.io"
+    }
+  },
+  "servers": [
+    {
+      "url": "https://2s.io"
+    }
+  ],
+  "components": {
+    "parameters": {
+      "TrialMode": {
+        "name": "trial",
+        "in": "query",
+        "required": false,
+        "description": "Try before you buy. Set to 1 for one free real call per endpoint per hour — no wallet or payment needed — to verify the endpoint before paying. Equivalent to sending the \"X-2s-Trial: 1\" request header. Works on every endpoint.",
+        "schema": {
+          "type": "integer",
+          "enum": [
+            1
+          ]
+        }
+      }
+    },
+    "securitySchemes": {
+      "x402Payment": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "PAYMENT-SIGNATURE",
+        "description": "x402 protocol v2: base64-encoded PaymentPayload. Call any paid endpoint without auth to receive a 402 with a multi-network PaymentRequirements envelope. Sign for either rail: EIP-3009 transferWithAuthorization (Base USDC) OR a partial SPL token transfer (Solana USDC). Retry with PAYMENT-SIGNATURE header. X-PAYMENT is also accepted for v1 buyer clients. See https://x402.org."
+      }
+    },
+    "schemas": {
+      "X402PaymentRequiredV2": {
+        "type": "object",
+        "description": "x402 v2 PaymentRequired envelope. Pick any entry from accepts[], sign for that rail, retry with the PAYMENT-SIGNATURE header.",
+        "required": [
+          "x402Version",
+          "accepts"
+        ],
+        "properties": {
+          "x402Version": {
+            "type": "integer",
+            "const": 2
+          },
+          "error": {
+            "type": "string",
+            "description": "Human-readable reason payment is required."
+          },
+          "resource": {
+            "type": "string",
+            "description": "The resource URL being purchased."
+          },
+          "accepts": {
+            "type": "array",
+            "description": "Payment requirement options, one per supported network (Base USDC, Solana USDC).",
+            "items": {
+              "type": "object",
+              "required": [
+                "scheme",
+                "network",
+                "amount",
+                "asset",
+                "payTo",
+                "maxTimeoutSeconds"
+              ],
+              "properties": {
+                "scheme": {
+                  "type": "string",
+                  "enum": [
+                    "exact"
+                  ]
+                },
+                "network": {
+                  "type": "string",
+                  "description": "CAIP-2 network id, e.g. \"eip155:8453\" (Base) or \"solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp\"."
+                },
+                "amount": {
+                  "type": "string",
+                  "description": "Price in atomic asset units (USDC has 6 decimals)."
+                },
+                "asset": {
+                  "type": "string",
+                  "description": "Asset contract address / mint."
+                },
+                "payTo": {
+                  "type": "string",
+                  "description": "Treasury address to pay."
+                },
+                "maxTimeoutSeconds": {
+                  "type": "integer"
+                },
+                "extra": {
+                  "type": "object",
+                  "description": "Rail-specific extras (EVM: EIP-712 domain name/version; Solana: feePayer).",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "extensions": {
+            "type": "object",
+            "description": "Optional discovery metadata (e.g. bazaar input/output schemas).",
+            "additionalProperties": true
+          }
+        }
+      }
+    }
+  },
+  "paths": {
+    "/api/aircraft/lookup": {
+      "get": {
+        "tags": [
+          "aircraft"
+        ],
+        "summary": "Look up a US-registered aircraft by tail number (N-number, e.g.",
+        "description": "Look up a US-registered aircraft by tail number (N-number, e.g. N757F) or icao24 Mode-S hex (e.g. aa3487). Pass exactly one of `tail` or `icao24`. Returns the airframe: registration, manufacturer, model, ICAO type code + class, serial number, operator, owner, build year, engines, category, plus the icao24 Mode-S address that ADS-B transponders broadcast — use it to join live flight-tracking feeds. ~307k US airframes. 404 if no match. Source: OpenSky Network aircraft database (CC-BY-SA).",
+        "operationId": "aircraft_lookup",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = [aircraft] (one airframe matched by tail or icao24); total = 1. 404 if no US airframe matches.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "icao24": {
+                                "type": "string",
+                                "description": "24-bit Mode-S address (lowercase hex) — broadcast by ADS-B."
+                              },
+                              "registration": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "Tail / N-number."
+                              },
+                              "manufacturer": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "model": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "typecode": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "ICAO type designator (e.g. BE36)."
+                              },
+                              "icaoType": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "ICAO aircraft type class (e.g. L1P = land, 1 piston engine)."
+                              },
+                              "serialNumber": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "operator": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "owner": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "built": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "engines": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "category": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "registered": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "regUntil": {
+                                "type": "string",
+                                "nullable": true
+                              }
+                            },
+                            "required": [
+                              "icao24",
+                              "registration",
+                              "manufacturer",
+                              "model",
+                              "typecode",
+                              "icaoType",
+                              "serialNumber",
+                              "operator",
+                              "owner",
+                              "built",
+                              "engines",
+                              "category",
+                              "registered",
+                              "regUntil"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.00144 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "aircraft.lookup",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.00144,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001440"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "tail",
+            "in": "query",
+            "required": false,
+            "description": "Tail.",
+            "schema": {
+              "type": "string",
+              "pattern": "^[Nn][0-9A-Za-z]{1,5}$"
+            }
+          },
+          {
+            "name": "icao24",
+            "in": "query",
+            "required": false,
+            "description": "Icao24.",
+            "schema": {
+              "type": "string",
+              "pattern": "^[0-9a-fA-F]{6}$"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/aircraft/profile": {
+      "get": {
+        "tags": [
+          "aircraft"
+        ],
+        "summary": "Look up a US-registered aircraft by tail (N-number) or...",
+        "description": "Identify a US-registered aircraft by tail (N-number) or icao24 Mode-S hex, AND screen its owner and operator against the OFAC sanctions list — in one call. Returns the full aircraft record (registration, manufacturer, model, type, serial, owner, operator, year built) plus a sanctions screen of the owner and operator names against OFAC SDN, with fuzzy-match confidence and a flagged boolean. OSINT, asset-tracing, sanctions-evasion investigation, due diligence. Composition of /api/aircraft/lookup + /api/law/sanctions-check (the sanctions section reports found/error independently). Note: screening is name-based and probabilistic — review flagged matches manually.",
+        "operationId": "aircraft_profile",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "aircraft": {
+                          "type": "object",
+                          "additionalProperties": {}
+                        },
+                        "ownerScreen": {
+                          "type": "object",
+                          "properties": {
+                            "found": {
+                              "type": "boolean"
+                            },
+                            "error": {
+                              "type": "string",
+                              "nullable": true
+                            },
+                            "flagged": {
+                              "type": "boolean"
+                            },
+                            "matchCount": {
+                              "type": "number"
+                            },
+                            "matches": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "additionalProperties": {}
+                              }
+                            }
+                          },
+                          "required": [
+                            "found",
+                            "error",
+                            "flagged",
+                            "matchCount",
+                            "matches"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "operatorScreen": {
+                          "type": "object",
+                          "properties": {
+                            "found": {
+                              "type": "boolean"
+                            },
+                            "error": {
+                              "type": "string",
+                              "nullable": true
+                            },
+                            "flagged": {
+                              "type": "boolean"
+                            },
+                            "matchCount": {
+                              "type": "number"
+                            },
+                            "matches": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "additionalProperties": {}
+                              }
+                            }
+                          },
+                          "required": [
+                            "found",
+                            "error",
+                            "flagged",
+                            "matchCount",
+                            "matches"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "sources": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
+                        }
+                      },
+                      "required": [
+                        "aircraft",
+                        "ownerScreen",
+                        "operatorScreen",
+                        "sources"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.00432 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "aircraft.profile",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.00432,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "legacy",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.004320"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "tail",
+            "in": "query",
+            "required": false,
+            "description": "Tail.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 10
+            }
+          },
+          {
+            "name": "icao24",
+            "in": "query",
+            "required": false,
+            "description": "Icao24.",
+            "schema": {
+              "type": "string",
+              "pattern": "^[0-9a-fA-F]{6}$"
+            }
+          },
+          {
+            "name": "threshold",
+            "in": "query",
+            "required": false,
+            "description": "Minimum score/threshold required to include a result.",
+            "schema": {
+              "type": "number",
+              "minimum": 0.1,
+              "maximum": 1,
+              "default": 0.5
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/airport/lookup": {
+      "get": {
+        "tags": [
+          "airport"
+        ],
+        "summary": "Look up an airport by 3-letter IATA (e.g.",
+        "description": "Look up an airport by 3-letter IATA (e.g. SFO) or 4-letter ICAO (e.g. KSFO) code. Query: code (3-5 chars, alphanumeric). Returns { airport: { id, ident, type, name, latitude, longitude, elevationFt, continent, isoCountry, isoRegion, municipality, scheduledService, icaoCode, iataCode, gpsCode, localCode, wikipediaLink } } or 404 NOT_FOUND.",
+        "operationId": "airport_lookup",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = [airport] (one OurAirports record); total = 1. 404 if no airport matches the code.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "integer",
+                                "description": "OurAirports stable numeric id."
+                              },
+                              "ident": {
+                                "type": "string",
+                                "description": "Globally unique identifier (usually ICAO)."
+                              },
+                              "type": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "large_airport | medium_airport | small_airport | heliport | seaplane_base | closed."
+                              },
+                              "name": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "latitude": {
+                                "type": "number"
+                              },
+                              "longitude": {
+                                "type": "number"
+                              },
+                              "elevationFt": {
+                                "type": "integer",
+                                "nullable": true
+                              },
+                              "continent": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "isoCountry": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "ISO 3166-1 alpha-2 country code."
+                              },
+                              "isoRegion": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "ISO 3166-2 region code (e.g. US-CA)."
+                              },
+                              "municipality": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "scheduledService": {
+                                "type": "boolean",
+                                "nullable": true
+                              },
+                              "icaoCode": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "iataCode": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "gpsCode": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "localCode": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "wikipediaLink": {
+                                "type": "string",
+                                "nullable": true
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "ident",
+                              "type",
+                              "name",
+                              "latitude",
+                              "longitude",
+                              "elevationFt",
+                              "continent",
+                              "isoCountry",
+                              "isoRegion",
+                              "municipality",
+                              "scheduledService",
+                              "icaoCode",
+                              "iataCode",
+                              "gpsCode",
+                              "localCode",
+                              "wikipediaLink"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.001 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "airport.lookup",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.001,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "code",
+            "in": "query",
+            "required": true,
+            "description": "3-letter IATA or 4-letter ICAO airport code (e.g. SFO, KSFO).",
+            "schema": {
+              "type": "string",
+              "minLength": 3,
+              "maxLength": 5
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/airport/near": {
+      "get": {
+        "tags": [
+          "airport"
+        ],
+        "summary": "Find airports within a radius of a coordinate",
+        "description": "Airports within a radius of a coordinate, sorted by distance. Query: lat (-90..90), lon (-180..180), radius_km (1-2000, default 200), limit (1-100, default 20), type (optional: large_airport|medium_airport|small_airport|heliport|seaplane_base|balloonport|closed), country (optional 2-letter ISO 3166-1), scheduled_service (optional bool, true = commercial-service airports only). Returns { query, count, airports: [{ id, ident, name, iataCode, icaoCode, type, latitude, longitude, distanceKm, ... }] }.",
+        "operationId": "airport_near",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = airports within radius_km, sorted by ascending distance; total = null (no upstream total; query-bounded set); meta.query echoes the search.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "integer"
+                              },
+                              "ident": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "iataCode": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "icaoCode": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "type": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "latitude": {
+                                "type": "number"
+                              },
+                              "longitude": {
+                                "type": "number"
+                              },
+                              "distanceKm": {
+                                "type": "number",
+                                "description": "Great-circle distance to (lat, lon), kilometers."
+                              },
+                              "isoCountry": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "isoRegion": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "municipality": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "scheduledService": {
+                                "type": "boolean",
+                                "nullable": true
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "ident",
+                              "name",
+                              "iataCode",
+                              "icaoCode",
+                              "type",
+                              "latitude",
+                              "longitude",
+                              "distanceKm",
+                              "isoCountry",
+                              "isoRegion",
+                              "municipality",
+                              "scheduledService"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "query": {
+                              "type": "object",
+                              "properties": {
+                                "latitude": {
+                                  "type": "number"
+                                },
+                                "longitude": {
+                                  "type": "number"
+                                },
+                                "radiusKm": {
+                                  "type": "number"
+                                },
+                                "limit": {
+                                  "type": "integer"
+                                },
+                                "type": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "country": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "scheduledServiceOnly": {
+                                  "type": "boolean",
+                                  "nullable": true
+                                }
+                              },
+                              "required": [
+                                "latitude",
+                                "longitude",
+                                "radiusKm",
+                                "limit",
+                                "type",
+                                "country",
+                                "scheduledServiceOnly"
+                              ],
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "query"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.001 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "airport.near",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.001,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "lat",
+            "in": "query",
+            "required": true,
+            "description": "Latitude in decimal degrees (-90 to 90).",
+            "schema": {
+              "type": "number",
+              "minimum": -90,
+              "maximum": 90
+            }
+          },
+          {
+            "name": "lon",
+            "in": "query",
+            "required": true,
+            "description": "Longitude in decimal degrees (-180 to 180).",
+            "schema": {
+              "type": "number",
+              "minimum": -180,
+              "maximum": 180
+            }
+          },
+          {
+            "name": "radius_km",
+            "in": "query",
+            "required": false,
+            "description": "Search radius in kilometers (1-2000). Default 200.",
+            "schema": {
+              "type": "number",
+              "minimum": 1,
+              "maximum": 2000,
+              "default": 200
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Max airports to return (1-100). Default 20.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 20
+            }
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "required": false,
+            "description": "Filter by airport type.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "large_airport",
+                "medium_airport",
+                "small_airport",
+                "heliport",
+                "seaplane_base",
+                "balloonport",
+                "closed"
+              ]
+            }
+          },
+          {
+            "name": "country",
+            "in": "query",
+            "required": false,
+            "description": "Filter by ISO 3166-1 alpha-2 country code (e.g. US).",
+            "schema": {
+              "type": "string",
+              "pattern": "^[A-Z]{2}$"
+            }
+          },
+          {
+            "name": "scheduled_service",
+            "in": "query",
+            "required": false,
+            "description": "When true, only commercial-service airports.",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/aviation/metar": {
+      "get": {
+        "tags": [
+          "aviation"
+        ],
+        "summary": "Fetch current METAR aviation weather for airports",
+        "description": "Current aviation weather observation (METAR) for one or more airports. Pass ids = comma-separated ICAO station ids (e.g. KATL, EGLL, KJFK). Returns the raw METAR plus decoded fields: flight category (VFR/MVFR/IFR/LIFR), temperature + dewpoint (°C), wind direction/speed/gust (kt), visibility, altimeter (inHg), and cloud layers. Source: NOAA Aviation Weather Center (keyless, public domain).",
+        "operationId": "aviation_metar",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = METAR observations (one per station); total = count.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "station": {
+                                "type": "string"
+                              },
+                              "observedAt": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "raw": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "flightCategory": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "tempC": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "dewpointC": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "windDirDeg": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "windSpeedKt": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "windGustKt": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "visibility": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "altimeterInHg": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "clouds": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "cover": {
+                                      "type": "string"
+                                    },
+                                    "baseFtAgl": {
+                                      "type": "number",
+                                      "nullable": true
+                                    }
+                                  },
+                                  "required": [
+                                    "cover",
+                                    "baseFtAgl"
+                                  ],
+                                  "additionalProperties": false
+                                }
+                              },
+                              "name": {
+                                "type": "string",
+                                "nullable": true
+                              }
+                            },
+                            "required": [
+                              "station",
+                              "observedAt",
+                              "raw",
+                              "flightCategory",
+                              "tempC",
+                              "dewpointC",
+                              "windDirDeg",
+                              "windSpeedKt",
+                              "windGustKt",
+                              "visibility",
+                              "altimeterInHg",
+                              "clouds",
+                              "name"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "aviation.metar",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "ids",
+            "in": "query",
+            "required": true,
+            "description": "Comma-separated list of identifiers.",
+            "schema": {
+              "type": "string",
+              "minLength": 3,
+              "maxLength": 120
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/aviation/taf": {
+      "get": {
+        "tags": [
+          "aviation"
+        ],
+        "summary": "Fetch Terminal Aerodrome Forecasts (TAF) for airports",
+        "description": "Terminal Aerodrome Forecast (TAF) for one or more airports — the official aviation forecast issued for an airport (~24–30h ahead). Pass ids = comma-separated ICAO station ids (e.g. KATL). Returns the raw TAF text + issue time. Source: NOAA Aviation Weather Center (keyless). For current conditions use aviation.metar.",
+        "operationId": "aviation_taf",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = TAFs (one per station); total = count.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "station": {
+                                "type": "string"
+                              },
+                              "issuedAt": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "raw": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "name": {
+                                "type": "string",
+                                "nullable": true
+                              }
+                            },
+                            "required": [
+                              "station",
+                              "issuedAt",
+                              "raw",
+                              "name"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "aviation.taf",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "ids",
+            "in": "query",
+            "required": true,
+            "description": "Comma-separated list of identifiers.",
+            "schema": {
+              "type": "string",
+              "minLength": 3,
+              "maxLength": 120
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/flight/status": {
+      "get": {
+        "tags": [
+          "flight"
+        ],
+        "summary": "Fetch live flight status and tracking",
+        "description": "Live flight status and tracking. Pass ident as an airline flight designator (ICAO \"UAL1\" or IATA \"UA1\") or an aircraft tail number; returns recent and upcoming instances of that flight with origin/destination airports (ICAO/IATA/name/city/timezone), status, cancellation/diversion flags, scheduled vs estimated vs actual gate and runway times (out/off/on/in), departure and arrival delays, en-route progress percent, aircraft type and registration, and route distance. limit controls how many instances return (default 5, newest first by scheduled departure). Real-time operational data — answer \"where is this flight, is it delayed, when does it land\" with live values. For aircraft registry data see /api/aircraft/lookup; for airport metadata see /api/airport/lookup.",
+        "operationId": "flight_status",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = recent + upcoming instances of a flight with live times, delays, progress, aircraft; total = instances returned; meta.ident echoes the queried designator.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "ident": {
+                                "type": "string"
+                              },
+                              "identIata": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "operator": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "flightNumber": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "registration": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "aircraftType": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "origin": {
+                                "type": "object",
+                                "properties": {
+                                  "icao": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "iata": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "name": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "city": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "timezone": {
+                                    "type": "string",
+                                    "nullable": true
+                                  }
+                                },
+                                "required": [
+                                  "icao",
+                                  "iata",
+                                  "name",
+                                  "city",
+                                  "timezone"
+                                ],
+                                "additionalProperties": false,
+                                "nullable": true
+                              },
+                              "destination": {
+                                "type": "object",
+                                "properties": {
+                                  "icao": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "iata": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "name": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "city": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "timezone": {
+                                    "type": "string",
+                                    "nullable": true
+                                  }
+                                },
+                                "required": [
+                                  "icao",
+                                  "iata",
+                                  "name",
+                                  "city",
+                                  "timezone"
+                                ],
+                                "additionalProperties": false,
+                                "nullable": true
+                              },
+                              "status": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "cancelled": {
+                                "type": "boolean"
+                              },
+                              "diverted": {
+                                "type": "boolean"
+                              },
+                              "scheduledOut": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "estimatedOut": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "actualOut": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "actualOff": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "Actual takeoff time."
+                              },
+                              "actualOn": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "Actual landing time."
+                              },
+                              "scheduledIn": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "estimatedIn": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "actualIn": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "progressPercent": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "departureDelaySec": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "arrivalDelaySec": {
+                                "type": "number",
+                                "nullable": true,
+                                "description": "Negative = early."
+                              },
+                              "routeDistanceKm": {
+                                "type": "number",
+                                "nullable": true
+                              }
+                            },
+                            "required": [
+                              "ident",
+                              "identIata",
+                              "operator",
+                              "flightNumber",
+                              "registration",
+                              "aircraftType",
+                              "origin",
+                              "destination",
+                              "status",
+                              "cancelled",
+                              "diverted",
+                              "scheduledOut",
+                              "estimatedOut",
+                              "actualOut",
+                              "actualOff",
+                              "actualOn",
+                              "scheduledIn",
+                              "estimatedIn",
+                              "actualIn",
+                              "progressPercent",
+                              "departureDelaySec",
+                              "arrivalDelaySec",
+                              "routeDistanceKm"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "ident": {
+                              "type": "string",
+                              "description": "Normalized (uppercased) ident that was queried."
+                            }
+                          },
+                          "required": [
+                            "ident"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.018 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "flight.status",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.018,
+          "tier": 2
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.018000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "ident",
+            "in": "query",
+            "required": true,
+            "description": "Flight designator (ICAO UAL1 or IATA UA1) or aircraft tail number.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 12,
+              "pattern": "^[A-Za-z0-9-]+$"
+            }
+          },
+          {
+            "name": "identType",
+            "in": "query",
+            "required": false,
+            "description": "Ident type.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "designator",
+                "registration",
+                "fa_flight_id"
+              ]
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of results to return.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 15,
+              "default": 5
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/vehicle/complaints": {
+      "get": {
+        "tags": [
+          "vehicle"
+        ],
+        "summary": "Fetch NHTSA consumer complaints for a US vehicle by (make",
+        "description": "NHTSA consumer complaints for a US vehicle by (make, model, modelYear). Returns the top N records (newest-filed first) with ODI number, affected component, plain-English summary, crash/fire flags, injury and death counts, partial VIN, and incident + filing dates. Backed by NHTSA's public complaints database; data is public-domain US government records.",
+        "operationId": "vehicle_complaints",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = NHTSA consumer-complaint records for the queried vehicle, newest first (total = all matching complaints upstream). To go straight from a VIN to its complaints (and recalls), see /api/vehicle/profile.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "odiNumber": {
+                                "type": "integer"
+                              },
+                              "manufacturer": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "components": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "summary": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "crash": {
+                                "type": "boolean"
+                              },
+                              "fire": {
+                                "type": "boolean"
+                              },
+                              "numberOfInjuries": {
+                                "type": "integer"
+                              },
+                              "numberOfDeaths": {
+                                "type": "integer"
+                              },
+                              "vin": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "dateOfIncident": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "dateComplaintFiled": {
+                                "type": "string",
+                                "nullable": true
+                              }
+                            },
+                            "required": [
+                              "odiNumber",
+                              "manufacturer",
+                              "components",
+                              "summary",
+                              "crash",
+                              "fire",
+                              "numberOfInjuries",
+                              "numberOfDeaths",
+                              "vin",
+                              "dateOfIncident",
+                              "dateComplaintFiled"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "query": {
+                              "type": "object",
+                              "properties": {
+                                "make": {
+                                  "type": "string"
+                                },
+                                "model": {
+                                  "type": "string"
+                                },
+                                "modelYear": {
+                                  "type": "integer"
+                                },
+                                "limit": {
+                                  "type": "integer"
+                                }
+                              },
+                              "required": [
+                                "make",
+                                "model",
+                                "modelYear",
+                                "limit"
+                              ],
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "query"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0024 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "vehicle.complaints",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0024,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.002400"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "make",
+            "in": "query",
+            "required": true,
+            "description": "Vehicle make. Examples: \"Honda\", \"Tesla\", \"Ford\".",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 40
+            }
+          },
+          {
+            "name": "model",
+            "in": "query",
+            "required": true,
+            "description": "Vehicle model. Examples: \"Accord\", \"Model 3\", \"F-150\".",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 40
+            }
+          },
+          {
+            "name": "modelYear",
+            "in": "query",
+            "required": true,
+            "description": "4-digit model year.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1949,
+              "maximum": 2099
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Max records to return, newest-filed first (1-100). Default 25.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 25
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/vehicle/decode-wmi": {
+      "get": {
+        "tags": [
+          "vehicle"
+        ],
+        "summary": "Parse a 3-character World Manufacturer Identifier (the...",
+        "description": "Decode a 3-character World Manufacturer Identifier (the first three characters of a VIN) to the assigning manufacturer. Returns full manufacturer legal name, common short name, make, vehicle type, and the date NHTSA published the assignment. Useful for partial-VIN analysis — crash reports, damaged-vehicle photos, fleet records — where only the WMI is recoverable. Backed by NHTSA.gov vPIC; data is public-domain US government records.",
+        "operationId": "vehicle_decode-wmi",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = single manufacturer record decoded from a 3-char WMI prefix.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "wmi": {
+                                "type": "string"
+                              },
+                              "manufacturerName": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "commonName": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "make": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "vehicleType": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "dateAvailableToPublic": {
+                                "type": "string",
+                                "nullable": true
+                              }
+                            },
+                            "required": [
+                              "wmi",
+                              "manufacturerName",
+                              "commonName",
+                              "make",
+                              "vehicleType",
+                              "dateAvailableToPublic"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0024 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "vehicle.decode-wmi",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0024,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.002400"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "wmi",
+            "in": "query",
+            "required": true,
+            "description": "3-character WMI (the first 3 chars of a VIN). Case-insensitive. Examples: 1HG (American Honda), 5YJ (Tesla US), WBA (BMW).",
+            "schema": {
+              "type": "string",
+              "minLength": 3,
+              "maxLength": 3,
+              "pattern": "^[A-HJ-NPR-Z0-9]{3}$"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/vehicle/investigations": {
+      "get": {
+        "tags": [
+          "vehicle"
+        ],
+        "summary": "Fetch Chronological feed of NHTSA ODI (Office of Defects...",
+        "description": "Chronological feed of NHTSA ODI (Office of Defects Investigation) investigations, newest first. Returns preliminary evaluations (PE), engineering analyses (EA), defect petitions (DP), and recall queries (RQ) — each with NHTSA ID, type code, open/close dates, status, subject, and full description (HTML stripped + raw). Useful for tracking what NHTSA is currently investigating (Tesla FSD, autonomous-vehicle crashes, Rivian suspension, etc.). NOTE: NHTSA's endpoint does NOT support make/model/year filtering — use vehicle.recalls or vehicle.complaints for vehicle-scoped lookups. Public-domain US government records.",
+        "operationId": "vehicle_investigations",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = chronological feed of NHTSA ODI investigations (total = all records upstream; paginate via meta.nextOffset).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "integer"
+                              },
+                              "nhtsaId": {
+                                "type": "string"
+                              },
+                              "investigationNumber": {
+                                "type": "string"
+                              },
+                              "investigationType": {
+                                "type": "string"
+                              },
+                              "issueYear": {
+                                "type": "string"
+                              },
+                              "openDate": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "latestActivityDate": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "status": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "subject": {
+                                "type": "string"
+                              },
+                              "description": {
+                                "type": "string"
+                              },
+                              "descriptionHtml": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "nhtsaId",
+                              "investigationNumber",
+                              "investigationType",
+                              "issueYear",
+                              "openDate",
+                              "latestActivityDate",
+                              "status",
+                              "subject",
+                              "description",
+                              "descriptionHtml"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "query": {
+                              "type": "object",
+                              "properties": {
+                                "limit": {
+                                  "type": "integer"
+                                },
+                                "offset": {
+                                  "type": "integer"
+                                },
+                                "status": {
+                                  "type": "string",
+                                  "nullable": true
+                                }
+                              },
+                              "required": [
+                                "limit",
+                                "offset",
+                                "status"
+                              ],
+                              "additionalProperties": false
+                            },
+                            "nextOffset": {
+                              "type": "integer",
+                              "nullable": true
+                            },
+                            "previousOffset": {
+                              "type": "integer",
+                              "nullable": true
+                            }
+                          },
+                          "required": [
+                            "query",
+                            "nextOffset",
+                            "previousOffset"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0024 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "vehicle.investigations",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0024,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.002400"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Max records to return (1-100). Default 25.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 25
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "description": "Offset into the chronological feed for pagination. Default 0.",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 10000,
+              "default": 0
+            }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "description": "Filter by status: \"O\" (open), \"C\" (closed). Omit for all.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "O",
+                "C"
+              ]
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/vehicle/manufacturers": {
+      "get": {
+        "tags": [
+          "vehicle"
+        ],
+        "summary": "Fetch Paginated list of every motor vehicle manufacturer",
+        "description": "Paginated list of every motor vehicle manufacturer NHTSA tracks via vPIC. Each record includes the canonical Mfr_ID, full legal name, common short name (e.g., \"Honda\"), country, and the list of vehicle types the manufacturer produces (Passenger Car, Truck, Motorcycle, Bus, MPV, etc.). Pass the optional `manufacturer` param to substring-search Mfr_Name. 100 records per page. Backed by NHTSA.gov; data is public-domain US government records.",
+        "operationId": "vehicle_manufacturers",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = manufacturer directory page (100 per page) with canonical NHTSA IDs. total is null — vPIC does not report an overall count; request the next page until items is empty.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "mfrId": {
+                                "type": "integer"
+                              },
+                              "mfrName": {
+                                "type": "string"
+                              },
+                              "commonName": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "country": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "vehicleTypes": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "isPrimary": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "isPrimary"
+                                  ],
+                                  "additionalProperties": false
+                                }
+                              }
+                            },
+                            "required": [
+                              "mfrId",
+                              "mfrName",
+                              "commonName",
+                              "country",
+                              "vehicleTypes"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "query": {
+                              "type": "object",
+                              "properties": {
+                                "page": {
+                                  "type": "integer"
+                                },
+                                "manufacturer": {
+                                  "type": "string",
+                                  "nullable": true
+                                }
+                              },
+                              "required": [
+                                "page",
+                                "manufacturer"
+                              ],
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "query"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0024 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "vehicle.manufacturers",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0024,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.002400"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "description": "1-indexed page (100 manufacturers per page). Default 1.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 1
+            }
+          },
+          {
+            "name": "manufacturer",
+            "in": "query",
+            "required": false,
+            "description": "Optional substring filter on the full Mfr_Name (case-insensitive on NHTSA side). Examples: \"honda\", \"tesla\", \"general motors\".",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 80
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/vehicle/models": {
+      "get": {
+        "tags": [
+          "vehicle"
+        ],
+        "summary": "List every model a manufacturer sold in a given model...",
+        "description": "Enumerate every model a manufacturer sold in a given model year via NHTSA's vPIC taxonomy database. Returns canonical NHTSA Model IDs + names plus the Make ID + name for reference. Useful as a discovery step before VIN decode (when the agent only knows make + year) or as input validation for vehicle.recalls / vehicle.complaints. Backed by NHTSA.gov; data is public-domain US government records.",
+        "operationId": "vehicle_models",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = models sold by the make in the queried year, with canonical NHTSA IDs.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "modelId": {
+                                "type": "integer"
+                              },
+                              "modelName": {
+                                "type": "string"
+                              },
+                              "makeId": {
+                                "type": "integer"
+                              },
+                              "makeName": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "modelId",
+                              "modelName",
+                              "makeId",
+                              "makeName"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "query": {
+                              "type": "object",
+                              "properties": {
+                                "make": {
+                                  "type": "string"
+                                },
+                                "modelYear": {
+                                  "type": "integer"
+                                }
+                              },
+                              "required": [
+                                "make",
+                                "modelYear"
+                              ],
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "query"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0024 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "vehicle.models",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0024,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.002400"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "make",
+            "in": "query",
+            "required": true,
+            "description": "Vehicle make. Case-insensitive on NHTSA side. Examples: \"Honda\", \"Tesla\", \"Ford\".",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 40
+            }
+          },
+          {
+            "name": "modelYear",
+            "in": "query",
+            "required": true,
+            "description": "4-digit model year.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1949,
+              "maximum": 2099
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/vehicle/profile": {
+      "get": {
+        "tags": [
+          "vehicle"
+        ],
+        "summary": "Parse a VIN and fetch its full safety picture",
+        "description": "Vehicle 360 — decode a VIN and get its full safety picture in one call. Returns the decoded vehicle (make, model, year, trim, engine, plant, body class, drivetrain — NHTSA vPIC) plus that exact make/model/year's open safety recalls (with park-it / park-outside / over-the-air-update flags) and NHTSA owner complaints (crash/fire/injury/death flags). recalls and complaints are keyed to the decoded make+model+year, so they describe THIS vehicle, not a generic feed. Each section reports found/error independently. Pass vin (17 chars); optional modelYear disambiguates pre-1980 VINs. Used for used-car due diligence, fleet safety, insurance. Individual sources: /api/vehicle/vin-decode, /api/vehicle/recalls, /api/vehicle/complaints.",
+        "operationId": "vehicle_profile",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "vin": {
+                          "type": "string"
+                        },
+                        "vehicle": {
+                          "type": "object",
+                          "properties": {
+                            "found": {
+                              "type": "boolean"
+                            },
+                            "error": {
+                              "type": "string",
+                              "nullable": true
+                            }
+                          },
+                          "required": [
+                            "found",
+                            "error"
+                          ],
+                          "additionalProperties": {}
+                        },
+                        "recalls": {
+                          "type": "object",
+                          "properties": {
+                            "found": {
+                              "type": "boolean"
+                            },
+                            "error": {
+                              "type": "string",
+                              "nullable": true
+                            },
+                            "count": {
+                              "type": "number",
+                              "nullable": true
+                            },
+                            "recalls": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "additionalProperties": {}
+                              }
+                            }
+                          },
+                          "required": [
+                            "found",
+                            "error",
+                            "count",
+                            "recalls"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "complaints": {
+                          "type": "object",
+                          "properties": {
+                            "found": {
+                              "type": "boolean"
+                            },
+                            "error": {
+                              "type": "string",
+                              "nullable": true
+                            },
+                            "count": {
+                              "type": "number",
+                              "nullable": true
+                            }
+                          },
+                          "required": [
+                            "found",
+                            "error",
+                            "count"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "sources": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
+                        }
+                      },
+                      "required": [
+                        "vin",
+                        "vehicle",
+                        "recalls",
+                        "complaints",
+                        "sources"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.00576 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "vehicle.profile",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.00576,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "legacy",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.005760"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "vin",
+            "in": "query",
+            "required": true,
+            "description": "VIN.",
+            "schema": {
+              "type": "string",
+              "minLength": 17,
+              "maxLength": 17
+            }
+          },
+          {
+            "name": "modelYear",
+            "in": "query",
+            "required": false,
+            "description": "Model year.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1949,
+              "maximum": 2099
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/vehicle/recalls": {
+      "get": {
+        "tags": [
+          "vehicle"
+        ],
+        "summary": "Fetch NHTSA recall campaigns for a US vehicle by (make",
+        "description": "NHTSA recall campaigns for a US vehicle by (make, model, modelYear). Returns every open + historical campaign with the NHTSA campaign number, manufacturer, affected component, plain-English summary/consequence/remedy text, and the parkIt / parkOutside fire-risk advisories. Backed by NHTSA's public recalls database; data is public-domain US government records.",
+        "operationId": "vehicle_recalls",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = recall campaigns matching the (make, model, modelYear) tuple. To go straight from a VIN to its recalls (and complaints), see /api/vehicle/profile.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "campaignNumber": {
+                                "type": "string"
+                              },
+                              "reportReceivedDate": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "manufacturer": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "component": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "summary": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "consequence": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "remedy": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "notes": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "parkIt": {
+                                "type": "boolean"
+                              },
+                              "parkOutside": {
+                                "type": "boolean"
+                              },
+                              "overTheAirUpdate": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "campaignNumber",
+                              "reportReceivedDate",
+                              "manufacturer",
+                              "component",
+                              "summary",
+                              "consequence",
+                              "remedy",
+                              "notes",
+                              "parkIt",
+                              "parkOutside",
+                              "overTheAirUpdate"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "query": {
+                              "type": "object",
+                              "properties": {
+                                "make": {
+                                  "type": "string"
+                                },
+                                "model": {
+                                  "type": "string"
+                                },
+                                "modelYear": {
+                                  "type": "integer"
+                                }
+                              },
+                              "required": [
+                                "make",
+                                "model",
+                                "modelYear"
+                              ],
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "query"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0024 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "vehicle.recalls",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0024,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.002400"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "make",
+            "in": "query",
+            "required": true,
+            "description": "Vehicle make. Examples: \"Honda\", \"Toyota\", \"Tesla\". Case-insensitive on NHTSA side.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 40
+            }
+          },
+          {
+            "name": "model",
+            "in": "query",
+            "required": true,
+            "description": "Vehicle model. Examples: \"Accord\", \"Model 3\", \"F-150\".",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 40
+            }
+          },
+          {
+            "name": "modelYear",
+            "in": "query",
+            "required": true,
+            "description": "4-digit model year.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1949,
+              "maximum": 2099
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/vehicle/vin-decode": {
+      "get": {
+        "tags": [
+          "vehicle"
+        ],
+        "summary": "Parse a 17-character VIN to manufacturer-supplied vehicle...",
+        "description": "Decode a 17-character VIN to manufacturer-supplied vehicle metadata via NHTSA's vPIC database. Returns identity (year, make, model, trim, series, body class, manufacturer), assembly plant (city, state, country), engine (cylinders, displacement, HP, fuel type, configuration, engine model), transmission (style, speeds), and body/weight specs. Curated to the ~30 fields agents actually use from vPIC's ~140-field response. Backed by NHTSA.gov; data is public-domain US government records.",
+        "operationId": "vehicle_vin-decode",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = single decoded-VIN record (identity, plant of origin, powertrain, body class). For the decode PLUS this vehicle's recalls and complaints in one call, see /api/vehicle/profile.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "vin": {
+                                "type": "string"
+                              },
+                              "modelYear": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "make": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "model": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "trim": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "series": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "bodyClass": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "manufacturer": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "plant": {
+                                "type": "object",
+                                "properties": {
+                                  "city": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "state": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "country": {
+                                    "type": "string",
+                                    "nullable": true
+                                  }
+                                },
+                                "required": [
+                                  "city",
+                                  "state",
+                                  "country"
+                                ],
+                                "additionalProperties": false
+                              },
+                              "engine": {
+                                "type": "object",
+                                "properties": {
+                                  "cylinders": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "displacementL": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "hp": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "fuelTypePrimary": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "configuration": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "model": {
+                                    "type": "string",
+                                    "nullable": true
+                                  }
+                                },
+                                "required": [
+                                  "cylinders",
+                                  "displacementL",
+                                  "hp",
+                                  "fuelTypePrimary",
+                                  "configuration",
+                                  "model"
+                                ],
+                                "additionalProperties": false
+                              },
+                              "transmission": {
+                                "type": "object",
+                                "properties": {
+                                  "style": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "speeds": {
+                                    "type": "string",
+                                    "nullable": true
+                                  }
+                                },
+                                "required": [
+                                  "style",
+                                  "speeds"
+                                ],
+                                "additionalProperties": false
+                              },
+                              "doors": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "driveType": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "vehicleType": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "gvwrClass": {
+                                "type": "string",
+                                "nullable": true
+                              }
+                            },
+                            "required": [
+                              "vin",
+                              "modelYear",
+                              "make",
+                              "model",
+                              "trim",
+                              "series",
+                              "bodyClass",
+                              "manufacturer",
+                              "plant",
+                              "engine",
+                              "transmission",
+                              "doors",
+                              "driveType",
+                              "vehicleType",
+                              "gvwrClass"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0024 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "vehicle.vin-decode",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0024,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.002400"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "vin",
+            "in": "query",
+            "required": true,
+            "description": "17-character VIN. Case-insensitive. Excludes letters I, O, and Q per VIN standard.",
+            "schema": {
+              "type": "string",
+              "minLength": 17,
+              "maxLength": 17,
+              "pattern": "^[A-HJ-NPR-Z0-9]{17}$"
+            }
+          },
+          {
+            "name": "modelYear",
+            "in": "query",
+            "required": false,
+            "description": "Optional model-year hint — disambiguates VINs where the year-digit wraps (A=1980/2010, etc.).",
+            "schema": {
+              "type": "integer",
+              "minimum": 1949,
+              "maximum": 2099
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/providers/2s/web/PAY.md
+++ b/providers/2s/web/PAY.md
@@ -1,0 +1,17 @@
+---
+name: web
+title: "2s Web"
+description: "Developer and web utilities: DNS and WHOIS, TLS certificate info, URL cleaning/rendering/unfurl, HTML-to-markdown, hashing, barcode generation, image compression, unit conversion, npm/PyPI lookups, phone normalization, and bank routing."
+use_case: "Use for DNS/WHOIS, TLS and URL inspection, HTML-to-markdown, hashing, unit conversion, package-registry lookups, and phone or routing-number checks."
+category: devtools
+service_url: https://2s.io
+openapi:
+  path: openapi.json
+---
+
+Part of 2s — a unified, agent-native JSON API. Pay per call in USDC on Solana (or Base) via x402; no accounts, no API keys. Add `?trial=1` (or header `X-2s-Trial: 1`) for one free real call per endpoint per hour.
+
+## Spend-aware usage
+
+- Prefer narrow lookups (by id/code) over broad searches; reuse identifiers across calls.
+- Cap result `limit` to the smallest count that answers the task.

--- a/providers/2s/web/openapi.json
+++ b/providers/2s/web/openapi.json
@@ -1,0 +1,5377 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "2s",
+    "version": "1",
+    "description": "Unified JSON REST API for AI agents — an ever-expanding catalog of endpoints, pay per call in USDC on Base or Solana via x402, no accounts, no API keys. Fund a wallet on either chain with USDC, hit any endpoint, and your client signs an EIP-3009 authorization (Base) or a partial SPL transfer (Solana) to settle the call. Try before you buy: add ?trial=1 (or header X-2s-Trial: 1) to any endpoint for one free real call per endpoint per hour — no wallet needed — to verify it works before paying. 2s is an open-ended experiment in maximally-comprehensive agent infrastructure — new endpoints land regularly.",
+    "contact": {
+      "name": "2s",
+      "url": "https://2s.io",
+      "email": "alley@2s.io"
+    }
+  },
+  "servers": [
+    {
+      "url": "https://2s.io"
+    }
+  ],
+  "components": {
+    "parameters": {
+      "TrialMode": {
+        "name": "trial",
+        "in": "query",
+        "required": false,
+        "description": "Try before you buy. Set to 1 for one free real call per endpoint per hour — no wallet or payment needed — to verify the endpoint before paying. Equivalent to sending the \"X-2s-Trial: 1\" request header. Works on every endpoint.",
+        "schema": {
+          "type": "integer",
+          "enum": [
+            1
+          ]
+        }
+      }
+    },
+    "securitySchemes": {
+      "x402Payment": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "PAYMENT-SIGNATURE",
+        "description": "x402 protocol v2: base64-encoded PaymentPayload. Call any paid endpoint without auth to receive a 402 with a multi-network PaymentRequirements envelope. Sign for either rail: EIP-3009 transferWithAuthorization (Base USDC) OR a partial SPL token transfer (Solana USDC). Retry with PAYMENT-SIGNATURE header. X-PAYMENT is also accepted for v1 buyer clients. See https://x402.org."
+      }
+    },
+    "schemas": {
+      "X402PaymentRequiredV2": {
+        "type": "object",
+        "description": "x402 v2 PaymentRequired envelope. Pick any entry from accepts[], sign for that rail, retry with the PAYMENT-SIGNATURE header.",
+        "required": [
+          "x402Version",
+          "accepts"
+        ],
+        "properties": {
+          "x402Version": {
+            "type": "integer",
+            "const": 2
+          },
+          "error": {
+            "type": "string",
+            "description": "Human-readable reason payment is required."
+          },
+          "resource": {
+            "type": "string",
+            "description": "The resource URL being purchased."
+          },
+          "accepts": {
+            "type": "array",
+            "description": "Payment requirement options, one per supported network (Base USDC, Solana USDC).",
+            "items": {
+              "type": "object",
+              "required": [
+                "scheme",
+                "network",
+                "amount",
+                "asset",
+                "payTo",
+                "maxTimeoutSeconds"
+              ],
+              "properties": {
+                "scheme": {
+                  "type": "string",
+                  "enum": [
+                    "exact"
+                  ]
+                },
+                "network": {
+                  "type": "string",
+                  "description": "CAIP-2 network id, e.g. \"eip155:8453\" (Base) or \"solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp\"."
+                },
+                "amount": {
+                  "type": "string",
+                  "description": "Price in atomic asset units (USDC has 6 decimals)."
+                },
+                "asset": {
+                  "type": "string",
+                  "description": "Asset contract address / mint."
+                },
+                "payTo": {
+                  "type": "string",
+                  "description": "Treasury address to pay."
+                },
+                "maxTimeoutSeconds": {
+                  "type": "integer"
+                },
+                "extra": {
+                  "type": "object",
+                  "description": "Rail-specific extras (EVM: EIP-712 domain name/version; Solana: feePayer).",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "extensions": {
+            "type": "object",
+            "description": "Optional discovery metadata (e.g. bazaar input/output schemas).",
+            "additionalProperties": true
+          }
+        }
+      }
+    }
+  },
+  "paths": {
+    "/api/bank/lookup": {
+      "get": {
+        "tags": [
+          "bank"
+        ],
+        "summary": "Look up FDIC-insured US banks",
+        "description": "FDIC-insured US bank directory lookup. Lookup by name (fuzzy match), FDIC certificate number, RSSD ID, or state. Each record includes name + short name, web address, active flag, city/state/county/zip, established + insured dates, charter class, bank class, primary federal regulator, number of branches, assets and deposits ($1000s), and closed-date + reason for inactive institutions. Public-domain FDIC data, free.",
+        "operationId": "bank_lookup",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = matched FDIC-insured institutions; total = upstream total match count; meta echoes the query + returned (this page).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "cert": {
+                                "type": "string"
+                              },
+                              "rssdId": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "shortName": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "webAddress": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "active": {
+                                "type": "boolean"
+                              },
+                              "city": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "state": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "zipcode": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "county": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "establishedDate": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "insuredDate": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "charterClass": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "bankClass": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "primaryRegulator": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "numberOfBranches": {
+                                "type": "integer",
+                                "nullable": true
+                              },
+                              "assets": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "deposits": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "closedDate": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "reasonClosed": {
+                                "type": "string",
+                                "nullable": true
+                              }
+                            },
+                            "required": [
+                              "cert",
+                              "rssdId",
+                              "name",
+                              "shortName",
+                              "webAddress",
+                              "active",
+                              "city",
+                              "state",
+                              "zipcode",
+                              "county",
+                              "establishedDate",
+                              "insuredDate",
+                              "charterClass",
+                              "bankClass",
+                              "primaryRegulator",
+                              "numberOfBranches",
+                              "assets",
+                              "deposits",
+                              "closedDate",
+                              "reasonClosed"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "query": {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "cert": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "rssdId": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "state": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "status": {
+                                  "type": "string"
+                                },
+                                "limit": {
+                                  "type": "integer"
+                                },
+                                "offset": {
+                                  "type": "integer"
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "cert",
+                                "rssdId",
+                                "state",
+                                "status",
+                                "limit",
+                                "offset"
+                              ],
+                              "additionalProperties": false
+                            },
+                            "returned": {
+                              "type": "integer",
+                              "description": "Records returned on this page."
+                            }
+                          },
+                          "required": [
+                            "query",
+                            "returned"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "bank.lookup",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "description": "Name to search for.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 200
+            }
+          },
+          {
+            "name": "cert",
+            "in": "query",
+            "required": false,
+            "description": "Cert.",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{1,7}$"
+            }
+          },
+          {
+            "name": "rssdId",
+            "in": "query",
+            "required": false,
+            "description": "Rssd ID.",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{1,10}$"
+            }
+          },
+          {
+            "name": "state",
+            "in": "query",
+            "required": false,
+            "description": "US state — two-letter postal abbreviation (e.g. CA) or full name.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 2,
+              "pattern": "^[A-Za-z]{2}$"
+            }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "description": "Filter results by status.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "active",
+                "inactive",
+                "any"
+              ],
+              "default": "active"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of results to return.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 50,
+              "default": 10
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "description": "Number of results to skip before returning (pagination offset).",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 10000,
+              "default": 0
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/barcode/generate": {
+      "post": {
+        "tags": [
+          "barcode"
+        ],
+        "summary": "Generate QR / Aztec / Data Matrix / PDF417 codes from...",
+        "description": "Generate QR / Aztec / Data Matrix / PDF417 codes from structured payloads (url, wifi, vcard, vevent, email, sms, tel, geo, bitcoin, json, text). QR supports rounded or dotted modules, solid colors or linear/radial gradients, transparent backgrounds, configurable error correction, and a centered logo image (URL or data URI).",
+        "operationId": "barcode_generate",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.001 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "barcode.generate",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.001,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "legacy",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "format": {
+                    "type": "string",
+                    "enum": [
+                      "qr",
+                      "aztec",
+                      "datamatrix",
+                      "pdf417"
+                    ],
+                    "default": "qr",
+                    "description": "Format."
+                  },
+                  "data": {
+                    "anyOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "enum": [
+                              "text"
+                            ],
+                            "description": "Filter results by type."
+                          },
+                          "text": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 2000,
+                            "description": "Text."
+                          }
+                        },
+                        "required": [
+                          "type",
+                          "text"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "enum": [
+                              "url"
+                            ],
+                            "description": "Filter results by type."
+                          },
+                          "url": {
+                            "type": "string",
+                            "format": "uri",
+                            "maxLength": 2000,
+                            "description": "URL to process."
+                          }
+                        },
+                        "required": [
+                          "type",
+                          "url"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "enum": [
+                              "email"
+                            ],
+                            "description": "Filter results by type."
+                          },
+                          "to": {
+                            "type": "string",
+                            "format": "email",
+                            "description": "End of the range."
+                          },
+                          "subject": {
+                            "type": "string",
+                            "maxLength": 200,
+                            "description": "Subject."
+                          },
+                          "body": {
+                            "type": "string",
+                            "maxLength": 1000,
+                            "description": "Body."
+                          }
+                        },
+                        "required": [
+                          "type",
+                          "to"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "enum": [
+                              "sms"
+                            ],
+                            "description": "Filter results by type."
+                          },
+                          "to": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 50,
+                            "description": "End of the range."
+                          },
+                          "body": {
+                            "type": "string",
+                            "maxLength": 1000,
+                            "description": "Body."
+                          }
+                        },
+                        "required": [
+                          "type",
+                          "to"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "enum": [
+                              "phone"
+                            ],
+                            "description": "Filter results by type."
+                          },
+                          "number": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 50,
+                            "description": "Item number or identifier."
+                          }
+                        },
+                        "required": [
+                          "type",
+                          "number"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "enum": [
+                              "wifi"
+                            ],
+                            "description": "Filter results by type."
+                          },
+                          "ssid": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 100,
+                            "description": "Ssid."
+                          },
+                          "password": {
+                            "type": "string",
+                            "maxLength": 200,
+                            "description": "Password."
+                          },
+                          "security": {
+                            "type": "string",
+                            "enum": [
+                              "WPA",
+                              "WEP",
+                              "none"
+                            ],
+                            "description": "Security."
+                          },
+                          "hidden": {
+                            "type": "boolean",
+                            "description": "Hidden."
+                          }
+                        },
+                        "required": [
+                          "type",
+                          "ssid"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "enum": [
+                              "vcard"
+                            ],
+                            "description": "Filter results by type."
+                          },
+                          "name": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 200,
+                            "description": "Name to search for."
+                          },
+                          "firstName": {
+                            "type": "string",
+                            "maxLength": 100,
+                            "description": "First name to filter by."
+                          },
+                          "lastName": {
+                            "type": "string",
+                            "maxLength": 100,
+                            "description": "Last name to filter by."
+                          },
+                          "phone": {
+                            "type": "string",
+                            "maxLength": 50,
+                            "description": "Phone."
+                          },
+                          "email": {
+                            "type": "string",
+                            "format": "email",
+                            "description": "Email."
+                          },
+                          "org": {
+                            "type": "string",
+                            "maxLength": 200,
+                            "description": "Org."
+                          },
+                          "title": {
+                            "type": "string",
+                            "maxLength": 200,
+                            "description": "Title to search for."
+                          },
+                          "url": {
+                            "type": "string",
+                            "format": "uri",
+                            "description": "URL to process."
+                          },
+                          "note": {
+                            "type": "string",
+                            "maxLength": 500,
+                            "description": "Note."
+                          }
+                        },
+                        "required": [
+                          "type",
+                          "name"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "enum": [
+                              "geo"
+                            ],
+                            "description": "Filter results by type."
+                          },
+                          "lat": {
+                            "type": "number",
+                            "minimum": -90,
+                            "maximum": 90,
+                            "description": "Latitude in decimal degrees (WGS84)."
+                          },
+                          "lon": {
+                            "type": "number",
+                            "minimum": -180,
+                            "maximum": 180,
+                            "description": "Longitude in decimal degrees (WGS84)."
+                          },
+                          "altitude": {
+                            "type": "number",
+                            "description": "Altitude."
+                          }
+                        },
+                        "required": [
+                          "type",
+                          "lat",
+                          "lon"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "enum": [
+                              "bitcoin"
+                            ],
+                            "description": "Filter results by type."
+                          },
+                          "address": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 100,
+                            "description": "Street address or full address string."
+                          },
+                          "amount": {
+                            "type": "number",
+                            "exclusiveMinimum": true,
+                            "minimum": 0,
+                            "description": "Amount."
+                          },
+                          "label": {
+                            "type": "string",
+                            "maxLength": 200,
+                            "description": "Label."
+                          },
+                          "message": {
+                            "type": "string",
+                            "maxLength": 500,
+                            "description": "Message."
+                          }
+                        },
+                        "required": [
+                          "type",
+                          "address"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "enum": [
+                              "calendar"
+                            ],
+                            "description": "Filter results by type."
+                          },
+                          "title": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 200,
+                            "description": "Title to search for."
+                          },
+                          "start": {
+                            "type": "string",
+                            "format": "date-time",
+                            "description": "Start."
+                          },
+                          "end": {
+                            "type": "string",
+                            "format": "date-time",
+                            "description": "End."
+                          },
+                          "location": {
+                            "type": "string",
+                            "maxLength": 200,
+                            "description": "Location."
+                          },
+                          "description": {
+                            "type": "string",
+                            "maxLength": 1000,
+                            "description": "Description."
+                          }
+                        },
+                        "required": [
+                          "type",
+                          "title",
+                          "start",
+                          "end"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "enum": [
+                              "json"
+                            ],
+                            "description": "Filter results by type."
+                          },
+                          "value": {
+                            "description": "Value."
+                          }
+                        },
+                        "required": [
+                          "type"
+                        ],
+                        "additionalProperties": false
+                      }
+                    ],
+                    "description": "Data."
+                  },
+                  "output": {
+                    "type": "string",
+                    "enum": [
+                      "svg",
+                      "png",
+                      "dataurl"
+                    ],
+                    "default": "svg",
+                    "description": "Output."
+                  },
+                  "size": {
+                    "type": "integer",
+                    "minimum": 64,
+                    "maximum": 4096,
+                    "default": 512,
+                    "description": "Size."
+                  },
+                  "margin": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 16,
+                    "default": 4,
+                    "description": "Margin."
+                  },
+                  "errorCorrection": {
+                    "type": "string",
+                    "enum": [
+                      "L",
+                      "M",
+                      "Q",
+                      "H"
+                    ],
+                    "default": "M",
+                    "description": "L=~7%, M=~15%, Q=~25%, H=~30% recoverable damage (QR only)."
+                  },
+                  "style": {
+                    "type": "object",
+                    "properties": {
+                      "modules": {
+                        "type": "string",
+                        "enum": [
+                          "square",
+                          "rounded",
+                          "dots"
+                        ],
+                        "description": "Modules."
+                      },
+                      "foreground": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "type": {
+                                "type": "string",
+                                "enum": [
+                                  "linear",
+                                  "radial"
+                                ],
+                                "description": "Gradient type."
+                              },
+                              "stops": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "offset": {
+                                      "type": "number",
+                                      "minimum": 0,
+                                      "maximum": 1,
+                                      "description": "Number of results to skip before returning (pagination offset)."
+                                    },
+                                    "color": {
+                                      "type": "string",
+                                      "description": "Color."
+                                    }
+                                  },
+                                  "required": [
+                                    "offset",
+                                    "color"
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                "minItems": 2,
+                                "maxItems": 10,
+                                "description": "Stops."
+                              },
+                              "rotation": {
+                                "type": "number",
+                                "description": "Linear gradient rotation in degrees."
+                              }
+                            },
+                            "required": [
+                              "type",
+                              "stops"
+                            ],
+                            "additionalProperties": false
+                          }
+                        ],
+                        "description": "Foreground."
+                      },
+                      "background": {
+                        "type": "string",
+                        "description": "CSS color or \"transparent\"."
+                      },
+                      "logo": {
+                        "type": "object",
+                        "properties": {
+                          "source": {
+                            "type": "string",
+                            "description": "https:// URL or data: URI. QR only."
+                          },
+                          "sizePct": {
+                            "type": "number",
+                            "minimum": 0.05,
+                            "maximum": 0.4,
+                            "description": "Size pct."
+                          },
+                          "padding": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 32,
+                            "description": "Padding."
+                          },
+                          "background": {
+                            "type": "string",
+                            "description": "Background."
+                          },
+                          "cornerRadius": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 64,
+                            "description": "Corner radius."
+                          }
+                        },
+                        "required": [
+                          "source"
+                        ],
+                        "additionalProperties": false,
+                        "description": "Logo."
+                      }
+                    },
+                    "additionalProperties": false,
+                    "description": "Style."
+                  }
+                },
+                "required": [
+                  "data"
+                ],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/calendar/business-days": {
+      "get": {
+        "tags": [
+          "calendar"
+        ],
+        "summary": "Calculate holiday-aware business days, 200+ countries",
+        "description": "Holiday-aware business-day calculator for 200+ countries. Three modes: pass start + addDays (signed integer) to shift a date by N business days; pass start + end to count business days between two dates (exclusive of start, inclusive of end); pass start alone to check one date (is it a business day, which holiday, next/previous business day). Query: country (ISO 3166-1 alpha-2), start (YYYY-MM-DD), optional region (subdivision code), addDays XOR end, optional weekend (comma-separated days, default sat,sun — e.g. fri,sat for the Gulf), optional types (holiday types treated as closures, default public,bank). Skipped holidays are itemized in the response. Use for payment terms, SLA deadlines, and delivery-date math.",
+        "operationId": "calendar_business-days",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = [one calculation result], shape depends on mode (check | add | between); total = 1.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "mode": {
+                                "type": "string",
+                                "description": "check | add | between — which calculation ran, inferred from the params."
+                              },
+                              "country": {
+                                "type": "string",
+                                "description": "Resolved ISO country code."
+                              },
+                              "region": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "Resolved subdivision code, or null."
+                              },
+                              "start": {
+                                "type": "string",
+                                "description": "Echoed anchor date."
+                              },
+                              "addDays": {
+                                "type": "integer",
+                                "description": "add mode: the requested shift."
+                              },
+                              "result": {
+                                "type": "string",
+                                "description": "add mode: the resulting business date, YYYY-MM-DD."
+                              },
+                              "calendarDaysSpanned": {
+                                "type": "integer",
+                                "description": "add mode: calendar days between start and result."
+                              },
+                              "holidaysSkipped": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "date": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "date",
+                                    "name"
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                "description": "add mode: weekday holidays skipped along the way."
+                              },
+                              "end": {
+                                "type": "string",
+                                "description": "between mode: echoed end date."
+                              },
+                              "businessDays": {
+                                "type": "integer",
+                                "description": "between mode: business days after start through end."
+                              },
+                              "calendarDays": {
+                                "type": "integer",
+                                "description": "between mode: calendar days between start and end."
+                              },
+                              "holidaysInRange": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "date": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "date",
+                                    "name"
+                                  ],
+                                  "additionalProperties": false
+                                },
+                                "description": "between mode: weekday holidays inside the range."
+                              },
+                              "isBusinessDay": {
+                                "type": "boolean",
+                                "description": "check mode: true when start is neither weekend nor closure holiday."
+                              },
+                              "isWeekend": {
+                                "type": "boolean",
+                                "description": "check mode: start falls on a configured weekend day."
+                              },
+                              "isHoliday": {
+                                "type": "boolean",
+                                "description": "check mode: start is a closure holiday."
+                              },
+                              "holidayNames": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "description": "check mode: names of holidays on start, if any."
+                              },
+                              "nextBusinessDay": {
+                                "type": "string",
+                                "description": "check mode: first business day after start."
+                              },
+                              "previousBusinessDay": {
+                                "type": "string",
+                                "description": "check mode: last business day before start."
+                              }
+                            },
+                            "required": [
+                              "mode",
+                              "country",
+                              "region",
+                              "start"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.001 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "calendar.business-days",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.001,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "country",
+            "in": "query",
+            "required": true,
+            "description": "ISO 3166-1 alpha-2 country code, e.g. US, DE, JP.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 2
+            }
+          },
+          {
+            "name": "start",
+            "in": "query",
+            "required": true,
+            "description": "Anchor date, YYYY-MM-DD.",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+            }
+          },
+          {
+            "name": "addDays",
+            "in": "query",
+            "required": false,
+            "description": "Signed number of business days to add to start (non-zero, ±3660). Mutually exclusive with end.",
+            "schema": {
+              "type": "integer",
+              "minimum": -3660,
+              "maximum": 3660
+            }
+          },
+          {
+            "name": "end",
+            "in": "query",
+            "required": false,
+            "description": "End date YYYY-MM-DD. Counts business days after start through end. Mutually exclusive with addDays.",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+            }
+          },
+          {
+            "name": "region",
+            "in": "query",
+            "required": false,
+            "description": "Optional subdivision code — e.g. CA for US-California, BY for DE-Bavaria.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 10
+            }
+          },
+          {
+            "name": "weekend",
+            "in": "query",
+            "required": false,
+            "description": "Optional comma-separated weekend days (mon..sun). Default \"sat,sun\"; use \"fri,sat\" for Gulf states.",
+            "schema": {
+              "type": "string",
+              "maxLength": 30
+            }
+          },
+          {
+            "name": "types",
+            "in": "query",
+            "required": false,
+            "description": "Optional comma-separated holiday types treated as business closures (public, bank, school, optional, observance). Default \"public,bank\".",
+            "schema": {
+              "type": "string",
+              "maxLength": 60
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/calendar/holidays": {
+      "get": {
+        "tags": [
+          "calendar"
+        ],
+        "summary": "List the official holidays for a country and year, with...",
+        "description": "List the official holidays for a country and year, with exact observed dates including substitute days (e.g. a Saturday July 4th observed on Friday). Query: country (ISO 3166-1 alpha-2, 200+ supported), year, optional region (subdivision code like CA for US-California or BY for DE-Bavaria), optional types filter (public, bank, school, optional, observance — comma-separated), optional lang (ISO 639-1) for localized names. Returns one item per holiday: { date (YYYY-MM-DD), name, type, substitute, rule }. Dates are computed from maintained per-country rules — including movable feasts and lunar-calendar holidays — so they stay correct year over year. Use for scheduling, delivery estimates, payment terms, and SLA math.",
+        "operationId": "calendar_holidays",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = holidays for the requested country/region/year, sorted by date; total = count.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "date": {
+                                "type": "string",
+                                "description": "Observed date, YYYY-MM-DD."
+                              },
+                              "name": {
+                                "type": "string",
+                                "description": "Holiday name (localized when lang is passed and a translation exists)."
+                              },
+                              "type": {
+                                "type": "string",
+                                "description": "public | bank | school | optional | observance."
+                              },
+                              "substitute": {
+                                "type": "boolean",
+                                "description": "True when this entry is a substitute/observed day for a holiday falling on a weekend."
+                              },
+                              "rule": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "The rule the date was computed from, e.g. \"3rd monday in January\"."
+                              }
+                            },
+                            "required": [
+                              "date",
+                              "name",
+                              "type",
+                              "substitute",
+                              "rule"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.001 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "calendar.holidays",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.001,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "country",
+            "in": "query",
+            "required": true,
+            "description": "ISO 3166-1 alpha-2 country code, e.g. US, DE, JP. 200+ countries supported.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 2
+            }
+          },
+          {
+            "name": "year",
+            "in": "query",
+            "required": true,
+            "description": "Calendar year (1950-2100).",
+            "schema": {
+              "type": "integer",
+              "minimum": 1950,
+              "maximum": 2100
+            }
+          },
+          {
+            "name": "region",
+            "in": "query",
+            "required": false,
+            "description": "Optional subdivision code — e.g. CA for US-California, BY for DE-Bavaria, ON for CA-Ontario.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 10
+            }
+          },
+          {
+            "name": "types",
+            "in": "query",
+            "required": false,
+            "description": "Optional comma-separated holiday-type filter: public, bank, school, optional, observance. Default: all types.",
+            "schema": {
+              "type": "string",
+              "maxLength": 60
+            }
+          },
+          {
+            "name": "lang",
+            "in": "query",
+            "required": false,
+            "description": "Optional ISO 639-1 language code for localized holiday names, e.g. en, de, fr.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 5
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/code/repo-lookup": {
+      "get": {
+        "tags": [
+          "code"
+        ],
+        "summary": "Look up a public GitHub repository by \"owner/name\" slug.",
+        "description": "Look up a public GitHub repository by \"owner/name\" slug. Returns full name, owner, description, homepage, default branch, primary language, topics, license (SPDX key + name), counts (stars / forks / watchers / open issues / subscribers / network), size, timestamps (created/updated/pushed), visibility, has-issues/projects/wiki/discussions flags. Unauthenticated GitHub access is rate-limited to 60 req/hour per server IP — returns 429 UPSTREAM_RATE_LIMIT when the bucket is empty.",
+        "operationId": "code_repo-lookup",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = [GitHub repo metadata] for the requested slug; total = 1.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "fullName": {
+                                "type": "string"
+                              },
+                              "owner": {
+                                "type": "string"
+                              },
+                              "repo": {
+                                "type": "string"
+                              },
+                              "description": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "homepage": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "htmlUrl": {
+                                "type": "string",
+                                "format": "uri"
+                              },
+                              "isFork": {
+                                "type": "boolean"
+                              },
+                              "isArchived": {
+                                "type": "boolean"
+                              },
+                              "isDisabled": {
+                                "type": "boolean"
+                              },
+                              "isPrivate": {
+                                "type": "boolean"
+                              },
+                              "isTemplate": {
+                                "type": "boolean"
+                              },
+                              "defaultBranch": {
+                                "type": "string"
+                              },
+                              "language": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "topics": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "license": {
+                                "type": "object",
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "key",
+                                  "name"
+                                ],
+                                "additionalProperties": false,
+                                "nullable": true
+                              },
+                              "starsCount": {
+                                "type": "integer"
+                              },
+                              "forksCount": {
+                                "type": "integer"
+                              },
+                              "watchersCount": {
+                                "type": "integer"
+                              },
+                              "openIssuesCount": {
+                                "type": "integer"
+                              },
+                              "subscribersCount": {
+                                "type": "integer",
+                                "nullable": true
+                              },
+                              "networkCount": {
+                                "type": "integer",
+                                "nullable": true
+                              },
+                              "size": {
+                                "type": "integer"
+                              },
+                              "createdAt": {
+                                "type": "string"
+                              },
+                              "updatedAt": {
+                                "type": "string"
+                              },
+                              "pushedAt": {
+                                "type": "string"
+                              },
+                              "visibility": {
+                                "type": "string"
+                              },
+                              "hasIssues": {
+                                "type": "boolean"
+                              },
+                              "hasProjects": {
+                                "type": "boolean"
+                              },
+                              "hasWiki": {
+                                "type": "boolean"
+                              },
+                              "hasDiscussions": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "fullName",
+                              "owner",
+                              "repo",
+                              "description",
+                              "homepage",
+                              "htmlUrl",
+                              "isFork",
+                              "isArchived",
+                              "isDisabled",
+                              "isPrivate",
+                              "isTemplate",
+                              "defaultBranch",
+                              "language",
+                              "topics",
+                              "license",
+                              "starsCount",
+                              "forksCount",
+                              "watchersCount",
+                              "openIssuesCount",
+                              "subscribersCount",
+                              "networkCount",
+                              "size",
+                              "createdAt",
+                              "updatedAt",
+                              "pushedAt",
+                              "visibility",
+                              "hasIssues",
+                              "hasProjects",
+                              "hasWiki",
+                              "hasDiscussions"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "code.repo-lookup",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "repo",
+            "in": "query",
+            "required": true,
+            "description": "Repo.",
+            "schema": {
+              "type": "string",
+              "pattern": "^[A-Za-z0-9][\\w.-]*\\/[A-Za-z0-9._-]+$"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/convert/unit": {
+      "get": {
+        "tags": [
+          "convert"
+        ],
+        "summary": "Convert a value between units of measure: mass (g, kg, mg...",
+        "description": "Convert a value between units of measure: mass (g, kg, mg, lb, oz, t, st), length (m, km, cm, mm, in, ft, yd, mi), volume (l, ml, m3, gal, gal-imp, qt, pt, cup, floz, tbsp, tsp), area (m2, km2, ft2, acre, ha), and temperature (C, F, K). Units are matched case-insensitively with common aliases (kg/kilogram/kgs). Returns {value, from, to, dimension, result}. Exact factors — the ground-truth answer a CPG/ETL pipeline needs instead of an LLM approximating conversions. Cross-dimension conversions (kg→m) return 400.",
+        "operationId": "convert_unit",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = [conversion result]; total = 1.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "value": {
+                                "type": "number"
+                              },
+                              "from": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "to": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "dimension": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "mass | length | volume | area | temperature"
+                              },
+                              "result": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "reason": {
+                                "type": "string",
+                                "nullable": true
+                              }
+                            },
+                            "required": [
+                              "value",
+                              "from",
+                              "to",
+                              "dimension",
+                              "result",
+                              "reason"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.001 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "convert.unit",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.001,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "value",
+            "in": "query",
+            "required": true,
+            "description": "Value.",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "from",
+            "in": "query",
+            "required": true,
+            "description": "Start of the range.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 40
+            }
+          },
+          {
+            "name": "to",
+            "in": "query",
+            "required": true,
+            "description": "End of the range.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 40
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/countdown/gif": {
+      "get": {
+        "tags": [
+          "countdown"
+        ],
+        "summary": "Generate an animated countdown GIF to an end date",
+        "description": "Animated countdown GIF from the current UTC time to endDate. Always uncached. Supports 5 templates (default, minimal, neon, retro, corporate) and full customization: colors, fonts, dimensions, padding, cell padding, labels, dividers. Animates for `seconds` frames at `fps`.",
+        "operationId": "countdown_gif",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.006 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "countdown.gif",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.006,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "legacy",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.006000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "endDate",
+            "in": "query",
+            "required": true,
+            "description": "End of the date range (YYYY-MM-DD).",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "name": "template",
+            "in": "query",
+            "required": false,
+            "description": "Template.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "default",
+                "minimal",
+                "neon",
+                "retro",
+                "corporate"
+              ]
+            }
+          },
+          {
+            "name": "seconds",
+            "in": "query",
+            "required": false,
+            "description": "Seconds.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 60
+            }
+          },
+          {
+            "name": "fps",
+            "in": "query",
+            "required": false,
+            "description": "Fps.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 10
+            }
+          },
+          {
+            "name": "width",
+            "in": "query",
+            "required": false,
+            "description": "Width.",
+            "schema": {
+              "type": "integer",
+              "minimum": 200,
+              "maximum": 1600
+            }
+          },
+          {
+            "name": "height",
+            "in": "query",
+            "required": false,
+            "description": "Height.",
+            "schema": {
+              "type": "integer",
+              "minimum": 80,
+              "maximum": 800
+            }
+          },
+          {
+            "name": "padding",
+            "in": "query",
+            "required": false,
+            "description": "Padding.",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 200
+            }
+          },
+          {
+            "name": "cellPadding",
+            "in": "query",
+            "required": false,
+            "description": "Cell padding.",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 200
+            }
+          },
+          {
+            "name": "digitFontSize",
+            "in": "query",
+            "required": false,
+            "description": "Digit font size.",
+            "schema": {
+              "type": "integer",
+              "minimum": 20,
+              "maximum": 300
+            }
+          },
+          {
+            "name": "labelFontSize",
+            "in": "query",
+            "required": false,
+            "description": "Label font size.",
+            "schema": {
+              "type": "integer",
+              "minimum": 6,
+              "maximum": 80
+            }
+          },
+          {
+            "name": "labelPaddingY",
+            "in": "query",
+            "required": false,
+            "description": "Label padding y.",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 60
+            }
+          },
+          {
+            "name": "digitPaddingY",
+            "in": "query",
+            "required": false,
+            "description": "Digit padding y.",
+            "schema": {
+              "type": "integer",
+              "minimum": -60,
+              "maximum": 60
+            }
+          },
+          {
+            "name": "letterSpacing",
+            "in": "query",
+            "required": false,
+            "description": "Letter spacing.",
+            "schema": {
+              "type": "number",
+              "minimum": 0,
+              "maximum": 20
+            }
+          },
+          {
+            "name": "bg",
+            "in": "query",
+            "required": false,
+            "description": "Bg.",
+            "schema": {
+              "type": "string",
+              "maxLength": 40
+            }
+          },
+          {
+            "name": "fg",
+            "in": "query",
+            "required": false,
+            "description": "Fg.",
+            "schema": {
+              "type": "string",
+              "maxLength": 40
+            }
+          },
+          {
+            "name": "labelColor",
+            "in": "query",
+            "required": false,
+            "description": "Label color.",
+            "schema": {
+              "type": "string",
+              "maxLength": 40
+            }
+          },
+          {
+            "name": "dividerColor",
+            "in": "query",
+            "required": false,
+            "description": "Divider color.",
+            "schema": {
+              "type": "string",
+              "maxLength": 40
+            }
+          },
+          {
+            "name": "digitFont",
+            "in": "query",
+            "required": false,
+            "description": "Digit font.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "mono",
+                "sans"
+              ]
+            }
+          },
+          {
+            "name": "labelFont",
+            "in": "query",
+            "required": false,
+            "description": "Label font.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "mono",
+                "sans"
+              ]
+            }
+          },
+          {
+            "name": "digitWeight",
+            "in": "query",
+            "required": false,
+            "description": "Digit weight.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "regular",
+                "bold"
+              ]
+            }
+          },
+          {
+            "name": "showLabels",
+            "in": "query",
+            "required": false,
+            "description": "Show labels.",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "true",
+                    "false",
+                    "0",
+                    "1"
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "name": "showDays",
+            "in": "query",
+            "required": false,
+            "description": "Show days.",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "true",
+                    "false",
+                    "0",
+                    "1"
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "name": "dividerChar",
+            "in": "query",
+            "required": false,
+            "description": "Divider char.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 3
+            }
+          },
+          {
+            "name": "expiredText",
+            "in": "query",
+            "required": false,
+            "description": "Expired text.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 30
+            }
+          },
+          {
+            "name": "labelDays",
+            "in": "query",
+            "required": false,
+            "description": "Label days.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 12
+            }
+          },
+          {
+            "name": "labelHours",
+            "in": "query",
+            "required": false,
+            "description": "Label hours.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 12
+            }
+          },
+          {
+            "name": "labelMinutes",
+            "in": "query",
+            "required": false,
+            "description": "Label minutes.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 12
+            }
+          },
+          {
+            "name": "labelSeconds",
+            "in": "query",
+            "required": false,
+            "description": "Label seconds.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 12
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/dns/lookup": {
+      "get": {
+        "tags": [
+          "dns"
+        ],
+        "summary": "Resolve a hostname over public DNS and return parsed records.",
+        "description": "Resolve a hostname over public DNS and return parsed records. Query: host (required FQDN), types (comma-separated: A,AAAA,MX,TXT,NS,CAA,SRV,CNAME,PTR,SOA — default A,AAAA,MX,TXT,NS), resolver (cloudflare|google|quad9|opendns, optional). Returns one normalized JSON shape per record type with per-type error pass-through. Reserved/local TLDs (.local, .internal, .invalid, .test, localhost) are rejected. 4s per-query timeout.",
+        "operationId": "dns_lookup",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = [DNS result] (query, resolver, durationMs, per-type answers object); total = 1 (single resolution, type-keyed answers are not a homogeneous list).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.001 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "dns.lookup",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.001,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "host",
+            "in": "query",
+            "required": true,
+            "description": "Hostname to look up.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 253
+            }
+          },
+          {
+            "name": "types",
+            "in": "query",
+            "required": false,
+            "description": "Types.",
+            "schema": {
+              "type": "string",
+              "pattern": "^(A|AAAA|MX|TXT|NS|CAA|SRV|CNAME|PTR|SOA)(,(A|AAAA|MX|TXT|NS|CAA|SRV|CNAME|PTR|SOA)){0,9}$"
+            }
+          },
+          {
+            "name": "resolver",
+            "in": "query",
+            "required": false,
+            "description": "Resolver.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "cloudflare",
+                "google",
+                "quad9",
+                "opendns"
+              ]
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/domain/whois": {
+      "get": {
+        "tags": [
+          "domain"
+        ],
+        "summary": "Look up modern WHOIS (RDAP) for a domain",
+        "description": "Modern WHOIS via RDAP. Query: domain (e.g. example.com). Returns { domain, ldhName, handle, registrar:{ name, ianaId, url, abuseEmail, abusePhone }, registeredAt, expiresAt, updatedAt, statuses (camelCase ICANN EPP codes), nameservers[], dnssecSigned, rdapUrl }. GDPR: registrant personal data is generally redacted upstream and not returned. Some TLDs without RDAP are not supported and return 404 TLD_NOT_SUPPORTED.",
+        "operationId": "domain_whois",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = [domain record] (registrar, registration/expiry/update dates, EPP statuses, nameservers, DNSSEC, rdapUrl); total = 1.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.001 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "domain.whois",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.001,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "domain",
+            "in": "query",
+            "required": true,
+            "description": "Domain name to look up.",
+            "schema": {
+              "type": "string",
+              "minLength": 3,
+              "maxLength": 253
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/hash/compute": {
+      "post": {
+        "tags": [
+          "hash"
+        ],
+        "summary": "Calculate one or more cryptographic digests (MD5, SHA-1...",
+        "description": "Compute one or more cryptographic digests (MD5, SHA-1, SHA-2 family, SHA-3 family, BLAKE2) of a string or hex/base64-encoded byte buffer. Returns hex or base64-encoded digests.",
+        "operationId": "hash_compute",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = [digest result] (input encoding/bytes, outputEncoding, per-algorithm digests); total = 1.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "input": {
+                                "type": "object",
+                                "properties": {
+                                  "encoding": {
+                                    "type": "string"
+                                  },
+                                  "bytes": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "required": [
+                                  "encoding",
+                                  "bytes"
+                                ],
+                                "additionalProperties": false
+                              },
+                              "outputEncoding": {
+                                "type": "string"
+                              },
+                              "digests": {
+                                "type": "object",
+                                "additionalProperties": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "required": [
+                              "input",
+                              "outputEncoding",
+                              "digests"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.001 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "hash.compute",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.001,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "input": {
+                    "type": "string",
+                    "maxLength": 524288,
+                    "description": "Input."
+                  },
+                  "algorithms": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "enum": [
+                        "md5",
+                        "sha1",
+                        "sha224",
+                        "sha256",
+                        "sha384",
+                        "sha512",
+                        "sha3-224",
+                        "sha3-256",
+                        "sha3-384",
+                        "sha3-512",
+                        "blake2b512",
+                        "blake2s256"
+                      ]
+                    },
+                    "minItems": 1,
+                    "maxItems": 12,
+                    "description": "Algorithms."
+                  },
+                  "algorithm": {
+                    "type": "string",
+                    "enum": [
+                      "md5",
+                      "sha1",
+                      "sha224",
+                      "sha256",
+                      "sha384",
+                      "sha512",
+                      "sha3-224",
+                      "sha3-256",
+                      "sha3-384",
+                      "sha3-512",
+                      "blake2b512",
+                      "blake2s256"
+                    ],
+                    "description": "Algorithm."
+                  },
+                  "inputEncoding": {
+                    "type": "string",
+                    "enum": [
+                      "utf8",
+                      "hex",
+                      "base64"
+                    ],
+                    "default": "utf8",
+                    "description": "Input encoding."
+                  },
+                  "outputEncoding": {
+                    "type": "string",
+                    "enum": [
+                      "hex",
+                      "base64"
+                    ],
+                    "default": "hex",
+                    "description": "Output encoding."
+                  }
+                },
+                "required": [
+                  "input"
+                ],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/html/to-markdown": {
+      "post": {
+        "tags": [
+          "html"
+        ],
+        "summary": "Convert raw HTML you already have into clean reading...",
+        "description": "Convert raw HTML you already have into clean reading markdown — no URL fetch. POST { html }. Strips scripts, styles, nav, ads, and comments, extracts the main article content, and returns markdown (headings, links, lists, emphasis preserved), plain text, the page title, and a word count. Use when you scraped or generated HTML elsewhere and want clean markdown without a round-trip. For fetching + cleaning a live URL instead, use /api/url/clean (or /api/url/render for JavaScript-rendered pages). Pure conversion, no network.",
+        "operationId": "html_to-markdown",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = [conversion] (title, markdown, plain text, wordCount); total = 1.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "title": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "markdown": {
+                                "type": "string"
+                              },
+                              "text": {
+                                "type": "string"
+                              },
+                              "wordCount": {
+                                "type": "number"
+                              }
+                            },
+                            "required": [
+                              "title",
+                              "markdown",
+                              "text",
+                              "wordCount"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.001 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "html.to-markdown",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.001,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "html": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 2000000,
+                    "description": "Html."
+                  }
+                },
+                "required": [
+                  "html"
+                ],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/image/compress": {
+      "post": {
+        "tags": [
+          "image"
+        ],
+        "summary": "Run Compress an image. POST exactly one of { url } or {...",
+        "description": "Compress an image. POST exactly one of { url } or { imageBase64 }, plus optional { format?: auto|png|jpeg|webp|avif (default auto = keep input format), quality?: 1-100 (default 75), lossy?: bool (default true), effort?: 1-10 (default 6) }. Returns compressed image bytes directly with X-2s-* headers: Original-Bytes, Compressed-Bytes, Saved-Percent, Output-Format, Source-Format, Source-Width, Source-Height, Process-Ms. Limits: 5MB URL fetch, ~3MB inline body, 4096 × 4096 input pixels. Animated GIF input becomes animated WebP when format=webp or auto.",
+        "operationId": "image_compress",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0024 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "image.compress",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0024,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "legacy",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.002400"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "url": {
+                    "type": "string",
+                    "format": "uri",
+                    "maxLength": 2048,
+                    "description": "URL to process."
+                  },
+                  "imageBase64": {
+                    "type": "string",
+                    "maxLength": 4400000,
+                    "description": "Image base64."
+                  },
+                  "format": {
+                    "type": "string",
+                    "enum": [
+                      "auto",
+                      "png",
+                      "jpeg",
+                      "webp",
+                      "avif"
+                    ],
+                    "description": "Format."
+                  },
+                  "quality": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 100,
+                    "description": "Quality."
+                  },
+                  "lossy": {
+                    "type": "boolean",
+                    "description": "Lossy."
+                  },
+                  "effort": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 10,
+                    "description": "Effort."
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/ipinfo/bulk": {
+      "post": {
+        "tags": [
+          "ipinfo"
+        ],
+        "summary": "Run Geolocate up to 100 IPv4 or IPv6 addresses in a single",
+        "description": "Geolocate up to 100 IPv4 or IPv6 addresses in a single call. Pass an array of IPs; results come back in input order. Each successful entry includes country (name + ISO code), region (name + code), city, postal code, lat/lon (city-level precision), timezone, and network info (ISP, organization, AS). Failed entries include an error object instead of geo fields, plus okCount/failedCount totals. Far cheaper than 100 single calls to /api/geo/ip when enriching logs, access lists, or analytics batches.",
+        "operationId": "ipinfo_bulk",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = per-IP geolocation results in input order (ok flag + geo fields, or an error object on failure); total = items.length; meta carries okCount/failedCount.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "okCount": {
+                              "type": "integer"
+                            },
+                            "failedCount": {
+                              "type": "integer"
+                            }
+                          },
+                          "required": [
+                            "okCount",
+                            "failedCount"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.006 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "ipinfo.bulk",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.006,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.006000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "ips": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "minLength": 1,
+                      "maxLength": 64
+                    },
+                    "minItems": 1,
+                    "maxItems": 100,
+                    "description": "Ips."
+                  }
+                },
+                "required": [
+                  "ips"
+                ],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/phone/normalize": {
+      "get": {
+        "tags": [
+          "phone"
+        ],
+        "summary": "Parse, validate and canonicalize a phone number using...",
+        "description": "Parse, validate and canonicalize a phone number using Google's libphonenumber metadata. Query: number (required; E.164 like \"+14155552671\" or national like \"(415) 555-2671\"), country (optional ISO 3166-1 alpha-2 like US/GB/JP — required when number is not E.164). Returns {input, valid (matches a real number range), possible (right shape/length), e164, national, international, rfc3966, country, countryCallingCode, type (mobile|fixed_line|fixed_line_or_mobile|toll_free|premium_rate|shared_cost|voip|personal_number|pager|uan|voicemail|unknown), possibleCountries[]}. Returns valid:false (not an error) for unparseable input.",
+        "operationId": "phone_normalize",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = [parsed phone number] (valid/possible flags, e164/national/international/rfc3966, country, type); total = 1. Returns valid:false (not a 4xx) for unparseable input.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "input": {
+                                "type": "string",
+                                "description": "The exact input string we received."
+                              },
+                              "valid": {
+                                "type": "boolean",
+                                "description": "True if the number matches a real, in-use number range for its country."
+                              },
+                              "possible": {
+                                "type": "boolean",
+                                "description": "True if the number is the right length/shape, even if not necessarily assigned."
+                              },
+                              "e164": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "E.164 canonical form (e.g. +14155552671). Null if unparseable."
+                              },
+                              "national": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "Country-local format (e.g. \"(415) 555-2671\"). Null if unparseable."
+                              },
+                              "international": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "Pretty international format (e.g. \"+1 415 555 2671\"). Null if unparseable."
+                              },
+                              "rfc3966": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "RFC 3966 tel: URI form (e.g. \"tel:+14155552671\"). Null if unparseable."
+                              },
+                              "country": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "ISO 3166-1 alpha-2 country code, or null when ambiguous across +cc."
+                              },
+                              "countryCallingCode": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "Country calling code with leading + (e.g. \"+1\"). Null if unparseable."
+                              },
+                              "type": {
+                                "type": "string",
+                                "enum": [
+                                  "fixed_line",
+                                  "mobile",
+                                  "fixed_line_or_mobile",
+                                  "toll_free",
+                                  "premium_rate",
+                                  "shared_cost",
+                                  "voip",
+                                  "personal_number",
+                                  "pager",
+                                  "uan",
+                                  "voicemail",
+                                  "unknown"
+                                ],
+                                "description": "Number type. \"unknown\" when libphonenumber cannot classify."
+                              },
+                              "possibleCountries": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "description": "All ISO 3166-1 alpha-2 codes this number could belong to."
+                              }
+                            },
+                            "required": [
+                              "input",
+                              "valid",
+                              "possible",
+                              "e164",
+                              "national",
+                              "international",
+                              "rfc3966",
+                              "country",
+                              "countryCallingCode",
+                              "type",
+                              "possibleCountries"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.001 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "phone.normalize",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.001,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "number",
+            "in": "query",
+            "required": true,
+            "description": "Phone number to normalize. E.164 (+15555551234) or a national format if country is provided.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 40
+            }
+          },
+          {
+            "name": "country",
+            "in": "query",
+            "required": false,
+            "description": "ISO 3166-1 alpha-2 country code (e.g. US, GB, JP). Required when number is not in E.164 form.",
+            "schema": {
+              "type": "string",
+              "pattern": "^[A-Z]{2}$"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/registry/npm-lookup": {
+      "get": {
+        "tags": [
+          "registry"
+        ],
+        "summary": "Look up an npm package by name (supports scoped packages...",
+        "description": "Look up an npm package by name (supports scoped packages like @sentry/node). Returns description, homepage, repository, license, author + maintainers list, keywords, distTags (latest/beta/rc/etc.), latest version + publication date, and the 50 most recent versions with their publish dates + deprecation status. ~3M JavaScript/TypeScript packages. npm public registry.",
+        "operationId": "registry_npm-lookup",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = [npm package metadata] (license, maintainers, distTags, recent versions); total = 1.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "description": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "homepage": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "repository": {
+                                "type": "object",
+                                "properties": {
+                                  "type": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "url": {
+                                    "type": "string",
+                                    "nullable": true
+                                  }
+                                },
+                                "required": [
+                                  "type",
+                                  "url"
+                                ],
+                                "additionalProperties": false,
+                                "nullable": true
+                              },
+                              "license": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "author": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "maintainers": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "keywords": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "distTags": {
+                                "type": "object",
+                                "additionalProperties": {
+                                  "type": "string"
+                                }
+                              },
+                              "latestVersion": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "latestPublished": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "versions": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "version": {
+                                      "type": "string"
+                                    },
+                                    "published": {
+                                      "type": "string",
+                                      "nullable": true
+                                    },
+                                    "deprecated": {
+                                      "type": "string",
+                                      "nullable": true
+                                    }
+                                  },
+                                  "required": [
+                                    "version",
+                                    "published",
+                                    "deprecated"
+                                  ],
+                                  "additionalProperties": false
+                                }
+                              }
+                            },
+                            "required": [
+                              "name",
+                              "description",
+                              "homepage",
+                              "repository",
+                              "license",
+                              "author",
+                              "maintainers",
+                              "keywords",
+                              "distTags",
+                              "latestVersion",
+                              "latestPublished",
+                              "versions"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "registry.npm-lookup",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "name",
+            "in": "query",
+            "required": true,
+            "description": "Name to search for.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 214
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/registry/pypi-lookup": {
+      "get": {
+        "tags": [
+          "registry"
+        ],
+        "summary": "Look up a Python package on PyPI by name.",
+        "description": "Look up a Python package on PyPI by name. Returns version, summary + long description, content-type, project URLs (Homepage, Source, Bug Tracker, Docs, etc.), license, author + maintainer (with emails), keywords, classifiers (top 30), requires-python spec, requires-dist (top 100 runtime deps), the 50 most recent releases with publish dates, and any yanked versions in that window. PyPI public registry.",
+        "operationId": "registry_pypi-lookup",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = [PyPI package metadata] (version, project URLs, classifiers, deps, recent releases); total = 1.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "version": {
+                                "type": "string"
+                              },
+                              "summary": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "description": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "descriptionContentType": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "homePage": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "projectUrls": {
+                                "type": "object",
+                                "additionalProperties": {
+                                  "type": "string"
+                                }
+                              },
+                              "license": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "author": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "authorEmail": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "maintainer": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "maintainerEmail": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "keywords": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "classifiers": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "requiresPython": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "requiresDist": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "releaseDates": {
+                                "type": "object",
+                                "additionalProperties": {
+                                  "type": "string",
+                                  "nullable": true
+                                }
+                              },
+                              "yankedVersions": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "required": [
+                              "name",
+                              "version",
+                              "summary",
+                              "description",
+                              "descriptionContentType",
+                              "homePage",
+                              "projectUrls",
+                              "license",
+                              "author",
+                              "authorEmail",
+                              "maintainer",
+                              "maintainerEmail",
+                              "keywords",
+                              "classifiers",
+                              "requiresPython",
+                              "requiresDist",
+                              "releaseDates",
+                              "yankedVersions"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.0012 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "registry.pypi-lookup",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.0012,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001200"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "name",
+            "in": "query",
+            "required": true,
+            "description": "Name to search for.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 200
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/tld/info": {
+      "get": {
+        "tags": [
+          "tld"
+        ],
+        "summary": "Fetch TLD registry intelligence and public-suffix data",
+        "description": "TLD registry intelligence and public-suffix analysis. Mode 1 (tld=io): IANA root-zone metadata — type (generic / country-code / sponsored), managing organization, unicode form for IDN TLDs. Mode 2 (domain=shop.example.co.uk): full Public Suffix List algorithm — the effective public suffix (co.uk), the registrable domain (example.co.uk), the subdomain part, the matched PSL rule, and whether the suffix is ICANN (registry) or private (corporate, e.g. github.io / s3.amazonaws.com) — plus the root-zone metadata for its TLD. Correctly handles wildcard and exception rules and IDN/punycode input. Use for cookie scoping, per-registrant rate limiting, URL dedup, and abuse/phishing analysis. Data: IANA root zone + Mozilla PSL, refreshed weekly.",
+        "operationId": "tld_info",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = [one TLD/domain analysis] (IANA TLD metadata, plus PSL public-suffix / registrable-domain analysis in domain mode); total = 1; meta.sources lists both upstream attributions.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "query": {
+                                "type": "string",
+                                "description": "Normalized (punycode) query value."
+                              },
+                              "tld": {
+                                "type": "object",
+                                "properties": {
+                                  "tld": {
+                                    "type": "string",
+                                    "description": "ASCII/punycode TLD label."
+                                  },
+                                  "unicodeTld": {
+                                    "type": "string",
+                                    "description": "Unicode display form (differs for IDN TLDs)."
+                                  },
+                                  "type": {
+                                    "type": "string",
+                                    "description": "IANA delegation type: generic, country-code, sponsored, generic-restricted, infrastructure, or test."
+                                  },
+                                  "manager": {
+                                    "type": "string",
+                                    "nullable": true,
+                                    "description": "Sponsoring organization; null when unassigned/retired."
+                                  }
+                                },
+                                "required": [
+                                  "tld",
+                                  "unicodeTld",
+                                  "type",
+                                  "manager"
+                                ],
+                                "additionalProperties": false,
+                                "nullable": true,
+                                "description": "IANA root-zone metadata; null when the TLD is not in the root zone."
+                              },
+                              "suffix": {
+                                "type": "object",
+                                "properties": {
+                                  "publicSuffix": {
+                                    "type": "string"
+                                  },
+                                  "registrableDomain": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "subdomain": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "matchedRule": {
+                                    "type": "string"
+                                  },
+                                  "section": {
+                                    "type": "string",
+                                    "enum": [
+                                      "icann",
+                                      "private",
+                                      "implicit"
+                                    ]
+                                  },
+                                  "isWildcard": {
+                                    "type": "boolean"
+                                  },
+                                  "isException": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "publicSuffix",
+                                  "registrableDomain",
+                                  "subdomain",
+                                  "matchedRule",
+                                  "section",
+                                  "isWildcard",
+                                  "isException"
+                                ],
+                                "additionalProperties": false,
+                                "nullable": true,
+                                "description": "PSL analysis (domain mode only)."
+                              }
+                            },
+                            "required": [
+                              "query",
+                              "tld",
+                              "suffix"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "sources": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "provider": {
+                                    "type": "string"
+                                  },
+                                  "url": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "provider",
+                                  "url"
+                                ],
+                                "additionalProperties": false
+                              },
+                              "description": "All attributions: IANA root zone + Mozilla PSL."
+                            }
+                          },
+                          "required": [
+                            "sources"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.001 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "tld.info",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.001,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "tld",
+            "in": "query",
+            "required": false,
+            "description": "TLD label, e.g. \"io\" or \".рф\". Provide tld or domain, not both.",
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 64
+            }
+          },
+          {
+            "name": "domain",
+            "in": "query",
+            "required": false,
+            "description": "Domain name to analyze, e.g. \"shop.example.co.uk\".",
+            "schema": {
+              "type": "string",
+              "minLength": 3,
+              "maxLength": 253
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/tls/cert-info": {
+      "get": {
+        "tags": [
+          "tls"
+        ],
+        "summary": "Check a live TLS connection to a host and return its...",
+        "description": "Open a live TLS connection to a host and return its certificate. Give a host (and optional port, default 443). Returns the negotiated TLS protocol + cipher, whether the chain validates against system roots, and the leaf certificate's subject + issuer (CN/O/C), validity window (valid-from / valid-to), days until expiry + expired flag, serial number, SHA-256 fingerprint, Subject Alternative Names, and the chain length. A genuine network probe agents can't do from their sandbox — for cert-expiry monitoring, TLS audits, and verifying who issued a site's certificate. SSRF-guarded: the host must resolve to a public address. Self-signed and expired certs are reported (not rejected).",
+        "operationId": "tls_cert-info",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized envelope: items = [certificate probe] (host, port, protocol, cipher, chain validity, leaf cert subject/issuer/validity/SANs); total = 1.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "ok": {
+                          "type": "boolean",
+                          "enum": [
+                            true
+                          ]
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "type": "number"
+                              },
+                              "resolvedIp": {
+                                "type": "string"
+                              },
+                              "protocol": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "cipher": {
+                                "type": "object",
+                                "properties": {
+                                  "name": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "version": {
+                                    "type": "string",
+                                    "nullable": true
+                                  }
+                                },
+                                "required": [
+                                  "name",
+                                  "version"
+                                ],
+                                "additionalProperties": false,
+                                "nullable": true
+                              },
+                              "authorized": {
+                                "type": "boolean"
+                              },
+                              "authorizationError": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "certificate": {
+                                "type": "object",
+                                "properties": {
+                                  "subject": {
+                                    "type": "object",
+                                    "additionalProperties": {}
+                                  },
+                                  "issuer": {
+                                    "type": "object",
+                                    "additionalProperties": {}
+                                  },
+                                  "validFrom": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "validTo": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "daysUntilExpiry": {
+                                    "type": "number",
+                                    "nullable": true
+                                  },
+                                  "expired": {
+                                    "type": "boolean"
+                                  },
+                                  "serialNumber": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "fingerprintSha256": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "subjectAltNames": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "isCa": {
+                                    "type": "boolean",
+                                    "nullable": true
+                                  }
+                                },
+                                "required": [
+                                  "subject",
+                                  "issuer",
+                                  "validFrom",
+                                  "validTo",
+                                  "daysUntilExpiry",
+                                  "expired",
+                                  "serialNumber",
+                                  "fingerprintSha256",
+                                  "subjectAltNames",
+                                  "isCa"
+                                ],
+                                "additionalProperties": false
+                              },
+                              "chainLength": {
+                                "type": "number"
+                              }
+                            },
+                            "required": [
+                              "host",
+                              "port",
+                              "resolvedIp",
+                              "protocol",
+                              "cipher",
+                              "authorized",
+                              "authorizationError",
+                              "certificate",
+                              "chainLength"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "nullable": true,
+                          "description": "Total matching rows upstream; null when unknown."
+                        },
+                        "source": {
+                          "type": "object",
+                          "properties": {
+                            "provider": {
+                              "type": "string"
+                            },
+                            "url": {
+                              "type": "string"
+                            },
+                            "license": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "provider",
+                            "url",
+                            "license"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "ok",
+                        "items",
+                        "total",
+                        "source"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.001 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "tls.cert-info",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.001,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "normalized",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "host",
+            "in": "query",
+            "required": true,
+            "description": "Hostname to look up.",
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 253
+            }
+          },
+          {
+            "name": "port",
+            "in": "query",
+            "required": false,
+            "description": "Port.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 65535,
+              "default": 443
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/url/clean": {
+      "get": {
+        "tags": [
+          "url"
+        ],
+        "summary": "Fetch any URL and return its article content with the...",
+        "description": "Fetch any URL and return its article content with the clutter stripped — nav, ads, sidebars, footers, scripts, styles, comments removed via heuristic extraction (<article> / <main> / role=main / densest block). Choose the output with `format`: markdown (default), text, both (JSON envelope), html (a self-contained readable reader-view page, raw text/html), or pdf (a clean typeset reading document, raw application/pdf). html/pdf are built from the same cleaned content, so they carry no live page, no third-party assets, no trackers. SSRF-guarded, 512KB body cap, 8s timeout, 5 redirects max. JSON formats return { url, finalUrl, title, markdown?, text?, wordCount, sourceBytes }. This uses a raw HTTP fetch (no JavaScript) — for client-rendered / SPA pages whose content only appears after JS runs, use /api/url/render (same formats, headless-rendered). For a pixel-perfect image of the live page use /api/ai/screenshot; to enumerate a page or sitemap into its links use /api/url/map.",
+        "operationId": "url_clean",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.00108 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "url.clean",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.00108,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "legacy",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001080"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "url",
+            "in": "query",
+            "required": true,
+            "description": "URL to process.",
+            "schema": {
+              "type": "string",
+              "format": "uri",
+              "maxLength": 2048
+            }
+          },
+          {
+            "name": "format",
+            "in": "query",
+            "required": false,
+            "description": "Format.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "markdown",
+                "text",
+                "both",
+                "html",
+                "pdf"
+              ],
+              "default": "markdown"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/url/map": {
+      "get": {
+        "tags": [
+          "url"
+        ],
+        "summary": "Search the URLs a page or sitemap points at in a single...",
+        "description": "Discover the URLs a page or sitemap points at in a single fetch. Point it at an XML sitemap or sitemap-index and it returns the <loc> URLs; point it at an HTML page and it returns the <a href> links — auto-detected. URLs are resolved to absolute, de-duplicated, fragment-stripped, and http(s)-only. `limit` (1-2000, default 200) caps the count; `sameHostOnly` keeps only links on the same host. Single SSRF-guarded fetch, no JavaScript, stateless — NOT a recursive crawler: to go deeper, call map again on a child sitemap or a discovered page. Returns { url, finalUrl, source: \"sitemap\"|\"links\", count, capped, urls }.",
+        "operationId": "url_map",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "meta"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "url": {
+                          "type": "string"
+                        },
+                        "finalUrl": {
+                          "type": "string"
+                        },
+                        "source": {
+                          "type": "string",
+                          "enum": [
+                            "sitemap",
+                            "links"
+                          ]
+                        },
+                        "count": {
+                          "type": "number"
+                        },
+                        "capped": {
+                          "type": "boolean"
+                        },
+                        "urls": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "url",
+                        "finalUrl",
+                        "source",
+                        "count",
+                        "capped",
+                        "urls"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "meta": {
+                      "type": "object",
+                      "description": "Per-call meta envelope — endpoint id, cost, caller kind, settlement details."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.00108 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "url.map",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.00108,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "legacy",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001080"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "url",
+            "in": "query",
+            "required": true,
+            "description": "URL to process.",
+            "schema": {
+              "type": "string",
+              "format": "uri",
+              "maxLength": 2048
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of results to return.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 2000,
+              "default": 200
+            }
+          },
+          {
+            "name": "sameHostOnly",
+            "in": "query",
+            "required": false,
+            "description": "Same host only.",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/url/render": {
+      "get": {
+        "tags": [
+          "url"
+        ],
+        "summary": "Render a URL in a real headless browser (JavaScript...",
+        "description": "Render a URL in a real headless browser (JavaScript executed) and return its article content with the clutter stripped — same cleaning + output formats as /api/url/clean, but for client-rendered / SPA pages whose content only appears after JS runs (where a raw HTTP fetch returns an empty shell). `format`: markdown (default), text, both (JSON envelope), html (self-contained reader page, raw text/html), or pdf (typeset reading doc, raw application/pdf). Optional `waitUntil` (load|domcontentloaded|networkidle0|networkidle2, default networkidle2) and `timeoutMs` (1000-15000, default 12000) control how long to let JS settle. Use /api/url/clean instead for server-rendered pages — it is Tier 0 and ~10× cheaper; only reach for render when JS rendering is required.",
+        "operationId": "url_render",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.006 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "url.render",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.006,
+          "tier": 2
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "legacy",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.006000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "url",
+            "in": "query",
+            "required": true,
+            "description": "URL to process.",
+            "schema": {
+              "type": "string",
+              "format": "uri",
+              "maxLength": 2048
+            }
+          },
+          {
+            "name": "format",
+            "in": "query",
+            "required": false,
+            "description": "Format.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "markdown",
+                "text",
+                "both",
+                "html",
+                "pdf"
+              ],
+              "default": "markdown"
+            }
+          },
+          {
+            "name": "waitUntil",
+            "in": "query",
+            "required": false,
+            "description": "Wait until.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "load",
+                "domcontentloaded",
+                "networkidle0",
+                "networkidle2"
+              ]
+            }
+          },
+          {
+            "name": "timeoutMs",
+            "in": "query",
+            "required": false,
+            "description": "Timeout ms.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1000,
+              "maximum": 15000
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    },
+    "/api/url/unfurl": {
+      "get": {
+        "tags": [
+          "url"
+        ],
+        "summary": "Fetch any URL and extract structured page metadata: title...",
+        "description": "Fetch any URL and extract structured page metadata: title, description, og:image, canonical, favicon, site name, author, published time, language, and the first ~500 chars of body text. SSRF-guarded against private networks. 8s timeout, 512 KB max body. Returns the parsed metadata plus the raw og:/twitter:/itemprop meta dictionary for inspection.",
+        "operationId": "url_unfurl",
+        "deprecated": false,
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "400": {
+            "description": "Bad request — invalid parameters."
+          },
+          "402": {
+            "description": "Payment required — costs $0.001 per call. Body contains the x402 PaymentRequirements envelope with a multi-network accepts array. Sign for whichever rail you hold USDC on (EIP-3009 for Base, partial SPL transfer for Solana) and retry with PAYMENT-SIGNATURE header (X-PAYMENT also accepted for v1 clients).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402PaymentRequiredV2"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method not allowed — see `Allow` header for the supported method."
+          },
+          "500": {
+            "description": "Internal server error."
+          },
+          "502": {
+            "description": "Upstream provider error."
+          }
+        },
+        "x-2s-id": "url.unfurl",
+        "x-2s-version": null,
+        "x-2s-price": {
+          "usd": 0.001,
+          "tier": 0
+        },
+        "x-2s-accepts": [
+          "x402"
+        ],
+        "x-2s-response-shape": "legacy",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "url",
+            "in": "query",
+            "required": true,
+            "description": "URL to process.",
+            "schema": {
+              "type": "string",
+              "format": "uri",
+              "maxLength": 2048
+            }
+          },
+          {
+            "$ref": "#/components/parameters/TrialMode"
+          }
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds **2s** (`2s/data`) — a unified, agent-native JSON API of 233+ deterministic endpoints over US public records and reference data (business identity/LEI, SEC filings, Congress trades, OFAC sanctions, legal citations, ICD-10/RxNorm, VIN decode, EDI X12 parse + 997 generate, identifier validation).

- Pays per call in **USDC on Solana** (and Base) via x402 — every endpoint returns a Solana-USDC 402 challenge.
- OpenAPI spec committed as a sidecar (`openapi: { path: openapi.json }`), ~948 KB, every parameter described.
- `pay catalog check --no-probe` passes (remaining items are non-blocking style warnings).
- Try before paying: `?trial=1` gives one free real call per endpoint per hour.