### PR TITLE
feat: add nodit provider

### DIFF
--- a/providers/lambda256/nodit/PAY.md
+++ b/providers/lambda256/nodit/PAY.md
@@ -1,0 +1,48 @@
+---
+name: nodit
+title: "Nodit"
+description: "On-chain access via x402 across Ethereum, Solana, Bitcoin, Base, Aptos, Sui, and more: raw JSON-RPC plus indexed Web3 data — native and token balances, transfers, holders, NFT and asset metadata, transactions, blocks, events, gas, ENS, and stats."
+use_case: "Use for on-chain reads: raw JSON-RPC calls, wallet and token balances, transfer and transaction history, token and NFT holders, asset and NFT metadata, block/event queries, gas, ENS resolution, and stats across EVM, Solana, Bitcoin, Aptos, and Sui."
+category: data
+service_url: https://x402.nodit.io
+version: v1
+openapi:
+  path: openapi.json
+---
+
+Nodit gives agents two layers of on-chain access through one x402 payment
+proxy: the **Node API** for raw JSON-RPC straight to the chain, and the
+**Web3 Data API** for the same on-chain history already indexed — token
+balances, transfers, holders, NFT and asset metadata, and activity stats.
+Read current state or query historical data in a single call, with no node
+to run and no indexing or ETL pipeline of your own — the data is already
+parsed, indexed, and queryable. Coverage spans EVM chains, Solana, Bitcoin,
+Aptos, Sui, XRPL, Tron, and more. Most endpoints are `POST` and take
+`{chain}/{network}` path parameters plus a JSON body.
+
+## Payment
+
+Paid calls settle as on-chain micropayments via the x402 (HTTP 402 Payment
+Required) protocol. Two modes share the same data surface:
+
+- **Pay-Per-Use** (`/pay-per-use/**`): settle each request on-chain — no
+  pre-funding, no authentication, no onboarding. An unpaid request returns
+  a `402` challenge; the agent signs and replays. From 0.001 USDC per
+  request. This is the mode agents should use.
+- **Credit** (`/credit/**`): top up USDC once, then deduct off-chain per
+  call. Sign in with your wallet (SIWX) for a 1-hour JWT. Suited to
+  high-frequency, predictable workloads that pre-fund rather than signing
+  per request.
+
+## Spend-aware usage
+
+- Prefer indexed Web3 Data API reads over raw JSON-RPC when an indexed
+  answer exists — one call instead of many round-trips.
+- Use narrow, account- or id-scoped reads (`getNativeBalanceByAccount`,
+  `getTokenContractMetadataByContracts`) over broad range or search
+  endpoints when you already hold the identifier.
+- Cap `getTokenTransfersByAccount` / `getTransactionsByAccount` paging to
+  the smallest window that answers the task; avoid full-history pulls.
+- Reuse `{chain}/{network}` and resolved addresses/ids across calls.
+- For repeated high-volume access, Credit mode avoids a per-call signature
+  round-trip.

--- a/providers/lambda256/nodit/openapi.json
+++ b/providers/lambda256/nodit/openapi.json
@@ -1,0 +1,18648 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Nodit x402 API",
+    "version": "1.0.0",
+    "description": "# Nodit on-chain APIs — raw JSON-RPC and indexed data queries\n\nNodit gives you two layers of on-chain access from one platform. Go straight to the chain with the **Node API** (raw JSON-RPC), or query the same data already indexed with the **Web3 Data API** — token balances, transfers, holders, NFTs, and stats, ready to use with no ETL of your own. Raw RPC when you need the chain as-is; indexed queries when you need answers.\n\n## Two ways to pay\n\n- **Pay-Per-Use** (`/pay-per-use/**`) — settle each request on-chain. No pre-funding, no authentication, no onboarding. Ideal for low-frequency calls and prototyping. From 0.001 USDC per request.\n- **Credit** (`/credit/**`) — top up USDC once, then deduct off-chain per call. Ideal for high-frequency, predictable workloads. Sign in with your wallet (SIWX) for a 1-hour JWT.\n",
+    "contact": {
+      "name": "Lambda256 Co., Ltd.",
+      "url": "https://www.nodit.io"
+    }
+  },
+  "servers": [
+    {
+      "url": "https://x402.nodit.io",
+      "description": "Nodit x402 server"
+    }
+  ],
+  "tags": [
+    {
+      "name": "auth",
+      "description": "Wallet-signature (SIWX) based authentication"
+    },
+    {
+      "name": "credit",
+      "description": "Credit balance management and credit-mode API calls"
+    },
+    {
+      "name": "ppu",
+      "description": "Pay-Per-Use mode API calls"
+    },
+    {
+      "name": "data",
+      "description": "Web3 Data API calls (proxied)"
+    },
+    {
+      "name": "rpc",
+      "description": "Node API (JSON-RPC) relay calls (proxied)"
+    },
+    {
+      "name": "payments",
+      "description": "Payment and usage history lookup"
+    }
+  ],
+  "paths": {
+    "/auth": {
+      "post": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Generate a short-lived JWT from a SIWX wallet signature",
+        "description": "Verifies a Sign In With X (SIWX) format message and wallet signature and issues an account-scope JWT access token. Authentication uses the wallet signature alone — no sign-up or KYC.\n\n**Why you need this:** the JWT is required for **Credit mode** payments. In Credit mode, each API call is settled by deducting from your pre-funded credit balance off-chain, so the server must know which account to charge — the JWT identifies that account on every `/credit/**` request. Send the token in the `Authorization: Bearer <token>` header; it is valid for 1 hour, after which you re-authenticate here.\n\n**Pay-Per-Use mode does not need this** — those calls carry an on-chain payment per request and require no authentication.",
+        "operationId": "authenticate",
+        "security": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SiwxAuthRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Authentication succeeded — JWT issued",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Malformed request or signature verification failure",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/credit/charge": {
+      "post": {
+        "tags": [
+          "credit"
+        ],
+        "summary": "Create a credit top-up with an x402 USDC payment",
+        "description": "Tops up the credit balance with an on-chain USDC payment.\n\n- When called without the `payment-signature` header, returns **402 Payment Required** along with the payment requirements (PaymentRequirements).\n- When called again with the payment signature in the `payment-signature` header, the facilitator verifies/settles the payment and returns the balance after the top-up.\n\nThe top-up amount must be a positive atomic USDC string of at least **$0.01** (`10000` atomic USDC, 6 decimals). A rate limit of 10 requests per minute applies.",
+        "operationId": "creditCharge",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ChargeRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Top-up succeeded",
+            "headers": {
+              "PAYMENT-RESPONSE": {
+                "$ref": "#/components/headers/PaymentResponseHeader"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChargeResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Top-up amount format/range error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "429": {
+            "description": "Top-up rate limit exceeded (10/min)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Payment settlement failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/credit/balance": {
+      "get": {
+        "tags": [
+          "credit"
+        ],
+        "summary": "Fetch the remaining prepaid Nodit credit balance",
+        "description": "Returns the current account's credit balance (atomic USDC). Returns \"0\" if the account does not exist.",
+        "operationId": "creditBalance",
+        "responses": {
+          "200": {
+            "description": "Balance",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BalanceResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/payments": {
+      "get": {
+        "tags": [
+          "payments"
+        ],
+        "summary": "List payment and usage history",
+        "description": "Returns a paginated payment history that combines credit top-ups, credit usage, and PPU payments. It is automatically filtered by the accountId in the JWT, and other accounts' data cannot be queried.",
+        "operationId": "paymentsList",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PaymentsFrom"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentsTo"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentsBilling"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentsStatus"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentsServiceChain"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentsSearch"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "description": "Page number",
+            "schema": {
+              "type": "integer",
+              "default": 1,
+              "minimum": 1
+            }
+          },
+          {
+            "name": "rpp",
+            "in": "query",
+            "required": false,
+            "description": "Rows per page",
+            "schema": {
+              "type": "integer",
+              "default": 12,
+              "minimum": 1
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Payment history list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentsListResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Query parameter validation failure",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/credit/{chain}/{network}/json-rpc": {
+      "post": {
+        "tags": [
+          "credit",
+          "rpc"
+        ],
+        "summary": "Send a raw JSON-RPC request to the chain node (credit)",
+        "description": "Nodit Node API (JSON-RPC) relay. Credit mode x402 payment. Without a payment-signature, returns 402. method/params are passed through to the node.",
+        "operationId": "credit_jsonRpc",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain01"
+          },
+          {
+            "$ref": "#/components/parameters/Network01"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JsonRpcRequest"
+              },
+              "example": {
+                "jsonrpc": "2.0",
+                "method": "eth_blockNumber",
+                "params": [],
+                "id": 1
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — node response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        }
+      }
+    },
+    "/pay-per-use/{chain}/{network}/json-rpc": {
+      "post": {
+        "tags": [
+          "ppu",
+          "rpc"
+        ],
+        "summary": "Send a raw JSON-RPC request to the chain node (pay-per-use)",
+        "description": "Nodit Node API (JSON-RPC) relay. Pay-Per-Use mode x402 payment. Without a payment-signature, returns 402. method/params are passed through to the node.",
+        "operationId": "payperuse_jsonRpc",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain01"
+          },
+          {
+            "$ref": "#/components/parameters/Network01"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JsonRpcRequest"
+              },
+              "example": {
+                "jsonrpc": "2.0",
+                "method": "eth_blockNumber",
+                "params": [],
+                "id": 1
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — node response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        },
+        "security": []
+      }
+    },
+    "/credit/v1/{chain}/{network}/token/searchTokenContractMetadataByKeyword": {
+      "post": {
+        "tags": [
+          "credit",
+          "data"
+        ],
+        "summary": "Search Token Contract Metadata by Keyword (credit)",
+        "description": "Retrieves the list of contracts matching the ERC20 token contract name or symbol.\n\n*Paid per call via x402 (Credit mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "credit_searchTokenContractMetadataByKeyword",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain02"
+          },
+          {
+            "$ref": "#/components/parameters/Network02"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/searchTokenContractMetadataByKeyword__evm__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/searchTokenContractMetadataByKeyword__tron__Req"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        }
+      }
+    },
+    "/pay-per-use/v1/{chain}/{network}/token/searchTokenContractMetadataByKeyword": {
+      "post": {
+        "tags": [
+          "ppu",
+          "data"
+        ],
+        "summary": "Search Token Contract Metadata by Keyword (pay-per-use)",
+        "description": "Retrieves the list of contracts matching the ERC20 token contract name or symbol.\n\n*Paid per call via x402 (Pay-Per-Use mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "payperuse_searchTokenContractMetadataByKeyword",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain02"
+          },
+          {
+            "$ref": "#/components/parameters/Network02"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/searchTokenContractMetadataByKeyword__evm__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/searchTokenContractMetadataByKeyword__tron__Req"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        },
+        "security": []
+      }
+    },
+    "/credit/v1/{chain}/{network}/token/getTokenTransfersByContract": {
+      "post": {
+        "tags": [
+          "credit",
+          "data"
+        ],
+        "summary": "Get Token Transfers by Contract (credit)",
+        "description": "Retrieves the list of ERC20 token transfers that occurred from a specific contract. Results include token contract metadata and the transferred token amount.\n\n*Paid per call via x402 (Credit mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "credit_getTokenTransfersByContract",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain02"
+          },
+          {
+            "$ref": "#/components/parameters/Network02"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/getTokenTransfersByContract__evm__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/getTokenTransfersByContract__kaia__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/getTokenTransfersByContract__tron__Req"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        }
+      }
+    },
+    "/pay-per-use/v1/{chain}/{network}/token/getTokenTransfersByContract": {
+      "post": {
+        "tags": [
+          "ppu",
+          "data"
+        ],
+        "summary": "Get Token Transfers by Contract (pay-per-use)",
+        "description": "Retrieves the list of ERC20 token transfers that occurred from a specific contract. Results include token contract metadata and the transferred token amount.\n\n*Paid per call via x402 (Pay-Per-Use mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "payperuse_getTokenTransfersByContract",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain02"
+          },
+          {
+            "$ref": "#/components/parameters/Network02"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/getTokenTransfersByContract__evm__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/getTokenTransfersByContract__kaia__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/getTokenTransfersByContract__tron__Req"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        },
+        "security": []
+      }
+    },
+    "/credit/v1/{chain}/{network}/token/getTokenPairByAssetType": {
+      "post": {
+        "tags": [
+          "credit",
+          "data"
+        ],
+        "summary": "Get Token Pair by Asset Type (credit)",
+        "description": "Retrieves token pair information for a specific asset type.\n\n*Paid per call via x402 (Credit mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "credit_getTokenPairByAssetType",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain03"
+          },
+          {
+            "$ref": "#/components/parameters/Network03"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/getTokenPairByAssetType__aptos__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/getTokenPairByAssetType__aptos__Res"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        }
+      }
+    },
+    "/pay-per-use/v1/{chain}/{network}/token/getTokenPairByAssetType": {
+      "post": {
+        "tags": [
+          "ppu",
+          "data"
+        ],
+        "summary": "Get Token Pair by Asset Type (pay-per-use)",
+        "description": "Retrieves token pair information for a specific asset type.\n\n*Paid per call via x402 (Pay-Per-Use mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "payperuse_getTokenPairByAssetType",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain03"
+          },
+          {
+            "$ref": "#/components/parameters/Network03"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/getTokenPairByAssetType__aptos__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/getTokenPairByAssetType__aptos__Res"
+                }
+              }
+            }
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        },
+        "security": []
+      }
+    },
+    "/credit/v1/{chain}/{network}/token/getTokenMetadataByAssetTypes": {
+      "post": {
+        "tags": [
+          "credit",
+          "data"
+        ],
+        "summary": "Get Token Metadata by Asset Types (credit)",
+        "description": "Retrieves token metadata for the specified asset types.\n\n*Paid per call via x402 (Credit mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "credit_getTokenMetadataByAssetTypes",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain03"
+          },
+          {
+            "$ref": "#/components/parameters/Network03"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/getTokenMetadataByAssetTypes__aptos__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/getTokenMetadataByAssetTypes__aptos__Res"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        }
+      }
+    },
+    "/pay-per-use/v1/{chain}/{network}/token/getTokenMetadataByAssetTypes": {
+      "post": {
+        "tags": [
+          "ppu",
+          "data"
+        ],
+        "summary": "Get Token Metadata by Asset Types (pay-per-use)",
+        "description": "Retrieves token metadata for the specified asset types.\n\n*Paid per call via x402 (Pay-Per-Use mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "payperuse_getTokenMetadataByAssetTypes",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain03"
+          },
+          {
+            "$ref": "#/components/parameters/Network03"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/getTokenMetadataByAssetTypes__aptos__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/getTokenMetadataByAssetTypes__aptos__Res"
+                }
+              }
+            }
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        },
+        "security": []
+      }
+    },
+    "/credit/v1/{chain}/{network}/token/getTokenBalanceChangesWithinRange": {
+      "post": {
+        "tags": [
+          "credit",
+          "data"
+        ],
+        "summary": "Get Token Balance Changes Within Range (credit)",
+        "description": "Retrieves token balance change history within the specified block range.\n\n*Paid per call via x402 (Credit mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "credit_getTokenBalanceChangesWithinRange",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain03"
+          },
+          {
+            "$ref": "#/components/parameters/Network03"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/getTokenBalanceChangesWithinRange__aptos__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        }
+      }
+    },
+    "/pay-per-use/v1/{chain}/{network}/token/getTokenBalanceChangesWithinRange": {
+      "post": {
+        "tags": [
+          "ppu",
+          "data"
+        ],
+        "summary": "Get Token Balance Changes Within Range (pay-per-use)",
+        "description": "Retrieves token balance change history within the specified block range.\n\n*Paid per call via x402 (Pay-Per-Use mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "payperuse_getTokenBalanceChangesWithinRange",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain03"
+          },
+          {
+            "$ref": "#/components/parameters/Network03"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/getTokenBalanceChangesWithinRange__aptos__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        },
+        "security": []
+      }
+    },
+    "/credit/v1/{chain}/{network}/token/getTokenBalanceChangesByAssetType": {
+      "post": {
+        "tags": [
+          "credit",
+          "data"
+        ],
+        "summary": "Get Token Balance Changes by Asset Type (credit)",
+        "description": "Retrieves token balance change history by asset type.\n\n*Paid per call via x402 (Credit mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "credit_getTokenBalanceChangesByAssetType",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain03"
+          },
+          {
+            "$ref": "#/components/parameters/Network03"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/getTokenBalanceChangesByAssetType__aptos__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        }
+      }
+    },
+    "/pay-per-use/v1/{chain}/{network}/token/getTokenBalanceChangesByAssetType": {
+      "post": {
+        "tags": [
+          "ppu",
+          "data"
+        ],
+        "summary": "Get Token Balance Changes by Asset Type (pay-per-use)",
+        "description": "Retrieves token balance change history by asset type.\n\n*Paid per call via x402 (Pay-Per-Use mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "payperuse_getTokenBalanceChangesByAssetType",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain03"
+          },
+          {
+            "$ref": "#/components/parameters/Network03"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/getTokenBalanceChangesByAssetType__aptos__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        },
+        "security": []
+      }
+    },
+    "/credit/v1/{chain}/{network}/token/getTokenPricesByContracts": {
+      "post": {
+        "tags": [
+          "credit",
+          "data"
+        ],
+        "summary": "Get Token Prices by Contracts (credit)",
+        "description": "Retrieves the on-chain market price of tokens issued by the specified ERC20 token contracts. Multiple contracts can be queried, up to a maximum of 100 contracts.\n\n> 🚧 Things to know when querying token prices\n>\n> Token prices provided by this API are based on CoinMarketCap data. Price information is updated periodically, so it may differ from real-time prices. Additionally, querying tokens not registered on CoinMarketCap will return an empty array.\n\n*Paid per call via x402 (Credit mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "credit_getTokenPricesByContracts",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain04"
+          },
+          {
+            "$ref": "#/components/parameters/Network02"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/getTokenPricesByContracts__evm__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/getTokenPricesByContracts__evm__Res"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        }
+      }
+    },
+    "/pay-per-use/v1/{chain}/{network}/token/getTokenPricesByContracts": {
+      "post": {
+        "tags": [
+          "ppu",
+          "data"
+        ],
+        "summary": "Get Token Prices by Contracts (pay-per-use)",
+        "description": "Retrieves the on-chain market price of tokens issued by the specified ERC20 token contracts. Multiple contracts can be queried, up to a maximum of 100 contracts.\n\n> 🚧 Things to know when querying token prices\n>\n> Token prices provided by this API are based on CoinMarketCap data. Price information is updated periodically, so it may differ from real-time prices. Additionally, querying tokens not registered on CoinMarketCap will return an empty array.\n\n*Paid per call via x402 (Pay-Per-Use mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "payperuse_getTokenPricesByContracts",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain04"
+          },
+          {
+            "$ref": "#/components/parameters/Network02"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/getTokenPricesByContracts__evm__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/getTokenPricesByContracts__evm__Res"
+                }
+              }
+            }
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        },
+        "security": []
+      }
+    },
+    "/credit/v1/{chain}/{network}/token/getTokenContractMetadataByContracts": {
+      "post": {
+        "tags": [
+          "credit",
+          "data"
+        ],
+        "summary": "Get Token Contract Metadata by Contracts (credit)",
+        "description": "Retrieves metadata for specific ERC20 contracts. Multiple contracts can be queried, up to a maximum of 100 contracts.\n\n*Paid per call via x402 (Credit mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "credit_getTokenContractMetadataByContracts",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain02"
+          },
+          {
+            "$ref": "#/components/parameters/Network02"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/contractAddresses__evm__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/getTokenContractMetadataByContracts__tron__Req"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/contractMetadataList__evm__Res"
+                    },
+                    {
+                      "$ref": "#/components/schemas/getTokenContractMetadataByContracts__tron__Res"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        }
+      }
+    },
+    "/pay-per-use/v1/{chain}/{network}/token/getTokenContractMetadataByContracts": {
+      "post": {
+        "tags": [
+          "ppu",
+          "data"
+        ],
+        "summary": "Get Token Contract Metadata by Contracts (pay-per-use)",
+        "description": "Retrieves metadata for specific ERC20 contracts. Multiple contracts can be queried, up to a maximum of 100 contracts.\n\n*Paid per call via x402 (Pay-Per-Use mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "payperuse_getTokenContractMetadataByContracts",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain02"
+          },
+          {
+            "$ref": "#/components/parameters/Network02"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/contractAddresses__evm__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/getTokenContractMetadataByContracts__tron__Req"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/contractMetadataList__evm__Res"
+                    },
+                    {
+                      "$ref": "#/components/schemas/getTokenContractMetadataByContracts__tron__Res"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        },
+        "security": []
+      }
+    },
+    "/credit/v1/{chain}/{network}/token/getTokenTransfersByCurrencyAndIssuer": {
+      "post": {
+        "tags": [
+          "credit",
+          "data"
+        ],
+        "summary": "Get Token Transfers By Currency And Issuer (credit)",
+        "description": "Retrieves token transfer history for a specific currency and issuer.\n\n*Paid per call via x402 (Credit mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "credit_getTokenTransfersByCurrencyAndIssuer",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain05"
+          },
+          {
+            "$ref": "#/components/parameters/Network04"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/getTokenTransfersByCurrencyAndIssuer__xrpl__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        }
+      }
+    },
+    "/pay-per-use/v1/{chain}/{network}/token/getTokenTransfersByCurrencyAndIssuer": {
+      "post": {
+        "tags": [
+          "ppu",
+          "data"
+        ],
+        "summary": "Get Token Transfers By Currency And Issuer (pay-per-use)",
+        "description": "Retrieves token transfer history for a specific currency and issuer.\n\n*Paid per call via x402 (Pay-Per-Use mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "payperuse_getTokenTransfersByCurrencyAndIssuer",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain05"
+          },
+          {
+            "$ref": "#/components/parameters/Network04"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/getTokenTransfersByCurrencyAndIssuer__xrpl__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        },
+        "security": []
+      }
+    },
+    "/credit/v1/{chain}/{network}/token/getTokenHoldersByContract": {
+      "post": {
+        "tags": [
+          "credit",
+          "data"
+        ],
+        "summary": "Get Token Holders By Contract (credit)",
+        "description": "Retrieves the holder list for a specific ERC20 token contract. The holder list includes holder addresses and the quantity of tokens held by each holder.\n\n*Paid per call via x402 (Credit mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "credit_getTokenHoldersByContract",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain02"
+          },
+          {
+            "$ref": "#/components/parameters/Network02"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/contractAddressPaged__evm__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/getTokenHoldersByContract__tron__Req"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        }
+      }
+    },
+    "/pay-per-use/v1/{chain}/{network}/token/getTokenHoldersByContract": {
+      "post": {
+        "tags": [
+          "ppu",
+          "data"
+        ],
+        "summary": "Get Token Holders By Contract (pay-per-use)",
+        "description": "Retrieves the holder list for a specific ERC20 token contract. The holder list includes holder addresses and the quantity of tokens held by each holder.\n\n*Paid per call via x402 (Pay-Per-Use mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "payperuse_getTokenHoldersByContract",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain02"
+          },
+          {
+            "$ref": "#/components/parameters/Network02"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/contractAddressPaged__evm__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/getTokenHoldersByContract__tron__Req"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        },
+        "security": []
+      }
+    },
+    "/credit/v1/{chain}/{network}/token/getTokenAccountsByAssetType": {
+      "post": {
+        "tags": [
+          "credit",
+          "data"
+        ],
+        "summary": "Get Token Accounts by Asset Type (credit)",
+        "description": "Retrieves the list of accounts holding a specific asset type.\n\n*Paid per call via x402 (Credit mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "credit_getTokenAccountsByAssetType",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain03"
+          },
+          {
+            "$ref": "#/components/parameters/Network03"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/getTokenAccountsByAssetType__aptos__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        }
+      }
+    },
+    "/pay-per-use/v1/{chain}/{network}/token/getTokenAccountsByAssetType": {
+      "post": {
+        "tags": [
+          "ppu",
+          "data"
+        ],
+        "summary": "Get Token Accounts by Asset Type (pay-per-use)",
+        "description": "Retrieves the list of accounts holding a specific asset type.\n\n*Paid per call via x402 (Pay-Per-Use mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "payperuse_getTokenAccountsByAssetType",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain03"
+          },
+          {
+            "$ref": "#/components/parameters/Network03"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/getTokenAccountsByAssetType__aptos__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        },
+        "security": []
+      }
+    },
+    "/credit/v1/{chain}/{network}/token/getTokenTransfersByAccount": {
+      "post": {
+        "tags": [
+          "credit",
+          "data"
+        ],
+        "summary": "Get Token Transfers by Account (credit)",
+        "description": "Retrieves the list of ERC20 token transfers sent or received by a specific address. Results include token contract metadata and the transferred token amount.\n\n*Paid per call via x402 (Credit mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "credit_getTokenTransfersByAccount",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain06"
+          },
+          {
+            "$ref": "#/components/parameters/Network02"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/getTokenTransfersByAccount__evm__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/getTokenTransfersByAccount__kaia__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/getTokenTransfersByAccount__tron__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/getTokenTransfersByAccount__xrpl__Req"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        }
+      }
+    },
+    "/pay-per-use/v1/{chain}/{network}/token/getTokenTransfersByAccount": {
+      "post": {
+        "tags": [
+          "ppu",
+          "data"
+        ],
+        "summary": "Get Token Transfers by Account (pay-per-use)",
+        "description": "Retrieves the list of ERC20 token transfers sent or received by a specific address. Results include token contract metadata and the transferred token amount.\n\n*Paid per call via x402 (Pay-Per-Use mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "payperuse_getTokenTransfersByAccount",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain06"
+          },
+          {
+            "$ref": "#/components/parameters/Network02"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/getTokenTransfersByAccount__evm__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/getTokenTransfersByAccount__kaia__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/getTokenTransfersByAccount__tron__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/getTokenTransfersByAccount__xrpl__Req"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        },
+        "security": []
+      }
+    },
+    "/credit/v1/{chain}/{network}/token/getTokensOwnedByAccount": {
+      "post": {
+        "tags": [
+          "credit",
+          "data"
+        ],
+        "summary": "Get Tokens Owned By Account (credit)",
+        "description": "Retrieves the list of ERC20 tokens held by a specific account. Results include the quantity held per token and token contract metadata.\n\n*Paid per call via x402 (Credit mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "credit_getTokensOwnedByAccount",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain07"
+          },
+          {
+            "$ref": "#/components/parameters/Network02"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/getTokensOwnedByAccount__evm__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/getTokensOwnedByAccount__tron__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/getTokensOwnedByAccount__aptos__Req"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/paginatedItems__common__Res"
+                    },
+                    {
+                      "$ref": "#/components/schemas/getTokensOwnedByAccount__aptos__Res"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        }
+      }
+    },
+    "/pay-per-use/v1/{chain}/{network}/token/getTokensOwnedByAccount": {
+      "post": {
+        "tags": [
+          "ppu",
+          "data"
+        ],
+        "summary": "Get Tokens Owned By Account (pay-per-use)",
+        "description": "Retrieves the list of ERC20 tokens held by a specific account. Results include the quantity held per token and token contract metadata.\n\n*Paid per call via x402 (Pay-Per-Use mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "payperuse_getTokensOwnedByAccount",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain07"
+          },
+          {
+            "$ref": "#/components/parameters/Network02"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/getTokensOwnedByAccount__evm__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/getTokensOwnedByAccount__tron__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/getTokensOwnedByAccount__aptos__Req"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/paginatedItems__common__Res"
+                    },
+                    {
+                      "$ref": "#/components/schemas/getTokensOwnedByAccount__aptos__Res"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        },
+        "security": []
+      }
+    },
+    "/credit/v1/{chain}/{network}/token/getTokenBalanceChangesByAccount": {
+      "post": {
+        "tags": [
+          "credit",
+          "data"
+        ],
+        "summary": "Get Token Balance Changes by Account (credit)",
+        "description": "Retrieves the IOU token balance change history for a specific account.\n\n*Paid per call via x402 (Credit mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "credit_getTokenBalanceChangesByAccount",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain08"
+          },
+          {
+            "$ref": "#/components/parameters/Network03"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/getTokenBalanceChangesByAccount__aptos__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/getTokenBalanceChangesByAccount__xrpl__Req"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        }
+      }
+    },
+    "/pay-per-use/v1/{chain}/{network}/token/getTokenBalanceChangesByAccount": {
+      "post": {
+        "tags": [
+          "ppu",
+          "data"
+        ],
+        "summary": "Get Token Balance Changes by Account (pay-per-use)",
+        "description": "Retrieves the IOU token balance change history for a specific account.\n\n*Paid per call via x402 (Pay-Per-Use mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "payperuse_getTokenBalanceChangesByAccount",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain08"
+          },
+          {
+            "$ref": "#/components/parameters/Network03"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/getTokenBalanceChangesByAccount__aptos__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/getTokenBalanceChangesByAccount__xrpl__Req"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        },
+        "security": []
+      }
+    },
+    "/credit/v1/{chain}/{network}/token/getTokenAllowance": {
+      "post": {
+        "tags": [
+          "credit",
+          "data"
+        ],
+        "summary": "Fetch the token allowance granted to a spender (credit)",
+        "description": "Retrieves the amount of ERC20 tokens that the owner has approved for the spender.\n\n*Paid per call via x402 (Credit mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "credit_getTokenAllowance",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain02"
+          },
+          {
+            "$ref": "#/components/parameters/Network02"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/getTokenAllowance__evm__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/getTokenAllowance__tron__Req"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/getTokenAllowance___shared__Res"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        }
+      }
+    },
+    "/pay-per-use/v1/{chain}/{network}/token/getTokenAllowance": {
+      "post": {
+        "tags": [
+          "ppu",
+          "data"
+        ],
+        "summary": "Fetch the token allowance granted to a spender (pay-per-use)",
+        "description": "Retrieves the amount of ERC20 tokens that the owner has approved for the spender.\n\n*Paid per call via x402 (Pay-Per-Use mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "payperuse_getTokenAllowance",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain02"
+          },
+          {
+            "$ref": "#/components/parameters/Network02"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/getTokenAllowance__evm__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/getTokenAllowance__tron__Req"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/getTokenAllowance___shared__Res"
+                }
+              }
+            }
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        },
+        "security": []
+      }
+    },
+    "/credit/v1/{chain}/{network}/token/getTokenTransfersWithinRange": {
+      "post": {
+        "tags": [
+          "credit",
+          "data"
+        ],
+        "summary": "Get Token Transfers Within Range (credit)",
+        "description": "Retrieves the list of ERC20 token transfers that occurred during a specific period. Results include token contract metadata and the transferred token amount.\n\n\n> 📘 Period setting tip\n> If the specified period is long, response time may increase. For faster responses, it is recommended to set only the necessary period.\n\n*Paid per call via x402 (Credit mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "credit_getTokenTransfersWithinRange",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain06"
+          },
+          {
+            "$ref": "#/components/parameters/Network02"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/getTokenTransfersWithinRange__evm__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/getTokenTransfersWithinRange__kaia__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/transfersWithinRange__tron__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/getTokenTransfersWithinRange__xrpl__Req"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        }
+      }
+    },
+    "/pay-per-use/v1/{chain}/{network}/token/getTokenTransfersWithinRange": {
+      "post": {
+        "tags": [
+          "ppu",
+          "data"
+        ],
+        "summary": "Get Token Transfers Within Range (pay-per-use)",
+        "description": "Retrieves the list of ERC20 token transfers that occurred during a specific period. Results include token contract metadata and the transferred token amount.\n\n\n> 📘 Period setting tip\n> If the specified period is long, response time may increase. For faster responses, it is recommended to set only the necessary period.\n\n*Paid per call via x402 (Pay-Per-Use mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "payperuse_getTokenTransfersWithinRange",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain06"
+          },
+          {
+            "$ref": "#/components/parameters/Network02"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/getTokenTransfersWithinRange__evm__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/getTokenTransfersWithinRange__kaia__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/transfersWithinRange__tron__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/getTokenTransfersWithinRange__xrpl__Req"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        },
+        "security": []
+      }
+    },
+    "/credit/v1/{chain}/{network}/ens/getEnsRecordsByAccount": {
+      "post": {
+        "tags": [
+          "credit",
+          "data"
+        ],
+        "summary": "Get ENS Records By Account (credit)",
+        "description": "Retrieves ENS domain information by entering the ENS domain owner address or the address that the domain points to. \nownerAddress indicates the ENS domain owner address, and resolvedAddress indicates the address that the ENS domain points to.\n\t\t\n\n> 🚧 Please verify the network when using!\n>\n> This API is supported only on Ethereum Mainnet and cannot be used on other networks. Please verify the network when using.\n\n*Paid per call via x402 (Credit mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "credit_getEnsRecordsByAccount",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain09"
+          },
+          {
+            "$ref": "#/components/parameters/Network04"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/getEnsRecordsByAccount__evm__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        }
+      }
+    },
+    "/pay-per-use/v1/{chain}/{network}/ens/getEnsRecordsByAccount": {
+      "post": {
+        "tags": [
+          "ppu",
+          "data"
+        ],
+        "summary": "Get ENS Records By Account (pay-per-use)",
+        "description": "Retrieves ENS domain information by entering the ENS domain owner address or the address that the domain points to. \nownerAddress indicates the ENS domain owner address, and resolvedAddress indicates the address that the ENS domain points to.\n\t\t\n\n> 🚧 Please verify the network when using!\n>\n> This API is supported only on Ethereum Mainnet and cannot be used on other networks. Please verify the network when using.\n\n*Paid per call via x402 (Pay-Per-Use mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "payperuse_getEnsRecordsByAccount",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain09"
+          },
+          {
+            "$ref": "#/components/parameters/Network04"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/getEnsRecordsByAccount__evm__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        },
+        "security": []
+      }
+    },
+    "/credit/v1/{chain}/{network}/ens/getEnsRecordByName": {
+      "post": {
+        "tags": [
+          "credit",
+          "data"
+        ],
+        "summary": "Fetch the ENS record registered for a name (credit)",
+        "description": "Retrieves ENS domain information by entering the ENS domain name.\n\t\t\n\n> 🚧 Please verify the network when using!\n>\n> This API is supported only on Ethereum Mainnet and cannot be used on other networks. Please verify the network when using.\n\n*Paid per call via x402 (Credit mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "credit_getEnsRecordByName",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain09"
+          },
+          {
+            "$ref": "#/components/parameters/Network04"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ensName__evm__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/getEnsRecordByName__evm__Res"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        }
+      }
+    },
+    "/pay-per-use/v1/{chain}/{network}/ens/getEnsRecordByName": {
+      "post": {
+        "tags": [
+          "ppu",
+          "data"
+        ],
+        "summary": "Fetch the ENS record registered for a name (pay-per-use)",
+        "description": "Retrieves ENS domain information by entering the ENS domain name.\n\t\t\n\n> 🚧 Please verify the network when using!\n>\n> This API is supported only on Ethereum Mainnet and cannot be used on other networks. Please verify the network when using.\n\n*Paid per call via x402 (Pay-Per-Use mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "payperuse_getEnsRecordByName",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain09"
+          },
+          {
+            "$ref": "#/components/parameters/Network04"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ensName__evm__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/getEnsRecordByName__evm__Res"
+                }
+              }
+            }
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        },
+        "security": []
+      }
+    },
+    "/credit/v1/{chain}/{network}/ens/getEnsNameByAddress": {
+      "post": {
+        "tags": [
+          "credit",
+          "data"
+        ],
+        "summary": "Resolve a wallet address to its ENS name (credit)",
+        "description": "Returns the mapped ENS domain name by entering an address.\n\n\n> 🚧 Seeing null even though the address has an ENS domain name?\n>\n> Multiple domain names can point to a single address. This API returns only the name registered as the Primary Name. If you want to check all names, try [Get Ens Records By Account](ref:getensrecordsbyaccount)!\n\n\n> 🚧 Please verify the network when using!\n>\n> This API is supported only on Ethereum Mainnet and cannot be used on other networks. Please verify the network when using.\n\n*Paid per call via x402 (Credit mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "credit_getEnsNameByAddress",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain09"
+          },
+          {
+            "$ref": "#/components/parameters/Network04"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/getEnsNameByAddress__evm__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/getEnsNameByAddress__evm__Res"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        }
+      }
+    },
+    "/pay-per-use/v1/{chain}/{network}/ens/getEnsNameByAddress": {
+      "post": {
+        "tags": [
+          "ppu",
+          "data"
+        ],
+        "summary": "Resolve a wallet address to its ENS name (pay-per-use)",
+        "description": "Returns the mapped ENS domain name by entering an address.\n\n\n> 🚧 Seeing null even though the address has an ENS domain name?\n>\n> Multiple domain names can point to a single address. This API returns only the name registered as the Primary Name. If you want to check all names, try [Get Ens Records By Account](ref:getensrecordsbyaccount)!\n\n\n> 🚧 Please verify the network when using!\n>\n> This API is supported only on Ethereum Mainnet and cannot be used on other networks. Please verify the network when using.\n\n*Paid per call via x402 (Pay-Per-Use mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "payperuse_getEnsNameByAddress",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain09"
+          },
+          {
+            "$ref": "#/components/parameters/Network04"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/getEnsNameByAddress__evm__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/getEnsNameByAddress__evm__Res"
+                }
+              }
+            }
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        },
+        "security": []
+      }
+    },
+    "/credit/v1/{chain}/{network}/ens/getAddressByEnsName": {
+      "post": {
+        "tags": [
+          "credit",
+          "data"
+        ],
+        "summary": "Resolve an ENS name to its wallet address (credit)",
+        "description": "Retrieves the mapped address by entering the ENS domain name.\n\n\n> 🚧 Please verify the network when using!\n>\n> This API is supported only on Ethereum Mainnet and cannot be used on other networks. Please verify the network when using.\n\n*Paid per call via x402 (Credit mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "credit_getAddressByEnsName",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain09"
+          },
+          {
+            "$ref": "#/components/parameters/Network04"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ensName__evm__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/getAddressByEnsName__evm__Res"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        }
+      }
+    },
+    "/pay-per-use/v1/{chain}/{network}/ens/getAddressByEnsName": {
+      "post": {
+        "tags": [
+          "ppu",
+          "data"
+        ],
+        "summary": "Resolve an ENS name to its wallet address (pay-per-use)",
+        "description": "Retrieves the mapped address by entering the ENS domain name.\n\n\n> 🚧 Please verify the network when using!\n>\n> This API is supported only on Ethereum Mainnet and cannot be used on other networks. Please verify the network when using.\n\n*Paid per call via x402 (Pay-Per-Use mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "payperuse_getAddressByEnsName",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain09"
+          },
+          {
+            "$ref": "#/components/parameters/Network04"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ensName__evm__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/getAddressByEnsName__evm__Res"
+                }
+              }
+            }
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        },
+        "security": []
+      }
+    },
+    "/credit/v1/{chain}/{network}/asset/getAssetTransfersById": {
+      "post": {
+        "tags": [
+          "credit",
+          "data"
+        ],
+        "summary": "Get Asset Transfers By ID (credit)",
+        "description": "Retrieves the transfer history for a specific TRC-10 asset.\n\n> 🚧 What is TRC10?\n>\n> TRC10 is the native token standard supported by Tron. Tokens issued under this standard are created according to the specification built into the Tron chain itself without using smart contracts. Thanks to this structural characteristic, tokens can be issued easily without complex processes, and each token is identified by a unique Asset ID.\n\n*Paid per call via x402 (Credit mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "credit_getAssetTransfersById",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain10"
+          },
+          {
+            "$ref": "#/components/parameters/Network04"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/getAssetTransfersById__tron__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        }
+      }
+    },
+    "/pay-per-use/v1/{chain}/{network}/asset/getAssetTransfersById": {
+      "post": {
+        "tags": [
+          "ppu",
+          "data"
+        ],
+        "summary": "Get Asset Transfers By ID (pay-per-use)",
+        "description": "Retrieves the transfer history for a specific TRC-10 asset.\n\n> 🚧 What is TRC10?\n>\n> TRC10 is the native token standard supported by Tron. Tokens issued under this standard are created according to the specification built into the Tron chain itself without using smart contracts. Thanks to this structural characteristic, tokens can be issued easily without complex processes, and each token is identified by a unique Asset ID.\n\n*Paid per call via x402 (Pay-Per-Use mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "payperuse_getAssetTransfersById",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain10"
+          },
+          {
+            "$ref": "#/components/parameters/Network04"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/getAssetTransfersById__tron__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        },
+        "security": []
+      }
+    },
+    "/credit/v1/{chain}/{network}/asset/getAssetMetadataByIssuer": {
+      "post": {
+        "tags": [
+          "credit",
+          "data"
+        ],
+        "summary": "Get Asset Metadata By Issuer (credit)",
+        "description": "Retrieves metadata for TRC-10 assets issued by a specific issuer.\n\n> 🚧 What is TRC10?\n>\n> TRC10 is the native token standard supported by Tron. Tokens issued under this standard are created according to the specification built into the Tron chain itself without using smart contracts. Thanks to this structural characteristic, tokens can be issued easily without complex processes, and each token is identified by a unique Asset ID.\n\n*Paid per call via x402 (Credit mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "credit_getAssetMetadataByIssuer",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain10"
+          },
+          {
+            "$ref": "#/components/parameters/Network04"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/getAssetMetadataByIssuer__tron__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/getAssetMetadataByIssuer__tron__Res"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        }
+      }
+    },
+    "/pay-per-use/v1/{chain}/{network}/asset/getAssetMetadataByIssuer": {
+      "post": {
+        "tags": [
+          "ppu",
+          "data"
+        ],
+        "summary": "Get Asset Metadata By Issuer (pay-per-use)",
+        "description": "Retrieves metadata for TRC-10 assets issued by a specific issuer.\n\n> 🚧 What is TRC10?\n>\n> TRC10 is the native token standard supported by Tron. Tokens issued under this standard are created according to the specification built into the Tron chain itself without using smart contracts. Thanks to this structural characteristic, tokens can be issued easily without complex processes, and each token is identified by a unique Asset ID.\n\n*Paid per call via x402 (Pay-Per-Use mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "payperuse_getAssetMetadataByIssuer",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain10"
+          },
+          {
+            "$ref": "#/components/parameters/Network04"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/getAssetMetadataByIssuer__tron__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/getAssetMetadataByIssuer__tron__Res"
+                }
+              }
+            }
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        },
+        "security": []
+      }
+    },
+    "/credit/v1/{chain}/{network}/asset/getAssetMetadataByIds": {
+      "post": {
+        "tags": [
+          "credit",
+          "data"
+        ],
+        "summary": "Get Asset Metadata By IDs (credit)",
+        "description": "Retrieves metadata for a specific TRC-10 asset.\n\n> 🚧 What is TRC10?\n>\n> TRC10 is the native token standard supported by Tron. Tokens issued under this standard are created according to the specification built into the Tron chain itself without using smart contracts. Thanks to this structural characteristic, tokens can be issued easily without complex processes, and each token is identified by a unique Asset ID.\n\n*Paid per call via x402 (Credit mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "credit_getAssetMetadataByIds",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain10"
+          },
+          {
+            "$ref": "#/components/parameters/Network04"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/getAssetMetadataByIds__tron__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/getAssetMetadataByIds__tron__Res"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        }
+      }
+    },
+    "/pay-per-use/v1/{chain}/{network}/asset/getAssetMetadataByIds": {
+      "post": {
+        "tags": [
+          "ppu",
+          "data"
+        ],
+        "summary": "Get Asset Metadata By IDs (pay-per-use)",
+        "description": "Retrieves metadata for a specific TRC-10 asset.\n\n> 🚧 What is TRC10?\n>\n> TRC10 is the native token standard supported by Tron. Tokens issued under this standard are created according to the specification built into the Tron chain itself without using smart contracts. Thanks to this structural characteristic, tokens can be issued easily without complex processes, and each token is identified by a unique Asset ID.\n\n*Paid per call via x402 (Pay-Per-Use mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "payperuse_getAssetMetadataByIds",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain10"
+          },
+          {
+            "$ref": "#/components/parameters/Network04"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/getAssetMetadataByIds__tron__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/getAssetMetadataByIds__tron__Res"
+                }
+              }
+            }
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        },
+        "security": []
+      }
+    },
+    "/credit/v1/{chain}/{network}/asset/getAssetTransfersWithinRange": {
+      "post": {
+        "tags": [
+          "credit",
+          "data"
+        ],
+        "summary": "Get Asset Transfers Within Range (credit)",
+        "description": "Retrieves TRC-10 asset transfer history within a specific block range.\n\n> 🚧 What is TRC10?\n>\n> TRC10 is the native token standard supported by Tron. Tokens issued under this standard are created according to the specification built into the Tron chain itself without using smart contracts. Thanks to this structural characteristic, tokens can be issued easily without complex processes, and each token is identified by a unique Asset ID.\n\n*Paid per call via x402 (Credit mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "credit_getAssetTransfersWithinRange",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain10"
+          },
+          {
+            "$ref": "#/components/parameters/Network04"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/getAssetTransfersWithinRange__tron__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        }
+      }
+    },
+    "/pay-per-use/v1/{chain}/{network}/asset/getAssetTransfersWithinRange": {
+      "post": {
+        "tags": [
+          "ppu",
+          "data"
+        ],
+        "summary": "Get Asset Transfers Within Range (pay-per-use)",
+        "description": "Retrieves TRC-10 asset transfer history within a specific block range.\n\n> 🚧 What is TRC10?\n>\n> TRC10 is the native token standard supported by Tron. Tokens issued under this standard are created according to the specification built into the Tron chain itself without using smart contracts. Thanks to this structural characteristic, tokens can be issued easily without complex processes, and each token is identified by a unique Asset ID.\n\n*Paid per call via x402 (Pay-Per-Use mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "payperuse_getAssetTransfersWithinRange",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain10"
+          },
+          {
+            "$ref": "#/components/parameters/Network04"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/getAssetTransfersWithinRange__tron__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        },
+        "security": []
+      }
+    },
+    "/credit/v1/{chain}/{network}/asset/searchAssetMetadataByKeyword": {
+      "post": {
+        "tags": [
+          "credit",
+          "data"
+        ],
+        "summary": "Search Asset Metadata By Keyword (credit)",
+        "description": "Searches for TRC-10 asset metadata by keyword.\n\n> 🚧 What is TRC10?\n>\n> TRC10 is the native token standard supported by Tron. Tokens issued under this standard are created according to the specification built into the Tron chain itself without using smart contracts. Thanks to this structural characteristic, tokens can be issued easily without complex processes, and each token is identified by a unique Asset ID.\n\n*Paid per call via x402 (Credit mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "credit_searchAssetMetadataByKeyword",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain10"
+          },
+          {
+            "$ref": "#/components/parameters/Network04"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/searchAssetMetadataByKeyword__tron__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        }
+      }
+    },
+    "/pay-per-use/v1/{chain}/{network}/asset/searchAssetMetadataByKeyword": {
+      "post": {
+        "tags": [
+          "ppu",
+          "data"
+        ],
+        "summary": "Search Asset Metadata By Keyword (pay-per-use)",
+        "description": "Searches for TRC-10 asset metadata by keyword.\n\n> 🚧 What is TRC10?\n>\n> TRC10 is the native token standard supported by Tron. Tokens issued under this standard are created according to the specification built into the Tron chain itself without using smart contracts. Thanks to this structural characteristic, tokens can be issued easily without complex processes, and each token is identified by a unique Asset ID.\n\n*Paid per call via x402 (Pay-Per-Use mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "payperuse_searchAssetMetadataByKeyword",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain10"
+          },
+          {
+            "$ref": "#/components/parameters/Network04"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/searchAssetMetadataByKeyword__tron__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        },
+        "security": []
+      }
+    },
+    "/credit/v1/{chain}/{network}/asset/getAssetTransfersByAccount": {
+      "post": {
+        "tags": [
+          "credit",
+          "data"
+        ],
+        "summary": "Get Asset Transfers By Account (credit)",
+        "description": "Retrieves the TRC-10 asset transfer history for a specific account.\n\n*Paid per call via x402 (Credit mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "credit_getAssetTransfersByAccount",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain10"
+          },
+          {
+            "$ref": "#/components/parameters/Network04"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/getAssetTransfersByAccount__tron__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        }
+      }
+    },
+    "/pay-per-use/v1/{chain}/{network}/asset/getAssetTransfersByAccount": {
+      "post": {
+        "tags": [
+          "ppu",
+          "data"
+        ],
+        "summary": "Get Asset Transfers By Account (pay-per-use)",
+        "description": "Retrieves the TRC-10 asset transfer history for a specific account.\n\n*Paid per call via x402 (Pay-Per-Use mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "payperuse_getAssetTransfersByAccount",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain10"
+          },
+          {
+            "$ref": "#/components/parameters/Network04"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/getAssetTransfersByAccount__tron__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        },
+        "security": []
+      }
+    },
+    "/credit/v1/{chain}/{network}/asset/getAssetHoldersById": {
+      "post": {
+        "tags": [
+          "credit",
+          "data"
+        ],
+        "summary": "Fetch holders of an asset by its identifier (credit)",
+        "description": "Retrieves the list of holders for a specific TRC-10 asset.\n\n> 🚧 What is TRC10?\n>\n> TRC10 is the native token standard supported by Tron. Tokens issued under this standard are created according to the specification built into the Tron chain itself without using smart contracts. Thanks to this structural characteristic, tokens can be issued easily without complex processes, and each token is identified by a unique Asset ID.\n\n*Paid per call via x402 (Credit mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "credit_getAssetHoldersById",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain10"
+          },
+          {
+            "$ref": "#/components/parameters/Network04"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/getAssetHoldersById__tron__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        }
+      }
+    },
+    "/pay-per-use/v1/{chain}/{network}/asset/getAssetHoldersById": {
+      "post": {
+        "tags": [
+          "ppu",
+          "data"
+        ],
+        "summary": "Fetch holders of an asset by its identifier (pay-per-use)",
+        "description": "Retrieves the list of holders for a specific TRC-10 asset.\n\n> 🚧 What is TRC10?\n>\n> TRC10 is the native token standard supported by Tron. Tokens issued under this standard are created according to the specification built into the Tron chain itself without using smart contracts. Thanks to this structural characteristic, tokens can be issued easily without complex processes, and each token is identified by a unique Asset ID.\n\n*Paid per call via x402 (Pay-Per-Use mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "payperuse_getAssetHoldersById",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain10"
+          },
+          {
+            "$ref": "#/components/parameters/Network04"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/getAssetHoldersById__tron__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        },
+        "security": []
+      }
+    },
+    "/credit/v1/{chain}/{network}/asset/getAssetsOwnedByAccount": {
+      "post": {
+        "tags": [
+          "credit",
+          "data"
+        ],
+        "summary": "Get Assets Owned By Account (credit)",
+        "description": "Retrieves the list of TRC-10 assets held by a specific account.\n\n> 🚧 What is TRC10?\n>\n> TRC10 is the native token standard supported by Tron. Tokens issued under this standard are created according to the specification built into the Tron chain itself without using smart contracts. Thanks to this structural characteristic, tokens can be issued easily without complex processes, and each token is identified by a unique Asset ID.\n\n*Paid per call via x402 (Credit mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "credit_getAssetsOwnedByAccount",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain10"
+          },
+          {
+            "$ref": "#/components/parameters/Network04"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/getAssetsOwnedByAccount__tron__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        }
+      }
+    },
+    "/pay-per-use/v1/{chain}/{network}/asset/getAssetsOwnedByAccount": {
+      "post": {
+        "tags": [
+          "ppu",
+          "data"
+        ],
+        "summary": "Get Assets Owned By Account (pay-per-use)",
+        "description": "Retrieves the list of TRC-10 assets held by a specific account.\n\n> 🚧 What is TRC10?\n>\n> TRC10 is the native token standard supported by Tron. Tokens issued under this standard are created according to the specification built into the Tron chain itself without using smart contracts. Thanks to this structural characteristic, tokens can be issued easily without complex processes, and each token is identified by a unique Asset ID.\n\n*Paid per call via x402 (Pay-Per-Use mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "payperuse_getAssetsOwnedByAccount",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain10"
+          },
+          {
+            "$ref": "#/components/parameters/Network04"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/getAssetsOwnedByAccount__tron__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        },
+        "security": []
+      }
+    },
+    "/credit/v1/{chain}/{network}/native/getNativeTransfersByAccount": {
+      "post": {
+        "tags": [
+          "credit",
+          "data"
+        ],
+        "summary": "Get Native Transfers By Account (credit)",
+        "description": "Retrieves the native token transfer history for a specific account.\n\n*Paid per call via x402 (Credit mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "credit_getNativeTransfersByAccount",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain11"
+          },
+          {
+            "$ref": "#/components/parameters/Network03"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/getNativeTransfersByAccount__evm__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/getNativeTransfersByAccount__tron__Req"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        }
+      }
+    },
+    "/pay-per-use/v1/{chain}/{network}/native/getNativeTransfersByAccount": {
+      "post": {
+        "tags": [
+          "ppu",
+          "data"
+        ],
+        "summary": "Get Native Transfers By Account (pay-per-use)",
+        "description": "Retrieves the native token transfer history for a specific account.\n\n*Paid per call via x402 (Pay-Per-Use mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "payperuse_getNativeTransfersByAccount",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain11"
+          },
+          {
+            "$ref": "#/components/parameters/Network03"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/getNativeTransfersByAccount__evm__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/getNativeTransfersByAccount__tron__Req"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        },
+        "security": []
+      }
+    },
+    "/credit/v1/{chain}/{network}/native/getNativeBalanceByAccount": {
+      "post": {
+        "tags": [
+          "credit",
+          "data"
+        ],
+        "summary": "Get Native Balance by Account (credit)",
+        "description": "Retrieves the native token balance held by a specific account. The token type may vary depending on the selected chain.\n\n*Paid per call via x402 (Credit mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "credit_getNativeBalanceByAccount",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain02"
+          },
+          {
+            "$ref": "#/components/parameters/Network02"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/getNativeBalanceByAccount__evm__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/getNativeBalanceByAccount__tron__Req"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/nativeBalance__common__Res"
+                    },
+                    {
+                      "$ref": "#/components/schemas/getNativeBalanceByAccount__tron__Res"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        }
+      }
+    },
+    "/pay-per-use/v1/{chain}/{network}/native/getNativeBalanceByAccount": {
+      "post": {
+        "tags": [
+          "ppu",
+          "data"
+        ],
+        "summary": "Get Native Balance by Account (pay-per-use)",
+        "description": "Retrieves the native token balance held by a specific account. The token type may vary depending on the selected chain.\n\n*Paid per call via x402 (Pay-Per-Use mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "payperuse_getNativeBalanceByAccount",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain02"
+          },
+          {
+            "$ref": "#/components/parameters/Network02"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/getNativeBalanceByAccount__evm__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/getNativeBalanceByAccount__tron__Req"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/nativeBalance__common__Res"
+                    },
+                    {
+                      "$ref": "#/components/schemas/getNativeBalanceByAccount__tron__Res"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        },
+        "security": []
+      }
+    },
+    "/credit/v1/{chain}/{network}/native/getNativeTokenBalanceChangesByAccount": {
+      "post": {
+        "tags": [
+          "credit",
+          "data"
+        ],
+        "summary": "Get Native Token Balance Changes By Account (credit)",
+        "description": "Retrieves the native token balance change history for a specific account.\n\n*Paid per call via x402 (Credit mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "credit_getNativeTokenBalanceChangesByAccount",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain05"
+          },
+          {
+            "$ref": "#/components/parameters/Network04"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/getNativeTokenBalanceChangesByAccount__xrpl__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        }
+      }
+    },
+    "/pay-per-use/v1/{chain}/{network}/native/getNativeTokenBalanceChangesByAccount": {
+      "post": {
+        "tags": [
+          "ppu",
+          "data"
+        ],
+        "summary": "Get Native Token Balance Changes By Account (pay-per-use)",
+        "description": "Retrieves the native token balance change history for a specific account.\n\n*Paid per call via x402 (Pay-Per-Use mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "payperuse_getNativeTokenBalanceChangesByAccount",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain05"
+          },
+          {
+            "$ref": "#/components/parameters/Network04"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/getNativeTokenBalanceChangesByAccount__xrpl__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        },
+        "security": []
+      }
+    },
+    "/credit/v1/{chain}/{network}/native/getNativeTokenBalanceByAccount": {
+      "post": {
+        "tags": [
+          "credit",
+          "data"
+        ],
+        "summary": "Get Native Token Balance by Account (credit)",
+        "description": "Retrieves the native token balance held by a specific account. The token type may vary depending on the selected chain. (e.g.,\nFor Bitcoin, you can query the BTC balance.)\n\n*Paid per call via x402 (Credit mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "credit_getNativeTokenBalanceByAccount",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain12"
+          },
+          {
+            "$ref": "#/components/parameters/Network04"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/accountAddress__utxo__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/getNativeTokenBalanceByAccount__xrpl__Req"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/nativeBalance__common__Res"
+                    },
+                    {
+                      "$ref": "#/components/schemas/getNativeTokenBalanceByAccount__xrpl__Res"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        }
+      }
+    },
+    "/pay-per-use/v1/{chain}/{network}/native/getNativeTokenBalanceByAccount": {
+      "post": {
+        "tags": [
+          "ppu",
+          "data"
+        ],
+        "summary": "Get Native Token Balance by Account (pay-per-use)",
+        "description": "Retrieves the native token balance held by a specific account. The token type may vary depending on the selected chain. (e.g.,\nFor Bitcoin, you can query the BTC balance.)\n\n*Paid per call via x402 (Pay-Per-Use mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "payperuse_getNativeTokenBalanceByAccount",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain12"
+          },
+          {
+            "$ref": "#/components/parameters/Network04"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/accountAddress__utxo__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/getNativeTokenBalanceByAccount__xrpl__Req"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/nativeBalance__common__Res"
+                    },
+                    {
+                      "$ref": "#/components/schemas/getNativeTokenBalanceByAccount__xrpl__Res"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        },
+        "security": []
+      }
+    },
+    "/credit/v1/{chain}/{network}/native/getNativeTransfersWithinRange": {
+      "post": {
+        "tags": [
+          "credit",
+          "data"
+        ],
+        "summary": "Get Native Transfers Within Range (credit)",
+        "description": "Retrieves the native token transfer history within a specific block range.\n\n*Paid per call via x402 (Credit mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "credit_getNativeTransfersWithinRange",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain11"
+          },
+          {
+            "$ref": "#/components/parameters/Network03"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/blockRangePaged__evm__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/transfersWithinRange__tron__Req"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        }
+      }
+    },
+    "/pay-per-use/v1/{chain}/{network}/native/getNativeTransfersWithinRange": {
+      "post": {
+        "tags": [
+          "ppu",
+          "data"
+        ],
+        "summary": "Get Native Transfers Within Range (pay-per-use)",
+        "description": "Retrieves the native token transfer history within a specific block range.\n\n*Paid per call via x402 (Pay-Per-Use mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "payperuse_getNativeTransfersWithinRange",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain11"
+          },
+          {
+            "$ref": "#/components/parameters/Network03"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/blockRangePaged__evm__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/transfersWithinRange__tron__Req"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        },
+        "security": []
+      }
+    },
+    "/credit/v1/{chain}/{network}/native/getNativeHolders": {
+      "post": {
+        "tags": [
+          "credit",
+          "data"
+        ],
+        "summary": "Fetch holders of the native blockchain token (credit)",
+        "description": "Retrieves the list of native token holders.\n\n*Paid per call via x402 (Credit mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "credit_getNativeHolders",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain10"
+          },
+          {
+            "$ref": "#/components/parameters/Network04"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/getNativeHolders__tron__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        }
+      }
+    },
+    "/pay-per-use/v1/{chain}/{network}/native/getNativeHolders": {
+      "post": {
+        "tags": [
+          "ppu",
+          "data"
+        ],
+        "summary": "Fetch holders of the native blockchain token (pay-per-use)",
+        "description": "Retrieves the list of native token holders.\n\n*Paid per call via x402 (Pay-Per-Use mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "payperuse_getNativeHolders",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain10"
+          },
+          {
+            "$ref": "#/components/parameters/Network04"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/getNativeHolders__tron__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        },
+        "security": []
+      }
+    },
+    "/credit/v1/{chain}/{network}/native/getNativeTokenTransfersByAccount": {
+      "post": {
+        "tags": [
+          "credit",
+          "data"
+        ],
+        "summary": "Get Native Token Transfers By Account (credit)",
+        "description": "Retrieves the native token transfer history associated with a specific address. The token type may vary depending on the selected chain. (e.g.,\nFor Bitcoin, you can query BTC transfer history.)\n\n*Paid per call via x402 (Credit mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "credit_getNativeTokenTransfersByAccount",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain13"
+          },
+          {
+            "$ref": "#/components/parameters/Network04"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/getNativeTokenTransfersByAccount__utxo__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        }
+      }
+    },
+    "/pay-per-use/v1/{chain}/{network}/native/getNativeTokenTransfersByAccount": {
+      "post": {
+        "tags": [
+          "ppu",
+          "data"
+        ],
+        "summary": "Get Native Token Transfers By Account (pay-per-use)",
+        "description": "Retrieves the native token transfer history associated with a specific address. The token type may vary depending on the selected chain. (e.g.,\nFor Bitcoin, you can query BTC transfer history.)\n\n*Paid per call via x402 (Pay-Per-Use mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "payperuse_getNativeTokenTransfersByAccount",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain13"
+          },
+          {
+            "$ref": "#/components/parameters/Network04"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/getNativeTokenTransfersByAccount__utxo__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        },
+        "security": []
+      }
+    },
+    "/credit/v1/{chain}/{network}/nft/syncNftMetadata": {
+      "post": {
+        "tags": [
+          "credit",
+          "data"
+        ],
+        "summary": "Create a resync request for stored NFT metadata (credit)",
+        "description": "Synchronizes metadata for specific NFTs. Up to 100 NFTs can be synchronized, and synchronization may take up to 10 seconds.\n\n\n> 📘 What are NFT Metadata and Token URI?\n>\n> NFTs are a technology that ensures ownership and uniqueness of digital assets. NFT metadata is a critical component that stores information about these assets. Metadata plays an important role in describing the essence of an NFT.\n> 1. NFT Metadata\n> Includes the NFT's creator, issuance date, attributes, and media files (e.g., images, videos). This metadata makes an NFT more than just a digital file—it defines a unique asset and establishes the NFT's scarcity or distinctive characteristics.\n> 2. Token URI\n> Storing data on the blockchain is costly. Therefore, metadata and media files are not stored on the blockchain but are kept in external storage such as IPFS or S3. Token URI is a field that points to the location of the metadata file in such external storage. Metadata is accessed via this URI. In other words, Token URI links metadata and media files, serving as the bridge between on-chain information and actual content.\n\n*Paid per call via x402 (Credit mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "credit_syncNftMetadata",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain04"
+          },
+          {
+            "$ref": "#/components/parameters/Network02"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/syncNftMetadata__evm__Res"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/syncNftMetadata__evm__Req"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pay-per-use/v1/{chain}/{network}/nft/syncNftMetadata": {
+      "post": {
+        "tags": [
+          "ppu",
+          "data"
+        ],
+        "summary": "Create a resync request for stored NFT metadata (pay-per-use)",
+        "description": "Synchronizes metadata for specific NFTs. Up to 100 NFTs can be synchronized, and synchronization may take up to 10 seconds.\n\n\n> 📘 What are NFT Metadata and Token URI?\n>\n> NFTs are a technology that ensures ownership and uniqueness of digital assets. NFT metadata is a critical component that stores information about these assets. Metadata plays an important role in describing the essence of an NFT.\n> 1. NFT Metadata\n> Includes the NFT's creator, issuance date, attributes, and media files (e.g., images, videos). This metadata makes an NFT more than just a digital file—it defines a unique asset and establishes the NFT's scarcity or distinctive characteristics.\n> 2. Token URI\n> Storing data on the blockchain is costly. Therefore, metadata and media files are not stored on the blockchain but are kept in external storage such as IPFS or S3. Token URI is a field that points to the location of the metadata file in such external storage. Metadata is accessed via this URI. In other words, Token URI links metadata and media files, serving as the bridge between on-chain information and actual content.\n\n*Paid per call via x402 (Pay-Per-Use mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "payperuse_syncNftMetadata",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain04"
+          },
+          {
+            "$ref": "#/components/parameters/Network02"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/syncNftMetadata__evm__Res"
+                }
+              }
+            }
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        },
+        "security": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/syncNftMetadata__evm__Req"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/credit/v1/{chain}/{network}/nft/getNftMetadataByTokenIds": {
+      "post": {
+        "tags": [
+          "credit",
+          "data"
+        ],
+        "summary": "Get NFT Metadata by Token IDs (credit)",
+        "description": "Retrieves metadata for specific NFTs. Multiple NFTs can be queried, up to a maximum of 100 NFTs.\n\n\n> 📘 What are NFT Metadata and Token URI?\n>\n> NFTs are a technology that ensures ownership and uniqueness of digital assets. NFT metadata is a critical component that stores information about these assets. Metadata plays an important role in describing the essence of an NFT.\n> 1. NFT Metadata\n> Includes the NFT's creator, issuance date, attributes, and media files (e.g., images, videos). This metadata makes an NFT more than just a digital file—it defines a unique asset and establishes the NFT's scarcity or distinctive characteristics.\n> 2. Token URI\n> Storing data on the blockchain is costly. Therefore, metadata and media files are not stored on the blockchain but are kept in external storage such as IPFS or S3. Token URI is a field that points to the location of the metadata file in such external storage. Metadata is accessed via this URI. In other words, Token URI links metadata and media files, serving as the bridge between on-chain information and actual content.\n\n*Paid per call via x402 (Credit mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "credit_getNftMetadataByTokenIds",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain04"
+          },
+          {
+            "$ref": "#/components/parameters/Network02"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/getNftMetadataByTokenIds__evm__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/getNftMetadataByTokenIds__evm__Res"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        }
+      }
+    },
+    "/pay-per-use/v1/{chain}/{network}/nft/getNftMetadataByTokenIds": {
+      "post": {
+        "tags": [
+          "ppu",
+          "data"
+        ],
+        "summary": "Get NFT Metadata by Token IDs (pay-per-use)",
+        "description": "Retrieves metadata for specific NFTs. Multiple NFTs can be queried, up to a maximum of 100 NFTs.\n\n\n> 📘 What are NFT Metadata and Token URI?\n>\n> NFTs are a technology that ensures ownership and uniqueness of digital assets. NFT metadata is a critical component that stores information about these assets. Metadata plays an important role in describing the essence of an NFT.\n> 1. NFT Metadata\n> Includes the NFT's creator, issuance date, attributes, and media files (e.g., images, videos). This metadata makes an NFT more than just a digital file—it defines a unique asset and establishes the NFT's scarcity or distinctive characteristics.\n> 2. Token URI\n> Storing data on the blockchain is costly. Therefore, metadata and media files are not stored on the blockchain but are kept in external storage such as IPFS or S3. Token URI is a field that points to the location of the metadata file in such external storage. Metadata is accessed via this URI. In other words, Token URI links metadata and media files, serving as the bridge between on-chain information and actual content.\n\n*Paid per call via x402 (Pay-Per-Use mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "payperuse_getNftMetadataByTokenIds",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain04"
+          },
+          {
+            "$ref": "#/components/parameters/Network02"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/getNftMetadataByTokenIds__evm__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/getNftMetadataByTokenIds__evm__Res"
+                }
+              }
+            }
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        },
+        "security": []
+      }
+    },
+    "/credit/v1/{chain}/{network}/nft/getNftTransfersByContract": {
+      "post": {
+        "tags": [
+          "credit",
+          "data"
+        ],
+        "summary": "Get NFT Transfers By Contract (credit)",
+        "description": "Retrieves the list of NFT transfers that occurred from a specific contract. Results include contract metadata and NFT metadata.\n\n*Paid per call via x402 (Credit mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "credit_getNftTransfersByContract",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain04"
+          },
+          {
+            "$ref": "#/components/parameters/Network02"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/getNftTransfersByContract__evm__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/getNftTransfersByContract__kaia__Req"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        }
+      }
+    },
+    "/pay-per-use/v1/{chain}/{network}/nft/getNftTransfersByContract": {
+      "post": {
+        "tags": [
+          "ppu",
+          "data"
+        ],
+        "summary": "Get NFT Transfers By Contract (pay-per-use)",
+        "description": "Retrieves the list of NFT transfers that occurred from a specific contract. Results include contract metadata and NFT metadata.\n\n*Paid per call via x402 (Pay-Per-Use mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "payperuse_getNftTransfersByContract",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain04"
+          },
+          {
+            "$ref": "#/components/parameters/Network02"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/getNftTransfersByContract__evm__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/getNftTransfersByContract__kaia__Req"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        },
+        "security": []
+      }
+    },
+    "/credit/v1/{chain}/{network}/nft/searchNftContractMetadataByKeyword": {
+      "post": {
+        "tags": [
+          "credit",
+          "data"
+        ],
+        "summary": "Search NFT Contract Metadata By Keyword (credit)",
+        "description": "Retrieves the list of contracts matching the NFT contract name or symbol.\n\n*Paid per call via x402 (Credit mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "credit_searchNftContractMetadataByKeyword",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain04"
+          },
+          {
+            "$ref": "#/components/parameters/Network02"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/searchNftContractMetadataByKeyword__evm__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        }
+      }
+    },
+    "/pay-per-use/v1/{chain}/{network}/nft/searchNftContractMetadataByKeyword": {
+      "post": {
+        "tags": [
+          "ppu",
+          "data"
+        ],
+        "summary": "Search NFT Contract Metadata By Keyword (pay-per-use)",
+        "description": "Retrieves the list of contracts matching the NFT contract name or symbol.\n\n*Paid per call via x402 (Pay-Per-Use mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "payperuse_searchNftContractMetadataByKeyword",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain04"
+          },
+          {
+            "$ref": "#/components/parameters/Network02"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/searchNftContractMetadataByKeyword__evm__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        },
+        "security": []
+      }
+    },
+    "/credit/v1/{chain}/{network}/nft/getNftHoldersByContract": {
+      "post": {
+        "tags": [
+          "credit",
+          "data"
+        ],
+        "summary": "Get NFT Holders by Contract (credit)",
+        "description": "Retrieves the holder list for a specific NFT contract. The holder list includes holder addresses and the quantity of NFTs held by each holder.\n\n*Paid per call via x402 (Credit mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "credit_getNftHoldersByContract",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain04"
+          },
+          {
+            "$ref": "#/components/parameters/Network02"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/contractAddressPaged__evm__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        }
+      }
+    },
+    "/pay-per-use/v1/{chain}/{network}/nft/getNftHoldersByContract": {
+      "post": {
+        "tags": [
+          "ppu",
+          "data"
+        ],
+        "summary": "Get NFT Holders by Contract (pay-per-use)",
+        "description": "Retrieves the holder list for a specific NFT contract. The holder list includes holder addresses and the quantity of NFTs held by each holder.\n\n*Paid per call via x402 (Pay-Per-Use mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "payperuse_getNftHoldersByContract",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain04"
+          },
+          {
+            "$ref": "#/components/parameters/Network02"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/contractAddressPaged__evm__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        },
+        "security": []
+      }
+    },
+    "/credit/v1/{chain}/{network}/nft/getNftTransfersByAccount": {
+      "post": {
+        "tags": [
+          "credit",
+          "data"
+        ],
+        "summary": "Get NFT Transfers By Account (credit)",
+        "description": "Retrieves the list of NFT transfers sent or received by a specific address. Results include contract metadata and NFT metadata.\n\n*Paid per call via x402 (Credit mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "credit_getNftTransfersByAccount",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain04"
+          },
+          {
+            "$ref": "#/components/parameters/Network02"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/getNftTransfersByAccount__evm__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/getNftTransfersByAccount__kaia__Req"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        }
+      }
+    },
+    "/pay-per-use/v1/{chain}/{network}/nft/getNftTransfersByAccount": {
+      "post": {
+        "tags": [
+          "ppu",
+          "data"
+        ],
+        "summary": "Get NFT Transfers By Account (pay-per-use)",
+        "description": "Retrieves the list of NFT transfers sent or received by a specific address. Results include contract metadata and NFT metadata.\n\n*Paid per call via x402 (Pay-Per-Use mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "payperuse_getNftTransfersByAccount",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain04"
+          },
+          {
+            "$ref": "#/components/parameters/Network02"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/getNftTransfersByAccount__evm__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/getNftTransfersByAccount__kaia__Req"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        },
+        "security": []
+      }
+    },
+    "/credit/v1/{chain}/{network}/nft/getNftsOwnedByAccount": {
+      "post": {
+        "tags": [
+          "credit",
+          "data"
+        ],
+        "summary": "Get NFTs Owned By Account (credit)",
+        "description": "Retrieves the list of NFTs held by a specific account. Results include the quantity held per token and token metadata.\n\n\n> 📘 What are NFT Metadata and Token URI?\n>\n> NFTs are a technology that ensures ownership and uniqueness of digital assets. NFT metadata is a critical component that stores information about these assets. Metadata plays an important role in describing the essence of an NFT.\n> 1. NFT Metadata\n> Includes the NFT's creator, issuance date, attributes, and media files (e.g., images, videos). This metadata makes an NFT more than just a digital file—it defines a unique asset and establishes the NFT's scarcity or distinctive characteristics.\n> 2. Token URI\n> Storing data on the blockchain is costly. Therefore, metadata and media files are not stored on the blockchain but are kept in external storage such as IPFS or S3. Token URI is a field that points to the location of the metadata file in such external storage. Metadata is accessed via this URI. In other words, Token URI links metadata and media files, serving as the bridge between on-chain information and actual content.\n\n*Paid per call via x402 (Credit mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "credit_getNftsOwnedByAccount",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain04"
+          },
+          {
+            "$ref": "#/components/parameters/Network02"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/getNftsOwnedByAccount__evm__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        }
+      }
+    },
+    "/pay-per-use/v1/{chain}/{network}/nft/getNftsOwnedByAccount": {
+      "post": {
+        "tags": [
+          "ppu",
+          "data"
+        ],
+        "summary": "Get NFTs Owned By Account (pay-per-use)",
+        "description": "Retrieves the list of NFTs held by a specific account. Results include the quantity held per token and token metadata.\n\n\n> 📘 What are NFT Metadata and Token URI?\n>\n> NFTs are a technology that ensures ownership and uniqueness of digital assets. NFT metadata is a critical component that stores information about these assets. Metadata plays an important role in describing the essence of an NFT.\n> 1. NFT Metadata\n> Includes the NFT's creator, issuance date, attributes, and media files (e.g., images, videos). This metadata makes an NFT more than just a digital file—it defines a unique asset and establishes the NFT's scarcity or distinctive characteristics.\n> 2. Token URI\n> Storing data on the blockchain is costly. Therefore, metadata and media files are not stored on the blockchain but are kept in external storage such as IPFS or S3. Token URI is a field that points to the location of the metadata file in such external storage. Metadata is accessed via this URI. In other words, Token URI links metadata and media files, serving as the bridge between on-chain information and actual content.\n\n*Paid per call via x402 (Pay-Per-Use mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "payperuse_getNftsOwnedByAccount",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain04"
+          },
+          {
+            "$ref": "#/components/parameters/Network02"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/getNftsOwnedByAccount__evm__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        },
+        "security": []
+      }
+    },
+    "/credit/v1/{chain}/{network}/nft/getNftTransfersByTokenId": {
+      "post": {
+        "tags": [
+          "credit",
+          "data"
+        ],
+        "summary": "Get NFT Transfers By TokenId (credit)",
+        "description": "Retrieves the list of transfers for a specific NFT. Results include contract metadata and NFT metadata.\n\n*Paid per call via x402 (Credit mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "credit_getNftTransfersByTokenId",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain04"
+          },
+          {
+            "$ref": "#/components/parameters/Network02"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/getNftTransfersByTokenId__evm__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/getNftTransfersByTokenId__kaia__Req"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        }
+      }
+    },
+    "/pay-per-use/v1/{chain}/{network}/nft/getNftTransfersByTokenId": {
+      "post": {
+        "tags": [
+          "ppu",
+          "data"
+        ],
+        "summary": "Get NFT Transfers By TokenId (pay-per-use)",
+        "description": "Retrieves the list of transfers for a specific NFT. Results include contract metadata and NFT metadata.\n\n*Paid per call via x402 (Pay-Per-Use mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "payperuse_getNftTransfersByTokenId",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain04"
+          },
+          {
+            "$ref": "#/components/parameters/Network02"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/getNftTransfersByTokenId__evm__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/getNftTransfersByTokenId__kaia__Req"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        },
+        "security": []
+      }
+    },
+    "/credit/v1/{chain}/{network}/nft/getNftHoldersByTokenId": {
+      "post": {
+        "tags": [
+          "credit",
+          "data"
+        ],
+        "summary": "Get NFT Holders by Token ID (credit)",
+        "description": "Retrieves the holder list for a specific NFT. The holder list includes holder addresses and the quantity of NFTs held by each holder.\n\n*Paid per call via x402 (Credit mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "credit_getNftHoldersByTokenId",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain04"
+          },
+          {
+            "$ref": "#/components/parameters/Network02"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/getNftHoldersByTokenId__evm__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        }
+      }
+    },
+    "/pay-per-use/v1/{chain}/{network}/nft/getNftHoldersByTokenId": {
+      "post": {
+        "tags": [
+          "ppu",
+          "data"
+        ],
+        "summary": "Get NFT Holders by Token ID (pay-per-use)",
+        "description": "Retrieves the holder list for a specific NFT. The holder list includes holder addresses and the quantity of NFTs held by each holder.\n\n*Paid per call via x402 (Pay-Per-Use mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "payperuse_getNftHoldersByTokenId",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain04"
+          },
+          {
+            "$ref": "#/components/parameters/Network02"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/getNftHoldersByTokenId__evm__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        },
+        "security": []
+      }
+    },
+    "/credit/v1/{chain}/{network}/nft/getNftTransfersWithinRange": {
+      "post": {
+        "tags": [
+          "credit",
+          "data"
+        ],
+        "summary": "Get NFT Transfers Within Range (credit)",
+        "description": "Retrieves the list of NFT transfers that occurred during a specific period. Results include contract metadata and NFT metadata.\n> 📘 Period setting tip\n> If the specified period is long, response time may increase. For faster responses, it is recommended to set only the necessary period.\n\n*Paid per call via x402 (Credit mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "credit_getNftTransfersWithinRange",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain04"
+          },
+          {
+            "$ref": "#/components/parameters/Network02"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/getNftTransfersWithinRange__evm__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/getNftTransfersWithinRange__kaia__Req"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        }
+      }
+    },
+    "/pay-per-use/v1/{chain}/{network}/nft/getNftTransfersWithinRange": {
+      "post": {
+        "tags": [
+          "ppu",
+          "data"
+        ],
+        "summary": "Get NFT Transfers Within Range (pay-per-use)",
+        "description": "Retrieves the list of NFT transfers that occurred during a specific period. Results include contract metadata and NFT metadata.\n> 📘 Period setting tip\n> If the specified period is long, response time may increase. For faster responses, it is recommended to set only the necessary period.\n\n*Paid per call via x402 (Pay-Per-Use mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "payperuse_getNftTransfersWithinRange",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain04"
+          },
+          {
+            "$ref": "#/components/parameters/Network02"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/getNftTransfersWithinRange__evm__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/getNftTransfersWithinRange__kaia__Req"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        },
+        "security": []
+      }
+    },
+    "/credit/v1/{chain}/{network}/nft/getNftContractMetadataByContracts": {
+      "post": {
+        "tags": [
+          "credit",
+          "data"
+        ],
+        "summary": "Get NFT Contract Metadata by Contracts (credit)",
+        "description": "Retrieves metadata for specific NFT contracts. Multiple contracts can be queried, up to a maximum of 100 contracts.\n\n*Paid per call via x402 (Credit mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "credit_getNftContractMetadataByContracts",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain04"
+          },
+          {
+            "$ref": "#/components/parameters/Network02"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/contractAddresses__evm__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/contractMetadataList__evm__Res"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        }
+      }
+    },
+    "/pay-per-use/v1/{chain}/{network}/nft/getNftContractMetadataByContracts": {
+      "post": {
+        "tags": [
+          "ppu",
+          "data"
+        ],
+        "summary": "Get NFT Contract Metadata by Contracts (pay-per-use)",
+        "description": "Retrieves metadata for specific NFT contracts. Multiple contracts can be queried, up to a maximum of 100 contracts.\n\n*Paid per call via x402 (Pay-Per-Use mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "payperuse_getNftContractMetadataByContracts",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain04"
+          },
+          {
+            "$ref": "#/components/parameters/Network02"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/contractAddresses__evm__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/contractMetadataList__evm__Res"
+                }
+              }
+            }
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        },
+        "security": []
+      }
+    },
+    "/credit/v1/{chain}/{network}/nft/getNftMetadataByContract": {
+      "post": {
+        "tags": [
+          "credit",
+          "data"
+        ],
+        "summary": "Get NFT Metadata by Contract (credit)",
+        "description": "Retrieves the metadata list for NFTs issued from a specific contract.\n\n\n> 📘 What are NFT Metadata and Token URI?\n>\n> NFTs are a technology that ensures ownership and uniqueness of digital assets. NFT metadata is a critical component that stores information about these assets. Metadata plays an important role in describing the essence of an NFT.\n> 1. NFT Metadata\n> Includes the NFT's creator, issuance date, attributes, and media files (e.g., images, videos). This metadata makes an NFT more than just a digital file—it defines a unique asset and establishes the NFT's scarcity or distinctive characteristics.\n> 2. Token URI\n> Storing data on the blockchain is costly. Therefore, metadata and media files are not stored on the blockchain but are kept in external storage such as IPFS or S3. Token URI is a field that points to the location of the metadata file in such external storage. Metadata is accessed via this URI. In other words, Token URI links metadata and media files, serving as the bridge between on-chain information and actual content.\n\n*Paid per call via x402 (Credit mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "credit_getNftMetadataByContract",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain04"
+          },
+          {
+            "$ref": "#/components/parameters/Network02"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/contractAddressPaged__evm__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        }
+      }
+    },
+    "/pay-per-use/v1/{chain}/{network}/nft/getNftMetadataByContract": {
+      "post": {
+        "tags": [
+          "ppu",
+          "data"
+        ],
+        "summary": "Get NFT Metadata by Contract (pay-per-use)",
+        "description": "Retrieves the metadata list for NFTs issued from a specific contract.\n\n\n> 📘 What are NFT Metadata and Token URI?\n>\n> NFTs are a technology that ensures ownership and uniqueness of digital assets. NFT metadata is a critical component that stores information about these assets. Metadata plays an important role in describing the essence of an NFT.\n> 1. NFT Metadata\n> Includes the NFT's creator, issuance date, attributes, and media files (e.g., images, videos). This metadata makes an NFT more than just a digital file—it defines a unique asset and establishes the NFT's scarcity or distinctive characteristics.\n> 2. Token URI\n> Storing data on the blockchain is costly. Therefore, metadata and media files are not stored on the blockchain but are kept in external storage such as IPFS or S3. Token URI is a field that points to the location of the metadata file in such external storage. Metadata is accessed via this URI. In other words, Token URI links metadata and media files, serving as the bridge between on-chain information and actual content.\n\n*Paid per call via x402 (Pay-Per-Use mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "payperuse_getNftMetadataByContract",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain04"
+          },
+          {
+            "$ref": "#/components/parameters/Network02"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/contractAddressPaged__evm__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        },
+        "security": []
+      }
+    },
+    "/credit/v1/{chain}/{network}/nft/getNftContractsByAccount": {
+      "post": {
+        "tags": [
+          "credit",
+          "data"
+        ],
+        "summary": "Get NFT Contracts by Account (credit)",
+        "description": "Retrieves NFTs held by a specific account, grouped by contract. Results include the quantity of NFTs per contract and contract metadata.\n\n*Paid per call via x402 (Credit mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "credit_getNftContractsByAccount",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain04"
+          },
+          {
+            "$ref": "#/components/parameters/Network02"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/getNftContractsByAccount__evm__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        }
+      }
+    },
+    "/pay-per-use/v1/{chain}/{network}/nft/getNftContractsByAccount": {
+      "post": {
+        "tags": [
+          "ppu",
+          "data"
+        ],
+        "summary": "Get NFT Contracts by Account (pay-per-use)",
+        "description": "Retrieves NFTs held by a specific account, grouped by contract. Results include the quantity of NFTs per contract and contract metadata.\n\n*Paid per call via x402 (Pay-Per-Use mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "payperuse_getNftContractsByAccount",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain04"
+          },
+          {
+            "$ref": "#/components/parameters/Network02"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/getNftContractsByAccount__evm__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        },
+        "security": []
+      }
+    },
+    "/credit/v1/{chain}/{network}/blockchain/getBlocksWithinRange": {
+      "post": {
+        "tags": [
+          "credit",
+          "data"
+        ],
+        "summary": "Fetch blockchain blocks within a block range (credit)",
+        "description": "Retrieves the list of blocks within a specific period or block range.\n\n*Paid per call via x402 (Credit mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "credit_getBlocksWithinRange",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain14"
+          },
+          {
+            "$ref": "#/components/parameters/Network02"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/getBlocksWithinRange__aptos__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/blockRangePaged__evm__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/getBlocksWithinRange__kaia__Req"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        }
+      }
+    },
+    "/pay-per-use/v1/{chain}/{network}/blockchain/getBlocksWithinRange": {
+      "post": {
+        "tags": [
+          "ppu",
+          "data"
+        ],
+        "summary": "Fetch blockchain blocks within a block range (pay-per-use)",
+        "description": "Retrieves the list of blocks within a specific period or block range.\n\n*Paid per call via x402 (Pay-Per-Use mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "payperuse_getBlocksWithinRange",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain14"
+          },
+          {
+            "$ref": "#/components/parameters/Network02"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/getBlocksWithinRange__aptos__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/blockRangePaged__evm__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/getBlocksWithinRange__kaia__Req"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        },
+        "security": []
+      }
+    },
+    "/credit/v1/{chain}/{network}/blockchain/getTransactionsByVersions": {
+      "post": {
+        "tags": [
+          "credit",
+          "data"
+        ],
+        "summary": "Get Transactions By Versions (credit)",
+        "description": "Retrieves information for multiple transactions. Up to 1,000 transactions can be queried.\n\n*Paid per call via x402 (Credit mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "credit_getTransactionsByVersions",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain03"
+          },
+          {
+            "$ref": "#/components/parameters/Network03"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/getTransactionsByVersions__aptos__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/transactionList__aptos__Res"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        }
+      }
+    },
+    "/pay-per-use/v1/{chain}/{network}/blockchain/getTransactionsByVersions": {
+      "post": {
+        "tags": [
+          "ppu",
+          "data"
+        ],
+        "summary": "Get Transactions By Versions (pay-per-use)",
+        "description": "Retrieves information for multiple transactions. Up to 1,000 transactions can be queried.\n\n*Paid per call via x402 (Pay-Per-Use mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "payperuse_getTransactionsByVersions",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain03"
+          },
+          {
+            "$ref": "#/components/parameters/Network03"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/getTransactionsByVersions__aptos__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/transactionList__aptos__Res"
+                }
+              }
+            }
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        },
+        "security": []
+      }
+    },
+    "/credit/v1/{chain}/{network}/blockchain/getTransactionsByTransactionIds": {
+      "post": {
+        "tags": [
+          "credit",
+          "data"
+        ],
+        "summary": "Get Transactions By Transaction IDs (credit)",
+        "description": "Retrieves information for multiple transactions. Up to 1,000 transactions can be queried.\n\n*Paid per call via x402 (Credit mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "credit_getTransactionsByTransactionIds",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain13"
+          },
+          {
+            "$ref": "#/components/parameters/Network04"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/getTransactionsByTransactionIds__utxo__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/getTransactionsByTransactionIds__utxo__Res"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        }
+      }
+    },
+    "/pay-per-use/v1/{chain}/{network}/blockchain/getTransactionsByTransactionIds": {
+      "post": {
+        "tags": [
+          "ppu",
+          "data"
+        ],
+        "summary": "Get Transactions By Transaction IDs (pay-per-use)",
+        "description": "Retrieves information for multiple transactions. Up to 1,000 transactions can be queried.\n\n*Paid per call via x402 (Pay-Per-Use mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "payperuse_getTransactionsByTransactionIds",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain13"
+          },
+          {
+            "$ref": "#/components/parameters/Network04"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/getTransactionsByTransactionIds__utxo__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/getTransactionsByTransactionIds__utxo__Res"
+                }
+              }
+            }
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        },
+        "security": []
+      }
+    },
+    "/credit/v1/{chain}/{network}/blockchain/getTransactionsByHashes": {
+      "post": {
+        "tags": [
+          "credit",
+          "data"
+        ],
+        "summary": "Get Transactions By Hashes (credit)",
+        "description": "Retrieves information for multiple transactions. Up to 1,000 transactions can be queried.\n\n*Paid per call via x402 (Credit mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "credit_getTransactionsByHashes",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain15"
+          },
+          {
+            "$ref": "#/components/parameters/Network02"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/getTransactionsByHashes__aptos__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/getTransactionsByHashes__evm__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/getTransactionsByHashes__tron__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/getTransactionsByHashes__xrpl__Req"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/transactionList__aptos__Res"
+                    },
+                    {
+                      "$ref": "#/components/schemas/getTransactionsByHashes__evm__Res"
+                    },
+                    {
+                      "$ref": "#/components/schemas/getTransactionsByHashes__tron__Res"
+                    },
+                    {
+                      "$ref": "#/components/schemas/getTransactionsByHashes__xrpl__Res"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        }
+      }
+    },
+    "/pay-per-use/v1/{chain}/{network}/blockchain/getTransactionsByHashes": {
+      "post": {
+        "tags": [
+          "ppu",
+          "data"
+        ],
+        "summary": "Get Transactions By Hashes (pay-per-use)",
+        "description": "Retrieves information for multiple transactions. Up to 1,000 transactions can be queried.\n\n*Paid per call via x402 (Pay-Per-Use mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "payperuse_getTransactionsByHashes",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain15"
+          },
+          {
+            "$ref": "#/components/parameters/Network02"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/getTransactionsByHashes__aptos__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/getTransactionsByHashes__evm__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/getTransactionsByHashes__tron__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/getTransactionsByHashes__xrpl__Req"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/transactionList__aptos__Res"
+                    },
+                    {
+                      "$ref": "#/components/schemas/getTransactionsByHashes__evm__Res"
+                    },
+                    {
+                      "$ref": "#/components/schemas/getTransactionsByHashes__tron__Res"
+                    },
+                    {
+                      "$ref": "#/components/schemas/getTransactionsByHashes__xrpl__Res"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        },
+        "security": []
+      }
+    },
+    "/credit/v1/{chain}/{network}/blockchain/getTotalTransactionCountByAccount": {
+      "post": {
+        "tags": [
+          "credit",
+          "data"
+        ],
+        "summary": "Get Total Transaction Count By Account (credit)",
+        "description": "This API returns the total count of transactions in which a specific account address is included as the sender or recipient.\n\n*Paid per call via x402 (Credit mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "credit_getTotalTransactionCountByAccount",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain16"
+          },
+          {
+            "$ref": "#/components/parameters/Network02"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/getTotalTransactionCountByAccount__aptos__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/getTotalTransactionCountByAccount__evm__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/accountAddress__utxo__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/getTotalTransactionCountByAccount__tron__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/getTotalTransactionCountByAccount__xrpl__Req"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/getTotalTransactionCountByAccount___shared__Res"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        }
+      }
+    },
+    "/pay-per-use/v1/{chain}/{network}/blockchain/getTotalTransactionCountByAccount": {
+      "post": {
+        "tags": [
+          "ppu",
+          "data"
+        ],
+        "summary": "Get Total Transaction Count By Account (pay-per-use)",
+        "description": "This API returns the total count of transactions in which a specific account address is included as the sender or recipient.\n\n*Paid per call via x402 (Pay-Per-Use mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "payperuse_getTotalTransactionCountByAccount",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain16"
+          },
+          {
+            "$ref": "#/components/parameters/Network02"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/getTotalTransactionCountByAccount__aptos__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/getTotalTransactionCountByAccount__evm__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/accountAddress__utxo__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/getTotalTransactionCountByAccount__tron__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/getTotalTransactionCountByAccount__xrpl__Req"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/getTotalTransactionCountByAccount___shared__Res"
+                }
+              }
+            }
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        },
+        "security": []
+      }
+    },
+    "/credit/v1/{chain}/{network}/blockchain/getInternalTransactionsByTransactionHash": {
+      "post": {
+        "tags": [
+          "credit",
+          "data"
+        ],
+        "summary": "Get Internal Transactions By Transaction Hash (credit)",
+        "description": "Retrieves the list of internal transactions that occurred in a specific transaction.\n\n*Paid per call via x402 (Credit mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "credit_getInternalTransactionsByTransactionHash",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain02"
+          },
+          {
+            "$ref": "#/components/parameters/Network02"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/getInternalTransactionsByTransactionHash__evm__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/getInternalTransactionsByTransactionHash__tron__Req"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        }
+      }
+    },
+    "/pay-per-use/v1/{chain}/{network}/blockchain/getInternalTransactionsByTransactionHash": {
+      "post": {
+        "tags": [
+          "ppu",
+          "data"
+        ],
+        "summary": "Get Internal Transactions By Transaction Hash (pay-per-use)",
+        "description": "Retrieves the list of internal transactions that occurred in a specific transaction.\n\n*Paid per call via x402 (Pay-Per-Use mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "payperuse_getInternalTransactionsByTransactionHash",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain02"
+          },
+          {
+            "$ref": "#/components/parameters/Network02"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/getInternalTransactionsByTransactionHash__evm__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/getInternalTransactionsByTransactionHash__tron__Req"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        },
+        "security": []
+      }
+    },
+    "/credit/v1/{chain}/{network}/blockchain/getTransactionsInBlock": {
+      "post": {
+        "tags": [
+          "credit",
+          "data"
+        ],
+        "summary": "Get Transactions In Block (credit)",
+        "description": "Retrieves the list of transactions within a specific block.\n\n\n> 🚧 Caution when using decodeInput\n>\n> The decodeInput field decodes the transaction's input field and provides the result. However, different functions can use the same function selector, so the provided result may not match the actually called function. Therefore, additional verification is recommended for functions that differ from ERC standard specifications.\n\n*Paid per call via x402 (Credit mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "credit_getTransactionsInBlock",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain07"
+          },
+          {
+            "$ref": "#/components/parameters/Network02"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/getTransactionsInBlock__evm__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/getTransactionsInBlock__aptos__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/getTransactionsInBlock__tron__Req"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        }
+      }
+    },
+    "/pay-per-use/v1/{chain}/{network}/blockchain/getTransactionsInBlock": {
+      "post": {
+        "tags": [
+          "ppu",
+          "data"
+        ],
+        "summary": "Get Transactions In Block (pay-per-use)",
+        "description": "Retrieves the list of transactions within a specific block.\n\n\n> 🚧 Caution when using decodeInput\n>\n> The decodeInput field decodes the transaction's input field and provides the result. However, different functions can use the same function selector, so the provided result may not match the actually called function. Therefore, additional verification is recommended for functions that differ from ERC standard specifications.\n\n*Paid per call via x402 (Pay-Per-Use mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "payperuse_getTransactionsInBlock",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain07"
+          },
+          {
+            "$ref": "#/components/parameters/Network02"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/getTransactionsInBlock__evm__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/getTransactionsInBlock__aptos__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/getTransactionsInBlock__tron__Req"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        },
+        "security": []
+      }
+    },
+    "/credit/v1/{chain}/{network}/blockchain/getEventsByType": {
+      "post": {
+        "tags": [
+          "credit",
+          "data"
+        ],
+        "summary": "Fetch contract events filtered by event type (credit)",
+        "description": "Retrieves the list of events filtered by a specific event type.\n\n*Paid per call via x402 (Credit mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "credit_getEventsByType",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain03"
+          },
+          {
+            "$ref": "#/components/parameters/Network03"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/getEventsByType__aptos__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        }
+      }
+    },
+    "/pay-per-use/v1/{chain}/{network}/blockchain/getEventsByType": {
+      "post": {
+        "tags": [
+          "ppu",
+          "data"
+        ],
+        "summary": "Fetch contract events filtered by event type (pay-per-use)",
+        "description": "Retrieves the list of events filtered by a specific event type.\n\n*Paid per call via x402 (Pay-Per-Use mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "payperuse_getEventsByType",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain03"
+          },
+          {
+            "$ref": "#/components/parameters/Network03"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/getEventsByType__aptos__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        },
+        "security": []
+      }
+    },
+    "/credit/v1/{chain}/{network}/blockchain/getTransactionByHash": {
+      "post": {
+        "tags": [
+          "credit",
+          "data"
+        ],
+        "summary": "Fetch a transaction by its transaction hash (credit)",
+        "description": "Retrieves information about a specific transaction.\n\n*Paid per call via x402 (Credit mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "credit_getTransactionByHash",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain17"
+          },
+          {
+            "$ref": "#/components/parameters/Network02"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/getTransactionByHash__aptos__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/getTransactionByHash__evm__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/getTransactionByHash__xrpl__Req"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/getTransactionByHash__evm__Res"
+                    },
+                    {
+                      "$ref": "#/components/schemas/transaction__aptos__Res"
+                    },
+                    {
+                      "$ref": "#/components/schemas/getTransactionByHash__xrpl__Res"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        }
+      }
+    },
+    "/pay-per-use/v1/{chain}/{network}/blockchain/getTransactionByHash": {
+      "post": {
+        "tags": [
+          "ppu",
+          "data"
+        ],
+        "summary": "Fetch a transaction by its transaction hash (pay-per-use)",
+        "description": "Retrieves information about a specific transaction.\n\n*Paid per call via x402 (Pay-Per-Use mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "payperuse_getTransactionByHash",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain17"
+          },
+          {
+            "$ref": "#/components/parameters/Network02"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/getTransactionByHash__aptos__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/getTransactionByHash__evm__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/getTransactionByHash__xrpl__Req"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/getTransactionByHash__evm__Res"
+                    },
+                    {
+                      "$ref": "#/components/schemas/transaction__aptos__Res"
+                    },
+                    {
+                      "$ref": "#/components/schemas/getTransactionByHash__xrpl__Res"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        },
+        "security": []
+      }
+    },
+    "/credit/v1/{chain}/{network}/blockchain/isContract": {
+      "post": {
+        "tags": [
+          "credit",
+          "data"
+        ],
+        "summary": "Check whether an address is a smart contract (credit)",
+        "description": "Checks whether the input address is a contract address or not.\n\n*Paid per call via x402 (Credit mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "credit_isContract",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain02"
+          },
+          {
+            "$ref": "#/components/parameters/Network02"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/address__evm__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/address__tron__Req"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/isContract___shared__Res"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        }
+      }
+    },
+    "/pay-per-use/v1/{chain}/{network}/blockchain/isContract": {
+      "post": {
+        "tags": [
+          "ppu",
+          "data"
+        ],
+        "summary": "Check whether an address is a smart contract (pay-per-use)",
+        "description": "Checks whether the input address is a contract address or not.\n\n*Paid per call via x402 (Pay-Per-Use mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "payperuse_isContract",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain02"
+          },
+          {
+            "$ref": "#/components/parameters/Network02"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/address__evm__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/address__tron__Req"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/isContract___shared__Res"
+                }
+              }
+            }
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        },
+        "security": []
+      }
+    },
+    "/credit/v1/{chain}/{network}/blockchain/getTransactionsInLedger": {
+      "post": {
+        "tags": [
+          "credit",
+          "data"
+        ],
+        "summary": "Get Transactions In Ledger (credit)",
+        "description": "Retrieves the list of transactions included in a specific Ledger.\n\n*Paid per call via x402 (Credit mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "credit_getTransactionsInLedger",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain05"
+          },
+          {
+            "$ref": "#/components/parameters/Network04"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/getTransactionsInLedger__xrpl__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        }
+      }
+    },
+    "/pay-per-use/v1/{chain}/{network}/blockchain/getTransactionsInLedger": {
+      "post": {
+        "tags": [
+          "ppu",
+          "data"
+        ],
+        "summary": "Get Transactions In Ledger (pay-per-use)",
+        "description": "Retrieves the list of transactions included in a specific Ledger.\n\n*Paid per call via x402 (Pay-Per-Use mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "payperuse_getTransactionsInLedger",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain05"
+          },
+          {
+            "$ref": "#/components/parameters/Network04"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/getTransactionsInLedger__xrpl__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        },
+        "security": []
+      }
+    },
+    "/credit/v1/{chain}/{network}/blockchain/getNextNonceByAccount": {
+      "post": {
+        "tags": [
+          "credit",
+          "data"
+        ],
+        "summary": "Get Next Nonce by Account (credit)",
+        "description": "Retrieves the next nonce for a specific account.\n\n*Paid per call via x402 (Credit mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "credit_getNextNonceByAccount",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain04"
+          },
+          {
+            "$ref": "#/components/parameters/Network02"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/getNextNonceByAccount__evm__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/getNextNonceByAccount__evm__Res"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        }
+      }
+    },
+    "/pay-per-use/v1/{chain}/{network}/blockchain/getNextNonceByAccount": {
+      "post": {
+        "tags": [
+          "ppu",
+          "data"
+        ],
+        "summary": "Get Next Nonce by Account (pay-per-use)",
+        "description": "Retrieves the next nonce for a specific account.\n\n*Paid per call via x402 (Pay-Per-Use mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "payperuse_getNextNonceByAccount",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain04"
+          },
+          {
+            "$ref": "#/components/parameters/Network02"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/getNextNonceByAccount__evm__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/getNextNonceByAccount__evm__Res"
+                }
+              }
+            }
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        },
+        "security": []
+      }
+    },
+    "/credit/v1/{chain}/{network}/blockchain/getLedgersWithinRange": {
+      "post": {
+        "tags": [
+          "credit",
+          "data"
+        ],
+        "summary": "Get Ledgers Within Range (credit)",
+        "description": "Retrieves the list of Ledgers within a specific range.\n\n*Paid per call via x402 (Credit mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "credit_getLedgersWithinRange",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain05"
+          },
+          {
+            "$ref": "#/components/parameters/Network04"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/getLedgersWithinRange__xrpl__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        }
+      }
+    },
+    "/pay-per-use/v1/{chain}/{network}/blockchain/getLedgersWithinRange": {
+      "post": {
+        "tags": [
+          "ppu",
+          "data"
+        ],
+        "summary": "Get Ledgers Within Range (pay-per-use)",
+        "description": "Retrieves the list of Ledgers within a specific range.\n\n*Paid per call via x402 (Pay-Per-Use mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "payperuse_getLedgersWithinRange",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain05"
+          },
+          {
+            "$ref": "#/components/parameters/Network04"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/getLedgersWithinRange__xrpl__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        },
+        "security": []
+      }
+    },
+    "/credit/v1/{chain}/{network}/blockchain/getUnspentTransactionOutputsByAccount": {
+      "post": {
+        "tags": [
+          "credit",
+          "data"
+        ],
+        "summary": "Get Unspent Transaction Outputs By Account (credit)",
+        "description": "Retrieves the list of UTXOs (Unspent Transaction Outputs) for a specific account.\n\n*Paid per call via x402 (Credit mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "credit_getUnspentTransactionOutputsByAccount",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain13"
+          },
+          {
+            "$ref": "#/components/parameters/Network04"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/getUnspentTransactionOutputsByAccount__utxo__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        }
+      }
+    },
+    "/pay-per-use/v1/{chain}/{network}/blockchain/getUnspentTransactionOutputsByAccount": {
+      "post": {
+        "tags": [
+          "ppu",
+          "data"
+        ],
+        "summary": "Get Unspent Transaction Outputs By Account (pay-per-use)",
+        "description": "Retrieves the list of UTXOs (Unspent Transaction Outputs) for a specific account.\n\n*Paid per call via x402 (Pay-Per-Use mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "payperuse_getUnspentTransactionOutputsByAccount",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain13"
+          },
+          {
+            "$ref": "#/components/parameters/Network04"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/getUnspentTransactionOutputsByAccount__utxo__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        },
+        "security": []
+      }
+    },
+    "/credit/v1/{chain}/{network}/blockchain/getEventsByAccount": {
+      "post": {
+        "tags": [
+          "credit",
+          "data"
+        ],
+        "summary": "Fetch contract events emitted for an account (credit)",
+        "description": "Retrieves the list of events emitted by a specific account.\n\n*Paid per call via x402 (Credit mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "credit_getEventsByAccount",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain03"
+          },
+          {
+            "$ref": "#/components/parameters/Network03"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/getEventsByAccount__aptos__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        }
+      }
+    },
+    "/pay-per-use/v1/{chain}/{network}/blockchain/getEventsByAccount": {
+      "post": {
+        "tags": [
+          "ppu",
+          "data"
+        ],
+        "summary": "Fetch contract events emitted for an account (pay-per-use)",
+        "description": "Retrieves the list of events emitted by a specific account.\n\n*Paid per call via x402 (Pay-Per-Use mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "payperuse_getEventsByAccount",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain03"
+          },
+          {
+            "$ref": "#/components/parameters/Network03"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/getEventsByAccount__aptos__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        },
+        "security": []
+      }
+    },
+    "/credit/v1/{chain}/{network}/blockchain/getTransactionByTransactionId": {
+      "post": {
+        "tags": [
+          "credit",
+          "data"
+        ],
+        "summary": "Get Transaction By Transaction ID (credit)",
+        "description": "Retrieves information about a specific transaction.\n\n*Paid per call via x402 (Credit mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "credit_getTransactionByTransactionId",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain13"
+          },
+          {
+            "$ref": "#/components/parameters/Network04"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/getTransactionByTransactionId__utxo__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/getTransactionByTransactionId__utxo__Res"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        }
+      }
+    },
+    "/pay-per-use/v1/{chain}/{network}/blockchain/getTransactionByTransactionId": {
+      "post": {
+        "tags": [
+          "ppu",
+          "data"
+        ],
+        "summary": "Get Transaction By Transaction ID (pay-per-use)",
+        "description": "Retrieves information about a specific transaction.\n\n*Paid per call via x402 (Pay-Per-Use mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "payperuse_getTransactionByTransactionId",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain13"
+          },
+          {
+            "$ref": "#/components/parameters/Network04"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/getTransactionByTransactionId__utxo__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/getTransactionByTransactionId__utxo__Res"
+                }
+              }
+            }
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        },
+        "security": []
+      }
+    },
+    "/credit/v1/{chain}/{network}/blockchain/searchEvents": {
+      "post": {
+        "tags": [
+          "credit",
+          "data"
+        ],
+        "summary": "Search contract event logs by filter criteria (credit)",
+        "description": "Searches for specific events within a specified range.\n\n*Paid per call via x402 (Credit mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "credit_searchEvents",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain04"
+          },
+          {
+            "$ref": "#/components/parameters/Network02"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/searchEvents__evm__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/searchEvents__kaia__Req"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        }
+      }
+    },
+    "/pay-per-use/v1/{chain}/{network}/blockchain/searchEvents": {
+      "post": {
+        "tags": [
+          "ppu",
+          "data"
+        ],
+        "summary": "Search contract event logs by filter criteria (pay-per-use)",
+        "description": "Searches for specific events within a specified range.\n\n*Paid per call via x402 (Pay-Per-Use mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "payperuse_searchEvents",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain04"
+          },
+          {
+            "$ref": "#/components/parameters/Network02"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/searchEvents__evm__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/searchEvents__kaia__Req"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        },
+        "security": []
+      }
+    },
+    "/credit/v1/{chain}/{network}/blockchain/getLedgerByHashOrIndex": {
+      "post": {
+        "tags": [
+          "credit",
+          "data"
+        ],
+        "summary": "Get Ledger By Hash Or Index (credit)",
+        "description": "Returns information about a Ledger queried by Ledger hash or index.\n\n*Paid per call via x402 (Credit mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "credit_getLedgerByHashOrIndex",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain05"
+          },
+          {
+            "$ref": "#/components/parameters/Network04"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/getLedgerByHashOrIndex__xrpl__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/getLedgerByHashOrIndex__xrpl__Res"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        }
+      }
+    },
+    "/pay-per-use/v1/{chain}/{network}/blockchain/getLedgerByHashOrIndex": {
+      "post": {
+        "tags": [
+          "ppu",
+          "data"
+        ],
+        "summary": "Get Ledger By Hash Or Index (pay-per-use)",
+        "description": "Returns information about a Ledger queried by Ledger hash or index.\n\n*Paid per call via x402 (Pay-Per-Use mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "payperuse_getLedgerByHashOrIndex",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain05"
+          },
+          {
+            "$ref": "#/components/parameters/Network04"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/getLedgerByHashOrIndex__xrpl__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/getLedgerByHashOrIndex__xrpl__Res"
+                }
+              }
+            }
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        },
+        "security": []
+      }
+    },
+    "/credit/v1/{chain}/{network}/blockchain/getTransactionsByAccount": {
+      "post": {
+        "tags": [
+          "credit",
+          "data"
+        ],
+        "summary": "Get Transactions By Account (credit)",
+        "description": "Retrieves the list of transactions sent or received by a specific account.\n\n*Paid per call via x402 (Credit mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "credit_getTransactionsByAccount",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain16"
+          },
+          {
+            "$ref": "#/components/parameters/Network02"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/getTransactionsByAccount__aptos__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/getTransactionsByAccount__evm__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/getTransactionsByAccount__kaia__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/getTransactionsByAccount__utxo__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/getTransactionsByAccount__tron__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/getTransactionsByAccount__xrpl__Req"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        }
+      }
+    },
+    "/pay-per-use/v1/{chain}/{network}/blockchain/getTransactionsByAccount": {
+      "post": {
+        "tags": [
+          "ppu",
+          "data"
+        ],
+        "summary": "Get Transactions By Account (pay-per-use)",
+        "description": "Retrieves the list of transactions sent or received by a specific account.\n\n*Paid per call via x402 (Pay-Per-Use mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "payperuse_getTransactionsByAccount",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain16"
+          },
+          {
+            "$ref": "#/components/parameters/Network02"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/getTransactionsByAccount__aptos__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/getTransactionsByAccount__evm__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/getTransactionsByAccount__kaia__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/getTransactionsByAccount__utxo__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/getTransactionsByAccount__tron__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/getTransactionsByAccount__xrpl__Req"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        },
+        "security": []
+      }
+    },
+    "/credit/v1/{chain}/{network}/blockchain/getTransactionByVersion": {
+      "post": {
+        "tags": [
+          "credit",
+          "data"
+        ],
+        "summary": "Get Transaction by Version (credit)",
+        "description": "Retrieves a specific transaction by version number.\n\n*Paid per call via x402 (Credit mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "credit_getTransactionByVersion",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain03"
+          },
+          {
+            "$ref": "#/components/parameters/Network03"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/getTransactionByVersion__aptos__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/transaction__aptos__Res"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        }
+      }
+    },
+    "/pay-per-use/v1/{chain}/{network}/blockchain/getTransactionByVersion": {
+      "post": {
+        "tags": [
+          "ppu",
+          "data"
+        ],
+        "summary": "Get Transaction by Version (pay-per-use)",
+        "description": "Retrieves a specific transaction by version number.\n\n*Paid per call via x402 (Pay-Per-Use mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "payperuse_getTransactionByVersion",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain03"
+          },
+          {
+            "$ref": "#/components/parameters/Network03"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/getTransactionByVersion__aptos__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/transaction__aptos__Res"
+                }
+              }
+            }
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        },
+        "security": []
+      }
+    },
+    "/credit/v1/{chain}/{network}/blockchain/getGasPrice": {
+      "post": {
+        "tags": [
+          "credit",
+          "data"
+        ],
+        "summary": "Fetch the current network gas price (credit)",
+        "description": "Retrieves the current Gas Price.\n\n*Paid per call via x402 (Credit mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "credit_getGasPrice",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain04"
+          },
+          {
+            "$ref": "#/components/parameters/Network02"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/getGasPrice__evm__Res"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        }
+      }
+    },
+    "/pay-per-use/v1/{chain}/{network}/blockchain/getGasPrice": {
+      "post": {
+        "tags": [
+          "ppu",
+          "data"
+        ],
+        "summary": "Fetch the current network gas price (pay-per-use)",
+        "description": "Retrieves the current Gas Price.\n\n*Paid per call via x402 (Pay-Per-Use mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "payperuse_getGasPrice",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain04"
+          },
+          {
+            "$ref": "#/components/parameters/Network02"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/getGasPrice__evm__Res"
+                }
+              }
+            }
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        },
+        "security": []
+      }
+    },
+    "/credit/v1/{chain}/{network}/blockchain/getInternalTransactionsByAccount": {
+      "post": {
+        "tags": [
+          "credit",
+          "data"
+        ],
+        "summary": "Get Internal Transactions By Account (credit)",
+        "description": "Retrieves the list of internal transactions related to a specific account.\n\n*Paid per call via x402 (Credit mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "credit_getInternalTransactionsByAccount",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain02"
+          },
+          {
+            "$ref": "#/components/parameters/Network02"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/getInternalTransactionsByAccount__evm__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/getInternalTransactionsByAccount__tron__Req"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        }
+      }
+    },
+    "/pay-per-use/v1/{chain}/{network}/blockchain/getInternalTransactionsByAccount": {
+      "post": {
+        "tags": [
+          "ppu",
+          "data"
+        ],
+        "summary": "Get Internal Transactions By Account (pay-per-use)",
+        "description": "Retrieves the list of internal transactions related to a specific account.\n\n*Paid per call via x402 (Pay-Per-Use mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "payperuse_getInternalTransactionsByAccount",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain02"
+          },
+          {
+            "$ref": "#/components/parameters/Network02"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/getInternalTransactionsByAccount__evm__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/getInternalTransactionsByAccount__tron__Req"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/paginatedItems__common__Res"
+                }
+              }
+            }
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        },
+        "security": []
+      }
+    },
+    "/credit/v1/{chain}/{network}/blockchain/getBlockByHashOrNumber": {
+      "post": {
+        "tags": [
+          "credit",
+          "data"
+        ],
+        "summary": "Get Block by Hash or Number (credit)",
+        "description": "Returns specific information about a block queried by block hash or block number.\n\n*Paid per call via x402 (Credit mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "credit_getBlockByHashOrNumber",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain18"
+          },
+          {
+            "$ref": "#/components/parameters/Network02"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/getBlockByHashOrNumber__aptos__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/getBlockByHashOrNumber__evm__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/getBlockByHashOrNumber__kaia__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/getBlockByHashOrNumber__utxo__Req"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/getBlockByHashOrNumber__aptos__Res"
+                    },
+                    {
+                      "$ref": "#/components/schemas/getBlockByHashOrNumber__evm__Res"
+                    },
+                    {
+                      "$ref": "#/components/schemas/getBlockByHashOrNumber__utxo__Res"
+                    },
+                    {
+                      "$ref": "#/components/schemas/getBlockByHashOrNumber__bitcoincash__Res"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        }
+      }
+    },
+    "/pay-per-use/v1/{chain}/{network}/blockchain/getBlockByHashOrNumber": {
+      "post": {
+        "tags": [
+          "ppu",
+          "data"
+        ],
+        "summary": "Get Block by Hash or Number (pay-per-use)",
+        "description": "Returns specific information about a block queried by block hash or block number.\n\n*Paid per call via x402 (Pay-Per-Use mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "payperuse_getBlockByHashOrNumber",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain18"
+          },
+          {
+            "$ref": "#/components/parameters/Network02"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/getBlockByHashOrNumber__aptos__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/getBlockByHashOrNumber__evm__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/getBlockByHashOrNumber__kaia__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/getBlockByHashOrNumber__utxo__Req"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/getBlockByHashOrNumber__aptos__Res"
+                    },
+                    {
+                      "$ref": "#/components/schemas/getBlockByHashOrNumber__evm__Res"
+                    },
+                    {
+                      "$ref": "#/components/schemas/getBlockByHashOrNumber__utxo__Res"
+                    },
+                    {
+                      "$ref": "#/components/schemas/getBlockByHashOrNumber__bitcoincash__Res"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        },
+        "security": []
+      }
+    },
+    "/credit/v1/{chain}/{network}/stats/getDailyActiveAccountsStats": {
+      "post": {
+        "tags": [
+          "credit",
+          "data"
+        ],
+        "summary": "Get Daily Active Accounts Stats (credit)",
+        "description": "Retrieves the number of daily active accounts within the specified range.\n\n> 📘 When is data reflected?\n>\n> In the current daily statistics API, a 'day' is based on UTC, and each day's data is aggregated from UTC 00:00:00 to before UTC 24:00:00 of that day. For daily statistics, the previous day's statistics may be delayed until 00:30:00 the next morning, so this should be considered when querying the latest data.\n\n\n> 🚧 Check the network when using!\n>\n> This API is only supported on Ethereum Mainnet. It cannot be used on other networks. Please verify the network when using.\n\n*Paid per call via x402 (Credit mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "credit_getDailyActiveAccountsStats",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain09"
+          },
+          {
+            "$ref": "#/components/parameters/Network04"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/dailyStatsRange__evm__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/statsItems__evm__Res"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        }
+      }
+    },
+    "/pay-per-use/v1/{chain}/{network}/stats/getDailyActiveAccountsStats": {
+      "post": {
+        "tags": [
+          "ppu",
+          "data"
+        ],
+        "summary": "Get Daily Active Accounts Stats (pay-per-use)",
+        "description": "Retrieves the number of daily active accounts within the specified range.\n\n> 📘 When is data reflected?\n>\n> In the current daily statistics API, a 'day' is based on UTC, and each day's data is aggregated from UTC 00:00:00 to before UTC 24:00:00 of that day. For daily statistics, the previous day's statistics may be delayed until 00:30:00 the next morning, so this should be considered when querying the latest data.\n\n\n> 🚧 Check the network when using!\n>\n> This API is only supported on Ethereum Mainnet. It cannot be used on other networks. Please verify the network when using.\n\n*Paid per call via x402 (Pay-Per-Use mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "payperuse_getDailyActiveAccountsStats",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain09"
+          },
+          {
+            "$ref": "#/components/parameters/Network04"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/dailyStatsRange__evm__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/statsItems__evm__Res"
+                }
+              }
+            }
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        },
+        "security": []
+      }
+    },
+    "/credit/v1/{chain}/{network}/stats/getDailyTransactionsStatsByContract": {
+      "post": {
+        "tags": [
+          "credit",
+          "data"
+        ],
+        "summary": "Get Daily Transactions Stats By Contract (credit)",
+        "description": "Retrieves the daily transaction volume for a specific contract within the specified range.\n\n> 📘 When is data reflected?\n>\n> In the current daily statistics API, a 'day' is based on UTC, and each day's data is aggregated from UTC 00:00:00 to before UTC 24:00:00 of that day. For daily statistics, the previous day's statistics may be delayed until 00:30:00 the next morning, so this should be considered when querying the latest data.\n\n\n> 🚧 Check the network when using!\n>\n> This API is only supported on Ethereum Mainnet. It cannot be used on other networks. Please verify the network when using.\n\n*Paid per call via x402 (Credit mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "credit_getDailyTransactionsStatsByContract",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain09"
+          },
+          {
+            "$ref": "#/components/parameters/Network04"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/dailyStatsByContract__evm__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/statsItems__evm__Res"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        }
+      }
+    },
+    "/pay-per-use/v1/{chain}/{network}/stats/getDailyTransactionsStatsByContract": {
+      "post": {
+        "tags": [
+          "ppu",
+          "data"
+        ],
+        "summary": "Get Daily Transactions Stats By Contract (pay-per-use)",
+        "description": "Retrieves the daily transaction volume for a specific contract within the specified range.\n\n> 📘 When is data reflected?\n>\n> In the current daily statistics API, a 'day' is based on UTC, and each day's data is aggregated from UTC 00:00:00 to before UTC 24:00:00 of that day. For daily statistics, the previous day's statistics may be delayed until 00:30:00 the next morning, so this should be considered when querying the latest data.\n\n\n> 🚧 Check the network when using!\n>\n> This API is only supported on Ethereum Mainnet. It cannot be used on other networks. Please verify the network when using.\n\n*Paid per call via x402 (Pay-Per-Use mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "payperuse_getDailyTransactionsStatsByContract",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain09"
+          },
+          {
+            "$ref": "#/components/parameters/Network04"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/dailyStatsByContract__evm__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/statsItems__evm__Res"
+                }
+              }
+            }
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        },
+        "security": []
+      }
+    },
+    "/credit/v1/{chain}/{network}/stats/getAccountStats": {
+      "post": {
+        "tags": [
+          "credit",
+          "data"
+        ],
+        "summary": "Fetch on-chain activity stats for an account (credit)",
+        "description": "Retrieves statistics for a specific address. Account activity can be analyzed through transaction data, transfer events, assets, and other information for the account.\n\n*Paid per call via x402 (Credit mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "credit_getAccountStats",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain07"
+          },
+          {
+            "$ref": "#/components/parameters/Network02"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/address__evm__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/address__tron__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/getAccountStats__aptos__Req"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/getAccountStats__evm__Res"
+                    },
+                    {
+                      "$ref": "#/components/schemas/getAccountStats__tron__Res"
+                    },
+                    {
+                      "$ref": "#/components/schemas/getAccountStats__aptos__Res"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        }
+      }
+    },
+    "/pay-per-use/v1/{chain}/{network}/stats/getAccountStats": {
+      "post": {
+        "tags": [
+          "ppu",
+          "data"
+        ],
+        "summary": "Fetch on-chain activity stats for an account (pay-per-use)",
+        "description": "Retrieves statistics for a specific address. Account activity can be analyzed through transaction data, transfer events, assets, and other information for the account.\n\n*Paid per call via x402 (Pay-Per-Use mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "payperuse_getAccountStats",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain07"
+          },
+          {
+            "$ref": "#/components/parameters/Network02"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/address__evm__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/address__tron__Req"
+                  },
+                  {
+                    "$ref": "#/components/schemas/getAccountStats__aptos__Req"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/getAccountStats__evm__Res"
+                    },
+                    {
+                      "$ref": "#/components/schemas/getAccountStats__tron__Res"
+                    },
+                    {
+                      "$ref": "#/components/schemas/getAccountStats__aptos__Res"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        },
+        "security": []
+      }
+    },
+    "/credit/v1/{chain}/{network}/stats/getHourlyActiveAccountsStats": {
+      "post": {
+        "tags": [
+          "credit",
+          "data"
+        ],
+        "summary": "Get Hourly Active Accounts Stats (credit)",
+        "description": "Retrieves the hourly count of active accounts within the specified range.\n\n> 📘 When is data reflected?\n>\n> In the current hourly statistics API, time is based on UTC, and each response item provides statistics for the period from the date +1 hour. For hourly statistics, the most recent hour's statistics may be delayed by up to 40 minutes, so this should be considered when querying the latest data.\n\n\n> 🚧 Check the network when using!\n>\n> This API is only supported on Ethereum Mainnet. It cannot be used on other networks. Please verify the network when using.\n\n*Paid per call via x402 (Credit mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "credit_getHourlyActiveAccountsStats",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain09"
+          },
+          {
+            "$ref": "#/components/parameters/Network04"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/hourlyStatsRange__evm__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/statsItems__evm__Res"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        }
+      }
+    },
+    "/pay-per-use/v1/{chain}/{network}/stats/getHourlyActiveAccountsStats": {
+      "post": {
+        "tags": [
+          "ppu",
+          "data"
+        ],
+        "summary": "Get Hourly Active Accounts Stats (pay-per-use)",
+        "description": "Retrieves the hourly count of active accounts within the specified range.\n\n> 📘 When is data reflected?\n>\n> In the current hourly statistics API, time is based on UTC, and each response item provides statistics for the period from the date +1 hour. For hourly statistics, the most recent hour's statistics may be delayed by up to 40 minutes, so this should be considered when querying the latest data.\n\n\n> 🚧 Check the network when using!\n>\n> This API is only supported on Ethereum Mainnet. It cannot be used on other networks. Please verify the network when using.\n\n*Paid per call via x402 (Pay-Per-Use mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "payperuse_getHourlyActiveAccountsStats",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain09"
+          },
+          {
+            "$ref": "#/components/parameters/Network04"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/hourlyStatsRange__evm__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/statsItems__evm__Res"
+                }
+              }
+            }
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        },
+        "security": []
+      }
+    },
+    "/credit/v1/{chain}/{network}/stats/getHourlyActiveAccountsStatsByContract": {
+      "post": {
+        "tags": [
+          "credit",
+          "data"
+        ],
+        "summary": "Get Hourly Active Accounts Stats By Contract (credit)",
+        "description": "Retrieves the hourly count of active accounts for a specific contract within the specified range.\n\n> 📘 When is data reflected?\n>\n> In the current hourly statistics API, time is based on UTC, and each response item provides statistics for the period from the date +1 hour. For hourly statistics, the most recent hour's statistics may be delayed by up to 40 minutes, so this should be considered when querying the latest data.\n\n\n> 🚧 Check the network when using!\n>\n> This API is only supported on Ethereum Mainnet. It cannot be used on other networks. Please verify the network when using.\n\n*Paid per call via x402 (Credit mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "credit_getHourlyActiveAccountsStatsByContract",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain09"
+          },
+          {
+            "$ref": "#/components/parameters/Network04"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/hourlyStatsByContract__evm__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/statsItems__evm__Res"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        }
+      }
+    },
+    "/pay-per-use/v1/{chain}/{network}/stats/getHourlyActiveAccountsStatsByContract": {
+      "post": {
+        "tags": [
+          "ppu",
+          "data"
+        ],
+        "summary": "Get Hourly Active Accounts Stats By Contract (pay-per-use)",
+        "description": "Retrieves the hourly count of active accounts for a specific contract within the specified range.\n\n> 📘 When is data reflected?\n>\n> In the current hourly statistics API, time is based on UTC, and each response item provides statistics for the period from the date +1 hour. For hourly statistics, the most recent hour's statistics may be delayed by up to 40 minutes, so this should be considered when querying the latest data.\n\n\n> 🚧 Check the network when using!\n>\n> This API is only supported on Ethereum Mainnet. It cannot be used on other networks. Please verify the network when using.\n\n*Paid per call via x402 (Pay-Per-Use mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "payperuse_getHourlyActiveAccountsStatsByContract",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain09"
+          },
+          {
+            "$ref": "#/components/parameters/Network04"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/hourlyStatsByContract__evm__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/statsItems__evm__Res"
+                }
+              }
+            }
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        },
+        "security": []
+      }
+    },
+    "/credit/v1/{chain}/{network}/stats/getDailyTransactionsStats": {
+      "post": {
+        "tags": [
+          "credit",
+          "data"
+        ],
+        "summary": "Get Daily Transactions Stats (credit)",
+        "description": "Retrieves the daily transaction volume within the specified range.\n\n> 📘 When is data reflected?\n>\n> In the current daily statistics API, a 'day' is based on UTC, and each day's data is aggregated from UTC 00:00:00 to before UTC 24:00:00 of that day. For daily statistics, the previous day's statistics may be delayed until 00:30:00 the next morning, so this should be considered when querying the latest data.\n\n\n> 🚧 Check the network when using!\n>\n> This API is only supported on Ethereum Mainnet. It cannot be used on other networks. Please verify the network when using.\n\n*Paid per call via x402 (Credit mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "credit_getDailyTransactionsStats",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain09"
+          },
+          {
+            "$ref": "#/components/parameters/Network04"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/dailyStatsRange__evm__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/statsItems__evm__Res"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        }
+      }
+    },
+    "/pay-per-use/v1/{chain}/{network}/stats/getDailyTransactionsStats": {
+      "post": {
+        "tags": [
+          "ppu",
+          "data"
+        ],
+        "summary": "Get Daily Transactions Stats (pay-per-use)",
+        "description": "Retrieves the daily transaction volume within the specified range.\n\n> 📘 When is data reflected?\n>\n> In the current daily statistics API, a 'day' is based on UTC, and each day's data is aggregated from UTC 00:00:00 to before UTC 24:00:00 of that day. For daily statistics, the previous day's statistics may be delayed until 00:30:00 the next morning, so this should be considered when querying the latest data.\n\n\n> 🚧 Check the network when using!\n>\n> This API is only supported on Ethereum Mainnet. It cannot be used on other networks. Please verify the network when using.\n\n*Paid per call via x402 (Pay-Per-Use mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "payperuse_getDailyTransactionsStats",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain09"
+          },
+          {
+            "$ref": "#/components/parameters/Network04"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/dailyStatsRange__evm__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/statsItems__evm__Res"
+                }
+              }
+            }
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        },
+        "security": []
+      }
+    },
+    "/credit/v1/{chain}/{network}/stats/getHourlyTransactionsStatsByContract": {
+      "post": {
+        "tags": [
+          "credit",
+          "data"
+        ],
+        "summary": "Get Hourly Transactions Stats By Contract (credit)",
+        "description": "Retrieves the hourly transaction count for a specific contract within the specified range.\n\n> 📘 When is the data reflected?\n> \n> In the current hourly statistics API, time is based on UTC, and each item in the response provides statistics within +1 hour from the date. For hourly statistics, the reflection of the most recent 1-hour statistics may be delayed by up to 40 minutes, so this should be considered when querying the latest data.\n\n\n> 🚧 Check the network before use!\n>\n> This API is only supported on Ethereum Mainnet, and cannot be used on other networks. Please verify the network before use.\n\n*Paid per call via x402 (Credit mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "credit_getHourlyTransactionsStatsByContract",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain09"
+          },
+          {
+            "$ref": "#/components/parameters/Network04"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/hourlyStatsByContract__evm__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/statsItems__evm__Res"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        }
+      }
+    },
+    "/pay-per-use/v1/{chain}/{network}/stats/getHourlyTransactionsStatsByContract": {
+      "post": {
+        "tags": [
+          "ppu",
+          "data"
+        ],
+        "summary": "Get Hourly Transactions Stats By Contract (pay-per-use)",
+        "description": "Retrieves the hourly transaction count for a specific contract within the specified range.\n\n> 📘 When is the data reflected?\n> \n> In the current hourly statistics API, time is based on UTC, and each item in the response provides statistics within +1 hour from the date. For hourly statistics, the reflection of the most recent 1-hour statistics may be delayed by up to 40 minutes, so this should be considered when querying the latest data.\n\n\n> 🚧 Check the network before use!\n>\n> This API is only supported on Ethereum Mainnet, and cannot be used on other networks. Please verify the network before use.\n\n*Paid per call via x402 (Pay-Per-Use mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "payperuse_getHourlyTransactionsStatsByContract",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain09"
+          },
+          {
+            "$ref": "#/components/parameters/Network04"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/hourlyStatsByContract__evm__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/statsItems__evm__Res"
+                }
+              }
+            }
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        },
+        "security": []
+      }
+    },
+    "/credit/v1/{chain}/{network}/stats/getDailyActiveAccountsStatsByContract": {
+      "post": {
+        "tags": [
+          "credit",
+          "data"
+        ],
+        "summary": "Get Daily Active Accounts Stats By Contract (credit)",
+        "description": "Retrieves the daily count of active accounts for a specific contract within the specified range.\n\n> 📘 When is data reflected?\n>\n> In the current daily statistics API, a 'day' is based on UTC, and each day's data is aggregated from UTC 00:00:00 to before UTC 24:00:00 of that day. For daily statistics, the previous day's statistics may be delayed until 00:30:00 the next morning, so this should be considered when querying the latest data.\n\n\n> 🚧 Check the network when using!\n>\n> This API is only supported on Ethereum Mainnet. It cannot be used on other networks. Please verify the network when using.\n\n*Paid per call via x402 (Credit mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "credit_getDailyActiveAccountsStatsByContract",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain09"
+          },
+          {
+            "$ref": "#/components/parameters/Network04"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/dailyStatsByContract__evm__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/statsItems__evm__Res"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        }
+      }
+    },
+    "/pay-per-use/v1/{chain}/{network}/stats/getDailyActiveAccountsStatsByContract": {
+      "post": {
+        "tags": [
+          "ppu",
+          "data"
+        ],
+        "summary": "Get Daily Active Accounts Stats By Contract (pay-per-use)",
+        "description": "Retrieves the daily count of active accounts for a specific contract within the specified range.\n\n> 📘 When is data reflected?\n>\n> In the current daily statistics API, a 'day' is based on UTC, and each day's data is aggregated from UTC 00:00:00 to before UTC 24:00:00 of that day. For daily statistics, the previous day's statistics may be delayed until 00:30:00 the next morning, so this should be considered when querying the latest data.\n\n\n> 🚧 Check the network when using!\n>\n> This API is only supported on Ethereum Mainnet. It cannot be used on other networks. Please verify the network when using.\n\n*Paid per call via x402 (Pay-Per-Use mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "payperuse_getDailyActiveAccountsStatsByContract",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain09"
+          },
+          {
+            "$ref": "#/components/parameters/Network04"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/dailyStatsByContract__evm__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/statsItems__evm__Res"
+                }
+              }
+            }
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        },
+        "security": []
+      }
+    },
+    "/credit/v1/{chain}/{network}/stats/getHourlyTransactionsStats": {
+      "post": {
+        "tags": [
+          "credit",
+          "data"
+        ],
+        "summary": "Get Hourly Transactions Stats (credit)",
+        "description": "Retrieves the hourly transaction count within the specified range.\n\n> 📘 When is data reflected?\n>\n> In the current hourly statistics API, time is based on UTC, and each response item provides statistics for the period from the date +1 hour. For hourly statistics, the most recent hour's statistics may be delayed by up to 40 minutes, so this should be considered when querying the latest data.\n\n\n> 🚧 Check the network when using!\n>\n> This API is only supported on Ethereum Mainnet. It cannot be used on other networks. Please verify the network when using.\n\n*Paid per call via x402 (Credit mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "credit_getHourlyTransactionsStats",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain09"
+          },
+          {
+            "$ref": "#/components/parameters/Network04"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/hourlyStatsRange__evm__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/statsItems__evm__Res"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        }
+      }
+    },
+    "/pay-per-use/v1/{chain}/{network}/stats/getHourlyTransactionsStats": {
+      "post": {
+        "tags": [
+          "ppu",
+          "data"
+        ],
+        "summary": "Get Hourly Transactions Stats (pay-per-use)",
+        "description": "Retrieves the hourly transaction count within the specified range.\n\n> 📘 When is data reflected?\n>\n> In the current hourly statistics API, time is based on UTC, and each response item provides statistics for the period from the date +1 hour. For hourly statistics, the most recent hour's statistics may be delayed by up to 40 minutes, so this should be considered when querying the latest data.\n\n\n> 🚧 Check the network when using!\n>\n> This API is only supported on Ethereum Mainnet. It cannot be used on other networks. Please verify the network when using.\n\n*Paid per call via x402 (Pay-Per-Use mode). Without a `payment-signature` header, the request returns **402 Payment Required** with the payment requirements; include the signed payment to receive the result.*",
+        "operationId": "payperuse_getHourlyTransactionsStats",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Chain09"
+          },
+          {
+            "$ref": "#/components/parameters/Network04"
+          },
+          {
+            "$ref": "#/components/parameters/PaymentSignatureHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/hourlyStatsRange__evm__Req"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success — Nodit Data API result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/statsItems__evm__Res"
+                }
+              }
+            }
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          }
+        },
+        "security": []
+      }
+    }
+  },
+  "components": {
+    "parameters": {
+      "PaymentSignatureHeader": {
+        "name": "payment-signature",
+        "in": "header",
+        "required": false,
+        "description": "Base64-encoded x402 v2 PaymentPayload JSON. When omitted, returns 402 with the payment requirements (PAYMENT-REQUIRED).",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "PaymentsFrom": {
+        "name": "from",
+        "in": "query",
+        "required": false,
+        "description": "Start date (inclusive, ISO 8601)",
+        "schema": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "PaymentsTo": {
+        "name": "to",
+        "in": "query",
+        "required": false,
+        "description": "End date (exclusive, ISO 8601)",
+        "schema": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "PaymentsBilling": {
+        "name": "billing",
+        "in": "query",
+        "required": false,
+        "description": "Payment method filter",
+        "schema": {
+          "type": "string",
+          "enum": [
+            "credit",
+            "ppu"
+          ]
+        }
+      },
+      "PaymentsStatus": {
+        "name": "status",
+        "in": "query",
+        "required": false,
+        "description": "Status filter",
+        "schema": {
+          "type": "string",
+          "enum": [
+            "COMPLETED",
+            "VERIFYING",
+            "FAILED"
+          ]
+        }
+      },
+      "PaymentsServiceChain": {
+        "name": "serviceChain",
+        "in": "query",
+        "required": false,
+        "description": "Service chain filter (lowercase/digits/hyphen)",
+        "schema": {
+          "type": "string",
+          "pattern": "^[a-z0-9-]+$"
+        }
+      },
+      "PaymentsSearch": {
+        "name": "search",
+        "in": "query",
+        "required": false,
+        "description": "Partial search by API method (case-insensitive)",
+        "schema": {
+          "type": "string",
+          "maxLength": 255
+        }
+      },
+      "Chain01": {
+        "name": "chain",
+        "in": "path",
+        "required": true,
+        "description": "Supported chains. Valid network combinations — arbitrum: mainnet,sepolia; arc: testnet; avalanche: fuji,mainnet; base: mainnet,sepolia; bnb: mainnet,testnet; ethereum: hoodi,mainnet,sepolia; giwa: sepolia; kaia: kairos,mainnet; luniverse: mainnet; optimism: mainnet,sepolia; polygon: mainnet; solana: devnet,mainnet; sui: mainnet",
+        "schema": {
+          "type": "string",
+          "enum": [
+            "arbitrum",
+            "arc",
+            "avalanche",
+            "base",
+            "bnb",
+            "ethereum",
+            "giwa",
+            "kaia",
+            "luniverse",
+            "optimism",
+            "polygon",
+            "solana",
+            "sui"
+          ]
+        }
+      },
+      "Network01": {
+        "name": "network",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "enum": [
+            "devnet",
+            "fuji",
+            "hoodi",
+            "kairos",
+            "mainnet",
+            "sepolia",
+            "testnet"
+          ]
+        }
+      },
+      "Chain02": {
+        "name": "chain",
+        "in": "path",
+        "required": true,
+        "description": "Supported chains. Valid network combinations — arbitrum: mainnet,sepolia; arc: testnet; base: mainnet,sepolia; bnb: mainnet,testnet; chiliz: mainnet; ethereum: mainnet,sepolia,hoodi; ethereumclassic: mainnet; giwa: sepolia; kaia: mainnet,kairos; luniverse: mainnet; optimism: mainnet,sepolia; polygon: mainnet; tron: mainnet",
+        "schema": {
+          "type": "string",
+          "enum": [
+            "arbitrum",
+            "arc",
+            "base",
+            "bnb",
+            "chiliz",
+            "ethereum",
+            "ethereumclassic",
+            "giwa",
+            "kaia",
+            "luniverse",
+            "optimism",
+            "polygon",
+            "tron"
+          ]
+        }
+      },
+      "Network02": {
+        "name": "network",
+        "in": "path",
+        "required": true,
+        "description": "Network (valid values per chain — see the chain description)",
+        "schema": {
+          "type": "string",
+          "enum": [
+            "hoodi",
+            "kairos",
+            "mainnet",
+            "sepolia",
+            "testnet"
+          ]
+        }
+      },
+      "Chain03": {
+        "name": "chain",
+        "in": "path",
+        "required": true,
+        "description": "Supported chains. Valid network combinations — aptos: mainnet,testnet",
+        "schema": {
+          "type": "string",
+          "enum": [
+            "aptos"
+          ]
+        }
+      },
+      "Network03": {
+        "name": "network",
+        "in": "path",
+        "required": true,
+        "description": "Network (valid values per chain — see the chain description)",
+        "schema": {
+          "type": "string",
+          "enum": [
+            "mainnet",
+            "testnet"
+          ]
+        }
+      },
+      "Chain04": {
+        "name": "chain",
+        "in": "path",
+        "required": true,
+        "description": "Supported chains. Valid network combinations — arbitrum: mainnet,sepolia; arc: testnet; base: mainnet,sepolia; bnb: mainnet,testnet; chiliz: mainnet; ethereum: mainnet,sepolia,hoodi; ethereumclassic: mainnet; giwa: sepolia; kaia: mainnet,kairos; luniverse: mainnet; optimism: mainnet,sepolia; polygon: mainnet",
+        "schema": {
+          "type": "string",
+          "enum": [
+            "arbitrum",
+            "arc",
+            "base",
+            "bnb",
+            "chiliz",
+            "ethereum",
+            "ethereumclassic",
+            "giwa",
+            "kaia",
+            "luniverse",
+            "optimism",
+            "polygon"
+          ]
+        }
+      },
+      "Chain05": {
+        "name": "chain",
+        "in": "path",
+        "required": true,
+        "description": "Supported chains. Valid network combinations — xrpl: mainnet",
+        "schema": {
+          "type": "string",
+          "enum": [
+            "xrpl"
+          ]
+        }
+      },
+      "Network04": {
+        "name": "network",
+        "in": "path",
+        "required": true,
+        "description": "Network (valid values per chain — see the chain description)",
+        "schema": {
+          "type": "string",
+          "enum": [
+            "mainnet"
+          ]
+        }
+      },
+      "Chain06": {
+        "name": "chain",
+        "in": "path",
+        "required": true,
+        "description": "Supported chains. Valid network combinations — arbitrum: mainnet,sepolia; arc: testnet; base: mainnet,sepolia; bnb: mainnet,testnet; chiliz: mainnet; ethereum: mainnet,sepolia,hoodi; ethereumclassic: mainnet; giwa: sepolia; kaia: mainnet,kairos; luniverse: mainnet; optimism: mainnet,sepolia; polygon: mainnet; tron: mainnet; xrpl: mainnet",
+        "schema": {
+          "type": "string",
+          "enum": [
+            "arbitrum",
+            "arc",
+            "base",
+            "bnb",
+            "chiliz",
+            "ethereum",
+            "ethereumclassic",
+            "giwa",
+            "kaia",
+            "luniverse",
+            "optimism",
+            "polygon",
+            "tron",
+            "xrpl"
+          ]
+        }
+      },
+      "Chain07": {
+        "name": "chain",
+        "in": "path",
+        "required": true,
+        "description": "Supported chains. Valid network combinations — aptos: mainnet,testnet; arbitrum: mainnet,sepolia; arc: testnet; base: mainnet,sepolia; bnb: mainnet,testnet; chiliz: mainnet; ethereum: mainnet,sepolia,hoodi; ethereumclassic: mainnet; giwa: sepolia; kaia: mainnet,kairos; luniverse: mainnet; optimism: mainnet,sepolia; polygon: mainnet; tron: mainnet",
+        "schema": {
+          "type": "string",
+          "enum": [
+            "aptos",
+            "arbitrum",
+            "arc",
+            "base",
+            "bnb",
+            "chiliz",
+            "ethereum",
+            "ethereumclassic",
+            "giwa",
+            "kaia",
+            "luniverse",
+            "optimism",
+            "polygon",
+            "tron"
+          ]
+        }
+      },
+      "Chain08": {
+        "name": "chain",
+        "in": "path",
+        "required": true,
+        "description": "Supported chains. Valid network combinations — aptos: mainnet,testnet; xrpl: mainnet",
+        "schema": {
+          "type": "string",
+          "enum": [
+            "aptos",
+            "xrpl"
+          ]
+        }
+      },
+      "Chain09": {
+        "name": "chain",
+        "in": "path",
+        "required": true,
+        "description": "Supported chains. Valid network combinations — ethereum: mainnet",
+        "schema": {
+          "type": "string",
+          "enum": [
+            "ethereum"
+          ]
+        }
+      },
+      "Chain10": {
+        "name": "chain",
+        "in": "path",
+        "required": true,
+        "description": "Supported chains. Valid network combinations — tron: mainnet",
+        "schema": {
+          "type": "string",
+          "enum": [
+            "tron"
+          ]
+        }
+      },
+      "Chain11": {
+        "name": "chain",
+        "in": "path",
+        "required": true,
+        "description": "Supported chains. Valid network combinations — arc: testnet; tron: mainnet",
+        "schema": {
+          "type": "string",
+          "enum": [
+            "arc",
+            "tron"
+          ]
+        }
+      },
+      "Chain12": {
+        "name": "chain",
+        "in": "path",
+        "required": true,
+        "description": "Supported chains. Valid network combinations — bitcoin: mainnet; bitcoincash: mainnet; dogecoin: mainnet; xrpl: mainnet",
+        "schema": {
+          "type": "string",
+          "enum": [
+            "bitcoin",
+            "bitcoincash",
+            "dogecoin",
+            "xrpl"
+          ]
+        }
+      },
+      "Chain13": {
+        "name": "chain",
+        "in": "path",
+        "required": true,
+        "description": "Supported chains. Valid network combinations — bitcoin: mainnet; bitcoincash: mainnet; dogecoin: mainnet",
+        "schema": {
+          "type": "string",
+          "enum": [
+            "bitcoin",
+            "bitcoincash",
+            "dogecoin"
+          ]
+        }
+      },
+      "Chain14": {
+        "name": "chain",
+        "in": "path",
+        "required": true,
+        "description": "Supported chains. Valid network combinations — aptos: mainnet,testnet; arbitrum: mainnet,sepolia; arc: testnet; base: mainnet,sepolia; bnb: mainnet,testnet; chiliz: mainnet; ethereum: mainnet,sepolia,hoodi; ethereumclassic: mainnet; giwa: sepolia; kaia: mainnet,kairos; luniverse: mainnet; optimism: mainnet,sepolia; polygon: mainnet",
+        "schema": {
+          "type": "string",
+          "enum": [
+            "aptos",
+            "arbitrum",
+            "arc",
+            "base",
+            "bnb",
+            "chiliz",
+            "ethereum",
+            "ethereumclassic",
+            "giwa",
+            "kaia",
+            "luniverse",
+            "optimism",
+            "polygon"
+          ]
+        }
+      },
+      "Chain15": {
+        "name": "chain",
+        "in": "path",
+        "required": true,
+        "description": "Supported chains. Valid network combinations — aptos: mainnet,testnet; arbitrum: mainnet,sepolia; arc: testnet; base: mainnet,sepolia; bnb: mainnet,testnet; chiliz: mainnet; ethereum: mainnet,sepolia,hoodi; ethereumclassic: mainnet; giwa: sepolia; kaia: mainnet,kairos; luniverse: mainnet; optimism: mainnet,sepolia; polygon: mainnet; tron: mainnet; xrpl: mainnet",
+        "schema": {
+          "type": "string",
+          "enum": [
+            "aptos",
+            "arbitrum",
+            "arc",
+            "base",
+            "bnb",
+            "chiliz",
+            "ethereum",
+            "ethereumclassic",
+            "giwa",
+            "kaia",
+            "luniverse",
+            "optimism",
+            "polygon",
+            "tron",
+            "xrpl"
+          ]
+        }
+      },
+      "Chain16": {
+        "name": "chain",
+        "in": "path",
+        "required": true,
+        "description": "Supported chains. Valid network combinations — aptos: mainnet,testnet; arbitrum: mainnet,sepolia; arc: testnet; base: mainnet,sepolia; bitcoin: mainnet; bitcoincash: mainnet; bnb: mainnet,testnet; chiliz: mainnet; dogecoin: mainnet; ethereum: mainnet,sepolia,hoodi; ethereumclassic: mainnet; giwa: sepolia; kaia: mainnet,kairos; luniverse: mainnet; optimism: mainnet,sepolia; polygon: mainnet; tron: mainnet; xrpl: mainnet",
+        "schema": {
+          "type": "string",
+          "enum": [
+            "aptos",
+            "arbitrum",
+            "arc",
+            "base",
+            "bitcoin",
+            "bitcoincash",
+            "bnb",
+            "chiliz",
+            "dogecoin",
+            "ethereum",
+            "ethereumclassic",
+            "giwa",
+            "kaia",
+            "luniverse",
+            "optimism",
+            "polygon",
+            "tron",
+            "xrpl"
+          ]
+        }
+      },
+      "Chain17": {
+        "name": "chain",
+        "in": "path",
+        "required": true,
+        "description": "Supported chains. Valid network combinations — aptos: mainnet,testnet; arbitrum: mainnet,sepolia; arc: testnet; base: mainnet,sepolia; bnb: mainnet,testnet; chiliz: mainnet; ethereum: mainnet,sepolia,hoodi; ethereumclassic: mainnet; giwa: sepolia; kaia: mainnet,kairos; luniverse: mainnet; optimism: mainnet,sepolia; polygon: mainnet; xrpl: mainnet",
+        "schema": {
+          "type": "string",
+          "enum": [
+            "aptos",
+            "arbitrum",
+            "arc",
+            "base",
+            "bnb",
+            "chiliz",
+            "ethereum",
+            "ethereumclassic",
+            "giwa",
+            "kaia",
+            "luniverse",
+            "optimism",
+            "polygon",
+            "xrpl"
+          ]
+        }
+      },
+      "Chain18": {
+        "name": "chain",
+        "in": "path",
+        "required": true,
+        "description": "Supported chains. Valid network combinations — aptos: mainnet,testnet; arbitrum: mainnet,sepolia; arc: testnet; base: mainnet,sepolia; bitcoin: mainnet; bitcoincash: mainnet; bnb: mainnet,testnet; chiliz: mainnet; dogecoin: mainnet; ethereum: mainnet,sepolia,hoodi; ethereumclassic: mainnet; giwa: sepolia; kaia: mainnet,kairos; luniverse: mainnet; optimism: mainnet,sepolia; polygon: mainnet",
+        "schema": {
+          "type": "string",
+          "enum": [
+            "aptos",
+            "arbitrum",
+            "arc",
+            "base",
+            "bitcoin",
+            "bitcoincash",
+            "bnb",
+            "chiliz",
+            "dogecoin",
+            "ethereum",
+            "ethereumclassic",
+            "giwa",
+            "kaia",
+            "luniverse",
+            "optimism",
+            "polygon"
+          ]
+        }
+      }
+    },
+    "headers": {
+      "PaymentResponseHeader": {
+        "description": "Base64-encoded payment settlement result (SettlementResponse) JSON",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "PaymentRequiredHeader": {
+        "description": "Base64-encoded payment requirements (PaymentRequirements) JSON",
+        "schema": {
+          "type": "string"
+        }
+      }
+    },
+    "requestBodies": {},
+    "responses": {
+      "Unauthorized": {
+        "description": "Authentication failed — JWT missing or expired",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            }
+          }
+        }
+      },
+      "PaymentRequired": {
+        "description": "Payment required — returns the payment requirements. The same content is also carried base64-encoded in the `PAYMENT-REQUIRED` response header.",
+        "headers": {
+          "PAYMENT-REQUIRED": {
+            "$ref": "#/components/headers/PaymentRequiredHeader"
+          }
+        },
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/PaymentRequirements"
+            }
+          }
+        }
+      }
+    },
+    "schemas": {
+      "SiwxAuthRequest": {
+        "type": "object",
+        "required": [
+          "message",
+          "signature"
+        ],
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "The SIWX-format message to be signed"
+          },
+          "signature": {
+            "type": "string",
+            "description": "The value signed by the wallet"
+          }
+        }
+      },
+      "AuthResponse": {
+        "type": "object",
+        "required": [
+          "accessToken"
+        ],
+        "properties": {
+          "accessToken": {
+            "type": "string",
+            "description": "account scope JWT"
+          }
+        }
+      },
+      "ChargeRequest": {
+        "type": "object",
+        "required": [
+          "amount"
+        ],
+        "properties": {
+          "amount": {
+            "type": "string",
+            "description": "Top-up amount (atomic USDC, 6 decimals). Must be positive and at least $0.01 (`10000` atomic units).",
+            "example": "1000000"
+          }
+        }
+      },
+      "ChargeResponse": {
+        "type": "object",
+        "description": "Top-up result. When payment is required, `requirements` is populated; on a successful top-up, `balance`/`paymentResponse` are populated.",
+        "properties": {
+          "balance": {
+            "type": "string",
+            "description": "Credit balance after top-up (atomic USDC)"
+          },
+          "paymentResponse": {
+            "$ref": "#/components/schemas/SettlementResponse"
+          },
+          "requirements": {
+            "$ref": "#/components/schemas/PaymentRequirements"
+          }
+        }
+      },
+      "BalanceResponse": {
+        "type": "object",
+        "required": [
+          "balance"
+        ],
+        "properties": {
+          "balance": {
+            "type": "string",
+            "description": "Credit balance (atomic USDC)",
+            "example": "0"
+          }
+        }
+      },
+      "PaymentsListResponse": {
+        "type": "object",
+        "required": [
+          "count",
+          "page",
+          "rpp",
+          "items"
+        ],
+        "properties": {
+          "count": {
+            "type": "integer",
+            "description": "Total number of rows matching the filter conditions"
+          },
+          "page": {
+            "type": "integer"
+          },
+          "rpp": {
+            "type": "integer"
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PaymentItem"
+            }
+          }
+        }
+      },
+      "PaymentItem": {
+        "type": "object",
+        "required": [
+          "id",
+          "accountId",
+          "chain",
+          "address",
+          "type",
+          "billingMode",
+          "status",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "accountId": {
+            "type": "string",
+            "description": "CAIP-10 format account ID",
+            "example": "eip155:8453:0x1234..."
+          },
+          "chain": {
+            "type": "string",
+            "enum": [
+              "BASE",
+              "SOLANA"
+            ],
+            "description": "Wallet chain"
+          },
+          "address": {
+            "type": "string",
+            "description": "Wallet address"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "DEPOSITED",
+              "PAID"
+            ],
+            "description": "DEPOSITED = top-up, PAID = usage"
+          },
+          "billingMode": {
+            "type": "string",
+            "enum": [
+              "credit",
+              "ppu"
+            ]
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "COMPLETED",
+              "VERIFYING",
+              "FAILED"
+            ]
+          },
+          "creditDelta": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Credit delta (credit row)"
+          },
+          "usdcDelta": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "USDC delta (PPU row or top-up purchase amount)"
+          },
+          "serviceChain": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The service chain of the API called"
+          },
+          "serviceNetwork": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "apiMethod": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The API method called",
+            "example": "eth_getLogs"
+          },
+          "txHash": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "On-chain transaction hash"
+          },
+          "failureReason": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Failure reason (when status=FAILED)"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "JsonRpcRequest": {
+        "type": "object",
+        "required": [
+          "jsonrpc",
+          "method"
+        ],
+        "properties": {
+          "jsonrpc": {
+            "type": "string",
+            "example": "2.0"
+          },
+          "method": {
+            "type": "string",
+            "example": "eth_getBalance"
+          },
+          "params": {
+            "type": "array",
+            "items": {}
+          },
+          "id": {
+            "type": [
+              "string",
+              "integer"
+            ]
+          }
+        }
+      },
+      "PaymentRequirements": {
+        "type": "object",
+        "required": [
+          "x402Version",
+          "accepts"
+        ],
+        "description": "x402 payment requirements. The client selects one of `accepts` to generate a payment signature.",
+        "properties": {
+          "x402Version": {
+            "type": "integer",
+            "description": "x402 protocol version",
+            "example": 2
+          },
+          "accepts": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PaymentAccepted"
+            }
+          },
+          "error": {
+            "type": "string",
+            "description": "Reason on payment failure (optional)"
+          }
+        }
+      },
+      "PaymentAccepted": {
+        "type": "object",
+        "required": [
+          "scheme",
+          "network",
+          "amount",
+          "asset",
+          "payTo",
+          "maxTimeoutSeconds"
+        ],
+        "properties": {
+          "scheme": {
+            "type": "string",
+            "enum": [
+              "exact"
+            ]
+          },
+          "network": {
+            "type": "string",
+            "description": "CAIP-2 network ID",
+            "example": "eip155:8453"
+          },
+          "amount": {
+            "type": "string",
+            "description": "Required payment amount (atomic units)"
+          },
+          "resource": {
+            "type": "string",
+            "description": "The resource path being paid for"
+          },
+          "asset": {
+            "type": "string",
+            "description": "Token contract address (e.g. USDC)"
+          },
+          "payTo": {
+            "type": "string",
+            "description": "Recipient address"
+          },
+          "maxTimeoutSeconds": {
+            "type": "integer",
+            "description": "Payment validity period (seconds)"
+          },
+          "extra": {
+            "type": "object",
+            "description": "Chain-specific additional information",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "EVM: EIP-712 domain name",
+                "example": "USD Coin"
+              },
+              "version": {
+                "type": "string",
+                "description": "EVM: EIP-712 domain version",
+                "example": "2"
+              },
+              "feePayer": {
+                "type": "string",
+                "description": "Solana: fee payer address for gas sponsorship"
+              }
+            },
+            "additionalProperties": true
+          }
+        }
+      },
+      "SettlementResponse": {
+        "type": "object",
+        "required": [
+          "success"
+        ],
+        "description": "The facilitator's payment settlement result. Carried base64-encoded in the `PAYMENT-RESPONSE` header of success/failure responses.",
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "txHash": {
+            "type": "string",
+            "description": "On-chain transaction hash (EVM)"
+          },
+          "transaction": {
+            "type": "string",
+            "description": "Signed transaction (Solana)"
+          },
+          "network": {
+            "type": "string",
+            "description": "CAIP-2 network ID"
+          },
+          "payer": {
+            "type": "string",
+            "description": "The actual payer address"
+          },
+          "reason": {
+            "type": "string",
+            "description": "Failure reason"
+          },
+          "alreadySettled": {
+            "type": "boolean"
+          }
+        }
+      },
+      "ErrorResponse": {
+        "type": "object",
+        "description": "Error response. Depending on the handler, follows either a `code`/`message` shape or a `statusCode`/`error`/`message` shape.",
+        "properties": {
+          "code": {
+            "type": "string",
+            "description": "Error code",
+            "example": "PAYMENT_INVALID"
+          },
+          "message": {
+            "type": "string",
+            "description": "Human-readable message"
+          },
+          "statusCode": {
+            "type": "integer",
+            "description": "HTTP status code"
+          },
+          "error": {
+            "type": "string",
+            "description": "Error name"
+          }
+        }
+      },
+      "searchTokenContractMetadataByKeyword__evm__Req": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "keyword"
+            ],
+            "properties": {
+              "keyword": {
+                "type": "string",
+                "description": "Parameter specifying the name or symbol of the token to query."
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "integer",
+                "description": "The page parameter specifies the data page to query. It accepts values up to 100; for pages exceeding 100, use the cursor pagination method.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used.",
+                "pattern": "^(?:[1-9][0-9]?|100)$"
+              },
+              "rpp": {
+                "type": "integer",
+                "description": "rpp stands for results per page and specifies the page size. You can specify a number greater than 0 and up to 100.",
+                "pattern": "^(?:[1-9][0-9]{0,2}?|100)$"
+              },
+              "cursor": {
+                "type": "string",
+                "description": "The cursor parameter supports pagination and data navigation between pages. Provide the cursor value from the previous page in the next request to load the next page of data.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used."
+              },
+              "withCount": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the count field in the response. The count field indicates the total number of requested data items. When set to true, the count field is included and response speed may be slower.",
+                "default": false
+              }
+            }
+          }
+        ],
+        "example": {
+          "keyword": "USDT",
+          "page": 1,
+          "rpp": 10
+        }
+      },
+      "searchTokenContractMetadataByKeyword__tron__Req": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "keyword"
+            ],
+            "properties": {
+              "keyword": {
+                "type": "string",
+                "description": "Parameter specifying the name or symbol of the token to query.",
+                "example": "USDT"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "integer",
+                "description": "The page parameter specifies the data page to query. It accepts values up to 100; for pages exceeding 100, use the cursor pagination method.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used.",
+                "pattern": "^(?:[1-9][0-9]?|100)$"
+              },
+              "rpp": {
+                "type": "integer",
+                "description": "rpp stands for results per page and specifies the page size. You can specify a number greater than 0 and up to 100.",
+                "pattern": "^(?:[1-9][0-9]{0,2}?|100)$"
+              },
+              "cursor": {
+                "type": "string",
+                "description": "The cursor parameter supports pagination and data navigation between pages. Provide the cursor value from the previous page in the next request to load the next page of data.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used."
+              },
+              "withCount": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the count field in the response. The count field indicates the total number of requested data items. When set to true, the count field is included and response speed may be slower.",
+                "default": false
+              }
+            }
+          }
+        ],
+        "example": {
+          "keyword": "USDT",
+          "page": 1,
+          "rpp": 10
+        }
+      },
+      "paginatedItems__common__Res": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "items"
+            ],
+            "properties": {
+              "page": {
+                "type": "integer",
+                "description": "Field representing the page number specified in the page parameter. This field is only included in the response when a value greater than 0 is specified for the page parameter."
+              },
+              "rpp": {
+                "type": "integer",
+                "description": "Field representing the number of results per page specified in the rpp parameter."
+              },
+              "cursor": {
+                "type": "string",
+                "description": "A field for cursor pagination. This value must be provided in the next request to load the next page of data."
+              },
+              "count": {
+                "type": "integer",
+                "description": "Field representing the total count of requested data. This field is only included in the response when true is set for the withCount parameter."
+              },
+              "items": {
+                "type": "array",
+                "description": "Field representing the list of queried data."
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "items": {
+                "type": "array",
+                "items": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "getTokenTransfersByContract__evm__Req": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "contractAddress"
+            ],
+            "properties": {
+              "contractAddress": {
+                "type": "string",
+                "description": "Parameter specifying the contract address to query. Can be entered as a 40-character hexadecimal string starting with 0x.",
+                "pattern": "^0[xX][0-9a-fA-F]{40}$"
+              },
+              "fromBlock": {
+                "type": "string",
+                "description": "Parameter specifying the starting block for the query. You can enter one of the following formats:\n- block number: Enter block number as a decimal string.\n- block hash: 64-character hexadecimal (including \"0x\").\n- block tag: Use \"earliest\" or \"latest\" to specify the first block or the most recent block.\n\nNotes:\n- This field cannot be used together with `fromDate` and `toDate`.\n- If provided without fromBlock, results are queried from genesis block to this block.\n- toBlock value cannot be less than fromBlock value.\n- If fromBlock and toBlock have the same value, only that block is queried.\n- \"earliest\" for toBlock is only allowed when fromBlock is \"earliest\".\n- If `fromBlock` and `toBlock` are not provided, the API queries data from the latest 30 days.\n",
+                "pattern": "^[0-9]+$|^0[xX][0-9a-fA-F]{64}|latest|earliest"
+              },
+              "toBlock": {
+                "type": "string",
+                "description": "Parameter specifying the ending block for the query. You can enter one of the following formats:\n- block number: Enter block number as a decimal string.\n- block hash: 64-character hexadecimal (including \"0x\").\n- block tag: Use \"earliest\" or \"latest\" to specify the first block or the most recent block.\n\nNotes:\n- This field cannot be used together with `fromDate` and `toDate`.\n- If provided without fromBlock, results are queried from genesis block to this block.\n- toBlock value cannot be less than fromBlock value.\n- If fromBlock and toBlock have the same value, only that block is queried.\n- \"earliest\" for toBlock is only allowed when fromBlock is \"earliest\".\n- If `fromBlock` and `toBlock` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]+$|^0[xX][0-9a-fA-F]{64}|latest|earliest"
+              },
+              "fromDate": {
+                "type": "string",
+                "description": "Parameter specifying the start date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without toDate, results are queried from this date to the latest block.\n- fromDate value must be equal to or earlier than toDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-01T00:00:00+00:00"
+              },
+              "toDate": {
+                "type": "string",
+                "description": "Parameter specifying the end date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without fromDate, results are queried from genesis block to this date.\n- toDate value must be equal to or later than fromDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-31T00:00:00+00:00"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "integer",
+                "description": "The page parameter specifies the data page to query. It accepts values up to 100; for pages exceeding 100, use the cursor pagination method.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used.",
+                "pattern": "^(?:[1-9][0-9]?|100)$"
+              },
+              "rpp": {
+                "type": "integer",
+                "description": "rpp stands for results per page and specifies the page size. You can specify a number greater than 0 and up to 100.",
+                "pattern": "^(?:[1-9][0-9]{0,2}?|100)$"
+              },
+              "cursor": {
+                "type": "string",
+                "description": "The cursor parameter supports pagination and data navigation between pages. Provide the cursor value from the previous page in the next request to load the next page of data.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used."
+              },
+              "withCount": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the count field in the response. The count field indicates the total number of requested data items. When set to true, the count field is included and response speed may be slower.",
+                "default": false
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "withZeroValue": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include results with value 0 in the response. Set to true for faster responses.",
+                "default": false
+              },
+              "withFunction": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the function field in the response. Response speed may be slower when set to true.",
+                "default": false
+              }
+            }
+          }
+        ],
+        "example": {
+          "contractAddress": "0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D",
+          "fromDate": "2026-01-01T00:00:00Z",
+          "toDate": "2026-02-01T00:00:00Z",
+          "page": 1,
+          "rpp": 10
+        }
+      },
+      "getTokenTransfersByContract__kaia__Req": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "contractAddress"
+            ],
+            "properties": {
+              "contractAddress": {
+                "type": "string",
+                "description": "Parameter specifying the contract address to query. Can be entered as a 40-character hexadecimal string starting with 0x.",
+                "pattern": "^0[xX][0-9a-fA-F]{40}$"
+              },
+              "fromBlock": {
+                "type": "string",
+                "description": "Parameter specifying the starting block for the query. You can enter one of the following formats:\n- block number: Enter block number as a decimal string.\n- block hash: 64-character hexadecimal (including \"0x\").\n- block tag: Use \"earliest\" or \"latest\" to specify the first block or the most recent block.\n\nNotes:\n- This field cannot be used together with `fromDate` and `toDate`.\n- If provided without fromBlock, results are queried from genesis block to this block.\n- toBlock value cannot be less than fromBlock value.\n- If fromBlock and toBlock have the same value, only that block is queried.\n- \"earliest\" for toBlock is only allowed when fromBlock is \"earliest\".\n- If `fromBlock` and `toBlock` are not provided, the API queries data from the latest 30 days.\n\nFor Kaia, entering \"earliest\" queries the block at the Kaia hardfork point.\n- Mainnet: 162,900,480 (Aug 29, 2024 11:08:01 UTC+9)\n- Kairos(Testnet): 156,660,000 (June 13, 2024 10:15:19 UTC+9)\n\n",
+                "pattern": "^[0-9]+$|^0[xX][0-9a-fA-F]{64}|latest|earliest"
+              },
+              "toBlock": {
+                "type": "string",
+                "description": "Parameter specifying the ending block for the query. You can enter one of the following formats:\n- block number: Enter block number as a decimal string.\n- block hash: 64-character hexadecimal (including \"0x\").\n- block tag: Use \"earliest\" or \"latest\" to specify the first block or the most recent block.\n\nNotes:\n- This field cannot be used together with `fromDate` and `toDate`.\n- If provided without fromBlock, results are queried from genesis block to this block.\n- toBlock value cannot be less than fromBlock value.\n- If fromBlock and toBlock have the same value, only that block is queried.\n- \"earliest\" for toBlock is only allowed when fromBlock is \"earliest\".\n- If `fromBlock` and `toBlock` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]+$|^0[xX][0-9a-fA-F]{64}|latest|earliest"
+              },
+              "fromDate": {
+                "type": "string",
+                "description": "Parameter specifying the start date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without toDate, results are queried from this date to the latest block.\n- fromDate value must be equal to or earlier than toDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-01T00:00:00+00:00"
+              },
+              "toDate": {
+                "type": "string",
+                "description": "Parameter specifying the end date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without fromDate, results are queried from genesis block to this date.\n- toDate value must be equal to or later than fromDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-31T00:00:00+00:00"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "integer",
+                "description": "The page parameter specifies the data page to query. It accepts values up to 100; for pages exceeding 100, use the cursor pagination method.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used.",
+                "pattern": "^(?:[1-9][0-9]?|100)$"
+              },
+              "rpp": {
+                "type": "integer",
+                "description": "rpp stands for results per page and specifies the page size. You can specify a number greater than 0 and up to 100.",
+                "pattern": "^(?:[1-9][0-9]{0,2}?|100)$"
+              },
+              "cursor": {
+                "type": "string",
+                "description": "The cursor parameter supports pagination and data navigation between pages. Provide the cursor value from the previous page in the next request to load the next page of data.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used."
+              },
+              "withCount": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the count field in the response. The count field indicates the total number of requested data items. When set to true, the count field is included and response speed may be slower.",
+                "default": false
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "withZeroValue": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include results with value 0 in the response. Set to true for faster responses.",
+                "default": false
+              },
+              "withFunction": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the function field in the response. Response speed may be slower when set to true.",
+                "default": false
+              }
+            }
+          }
+        ],
+        "example": {
+          "contractAddress": "0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D",
+          "fromDate": "2026-01-01T00:00:00Z",
+          "toDate": "2026-02-01T00:00:00Z",
+          "page": 1,
+          "rpp": 10
+        }
+      },
+      "getTokenTransfersByContract__tron__Req": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "contractAddress"
+            ],
+            "properties": {
+              "contractAddress": {
+                "type": "string",
+                "description": "Parameter specifying the contract address to query. This field uses a 34-character base58 string format starting with \"T\".",
+                "pattern": "^T[1-9A-HJ-NP-Za-km-z]{33}$",
+                "example": "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t"
+              },
+              "fromBlock": {
+                "type": "string",
+                "description": "Parameter specifying the starting point for the query. You can enter block number, block hash, or block tag. Default is 0.\n- block number: Enter as a decimal string.\n- block hash: Enter as a 64-character hexadecimal string, excluding the 0x prefix.\n- block tag: You can enter \"earliest\" for fromBlock.\n\nNotes:\n- If only fromBlock is provided without toBlock, results are queried from fromBlock to the most recent block.\n- fromBlock's block number must be less than or equal to toBlock's block number.\n- If toBlock and fromBlock have the same value, only that single block's results are queried.\n- \"latest\" cannot be entered for fromBlock.\n",
+                "pattern": "^[0-9]+$|^[0-9a-fA-F]{64}|latest|earliest",
+                "default": "earliest",
+                "example": "80453005"
+              },
+              "toBlock": {
+                "type": "string",
+                "description": "Parameter specifying the ending point for the query. You can enter block number, block hash, or block tag. Default is \"latest\".\n- block number: Enter as a decimal string.\n- block hash: Enter as a 64-character hexadecimal string, excluding the 0x prefix.\n- block tag: You can enter \"latest\".\n\nNotes:\n- The blockNumber for toBlock must be greater than or equal to the blockNumber for fromBlock.\n- If toBlock and fromBlock have the same value, only that single block's results are queried.\n- If only toBlock is provided without fromBlock, results are queried from genesis block to the time specified in toBlock.\n- \"earliest\" cannot be entered for toBlock.",
+                "pattern": "^[0-9]+$|^[0-9a-fA-F]{64}|latest|earliest",
+                "default": "latest",
+                "example": "80453006"
+              },
+              "fromDate": {
+                "type": "string",
+                "description": "Parameter specifying the start date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without toDate, results are queried from this date to the latest block.\n- fromDate value must be equal to or earlier than toDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-01T00:00:00+00:00"
+              },
+              "toDate": {
+                "type": "string",
+                "description": "Parameter specifying the end date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without fromDate, results are queried from genesis block to this date.\n- toDate value must be equal to or later than fromDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-31T00:00:00+00:00"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "integer",
+                "description": "The page parameter specifies the data page to query. It accepts values up to 100; for pages exceeding 100, use the cursor pagination method.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used.",
+                "pattern": "^(?:[1-9][0-9]?|100)$"
+              },
+              "rpp": {
+                "type": "integer",
+                "description": "rpp stands for results per page and specifies the page size. You can specify a number greater than 0 and up to 100.",
+                "pattern": "^(?:[1-9][0-9]{0,2}?|100)$"
+              },
+              "cursor": {
+                "type": "string",
+                "description": "The cursor parameter supports pagination and data navigation between pages. Provide the cursor value from the previous page in the next request to load the next page of data.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used."
+              },
+              "withCount": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the count field in the response. The count field indicates the total number of requested data items. When set to true, the count field is included and response speed may be slower.",
+                "default": false
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "withZeroValue": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include results with value 0 in the response. Set to true for faster responses.",
+                "default": false
+              }
+            }
+          }
+        ],
+        "example": {
+          "contractAddress": "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
+          "fromDate": "2026-01-01T00:00:00Z",
+          "toDate": "2026-02-01T00:00:00Z",
+          "page": 1,
+          "rpp": 10
+        }
+      },
+      "getTokenPairByAssetType__aptos__Req": {
+        "type": "object",
+        "required": [
+          "assetType"
+        ],
+        "properties": {
+          "assetType": {
+            "type": "string",
+            "description": "Parameter specifying the asset type to query.\nThe asset type must be entered as a 64-character hexadecimal string (including \"0x\") using one of the following formats:\n\n- Coin: Asset ID in Struct format such as \"0x1::aptos_coin::AptosCoin\"\n- Fungible Asset: Object address that owns the Token Metadata",
+            "pattern": "^0x[0-9a-fA-F]{1,64}::[a-z][a-zA-Z0-9_]*::[A-Z][a-zA-Z0-9_]*$|^0[xX][0-9a-fA-F]{64}",
+            "example": "0x1::aptos_coin::AptosCoin"
+          }
+        },
+        "example": {
+          "assetType": "0x1::aptos_coin::AptosCoin"
+        }
+      },
+      "getTokenPairByAssetType__aptos__Res": {
+        "type": "object",
+        "required": [
+          "coinAssetType",
+          "fungibleAssetType",
+          "linkedAssetType"
+        ],
+        "properties": {
+          "coinAssetType": {
+            "type": "string",
+            "description": "A field that represents the type of the asset belonging to the Coin standard.\nThe Coin standard is provided in 'moduleAddress::moduleName::structName' format.\n"
+          },
+          "fungibleAssetType": {
+            "type": "string",
+            "description": "A field that represents the type of the asset belonging to the Fungible Asset standard.\nThe Fungible Asset standard is provided as a 64-character hexadecimal string prefixed with 0x; the Object address that owns the metadata of the asset is provided.\n"
+          },
+          "linkedAssetType": {
+            "type": "string",
+            "description": "A common identifier that links Coin and Fungible Asset when they have been migrated.\nThis field serves as a unified key that groups Coin/Fungible Asset into a single asset unit for identification and retrieval, providing the Object address where the migrated Fungible Asset's Metadata is stored.\n"
+          }
+        }
+      },
+      "getTokenMetadataByAssetTypes__aptos__Req": {
+        "type": "object",
+        "required": [
+          "assetTypes"
+        ],
+        "properties": {
+          "assetTypes": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "description": "Parameter specifying the asset type to query.\nThe asset type must be entered as a 64-character hexadecimal string (including \"0x\") using one of the following formats:\n\n- Coin: Asset ID in Struct format such as \"0x1::aptos_coin::AptosCoin\"\n- Fungible Asset: Object address that owns the Token Metadata",
+              "pattern": "^0x[0-9a-fA-F]{1,64}::[a-z][a-zA-Z0-9_]*::[A-Z][a-zA-Z0-9_]*$|^0[xX][0-9a-fA-F]{64}",
+              "example": "0x1::aptos_coin::AptosCoin"
+            },
+            "description": "Enter the Asset Types to query as an array."
+          }
+        }
+      },
+      "getTokenMetadataByAssetTypes__aptos__Res": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "required": [
+            "name",
+            "symbol",
+            "decimals",
+            "totalSupply",
+            "maximumSupply",
+            "creatorAddress",
+            "projectURI",
+            "iconURI"
+          ],
+          "properties": {
+            "assetType": {
+              "type": "string",
+              "description": "A field that represents the unique identifier of the asset.\nProvided in one of two formats:\n- Coin: Asset ID in Move struct format (e.g., 0x1::aptos_coin::AptosCoin)\n- Fungible Asset: Object address that owns the metadata of the asset\n"
+            },
+            "tokenStandard": {
+              "type": "string",
+              "description": "A field that represents the standard the asset follows.\n- v1: Assets following the Coin standard\n- v2: Assets following the Fungible Asset standard\n"
+            },
+            "name": {
+              "type": "string",
+              "description": "A field that represents the name of the asset.\nThe official name of the asset displayed in the user interface; used to identify and distinguish assets.\n"
+            },
+            "symbol": {
+              "type": "string",
+              "description": "A field that represents the symbol of the asset.\nThe abbreviated identifier of the asset used in exchanges and wallets.\n"
+            },
+            "decimals": {
+              "type": "integer",
+              "description": "A field that represents the decimal places of the asset.\nDefines the number of decimal places applied when displaying the actual asset quantity.\nFor example, if decimals is 8, 100000000 (10^8) is displayed as 1.0.\n"
+            },
+            "totalSupply": {
+              "type": "string",
+              "description": "A field that represents the total circulating supply.\nProvided as an integer value before decimals are applied.\nThe asset's decimals must be considered when calculating the actual circulating supply.\n"
+            },
+            "maximumSupply": {
+              "type": "string",
+              "description": "A field that represents the maximum supply that can be minted.\nProvided as an integer value before decimals are applied.\nAn empty string (\"\") means there is no maximum supply limit.\n"
+            },
+            "creatorAddress": {
+              "type": "string",
+              "description": "A field that represents the address of the account that created the asset.\nProvided as a 64-character hexadecimal string prefixed with 0x; identifies the asset creator.\nUsed to track asset management authority and ownership.\n"
+            },
+            "projectURI": {
+              "type": "string",
+              "description": "A field that represents the URI that provides project-related information.\nA URL is provided where you can find detailed information about the project such as website, whitepaper, and documentation.\nUsed to obtain additional information related to the asset.\n"
+            },
+            "iconURI": {
+              "type": "string",
+              "description": "A field that represents the icon image URL of the asset.\nThe URL of an image that allows visual identification of the asset is provided.\n"
+            }
+          }
+        }
+      },
+      "getTokenBalanceChangesWithinRange__aptos__Req": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "fromBlock": {
+                "type": "string",
+                "description": "Parameter specifying the starting block for the query. You can enter one of the following formats:\n- block number: Enter block number as a decimal string.\n- block hash: 64-character hexadecimal (including \"0x\").\n- block tag: Use \"earliest\" or \"latest\" to specify the first block or the most recent block.\n\nNotes:\n- This field cannot be used together with `fromDate` and `toDate`.\n- If provided without fromBlock, results are queried from genesis block to this block.\n- toBlock value cannot be less than fromBlock value.\n- If fromBlock and toBlock have the same value, only that block is queried.\n- \"earliest\" for toBlock is only allowed when fromBlock is \"earliest\".\n- If `fromBlock` and `toBlock` are not provided, the API queries data from the latest 30 days.\n",
+                "pattern": "^[0-9]+$|^0[xX][0-9a-fA-F]{64}|latest|earliest",
+                "default": "earliest"
+              },
+              "toBlock": {
+                "type": "string",
+                "description": "Parameter specifying the ending block for the query. You can enter one of the following formats:\n- block number: Enter block number as a decimal string.\n- block hash: 64-character hexadecimal (including \"0x\").\n- block tag: Use \"earliest\" or \"latest\" to specify the first block or the most recent block.\n\nNotes:\n- This field cannot be used together with `fromDate` and `toDate`.\n- If provided without fromBlock, results are queried from genesis block to this block.\n- toBlock value cannot be less than fromBlock value.\n- If fromBlock and toBlock have the same value, only that block is queried.\n- \"earliest\" for toBlock is only allowed when fromBlock is \"earliest\".\n- If `fromBlock` and `toBlock` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]+$|^0[xX][0-9a-fA-F]{64}|latest|earliest"
+              },
+              "fromDate": {
+                "type": "string",
+                "description": "Parameter specifying the start date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without toDate, results are queried from this date to the latest block.\n- fromDate value must be equal to or earlier than toDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-01T00:00:00+00:00"
+              },
+              "toDate": {
+                "type": "string",
+                "description": "Parameter specifying the end date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without fromDate, results are queried from genesis block to this date.\n- toDate value must be equal to or later than fromDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-31T00:00:00+00:00"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "integer",
+                "description": "The page parameter specifies the data page to query. It accepts values up to 100; for pages exceeding 100, use the cursor pagination method.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used.",
+                "pattern": "^(?:[1-9][0-9]?|100)$"
+              },
+              "rpp": {
+                "type": "integer",
+                "description": "rpp stands for results per page and specifies the page size. You can specify a number greater than 0 and up to 100.",
+                "pattern": "^(?:[1-9][0-9]{0,2}?|100)$"
+              },
+              "cursor": {
+                "type": "string",
+                "description": "The cursor parameter supports pagination and data navigation between pages. Provide the cursor value from the previous page in the next request to load the next page of data.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used."
+              },
+              "withCount": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the count field in the response. The count field indicates the total number of requested data items. When set to true, the count field is included and response speed may be slower.",
+                "default": false
+              }
+            }
+          }
+        ],
+        "example": {
+          "fromDate": "2026-01-01T00:00:00Z",
+          "toDate": "2026-02-01T00:00:00Z"
+        }
+      },
+      "getTokenBalanceChangesByAssetType__aptos__Req": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "assetType": {
+                "type": "string",
+                "description": "Parameter specifying the asset type to query.\nThe asset type must be entered as a 64-character hexadecimal string (including \"0x\") using one of the following formats:\n\n- Coin: Asset ID in Struct format such as \"0x1::aptos_coin::AptosCoin\"\n- Fungible Asset: Object address that owns the Token Metadata",
+                "pattern": "^0x[0-9a-fA-F]{1,64}::[a-z][a-zA-Z0-9_]*::[A-Z][a-zA-Z0-9_]*$|^0[xX][0-9a-fA-F]{64}",
+                "example": "0x1::aptos_coin::AptosCoin"
+              },
+              "linkedAssetType": {
+                "type": "string",
+                "description": "Common identifier for querying Coin and FA (Fungible Asset) as a single asset unit.\n\nlinkedAssetType must contain the Object address of the migrated FA, entered in 64-character hexadecimal format (including \"0x\").",
+                "pattern": "^0[xX][0-9a-fA-F]{64}",
+                "example": "0x000000000000000000000000000000000000000000000000000000000000000a"
+              },
+              "fromBlock": {
+                "type": "string",
+                "description": "Parameter specifying the starting block for the query. You can enter one of the following formats:\n- block number: Enter block number as a decimal string.\n- block hash: 64-character hexadecimal (including \"0x\").\n- block tag: Use \"earliest\" or \"latest\" to specify the first block or the most recent block.\n\nNotes:\n- This field cannot be used together with `fromDate` and `toDate`.\n- If provided without fromBlock, results are queried from genesis block to this block.\n- toBlock value cannot be less than fromBlock value.\n- If fromBlock and toBlock have the same value, only that block is queried.\n- \"earliest\" for toBlock is only allowed when fromBlock is \"earliest\".\n- If `fromBlock` and `toBlock` are not provided, the API queries data from the latest 30 days.\n",
+                "pattern": "^[0-9]+$|^0[xX][0-9a-fA-F]{64}|latest|earliest",
+                "default": "earliest"
+              },
+              "toBlock": {
+                "type": "string",
+                "description": "Parameter specifying the ending block for the query. You can enter one of the following formats:\n- block number: Enter block number as a decimal string.\n- block hash: 64-character hexadecimal (including \"0x\").\n- block tag: Use \"earliest\" or \"latest\" to specify the first block or the most recent block.\n\nNotes:\n- This field cannot be used together with `fromDate` and `toDate`.\n- If provided without fromBlock, results are queried from genesis block to this block.\n- toBlock value cannot be less than fromBlock value.\n- If fromBlock and toBlock have the same value, only that block is queried.\n- \"earliest\" for toBlock is only allowed when fromBlock is \"earliest\".\n- If `fromBlock` and `toBlock` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]+$|^0[xX][0-9a-fA-F]{64}|latest|earliest"
+              },
+              "fromDate": {
+                "type": "string",
+                "description": "Parameter specifying the start date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without toDate, results are queried from this date to the latest block.\n- fromDate value must be equal to or earlier than toDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-01T00:00:00+00:00"
+              },
+              "toDate": {
+                "type": "string",
+                "description": "Parameter specifying the end date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without fromDate, results are queried from genesis block to this date.\n- toDate value must be equal to or later than fromDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-31T00:00:00+00:00"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "integer",
+                "description": "The page parameter specifies the data page to query. It accepts values up to 100; for pages exceeding 100, use the cursor pagination method.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used.",
+                "pattern": "^(?:[1-9][0-9]?|100)$"
+              },
+              "rpp": {
+                "type": "integer",
+                "description": "rpp stands for results per page and specifies the page size. You can specify a number greater than 0 and up to 100.",
+                "pattern": "^(?:[1-9][0-9]{0,2}?|100)$"
+              },
+              "cursor": {
+                "type": "string",
+                "description": "The cursor parameter supports pagination and data navigation between pages. Provide the cursor value from the previous page in the next request to load the next page of data.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used."
+              },
+              "withCount": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the count field in the response. The count field indicates the total number of requested data items. When set to true, the count field is included and response speed may be slower.",
+                "default": false
+              }
+            }
+          }
+        ],
+        "example": {
+          "linkedAssetType": "0x000000000000000000000000000000000000000000000000000000000000000a",
+          "fromDate": "2026-01-01T00:00:00Z",
+          "toDate": "2026-02-01T00:00:00Z"
+        }
+      },
+      "getTokenPricesByContracts__evm__Req": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "contractAddresses"
+            ],
+            "properties": {
+              "contractAddresses": {
+                "type": "array",
+                "description": "Parameter specifying an array of contract addresses to query. Contract addresses can be entered as 40-character hexadecimal strings starting with 0x.",
+                "items": {
+                  "type": "string",
+                  "description": "Parameter specifying the contract address to query. Can be entered as a 40-character hexadecimal string starting with 0x.",
+                  "pattern": "^0[xX][0-9a-fA-F]{40}$"
+                }
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "currency": {
+                "type": "string",
+                "description": "Parameter for selecting the currency unit for Token Price queries. Supports USD and KRW. Default is USD.",
+                "default": "USD"
+              }
+            }
+          }
+        ],
+        "example": {
+          "contractAddresses": [
+            "0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D",
+            "0x60E4d786628Fea6478F785A6d7e704777c86a7c6"
+          ],
+          "currency": "USD"
+        }
+      },
+      "getTokenPricesByContracts__evm__Res": {
+        "type": "array",
+        "items": {
+          "allOf": [
+            {
+              "type": "object",
+              "properties": {
+                "currency": {
+                  "type": "string",
+                  "description": "A field representing the type of currency used for trading. Provided in ISO 4217 currency code format."
+                },
+                "price": {
+                  "type": "string",
+                  "description": "A field representing the current price of the token. Provided in decimal string format."
+                },
+                "volumeFor24h": {
+                  "type": "string",
+                  "description": "A field representing the total trading volume over the past 24 hours. Used as an indicator of active trading activity. Provided in decimal string format."
+                },
+                "volumeChangeFor24h": {
+                  "type": "string",
+                  "description": "A field representing the trading volume change over the past 24 hours. Used as an indicator of market volatility. Provided in decimal string format."
+                },
+                "percentChangeFor1h": {
+                  "type": "string",
+                  "description": "A field representing the price change percentage over the past 1 hour. Used as an indicator of short-term market trends."
+                },
+                "percentChangeFor24h": {
+                  "type": "string",
+                  "description": "A field representing the price change percentage over the past 24 hours. Used as an indicator of medium-term market trends."
+                },
+                "percentChangeFor7d": {
+                  "type": "string",
+                  "description": "A field representing the price change percentage over the past 7 days. Used as an indicator of long-term market trends."
+                },
+                "marketCap": {
+                  "type": "string",
+                  "description": "A field representing the market capitalization of the token. Reflects the total market value of the asset. Provided in decimal string format."
+                },
+                "updatedAt": {
+                  "type": "string",
+                  "description": "A field representing when the data was last updated. Provided in ISO 8601 format."
+                },
+                "listings": {
+                  "type": "array",
+                  "description": "A field representing the list of exchanges where the token is listed.",
+                  "items": {
+                    "type": "string",
+                    "description": "A field representing the name of the exchange."
+                  }
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "contract": {
+                  "type": "object"
+                }
+              }
+            }
+          ]
+        }
+      },
+      "contractAddresses__evm__Req": {
+        "type": "object",
+        "required": [
+          "contractAddresses"
+        ],
+        "properties": {
+          "contractAddresses": {
+            "type": "array",
+            "description": "Parameter specifying an array of contract addresses to query. Contract addresses can be entered as 40-character hexadecimal strings starting with 0x.",
+            "items": {
+              "type": "string",
+              "description": "Parameter specifying the contract address to query. Can be entered as a 40-character hexadecimal string starting with 0x.",
+              "pattern": "^0[xX][0-9a-fA-F]{40}$"
+            }
+          }
+        },
+        "example": {
+          "contractAddresses": [
+            "0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D",
+            "0x60E4d786628Fea6478F785A6d7e704777c86a7c6"
+          ]
+        }
+      },
+      "getTokenContractMetadataByContracts__tron__Req": {
+        "type": "object",
+        "required": [
+          "contractAddresses"
+        ],
+        "properties": {
+          "contractAddresses": {
+            "type": "array",
+            "description": "Parameter specifying the array of contract addresses to query. Contract addresses use a 34-character base58 string format starting with \"T\".",
+            "items": {
+              "type": "string",
+              "description": "Parameter specifying the contract address to query. This field uses a 34-character base58 string format starting with \"T\".",
+              "pattern": "^T[1-9A-HJ-NP-Za-km-z]{33}$"
+            },
+            "example": [
+              "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
+              "TLZSucJRjnqBKwvQz6n5hd29gbS4P7u7w8"
+            ]
+          }
+        },
+        "example": {
+          "contractAddresses": [
+            "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
+            "TLZSucJRjnqBKwvQz6n5hd29gbS4P7u7w8"
+          ]
+        }
+      },
+      "contractMetadataList__evm__Res": {
+        "type": "array",
+        "items": {
+          "allOf": [
+            {
+              "type": "object",
+              "required": [
+                "address",
+                "deployedTransactionHash",
+                "deployedAt",
+                "deployerAddress",
+                "logoUrl",
+                "type"
+              ],
+              "properties": {
+                "address": {
+                  "type": "string",
+                  "description": "A field representing the contract address."
+                },
+                "deployedTransactionHash": {
+                  "type": "string",
+                  "description": "A field representing the hash of the transaction in which the contract was deployed."
+                },
+                "deployedAt": {
+                  "type": "string",
+                  "description": "A field representing the time when the contract was deployed. This field is provided in ISO 8601 date and time format."
+                },
+                "deployerAddress": {
+                  "type": "string",
+                  "description": "A field representing the address that deployed the contract."
+                },
+                "logoUrl": {
+                  "type": "string",
+                  "description": "A field representing the logo URL of the contract. This URL can be used to visually identify the contract.\n\n [Note]\n Not all contracts have logo images available. If a contract has no logo, this field is provided as null."
+                },
+                "type": {
+                  "type": "string",
+                  "description": "A field representing the type of the contract. Contract types are denoted by standard specification names (e.g., ERC721, ERC1155, ERC20, ERC721, ERC1155, ERC20)."
+                }
+              }
+            },
+            {
+              "type": "object",
+              "required": [
+                "name",
+                "symbol"
+              ],
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "description": "A field representing the name of the contract. Returns an empty string if the contract does not follow the standard or if name was not provided at contract creation."
+                },
+                "symbol": {
+                  "type": "string",
+                  "description": "A field representing the symbol of the contract. Returns an empty string if the contract does not follow the standard or if symbol was not provided at contract creation."
+                },
+                "totalSupply": {
+                  "type": "string",
+                  "description": "A field representing the total supply of the contract. This value indicates the total token supply and is provided as a decimal string. Included in the response only when the contract type is ERC20."
+                },
+                "decimals": {
+                  "type": "integer",
+                  "description": "A field representing the decimal places of the contract. Included in the response only when the contract type is ERC20 or ERC1155."
+                }
+              }
+            }
+          ]
+        }
+      },
+      "getTokenContractMetadataByContracts__tron__Res": {
+        "type": "array",
+        "items": {
+          "allOf": [
+            {
+              "type": "object",
+              "required": [
+                "address",
+                "deployedTransactionHash",
+                "deployedAt",
+                "deployerAddress",
+                "logoUrl",
+                "type"
+              ],
+              "properties": {
+                "address": {
+                  "type": "string",
+                  "description": "Returns the contract address. This address serves as a unique identifier for the contract within the blockchain network where it is deployed."
+                },
+                "deployedTransactionHash": {
+                  "type": "string",
+                  "description": "Returns the hash of the transaction generated when the contract was deployed."
+                },
+                "deployedAt": {
+                  "type": "string",
+                  "description": "Returns the exact time when the contract was deployed. Displayed in ISO 8601 date and time format."
+                },
+                "deployerAddress": {
+                  "type": "string",
+                  "description": "Returns the address that deployed the contract. This address represents the entity or account that created and deployed the contract to the network."
+                },
+                "logoUrl": {
+                  "type": "string",
+                  "description": "Returns the URL of the logo or image associated with the contract. This URL can be used to visually identify the contract. \n<strong style='color: red;'>*</strong> Logo images are not provided for all contracts."
+                },
+                "type": {
+                  "type": "string",
+                  "description": "Returns the contract type. The contract type is specified by the name of the standard specification (e.g., TRC20)."
+                }
+              }
+            },
+            {
+              "type": "object",
+              "required": [
+                "name",
+                "symbol",
+                "totalSupply",
+                "decimals"
+              ],
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "description": "Represents the name of the contract. Returns an empty string if the contract does not follow the standard or if name was not provided during contract creation."
+                },
+                "symbol": {
+                  "type": "string",
+                  "description": "Represents the symbol of the contract. Returns an empty string if the contract does not follow the standard or if symbol was not provided during contract creation."
+                },
+                "totalSupply": {
+                  "type": "string",
+                  "description": "Represents the total supply of the contract. This value indicates the total token issuance and is displayed as a decimal string."
+                },
+                "decimals": {
+                  "type": "integer",
+                  "description": "Represents the number of decimal places for the token."
+                }
+              }
+            }
+          ]
+        }
+      },
+      "getTokenTransfersByCurrencyAndIssuer__xrpl__Req": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "currency"
+            ],
+            "properties": {
+              "currency": {
+                "type": "string",
+                "description": "Parameter specifying the currency symbol to query. Can be entered as an ISO-4217 format string such as \"USD\" or \"EUR\".",
+                "default": "USD"
+              },
+              "issuer": {
+                "type": "string",
+                "description": "Parameter specifying the issuer of the currency to query. Enter the issuer account address using a Base58-encoded string of 25-35 characters (starting with \"r\").",
+                "default": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq"
+              },
+              "fromLedger": {
+                "type": "string",
+                "description": "Parameter specifying the starting ledger for the query. You can enter one of the following formats:\n- **ledger index**: Enter ledger number as a decimal string\n- **ledger hash**: 64-character hexadecimal string (excluding 0x prefix)\n- **ledger tag**: Enter \"earliest\" or \"latest\" (oldest or most recent ledger)\n\nNotes:\n- If provided without toLedger, results are queried from this ledger to the latest ledger.\n- fromLedger value cannot be greater than toLedger value.\n- If fromLedger and toLedger have the same value, only that ledger is queried.\n- \"latest\" for fromLedger is only allowed when toLedger is \"latest\".",
+                "pattern": "^[0-9]+$|^0[xX][0-9a-fA-F]{64}|latest|earliest"
+              },
+              "toLedger": {
+                "type": "string",
+                "description": "Parameter specifying the ending ledger for the query. You can enter one of the following formats:\n- **ledger index**: Enter ledger number as a decimal string\n- **ledger hash**: 64-character hexadecimal string (excluding 0x prefix)\n- **ledger tag**: Enter \"earliest\" or \"latest\" (oldest or most recent ledger)\n\nNotes:\n- If provided without fromLedger, results are queried from genesis ledger to this ledger.\n- toLedger value cannot be less than fromLedger value.\n- If fromLedger and toLedger have the same value, only that ledger is queried.\n- \"earliest\" for toLedger is only allowed when fromLedger is \"earliest\".",
+                "pattern": "^[0-9]+$|^0[xX][0-9a-fA-F]{64}|latest|earliest"
+              },
+              "fromDate": {
+                "type": "string",
+                "description": "Parameter specifying the start date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without toDate, results are queried from this date to the latest block.\n- fromDate value must be equal to or earlier than toDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-01T00:00:00+00:00"
+              },
+              "toDate": {
+                "type": "string",
+                "description": "Parameter specifying the end date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without fromDate, results are queried from genesis block to this date.\n- toDate value must be equal to or later than fromDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-31T00:00:00+00:00"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "integer",
+                "description": "The page parameter specifies the data page to query. It accepts values up to 100; for pages exceeding 100, use the cursor pagination method.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used.",
+                "pattern": "^(?:[1-9][0-9]?|100)$"
+              },
+              "rpp": {
+                "type": "integer",
+                "description": "rpp stands for results per page and specifies the page size. You can specify a number greater than 0 and up to 100.",
+                "pattern": "^(?:[1-9][0-9]{0,2}?|100)$"
+              },
+              "cursor": {
+                "type": "string",
+                "description": "The cursor parameter supports pagination and data navigation between pages. Provide the cursor value from the previous page in the next request to load the next page of data.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used."
+              },
+              "withCount": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the count field in the response. The count field indicates the total number of requested data items. When set to true, the count field is included and response speed may be slower.",
+                "default": false
+              }
+            }
+          }
+        ],
+        "example": {
+          "currency": "USD",
+          "issuer": "rMwjYedjc7qqtVWGkcvvLtAp8MuyesLb1Yk",
+          "fromDate": "2026-01-01T00:00:00Z",
+          "toDate": "2026-02-01T00:00:00Z",
+          "page": 1,
+          "rpp": 10
+        }
+      },
+      "contractAddressPaged__evm__Req": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "contractAddress"
+            ],
+            "properties": {
+              "contractAddress": {
+                "type": "string",
+                "description": "Parameter specifying the contract address to query. Can be entered as a 40-character hexadecimal string starting with 0x.",
+                "pattern": "^0[xX][0-9a-fA-F]{40}$"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "integer",
+                "description": "The page parameter specifies the data page to query. It accepts values up to 100; for pages exceeding 100, use the cursor pagination method.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used.",
+                "pattern": "^(?:[1-9][0-9]?|100)$"
+              },
+              "rpp": {
+                "type": "integer",
+                "description": "rpp stands for results per page and specifies the page size. You can specify a number greater than 0 and up to 100.",
+                "pattern": "^(?:[1-9][0-9]{0,2}?|100)$"
+              },
+              "cursor": {
+                "type": "string",
+                "description": "The cursor parameter supports pagination and data navigation between pages. Provide the cursor value from the previous page in the next request to load the next page of data.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used."
+              },
+              "withCount": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the count field in the response. The count field indicates the total number of requested data items. When set to true, the count field is included and response speed may be slower.",
+                "default": false
+              }
+            }
+          }
+        ],
+        "example": {
+          "contractAddress": "0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D",
+          "page": 1,
+          "rpp": 10
+        }
+      },
+      "getTokenHoldersByContract__tron__Req": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "contractAddress"
+            ],
+            "properties": {
+              "contractAddress": {
+                "type": "string",
+                "description": "Parameter specifying the contract address to query. This field uses a 34-character base58 string format starting with \"T\".",
+                "pattern": "^T[1-9A-HJ-NP-Za-km-z]{33}$",
+                "example": "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "integer",
+                "description": "The page parameter specifies the data page to query. It accepts values up to 100; for pages exceeding 100, use the cursor pagination method.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used.",
+                "pattern": "^(?:[1-9][0-9]?|100)$"
+              },
+              "rpp": {
+                "type": "integer",
+                "description": "rpp stands for results per page and specifies the page size. You can specify a number greater than 0 and up to 100.",
+                "pattern": "^(?:[1-9][0-9]{0,2}?|100)$"
+              },
+              "cursor": {
+                "type": "string",
+                "description": "The cursor parameter supports pagination and data navigation between pages. Provide the cursor value from the previous page in the next request to load the next page of data.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used."
+              },
+              "withCount": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the count field in the response. The count field indicates the total number of requested data items. When set to true, the count field is included and response speed may be slower.",
+                "default": false
+              }
+            }
+          }
+        ],
+        "example": {
+          "contractAddress": "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
+          "page": 1,
+          "rpp": 10
+        }
+      },
+      "getTokenAccountsByAssetType__aptos__Req": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "assetType": {
+                "type": "string",
+                "description": "Parameter specifying the asset type to query.\nThe asset type must be entered as a 64-character hexadecimal string (including \"0x\") using one of the following formats:\n\n- Coin: Asset ID in Struct format such as \"0x1::aptos_coin::AptosCoin\"\n- Fungible Asset: Object address that owns the Token Metadata",
+                "pattern": "^0x[0-9a-fA-F]{1,64}::[a-z][a-zA-Z0-9_]*::[A-Z][a-zA-Z0-9_]*$|^0[xX][0-9a-fA-F]{64}",
+                "example": "0x1::aptos_coin::AptosCoin"
+              },
+              "linkedAssetType": {
+                "type": "string",
+                "description": "Common identifier for querying Coin and FA (Fungible Asset) as a single asset unit.\n\nlinkedAssetType must contain the Object address of the migrated FA, entered in 64-character hexadecimal format (including \"0x\").",
+                "pattern": "^0[xX][0-9a-fA-F]{64}",
+                "example": "0x000000000000000000000000000000000000000000000000000000000000000a"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "integer",
+                "description": "The page parameter specifies the data page to query. It accepts values up to 100; for pages exceeding 100, use the cursor pagination method.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used.",
+                "pattern": "^(?:[1-9][0-9]?|100)$"
+              },
+              "rpp": {
+                "type": "integer",
+                "description": "rpp stands for results per page and specifies the page size. You can specify a number greater than 0 and up to 100.",
+                "pattern": "^(?:[1-9][0-9]{0,2}?|100)$"
+              },
+              "cursor": {
+                "type": "string",
+                "description": "The cursor parameter supports pagination and data navigation between pages. Provide the cursor value from the previous page in the next request to load the next page of data.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used."
+              },
+              "withCount": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the count field in the response. The count field indicates the total number of requested data items. When set to true, the count field is included and response speed may be slower.",
+                "default": false
+              }
+            }
+          }
+        ],
+        "example": {
+          "assetType": "0x1::aptos_coin::AptosCoin",
+          "linkedAssetType": "0x000000000000000000000000000000000000000000000000000000000000000a",
+          "page": 1,
+          "rpp": 10
+        }
+      },
+      "getTokenTransfersByAccount__evm__Req": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "accountAddress"
+            ],
+            "properties": {
+              "accountAddress": {
+                "type": "string",
+                "description": "Parameter specifying the account address to query. Can be entered as a 40-character hexadecimal string starting with 0x.",
+                "pattern": "^0[xX][0-9a-fA-F]{40}$",
+                "example": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+              },
+              "relation": {
+                "type": "string",
+                "description": "Parameter for filtering transactions where the queried account address is the sender or recipient.\n- from: Filter by sender only.\n- to: Filter by recipient only.\n- both (default): Returns all transactions where the queried address appears in from or to.",
+                "enum": [
+                  "from",
+                  "to",
+                  "both"
+                ],
+                "pattern": "from|to|both",
+                "default": "both"
+              },
+              "contractAddresses": {
+                "type": "array",
+                "description": "Parameter specifying an array of contract addresses to query. Contract addresses can be entered as 40-character hexadecimal strings starting with 0x.",
+                "items": {
+                  "type": "string",
+                  "description": "Parameter specifying the contract address to query. Can be entered as a 40-character hexadecimal string starting with 0x.",
+                  "pattern": "^0[xX][0-9a-fA-F]{40}$"
+                }
+              },
+              "fromBlock": {
+                "type": "string",
+                "description": "Parameter specifying the starting block for the query. You can enter one of the following formats:\n- block number: Enter block number as a decimal string.\n- block hash: 64-character hexadecimal (including \"0x\").\n- block tag: Use \"earliest\" or \"latest\" to specify the first block or the most recent block.\n\nNotes:\n- This field cannot be used together with `fromDate` and `toDate`.\n- If provided without fromBlock, results are queried from genesis block to this block.\n- toBlock value cannot be less than fromBlock value.\n- If fromBlock and toBlock have the same value, only that block is queried.\n- \"earliest\" for toBlock is only allowed when fromBlock is \"earliest\".\n- If `fromBlock` and `toBlock` are not provided, the API queries data from the latest 30 days.\n",
+                "pattern": "^[0-9]+$|^0[xX][0-9a-fA-F]{64}|latest|earliest"
+              },
+              "toBlock": {
+                "type": "string",
+                "description": "Parameter specifying the ending block for the query. You can enter one of the following formats:\n- block number: Enter block number as a decimal string.\n- block hash: 64-character hexadecimal (including \"0x\").\n- block tag: Use \"earliest\" or \"latest\" to specify the first block or the most recent block.\n\nNotes:\n- This field cannot be used together with `fromDate` and `toDate`.\n- If provided without fromBlock, results are queried from genesis block to this block.\n- toBlock value cannot be less than fromBlock value.\n- If fromBlock and toBlock have the same value, only that block is queried.\n- \"earliest\" for toBlock is only allowed when fromBlock is \"earliest\".\n- If `fromBlock` and `toBlock` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]+$|^0[xX][0-9a-fA-F]{64}|latest|earliest"
+              },
+              "fromDate": {
+                "type": "string",
+                "description": "Parameter specifying the start date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without toDate, results are queried from this date to the latest block.\n- fromDate value must be equal to or earlier than toDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-01T00:00:00+00:00"
+              },
+              "toDate": {
+                "type": "string",
+                "description": "Parameter specifying the end date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without fromDate, results are queried from genesis block to this date.\n- toDate value must be equal to or later than fromDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-31T00:00:00+00:00"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "integer",
+                "description": "The page parameter specifies the data page to query. It accepts values up to 100; for pages exceeding 100, use the cursor pagination method.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used.",
+                "pattern": "^(?:[1-9][0-9]?|100)$"
+              },
+              "rpp": {
+                "type": "integer",
+                "description": "rpp stands for results per page and specifies the page size. You can specify a number greater than 0 and up to 100.",
+                "pattern": "^(?:[1-9][0-9]{0,2}?|100)$"
+              },
+              "cursor": {
+                "type": "string",
+                "description": "The cursor parameter supports pagination and data navigation between pages. Provide the cursor value from the previous page in the next request to load the next page of data.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used."
+              },
+              "withCount": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the count field in the response. The count field indicates the total number of requested data items. When set to true, the count field is included and response speed may be slower.",
+                "default": false
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "withZeroValue": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include results with value 0 in the response. Set to true for faster responses.",
+                "default": false
+              },
+              "withFunction": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the function field in the response. Response speed may be slower when set to true.",
+                "default": false
+              }
+            }
+          }
+        ],
+        "example": {
+          "accountAddress": "0x742d35Cc6634C0532925a3b844Bc454e4438f44e",
+          "fromDate": "2026-01-01T00:00:00Z",
+          "toDate": "2026-02-01T00:00:00Z",
+          "page": 1,
+          "rpp": 10
+        }
+      },
+      "getTokenTransfersByAccount__kaia__Req": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "accountAddress"
+            ],
+            "properties": {
+              "accountAddress": {
+                "type": "string",
+                "description": "Parameter specifying the account address to query. Can be entered as a 40-character hexadecimal string starting with 0x.",
+                "pattern": "^0[xX][0-9a-fA-F]{40}$",
+                "example": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+              },
+              "relation": {
+                "type": "string",
+                "description": "Parameter for filtering transactions where the queried account address is the sender or recipient.\n- from: Filter by sender only.\n- to: Filter by recipient only.\n- both (default): Returns all transactions where the queried address appears in from or to.",
+                "enum": [
+                  "from",
+                  "to",
+                  "both"
+                ],
+                "pattern": "from|to|both",
+                "default": "both"
+              },
+              "contractAddresses": {
+                "type": "array",
+                "description": "Parameter specifying an array of contract addresses to query. Contract addresses can be entered as 40-character hexadecimal strings starting with 0x.",
+                "items": {
+                  "type": "string",
+                  "description": "Parameter specifying the contract address to query. Can be entered as a 40-character hexadecimal string starting with 0x.",
+                  "pattern": "^0[xX][0-9a-fA-F]{40}$"
+                }
+              },
+              "fromBlock": {
+                "type": "string",
+                "description": "Parameter specifying the starting block for the query. You can enter one of the following formats:\n- block number: Enter block number as a decimal string.\n- block hash: 64-character hexadecimal (including \"0x\").\n- block tag: Use \"earliest\" or \"latest\" to specify the first block or the most recent block.\n\nNotes:\n- This field cannot be used together with `fromDate` and `toDate`.\n- If provided without fromBlock, results are queried from genesis block to this block.\n- toBlock value cannot be less than fromBlock value.\n- If fromBlock and toBlock have the same value, only that block is queried.\n- \"earliest\" for toBlock is only allowed when fromBlock is \"earliest\".\n- If `fromBlock` and `toBlock` are not provided, the API queries data from the latest 30 days.\n\nFor Kaia, entering \"earliest\" queries the block at the Kaia hardfork point.\n- Mainnet: 162,900,480 (Aug 29, 2024 11:08:01 UTC+9)\n- Kairos(Testnet): 156,660,000 (June 13, 2024 10:15:19 UTC+9)\n\n",
+                "pattern": "^[0-9]+$|^0[xX][0-9a-fA-F]{64}|latest|earliest"
+              },
+              "toBlock": {
+                "type": "string",
+                "description": "Parameter specifying the ending block for the query. You can enter one of the following formats:\n- block number: Enter block number as a decimal string.\n- block hash: 64-character hexadecimal (including \"0x\").\n- block tag: Use \"earliest\" or \"latest\" to specify the first block or the most recent block.\n\nNotes:\n- This field cannot be used together with `fromDate` and `toDate`.\n- If provided without fromBlock, results are queried from genesis block to this block.\n- toBlock value cannot be less than fromBlock value.\n- If fromBlock and toBlock have the same value, only that block is queried.\n- \"earliest\" for toBlock is only allowed when fromBlock is \"earliest\".\n- If `fromBlock` and `toBlock` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]+$|^0[xX][0-9a-fA-F]{64}|latest|earliest"
+              },
+              "fromDate": {
+                "type": "string",
+                "description": "Parameter specifying the start date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without toDate, results are queried from this date to the latest block.\n- fromDate value must be equal to or earlier than toDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-01T00:00:00+00:00"
+              },
+              "toDate": {
+                "type": "string",
+                "description": "Parameter specifying the end date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without fromDate, results are queried from genesis block to this date.\n- toDate value must be equal to or later than fromDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-31T00:00:00+00:00"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "integer",
+                "description": "The page parameter specifies the data page to query. It accepts values up to 100; for pages exceeding 100, use the cursor pagination method.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used.",
+                "pattern": "^(?:[1-9][0-9]?|100)$"
+              },
+              "rpp": {
+                "type": "integer",
+                "description": "rpp stands for results per page and specifies the page size. You can specify a number greater than 0 and up to 100.",
+                "pattern": "^(?:[1-9][0-9]{0,2}?|100)$"
+              },
+              "cursor": {
+                "type": "string",
+                "description": "The cursor parameter supports pagination and data navigation between pages. Provide the cursor value from the previous page in the next request to load the next page of data.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used."
+              },
+              "withCount": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the count field in the response. The count field indicates the total number of requested data items. When set to true, the count field is included and response speed may be slower.",
+                "default": false
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "withZeroValue": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include results with value 0 in the response. Set to true for faster responses.",
+                "default": false
+              },
+              "withFunction": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the function field in the response. Response speed may be slower when set to true.",
+                "default": false
+              }
+            }
+          }
+        ],
+        "example": {
+          "accountAddress": "0x742d35Cc6634C0532925a3b844Bc454e4438f44e",
+          "fromDate": "2026-01-01T00:00:00Z",
+          "toDate": "2026-02-01T00:00:00Z",
+          "page": 1,
+          "rpp": 10
+        }
+      },
+      "getTokenTransfersByAccount__tron__Req": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "accountAddress"
+            ],
+            "properties": {
+              "accountAddress": {
+                "type": "string",
+                "description": "Parameter specifying the account address to query. This field uses a 34-character base58 string format starting with \"T\".",
+                "pattern": "^T[1-9A-HJ-NP-Za-km-z]{33}$",
+                "example": "TPswDDCAWhJAZGdHPidFg5nEf8TkNToDX1"
+              },
+              "relation": {
+                "type": "string",
+                "description": "Parameter for filtering transactions where the queried account address is the sender or recipient.\n- from: Filter by sender only.\n- to: Filter by recipient only.\n- both (default): Returns all transactions where the queried address appears in from or to.",
+                "enum": [
+                  "from",
+                  "to",
+                  "both"
+                ],
+                "pattern": "from|to|both",
+                "default": "both"
+              },
+              "contractAddresses": {
+                "type": "array",
+                "description": "Parameter specifying the array of contract addresses to query. Contract addresses use a 34-character base58 string format starting with \"T\".",
+                "items": {
+                  "type": "string",
+                  "description": "Parameter specifying the contract address to query. This field uses a 34-character base58 string format starting with \"T\".",
+                  "pattern": "^T[1-9A-HJ-NP-Za-km-z]{33}$"
+                },
+                "example": [
+                  "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
+                  "TLZSucJRjnqBKwvQz6n5hd29gbS4P7u7w8"
+                ]
+              },
+              "fromBlock": {
+                "type": "string",
+                "description": "Parameter specifying the starting point for the query. You can enter block number, block hash, or block tag. Default is 0.\n- block number: Enter as a decimal string.\n- block hash: Enter as a 64-character hexadecimal string, excluding the 0x prefix.\n- block tag: You can enter \"earliest\" for fromBlock.\n\nNotes:\n- If only fromBlock is provided without toBlock, results are queried from fromBlock to the most recent block.\n- fromBlock's block number must be less than or equal to toBlock's block number.\n- If toBlock and fromBlock have the same value, only that single block's results are queried.\n- \"latest\" cannot be entered for fromBlock.\n",
+                "pattern": "^[0-9]+$|^[0-9a-fA-F]{64}|latest|earliest",
+                "default": "earliest",
+                "example": "80453005"
+              },
+              "toBlock": {
+                "type": "string",
+                "description": "Parameter specifying the ending point for the query. You can enter block number, block hash, or block tag. Default is \"latest\".\n- block number: Enter as a decimal string.\n- block hash: Enter as a 64-character hexadecimal string, excluding the 0x prefix.\n- block tag: You can enter \"latest\".\n\nNotes:\n- The blockNumber for toBlock must be greater than or equal to the blockNumber for fromBlock.\n- If toBlock and fromBlock have the same value, only that single block's results are queried.\n- If only toBlock is provided without fromBlock, results are queried from genesis block to the time specified in toBlock.\n- \"earliest\" cannot be entered for toBlock.",
+                "pattern": "^[0-9]+$|^[0-9a-fA-F]{64}|latest|earliest",
+                "default": "latest",
+                "example": "80453006"
+              },
+              "fromDate": {
+                "type": "string",
+                "description": "Parameter specifying the start date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without toDate, results are queried from this date to the latest block.\n- fromDate value must be equal to or earlier than toDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-01T00:00:00+00:00"
+              },
+              "toDate": {
+                "type": "string",
+                "description": "Parameter specifying the end date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without fromDate, results are queried from genesis block to this date.\n- toDate value must be equal to or later than fromDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-31T00:00:00+00:00"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "integer",
+                "description": "The page parameter specifies the data page to query. It accepts values up to 100; for pages exceeding 100, use the cursor pagination method.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used.",
+                "pattern": "^(?:[1-9][0-9]?|100)$"
+              },
+              "rpp": {
+                "type": "integer",
+                "description": "rpp stands for results per page and specifies the page size. You can specify a number greater than 0 and up to 100.",
+                "pattern": "^(?:[1-9][0-9]{0,2}?|100)$"
+              },
+              "cursor": {
+                "type": "string",
+                "description": "The cursor parameter supports pagination and data navigation between pages. Provide the cursor value from the previous page in the next request to load the next page of data.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used."
+              },
+              "withCount": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the count field in the response. The count field indicates the total number of requested data items. When set to true, the count field is included and response speed may be slower.",
+                "default": false
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "withZeroValue": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include results with value 0 in the response. Set to true for faster responses.",
+                "default": false
+              }
+            }
+          }
+        ],
+        "example": {
+          "accountAddress": "TGEj7Eawpj8xnPm82FVHeWYvBRKQzdBoVQ",
+          "fromDate": "2026-01-01T00:00:00Z",
+          "toDate": "2026-02-01T00:00:00Z",
+          "page": 1,
+          "rpp": 10
+        }
+      },
+      "getTokenTransfersByAccount__xrpl__Req": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "accountAddress"
+            ],
+            "properties": {
+              "accountAddress": {
+                "type": "string",
+                "description": "Parameter specifying the account address for balance query. It is a Base58-encoded string of 25-35 characters, always starting with \"r\".",
+                "pattern": "^r[1-9A-HJ-NP-Za-km-z]{25,35}$"
+              },
+              "relation": {
+                "type": "string",
+                "description": "Parameter for filtering transactions where the queried account address is the sender or recipient.\n- from: Filter by sender only.\n- to: Filter by recipient only.\n- both (default): Returns all transactions where the queried address appears in from or to.",
+                "enum": [
+                  "from",
+                  "to",
+                  "both"
+                ],
+                "pattern": "from|to|both",
+                "default": "both"
+              },
+              "currency": {
+                "type": "string",
+                "description": "Parameter specifying the currency symbol to query. Can be entered as an ISO-4217 format string such as \"USD\" or \"EUR\".",
+                "default": "USD"
+              },
+              "issuer": {
+                "type": "string",
+                "description": "Parameter specifying the issuer of the currency to query. Enter the issuer account address using a Base58-encoded string of 25-35 characters (starting with \"r\").",
+                "default": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq"
+              },
+              "fromLedger": {
+                "type": "string",
+                "description": "Parameter specifying the starting ledger for the query. You can enter one of the following formats:\n- **ledger index**: Enter ledger number as a decimal string\n- **ledger hash**: 64-character hexadecimal string (excluding 0x prefix)\n- **ledger tag**: Enter \"earliest\" or \"latest\" (oldest or most recent ledger)\n\nNotes:\n- If provided without toLedger, results are queried from this ledger to the latest ledger.\n- fromLedger value cannot be greater than toLedger value.\n- If fromLedger and toLedger have the same value, only that ledger is queried.\n- \"latest\" for fromLedger is only allowed when toLedger is \"latest\".",
+                "pattern": "^[0-9]+$|^0[xX][0-9a-fA-F]{64}|latest|earliest"
+              },
+              "toLedger": {
+                "type": "string",
+                "description": "Parameter specifying the ending ledger for the query. You can enter one of the following formats:\n- **ledger index**: Enter ledger number as a decimal string\n- **ledger hash**: 64-character hexadecimal string (excluding 0x prefix)\n- **ledger tag**: Enter \"earliest\" or \"latest\" (oldest or most recent ledger)\n\nNotes:\n- If provided without fromLedger, results are queried from genesis ledger to this ledger.\n- toLedger value cannot be less than fromLedger value.\n- If fromLedger and toLedger have the same value, only that ledger is queried.\n- \"earliest\" for toLedger is only allowed when fromLedger is \"earliest\".",
+                "pattern": "^[0-9]+$|^0[xX][0-9a-fA-F]{64}|latest|earliest"
+              },
+              "fromDate": {
+                "type": "string",
+                "description": "Parameter specifying the start date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without toDate, results are queried from this date to the latest block.\n- fromDate value must be equal to or earlier than toDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-01T00:00:00+00:00"
+              },
+              "toDate": {
+                "type": "string",
+                "description": "Parameter specifying the end date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without fromDate, results are queried from genesis block to this date.\n- toDate value must be equal to or later than fromDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-31T00:00:00+00:00"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "integer",
+                "description": "The page parameter specifies the data page to query. It accepts values up to 100; for pages exceeding 100, use the cursor pagination method.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used.",
+                "pattern": "^(?:[1-9][0-9]?|100)$"
+              },
+              "rpp": {
+                "type": "integer",
+                "description": "rpp stands for results per page and specifies the page size. You can specify a number greater than 0 and up to 100.",
+                "pattern": "^(?:[1-9][0-9]{0,2}?|100)$"
+              },
+              "cursor": {
+                "type": "string",
+                "description": "The cursor parameter supports pagination and data navigation between pages. Provide the cursor value from the previous page in the next request to load the next page of data.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used."
+              },
+              "withCount": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the count field in the response. The count field indicates the total number of requested data items. When set to true, the count field is included and response speed may be slower.",
+                "default": false
+              }
+            }
+          }
+        ],
+        "example": {
+          "accountAddress": "rMwjYedjc7qqtVWGkcvvLtAp8MuyesLb1Yk",
+          "fromDate": "2026-01-01T00:00:00Z",
+          "toDate": "2026-02-01T00:00:00Z",
+          "page": 1,
+          "rpp": 10
+        }
+      },
+      "getTokensOwnedByAccount__evm__Req": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "accountAddress"
+            ],
+            "properties": {
+              "accountAddress": {
+                "type": "string",
+                "description": "Parameter specifying the account address to query. Can be entered as a 40-character hexadecimal string starting with 0x.",
+                "pattern": "^0[xX][0-9a-fA-F]{40}$",
+                "example": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+              },
+              "contractAddresses": {
+                "type": "array",
+                "description": "Parameter specifying an array of contract addresses to query. Contract addresses can be entered as 40-character hexadecimal strings starting with 0x.",
+                "items": {
+                  "type": "string",
+                  "description": "Parameter specifying the contract address to query. Can be entered as a 40-character hexadecimal string starting with 0x.",
+                  "pattern": "^0[xX][0-9a-fA-F]{40}$"
+                }
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "integer",
+                "description": "The page parameter specifies the data page to query. It accepts values up to 100; for pages exceeding 100, use the cursor pagination method.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used.",
+                "pattern": "^(?:[1-9][0-9]?|100)$"
+              },
+              "rpp": {
+                "type": "integer",
+                "description": "rpp stands for results per page and specifies the page size. You can specify a number greater than 0 and up to 100.",
+                "pattern": "^(?:[1-9][0-9]{0,2}?|100)$"
+              },
+              "cursor": {
+                "type": "string",
+                "description": "The cursor parameter supports pagination and data navigation between pages. Provide the cursor value from the previous page in the next request to load the next page of data.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used."
+              },
+              "withCount": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the count field in the response. The count field indicates the total number of requested data items. When set to true, the count field is included and response speed may be slower.",
+                "default": false
+              }
+            }
+          }
+        ],
+        "example": {
+          "accountAddress": "0x742d35Cc6634C0532925a3b844Bc454e4438f44e",
+          "contractAddresses": [
+            "0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D",
+            "0x60E4d786628Fea6478F785A6d7e704777c86a7c6"
+          ],
+          "page": 1,
+          "rpp": 10
+        }
+      },
+      "getTokensOwnedByAccount__tron__Req": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "accountAddress"
+            ],
+            "properties": {
+              "accountAddress": {
+                "type": "string",
+                "description": "Parameter specifying the account address to query. This field uses a 34-character base58 string format starting with \"T\".",
+                "pattern": "^T[1-9A-HJ-NP-Za-km-z]{33}$",
+                "example": "TPswDDCAWhJAZGdHPidFg5nEf8TkNToDX1"
+              },
+              "contractAddresses": {
+                "type": "array",
+                "description": "Parameter specifying the array of contract addresses to query. Contract addresses use a 34-character base58 string format starting with \"T\".",
+                "items": {
+                  "type": "string",
+                  "description": "Parameter specifying the contract address to query. This field uses a 34-character base58 string format starting with \"T\".",
+                  "pattern": "^T[1-9A-HJ-NP-Za-km-z]{33}$"
+                },
+                "example": [
+                  "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
+                  "TLZSucJRjnqBKwvQz6n5hd29gbS4P7u7w8"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "integer",
+                "description": "The page parameter specifies the data page to query. It accepts values up to 100; for pages exceeding 100, use the cursor pagination method.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used.",
+                "pattern": "^(?:[1-9][0-9]?|100)$"
+              },
+              "rpp": {
+                "type": "integer",
+                "description": "rpp stands for results per page and specifies the page size. You can specify a number greater than 0 and up to 100.",
+                "pattern": "^(?:[1-9][0-9]{0,2}?|100)$"
+              },
+              "cursor": {
+                "type": "string",
+                "description": "The cursor parameter supports pagination and data navigation between pages. Provide the cursor value from the previous page in the next request to load the next page of data.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used."
+              },
+              "withCount": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the count field in the response. The count field indicates the total number of requested data items. When set to true, the count field is included and response speed may be slower.",
+                "default": false
+              }
+            }
+          }
+        ],
+        "example": {
+          "accountAddress": "TGEj7Eawpj8xnPm82FVHeWYvBRKQzdBoVQ",
+          "contractAddresses": [
+            "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
+            "TLZSucJRjnqBKwvQz6n5hd29gbS4P7u7w8"
+          ],
+          "page": 1,
+          "rpp": 10
+        }
+      },
+      "getTokensOwnedByAccount__aptos__Req": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "accountAddress"
+            ],
+            "properties": {
+              "accountAddress": {
+                "type": "string",
+                "description": "Parameter specifying the account address to query. The account address must be entered as a 64-character hexadecimal string (including \"0x\").",
+                "pattern": "^0[xX][0-9a-fA-F]{64}",
+                "example": "0xd91c64b777e51395c6ea9dec562ed79a4afa0cd6dad5a87b187c37198a1f855a"
+              },
+              "assetTypes": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "description": "Parameter specifying the asset type to query.\nThe asset type must be entered as a 64-character hexadecimal string (including \"0x\") using one of the following formats:\n\n- Coin: Asset ID in Struct format such as \"0x1::aptos_coin::AptosCoin\"\n- Fungible Asset: Object address that owns the Token Metadata",
+                  "pattern": "^0x[0-9a-fA-F]{1,64}::[a-z][a-zA-Z0-9_]*::[A-Z][a-zA-Z0-9_]*$|^0[xX][0-9a-fA-F]{64}",
+                  "example": "0x1::aptos_coin::AptosCoin"
+                }
+              },
+              "linkedAssetTypes": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "description": "Common identifier for querying Coin and FA (Fungible Asset) as a single asset unit.\n\nlinkedAssetType must contain the Object address of the migrated FA, entered in 64-character hexadecimal format (including \"0x\").",
+                  "pattern": "^0[xX][0-9a-fA-F]{64}",
+                  "example": "0x000000000000000000000000000000000000000000000000000000000000000a"
+                }
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "integer",
+                "description": "The page parameter specifies the data page to query. It accepts values up to 100; for pages exceeding 100, use the cursor pagination method.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used.",
+                "pattern": "^(?:[1-9][0-9]?|100)$"
+              },
+              "rpp": {
+                "type": "integer",
+                "description": "rpp stands for results per page and specifies the page size. You can specify a number greater than 0 and up to 100.",
+                "pattern": "^(?:[1-9][0-9]{0,2}?|100)$"
+              },
+              "cursor": {
+                "type": "string",
+                "description": "The cursor parameter supports pagination and data navigation between pages. Provide the cursor value from the previous page in the next request to load the next page of data.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used."
+              },
+              "withCount": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the count field in the response. The count field indicates the total number of requested data items. When set to true, the count field is included and response speed may be slower.",
+                "default": false
+              }
+            }
+          }
+        ],
+        "example": {
+          "accountAddress": "0xd91c64b777e51395c6ea9dec562ed79a4afa0cd6dad5a87b187c37198a1f855a",
+          "linkedAssetTypes": [
+            "0x000000000000000000000000000000000000000000000000000000000000000a"
+          ],
+          "page": 1,
+          "rpp": 10
+        }
+      },
+      "getTokensOwnedByAccount__aptos__Res": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "items"
+            ],
+            "properties": {
+              "page": {
+                "type": "integer",
+                "description": "Field representing the page number specified in the page parameter. This field is only included in the response when a value greater than 0 is specified for the page parameter."
+              },
+              "rpp": {
+                "type": "integer",
+                "description": "Field representing the number of results per page specified in the rpp parameter."
+              },
+              "cursor": {
+                "type": "string",
+                "description": "A field for cursor pagination. This value must be provided in the next request to load the next page of data."
+              },
+              "count": {
+                "type": "integer",
+                "description": "Field representing the total count of requested data. This field is only included in the response when true is set for the withCount parameter."
+              },
+              "items": {
+                "type": "array",
+                "description": "Field representing the list of queried data."
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "items": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "description": "To obtain the total held quantity of a specific token, you must sum all results queried by the token's assetType or linkedAssetType.\n"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "getTokenBalanceChangesByAccount__aptos__Req": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "accountAddress"
+            ],
+            "properties": {
+              "accountAddress": {
+                "type": "string",
+                "description": "Parameter specifying the account address to query. The account address must be entered as a 64-character hexadecimal string (including \"0x\").",
+                "pattern": "^0[xX][0-9a-fA-F]{64}",
+                "example": "0xd91c64b777e51395c6ea9dec562ed79a4afa0cd6dad5a87b187c37198a1f855a"
+              },
+              "assetTypes": {
+                "type": "array",
+                "description": "Specifies the type of asset to query. The asset type must be a 64-character hexadecimal value (including \"0x\") in one of the following formats:\n\n* Coin: A Struct-format asset ID such as \"0x1::aptos_coin::AptosCoin\"\n* Fungible Asset: The Object address that owns the Token Metadata\n\n⚠️ assetTypes and linkedAssetTypes cannot be used at the same time.\n",
+                "items": {
+                  "type": "string",
+                  "description": "Parameter specifying the asset type to query.\nThe asset type must be entered as a 64-character hexadecimal string (including \"0x\") using one of the following formats:\n\n- Coin: Asset ID in Struct format such as \"0x1::aptos_coin::AptosCoin\"\n- Fungible Asset: Object address that owns the Token Metadata",
+                  "pattern": "^0x[0-9a-fA-F]{1,64}::[a-z][a-zA-Z0-9_]*::[A-Z][a-zA-Z0-9_]*$|^0[xX][0-9a-fA-F]{64}",
+                  "example": "0x1::aptos_coin::AptosCoin"
+                }
+              },
+              "linkedAssetTypes": {
+                "type": "array",
+                "description": "A common identifier used to query Coin and FA (Fungible Asset) as a single asset unit.\n\nThe linkedAssetType must be the Object address of a migrated FA, entered in 64-character hexadecimal format (including \"0x\").\n\n⚠️ assetTypes and linkedAssetTypes cannot be used at the same time.\n",
+                "items": {
+                  "type": "string",
+                  "description": "Common identifier for querying Coin and FA (Fungible Asset) as a single asset unit.\n\nlinkedAssetType must contain the Object address of the migrated FA, entered in 64-character hexadecimal format (including \"0x\").",
+                  "pattern": "^0[xX][0-9a-fA-F]{64}",
+                  "example": "0x000000000000000000000000000000000000000000000000000000000000000a"
+                }
+              },
+              "fromBlock": {
+                "type": "string",
+                "description": "Parameter specifying the starting block for the query. You can enter one of the following formats:\n- block number: Enter block number as a decimal string.\n- block hash: 64-character hexadecimal (including \"0x\").\n- block tag: Use \"earliest\" or \"latest\" to specify the first block or the most recent block.\n\nNotes:\n- This field cannot be used together with `fromDate` and `toDate`.\n- If provided without fromBlock, results are queried from genesis block to this block.\n- toBlock value cannot be less than fromBlock value.\n- If fromBlock and toBlock have the same value, only that block is queried.\n- \"earliest\" for toBlock is only allowed when fromBlock is \"earliest\".\n- If `fromBlock` and `toBlock` are not provided, the API queries data from the latest 30 days.\n",
+                "pattern": "^[0-9]+$|^0[xX][0-9a-fA-F]{64}|latest|earliest",
+                "default": "earliest"
+              },
+              "toBlock": {
+                "type": "string",
+                "description": "Parameter specifying the ending block for the query. You can enter one of the following formats:\n- block number: Enter block number as a decimal string.\n- block hash: 64-character hexadecimal (including \"0x\").\n- block tag: Use \"earliest\" or \"latest\" to specify the first block or the most recent block.\n\nNotes:\n- This field cannot be used together with `fromDate` and `toDate`.\n- If provided without fromBlock, results are queried from genesis block to this block.\n- toBlock value cannot be less than fromBlock value.\n- If fromBlock and toBlock have the same value, only that block is queried.\n- \"earliest\" for toBlock is only allowed when fromBlock is \"earliest\".\n- If `fromBlock` and `toBlock` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]+$|^0[xX][0-9a-fA-F]{64}|latest|earliest"
+              },
+              "fromDate": {
+                "type": "string",
+                "description": "Parameter specifying the start date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without toDate, results are queried from this date to the latest block.\n- fromDate value must be equal to or earlier than toDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-01T00:00:00+00:00"
+              },
+              "toDate": {
+                "type": "string",
+                "description": "Parameter specifying the end date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without fromDate, results are queried from genesis block to this date.\n- toDate value must be equal to or later than fromDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-31T00:00:00+00:00"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "integer",
+                "description": "The page parameter specifies the data page to query. It accepts values up to 100; for pages exceeding 100, use the cursor pagination method.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used.",
+                "pattern": "^(?:[1-9][0-9]?|100)$"
+              },
+              "rpp": {
+                "type": "integer",
+                "description": "rpp stands for results per page and specifies the page size. You can specify a number greater than 0 and up to 100.",
+                "pattern": "^(?:[1-9][0-9]{0,2}?|100)$"
+              },
+              "cursor": {
+                "type": "string",
+                "description": "The cursor parameter supports pagination and data navigation between pages. Provide the cursor value from the previous page in the next request to load the next page of data.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used."
+              },
+              "withCount": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the count field in the response. The count field indicates the total number of requested data items. When set to true, the count field is included and response speed may be slower.",
+                "default": false
+              }
+            }
+          }
+        ]
+      },
+      "getTokenBalanceChangesByAccount__xrpl__Req": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "accountAddress"
+            ],
+            "properties": {
+              "accountAddress": {
+                "type": "string",
+                "description": "Parameter specifying the account address for balance query. It is a Base58-encoded string of 25-35 characters, always starting with \"r\".",
+                "pattern": "^r[1-9A-HJ-NP-Za-km-z]{25,35}$"
+              },
+              "currency": {
+                "type": "string",
+                "description": "Parameter specifying the currency symbol to query. Can be entered as an ISO-4217 format string such as \"USD\" or \"EUR\".",
+                "default": "USD"
+              },
+              "issuer": {
+                "type": "string",
+                "description": "Parameter specifying the issuer of the currency to query. Enter the issuer account address using a Base58-encoded string of 25-35 characters (starting with \"r\").",
+                "default": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq"
+              },
+              "fromLedger": {
+                "type": "string",
+                "description": "Parameter specifying the starting ledger for the query. You can enter one of the following formats:\n- **ledger index**: Enter ledger number as a decimal string\n- **ledger hash**: 64-character hexadecimal string (excluding 0x prefix)\n- **ledger tag**: Enter \"earliest\" or \"latest\" (oldest or most recent ledger)\n\nNotes:\n- If provided without toLedger, results are queried from this ledger to the latest ledger.\n- fromLedger value cannot be greater than toLedger value.\n- If fromLedger and toLedger have the same value, only that ledger is queried.\n- \"latest\" for fromLedger is only allowed when toLedger is \"latest\".",
+                "pattern": "^[0-9]+$|^0[xX][0-9a-fA-F]{64}|latest|earliest"
+              },
+              "toLedger": {
+                "type": "string",
+                "description": "Parameter specifying the ending ledger for the query. You can enter one of the following formats:\n- **ledger index**: Enter ledger number as a decimal string\n- **ledger hash**: 64-character hexadecimal string (excluding 0x prefix)\n- **ledger tag**: Enter \"earliest\" or \"latest\" (oldest or most recent ledger)\n\nNotes:\n- If provided without fromLedger, results are queried from genesis ledger to this ledger.\n- toLedger value cannot be less than fromLedger value.\n- If fromLedger and toLedger have the same value, only that ledger is queried.\n- \"earliest\" for toLedger is only allowed when fromLedger is \"earliest\".",
+                "pattern": "^[0-9]+$|^0[xX][0-9a-fA-F]{64}|latest|earliest"
+              },
+              "fromDate": {
+                "type": "string",
+                "description": "Parameter specifying the start date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without toDate, results are queried from this date to the latest block.\n- fromDate value must be equal to or earlier than toDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-01T00:00:00+00:00"
+              },
+              "toDate": {
+                "type": "string",
+                "description": "Parameter specifying the end date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without fromDate, results are queried from genesis block to this date.\n- toDate value must be equal to or later than fromDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-31T00:00:00+00:00"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "integer",
+                "description": "The page parameter specifies the data page to query. It accepts values up to 100; for pages exceeding 100, use the cursor pagination method.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used.",
+                "pattern": "^(?:[1-9][0-9]?|100)$"
+              },
+              "rpp": {
+                "type": "integer",
+                "description": "rpp stands for results per page and specifies the page size. You can specify a number greater than 0 and up to 100.",
+                "pattern": "^(?:[1-9][0-9]{0,2}?|100)$"
+              },
+              "cursor": {
+                "type": "string",
+                "description": "The cursor parameter supports pagination and data navigation between pages. Provide the cursor value from the previous page in the next request to load the next page of data.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used."
+              },
+              "withCount": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the count field in the response. The count field indicates the total number of requested data items. When set to true, the count field is included and response speed may be slower.",
+                "default": false
+              }
+            }
+          }
+        ],
+        "example": {
+          "accountAddress": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+          "currency": "USD",
+          "issuer": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+          "fromDate": "2026-01-01T00:00:00Z",
+          "toDate": "2026-02-01T00:00:00Z"
+        }
+      },
+      "getTokenAllowance__evm__Req": {
+        "type": "object",
+        "required": [
+          "contractAddress",
+          "ownerAddress",
+          "spenderAddress"
+        ],
+        "properties": {
+          "contractAddress": {
+            "type": "string",
+            "description": "Parameter specifying the contract address to query. Can be entered as a 40-character hexadecimal string starting with 0x.",
+            "pattern": "^0[xX][0-9a-fA-F]{40}$"
+          },
+          "ownerAddress": {
+            "type": "string",
+            "description": "Parameter specifying the account address to query. Can be entered as a 40-character hexadecimal string starting with 0x.",
+            "pattern": "^0[xX][0-9a-fA-F]{40}$",
+            "example": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+          },
+          "spenderAddress": {
+            "type": "string",
+            "description": "Parameter specifying the account address to query. Can be entered as a 40-character hexadecimal string starting with 0x.",
+            "pattern": "^0[xX][0-9a-fA-F]{40}$",
+            "example": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+          }
+        },
+        "example": {
+          "contractAddress": "0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D",
+          "ownerAddress": "0x742d35Cc6634C0532925a3b844Bc454e4438f44e",
+          "spenderAddress": "0x742d35Cc6634C0532925a3b844Bc454e4438f44e"
+        }
+      },
+      "getTokenAllowance__tron__Req": {
+        "type": "object",
+        "required": [
+          "contractAddress",
+          "ownerAddress",
+          "spenderAddress"
+        ],
+        "properties": {
+          "contractAddress": {
+            "type": "string",
+            "description": "Parameter specifying the contract address to query. This field uses a 34-character base58 string format starting with \"T\".",
+            "pattern": "^T[1-9A-HJ-NP-Za-km-z]{33}$",
+            "example": "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t"
+          },
+          "ownerAddress": {
+            "type": "string",
+            "description": "Parameter specifying the account address to query. This field uses a 34-character base58 string format starting with \"T\".",
+            "pattern": "^T[1-9A-HJ-NP-Za-km-z]{33}$",
+            "example": "TPswDDCAWhJAZGdHPidFg5nEf8TkNToDX1"
+          },
+          "spenderAddress": {
+            "type": "string",
+            "description": "Parameter specifying the account address to query. This field uses a 34-character base58 string format starting with \"T\".",
+            "pattern": "^T[1-9A-HJ-NP-Za-km-z]{33}$",
+            "example": "TPswDDCAWhJAZGdHPidFg5nEf8TkNToDX1"
+          }
+        }
+      },
+      "getTokenAllowance___shared__Res": {
+        "type": "object",
+        "properties": {
+          "allowance": {
+            "type": "string",
+            "description": "Returns the remaining number of tokens that the spender can use on behalf of the owner through transferFrom. This value changes when approve or transferFrom is called."
+          }
+        }
+      },
+      "getTokenTransfersWithinRange__evm__Req": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "fromBlock": {
+                "type": "string",
+                "description": "Parameter specifying the starting block for the query. You can enter one of the following formats:\n- block number: Enter block number as a decimal string.\n- block hash: 64-character hexadecimal (including \"0x\").\n- block tag: Use \"earliest\" or \"latest\" to specify the first block or the most recent block.\n\nNotes:\n- This field cannot be used together with `fromDate` and `toDate`.\n- If provided without fromBlock, results are queried from genesis block to this block.\n- toBlock value cannot be less than fromBlock value.\n- If fromBlock and toBlock have the same value, only that block is queried.\n- \"earliest\" for toBlock is only allowed when fromBlock is \"earliest\".\n- If `fromBlock` and `toBlock` are not provided, the API queries data from the latest 30 days.\n",
+                "pattern": "^[0-9]+$|^0[xX][0-9a-fA-F]{64}|latest|earliest"
+              },
+              "toBlock": {
+                "type": "string",
+                "description": "Parameter specifying the ending block for the query. You can enter one of the following formats:\n- block number: Enter block number as a decimal string.\n- block hash: 64-character hexadecimal (including \"0x\").\n- block tag: Use \"earliest\" or \"latest\" to specify the first block or the most recent block.\n\nNotes:\n- This field cannot be used together with `fromDate` and `toDate`.\n- If provided without fromBlock, results are queried from genesis block to this block.\n- toBlock value cannot be less than fromBlock value.\n- If fromBlock and toBlock have the same value, only that block is queried.\n- \"earliest\" for toBlock is only allowed when fromBlock is \"earliest\".\n- If `fromBlock` and `toBlock` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]+$|^0[xX][0-9a-fA-F]{64}|latest|earliest"
+              },
+              "fromDate": {
+                "type": "string",
+                "description": "Parameter specifying the start date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without toDate, results are queried from this date to the latest block.\n- fromDate value must be equal to or earlier than toDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-01T00:00:00+00:00"
+              },
+              "toDate": {
+                "type": "string",
+                "description": "Parameter specifying the end date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without fromDate, results are queried from genesis block to this date.\n- toDate value must be equal to or later than fromDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-31T00:00:00+00:00"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "integer",
+                "description": "The page parameter specifies the data page to query. It accepts values up to 100; for pages exceeding 100, use the cursor pagination method.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used.",
+                "pattern": "^(?:[1-9][0-9]?|100)$"
+              },
+              "rpp": {
+                "type": "integer",
+                "description": "rpp stands for results per page and specifies the page size. You can specify a number greater than 0 and up to 100.",
+                "pattern": "^(?:[1-9][0-9]{0,2}?|100)$"
+              },
+              "cursor": {
+                "type": "string",
+                "description": "The cursor parameter supports pagination and data navigation between pages. Provide the cursor value from the previous page in the next request to load the next page of data.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used."
+              },
+              "withCount": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the count field in the response. The count field indicates the total number of requested data items. When set to true, the count field is included and response speed may be slower.",
+                "default": false
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "withZeroValue": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include results with value 0 in the response. Set to true for faster responses.",
+                "default": false
+              },
+              "withFunction": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the function field in the response. Response speed may be slower when set to true.",
+                "default": false
+              }
+            }
+          }
+        ],
+        "example": {
+          "fromDate": "2026-01-01T00:00:00Z",
+          "toDate": "2026-02-01T00:00:00Z",
+          "page": 1,
+          "rpp": 10
+        }
+      },
+      "getTokenTransfersWithinRange__kaia__Req": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "fromBlock": {
+                "type": "string",
+                "description": "Parameter specifying the starting block for the query. You can enter one of the following formats:\n- block number: Enter block number as a decimal string.\n- block hash: 64-character hexadecimal (including \"0x\").\n- block tag: Use \"earliest\" or \"latest\" to specify the first block or the most recent block.\n\nNotes:\n- This field cannot be used together with `fromDate` and `toDate`.\n- If provided without fromBlock, results are queried from genesis block to this block.\n- toBlock value cannot be less than fromBlock value.\n- If fromBlock and toBlock have the same value, only that block is queried.\n- \"earliest\" for toBlock is only allowed when fromBlock is \"earliest\".\n- If `fromBlock` and `toBlock` are not provided, the API queries data from the latest 30 days.\n\nFor Kaia, entering \"earliest\" queries the block at the Kaia hardfork point.\n- Mainnet: 162,900,480 (Aug 29, 2024 11:08:01 UTC+9)\n- Kairos(Testnet): 156,660,000 (June 13, 2024 10:15:19 UTC+9)\n\n",
+                "pattern": "^[0-9]+$|^0[xX][0-9a-fA-F]{64}|latest|earliest"
+              },
+              "toBlock": {
+                "type": "string",
+                "description": "Parameter specifying the ending block for the query. You can enter one of the following formats:\n- block number: Enter block number as a decimal string.\n- block hash: 64-character hexadecimal (including \"0x\").\n- block tag: Use \"earliest\" or \"latest\" to specify the first block or the most recent block.\n\nNotes:\n- This field cannot be used together with `fromDate` and `toDate`.\n- If provided without fromBlock, results are queried from genesis block to this block.\n- toBlock value cannot be less than fromBlock value.\n- If fromBlock and toBlock have the same value, only that block is queried.\n- \"earliest\" for toBlock is only allowed when fromBlock is \"earliest\".\n- If `fromBlock` and `toBlock` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]+$|^0[xX][0-9a-fA-F]{64}|latest|earliest"
+              },
+              "fromDate": {
+                "type": "string",
+                "description": "Parameter specifying the start date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without toDate, results are queried from this date to the latest block.\n- fromDate value must be equal to or earlier than toDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-01T00:00:00+00:00"
+              },
+              "toDate": {
+                "type": "string",
+                "description": "Parameter specifying the end date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without fromDate, results are queried from genesis block to this date.\n- toDate value must be equal to or later than fromDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-31T00:00:00+00:00"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "integer",
+                "description": "The page parameter specifies the data page to query. It accepts values up to 100; for pages exceeding 100, use the cursor pagination method.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used.",
+                "pattern": "^(?:[1-9][0-9]?|100)$"
+              },
+              "rpp": {
+                "type": "integer",
+                "description": "rpp stands for results per page and specifies the page size. You can specify a number greater than 0 and up to 100.",
+                "pattern": "^(?:[1-9][0-9]{0,2}?|100)$"
+              },
+              "cursor": {
+                "type": "string",
+                "description": "The cursor parameter supports pagination and data navigation between pages. Provide the cursor value from the previous page in the next request to load the next page of data.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used."
+              },
+              "withCount": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the count field in the response. The count field indicates the total number of requested data items. When set to true, the count field is included and response speed may be slower.",
+                "default": false
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "withZeroValue": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include results with value 0 in the response. Set to true for faster responses.",
+                "default": false
+              },
+              "withFunction": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the function field in the response. Response speed may be slower when set to true.",
+                "default": false
+              }
+            }
+          }
+        ],
+        "example": {
+          "fromDate": "2026-01-01T00:00:00Z",
+          "toDate": "2026-02-01T00:00:00Z",
+          "page": 1,
+          "rpp": 10
+        }
+      },
+      "transfersWithinRange__tron__Req": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "fromBlock": {
+                "type": "string",
+                "description": "Parameter specifying the starting point for the query. You can enter block number, block hash, or block tag. Default is 0.\n- block number: Enter as a decimal string.\n- block hash: Enter as a 64-character hexadecimal string, excluding the 0x prefix.\n- block tag: You can enter \"earliest\" for fromBlock.\n\nNotes:\n- If only fromBlock is provided without toBlock, results are queried from fromBlock to the most recent block.\n- fromBlock's block number must be less than or equal to toBlock's block number.\n- If toBlock and fromBlock have the same value, only that single block's results are queried.\n- \"latest\" cannot be entered for fromBlock.\n",
+                "pattern": "^[0-9]+$|^[0-9a-fA-F]{64}|latest|earliest",
+                "default": "earliest",
+                "example": "80453005"
+              },
+              "toBlock": {
+                "type": "string",
+                "description": "Parameter specifying the ending point for the query. You can enter block number, block hash, or block tag. Default is \"latest\".\n- block number: Enter as a decimal string.\n- block hash: Enter as a 64-character hexadecimal string, excluding the 0x prefix.\n- block tag: You can enter \"latest\".\n\nNotes:\n- The blockNumber for toBlock must be greater than or equal to the blockNumber for fromBlock.\n- If toBlock and fromBlock have the same value, only that single block's results are queried.\n- If only toBlock is provided without fromBlock, results are queried from genesis block to the time specified in toBlock.\n- \"earliest\" cannot be entered for toBlock.",
+                "pattern": "^[0-9]+$|^[0-9a-fA-F]{64}|latest|earliest",
+                "default": "latest",
+                "example": "80453006"
+              },
+              "fromDate": {
+                "type": "string",
+                "description": "Parameter specifying the start date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without toDate, results are queried from this date to the latest block.\n- fromDate value must be equal to or earlier than toDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-01T00:00:00+00:00"
+              },
+              "toDate": {
+                "type": "string",
+                "description": "Parameter specifying the end date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without fromDate, results are queried from genesis block to this date.\n- toDate value must be equal to or later than fromDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-31T00:00:00+00:00"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "integer",
+                "description": "The page parameter specifies the data page to query. It accepts values up to 100; for pages exceeding 100, use the cursor pagination method.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used.",
+                "pattern": "^(?:[1-9][0-9]?|100)$"
+              },
+              "rpp": {
+                "type": "integer",
+                "description": "rpp stands for results per page and specifies the page size. You can specify a number greater than 0 and up to 100.",
+                "pattern": "^(?:[1-9][0-9]{0,2}?|100)$"
+              },
+              "cursor": {
+                "type": "string",
+                "description": "The cursor parameter supports pagination and data navigation between pages. Provide the cursor value from the previous page in the next request to load the next page of data.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used."
+              },
+              "withCount": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the count field in the response. The count field indicates the total number of requested data items. When set to true, the count field is included and response speed may be slower.",
+                "default": false
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "withZeroValue": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include results with value 0 in the response. Set to true for faster responses.",
+                "default": false
+              }
+            }
+          }
+        ],
+        "example": {
+          "fromDate": "2026-01-01T00:00:00Z",
+          "toDate": "2026-02-01T00:00:00Z",
+          "page": 1,
+          "rpp": 10
+        }
+      },
+      "getTokenTransfersWithinRange__xrpl__Req": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "fromLedger": {
+                "type": "string",
+                "description": "Parameter specifying the starting ledger for the query. You can enter one of the following formats:\n- **ledger index**: Enter ledger number as a decimal string\n- **ledger hash**: 64-character hexadecimal string (excluding 0x prefix)\n- **ledger tag**: Enter \"earliest\" or \"latest\" (oldest or most recent ledger)\n\nNotes:\n- If provided without toLedger, results are queried from this ledger to the latest ledger.\n- fromLedger value cannot be greater than toLedger value.\n- If fromLedger and toLedger have the same value, only that ledger is queried.\n- \"latest\" for fromLedger is only allowed when toLedger is \"latest\".",
+                "pattern": "^[0-9]+$|^0[xX][0-9a-fA-F]{64}|latest|earliest"
+              },
+              "toLedger": {
+                "type": "string",
+                "description": "Parameter specifying the ending ledger for the query. You can enter one of the following formats:\n- **ledger index**: Enter ledger number as a decimal string\n- **ledger hash**: 64-character hexadecimal string (excluding 0x prefix)\n- **ledger tag**: Enter \"earliest\" or \"latest\" (oldest or most recent ledger)\n\nNotes:\n- If provided without fromLedger, results are queried from genesis ledger to this ledger.\n- toLedger value cannot be less than fromLedger value.\n- If fromLedger and toLedger have the same value, only that ledger is queried.\n- \"earliest\" for toLedger is only allowed when fromLedger is \"earliest\".",
+                "pattern": "^[0-9]+$|^0[xX][0-9a-fA-F]{64}|latest|earliest"
+              },
+              "fromDate": {
+                "type": "string",
+                "description": "Parameter specifying the start date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without toDate, results are queried from this date to the latest block.\n- fromDate value must be equal to or earlier than toDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-01T00:00:00+00:00"
+              },
+              "toDate": {
+                "type": "string",
+                "description": "Parameter specifying the end date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without fromDate, results are queried from genesis block to this date.\n- toDate value must be equal to or later than fromDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-31T00:00:00+00:00"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "integer",
+                "description": "The page parameter specifies the data page to query. It accepts values up to 100; for pages exceeding 100, use the cursor pagination method.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used.",
+                "pattern": "^(?:[1-9][0-9]?|100)$"
+              },
+              "rpp": {
+                "type": "integer",
+                "description": "rpp stands for results per page and specifies the page size. You can specify a number greater than 0 and up to 100.",
+                "pattern": "^(?:[1-9][0-9]{0,2}?|100)$"
+              },
+              "cursor": {
+                "type": "string",
+                "description": "The cursor parameter supports pagination and data navigation between pages. Provide the cursor value from the previous page in the next request to load the next page of data.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used."
+              },
+              "withCount": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the count field in the response. The count field indicates the total number of requested data items. When set to true, the count field is included and response speed may be slower.",
+                "default": false
+              }
+            }
+          }
+        ],
+        "example": {
+          "fromDate": "2026-01-01T00:00:00Z",
+          "toDate": "2026-02-01T00:00:00Z",
+          "page": 1,
+          "rpp": 10
+        }
+      },
+      "getEnsRecordsByAccount__evm__Req": {
+        "allOf": [
+          {
+            "oneOf": [
+              {
+                "title": "owner Address",
+                "required": [
+                  "ownerAddress"
+                ],
+                "type": "object",
+                "properties": {
+                  "ownerAddress": {
+                    "type": "string",
+                    "description": "Enter the ENS domain owner address. A 40-character hexadecimal string starting with 0x. Either ownerAddress or resolvedAddress must be specified.",
+                    "pattern": "^0x[0-9a-fA-F]{40}$",
+                    "example": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+                  }
+                }
+              },
+              {
+                "title": "resolved Address",
+                "required": [
+                  "resolvedAddress"
+                ],
+                "type": "object",
+                "properties": {
+                  "resolvedAddress": {
+                    "type": "string",
+                    "description": "Enter the address that the ENS domain points to. A 40-character hexadecimal string starting with 0x. Either ownerAddress or resolvedAddress must be specified.",
+                    "pattern": "^0x[0-9a-fA-F]{40}$",
+                    "example": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "integer",
+                "description": "The page parameter specifies the data page to query. It accepts values up to 100; for pages exceeding 100, use the cursor pagination method.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used.",
+                "pattern": "^(?:[1-9][0-9]?|100)$"
+              },
+              "rpp": {
+                "type": "integer",
+                "description": "rpp stands for results per page and specifies the page size. You can specify a number greater than 0 and up to 100.",
+                "pattern": "^(?:[1-9][0-9]{0,2}?|100)$"
+              },
+              "cursor": {
+                "type": "string",
+                "description": "The cursor parameter supports pagination and data navigation between pages. Provide the cursor value from the previous page in the next request to load the next page of data.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used."
+              },
+              "withCount": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the count field in the response. The count field indicates the total number of requested data items. When set to true, the count field is included and response speed may be slower.",
+                "default": false
+              }
+            }
+          }
+        ],
+        "example": {
+          "ownerAddress": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
+          "page": 1,
+          "rpp": 10
+        }
+      },
+      "ensName__evm__Req": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Enter the ENS domain name.",
+            "default": "vitalik.eth"
+          }
+        },
+        "example": {
+          "name": "vitalik.eth"
+        },
+        "required": [
+          "name"
+        ]
+      },
+      "getEnsRecordByName__evm__Res": {
+        "type": "object",
+        "required": [
+          "name",
+          "isMigrated",
+          "isPrimaryName",
+          "node",
+          "labelName",
+          "labelHash",
+          "ownerAddress",
+          "resolver",
+          "registration",
+          "nameWrapper"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "A field representing the name of the ENS domain."
+          },
+          "isMigrated": {
+            "type": "boolean",
+            "description": "A field indicating whether the ENS domain has been migrated to the latest version. If true, the domain has been migrated to the latest version; if false, the domain has not been migrated. Migration status is important for domain management and compatibility."
+          },
+          "isPrimaryName": {
+            "type": "boolean",
+            "description": "A field indicating whether the ENS domain is the Primary Name. In the ENS structure, multiple domains can be linked to a single address, and the primary domain is called the Primary Name. If true, the domain is registered as Primary Name; if false, it indicates a non-Primary domain."
+          },
+          "node": {
+            "type": "string",
+            "description": "A field representing the unique identifier of the ENS domain, which is a hash value generated by the namehash algorithm. For example, if the domain name is example.nodit.eth, the node value is generated as namehash('example.nodit.eth'). Provided as a 64-character hexadecimal string prefixed with 0x."
+          },
+          "labelName": {
+            "type": "string",
+            "description": "A field representing the lowest-level label of the domain name. For example, for example.nodit.eth, labelName is 'example'."
+          },
+          "labelHash": {
+            "type": "string",
+            "description": "A field representing the hash value of the lowest-level label of the domain name. For example, for example.nodit.eth, labelHash is generated as keccak256('example'). Provided as a 64-character hexadecimal string prefixed with 0x. <br/> <strong style='color: red;'>*</strong> For wrapped domains, the address shown in ownerAddress may be the wrapping contract address. Please refer to the wrappedOwnerAddress field to verify the actual owner address."
+          },
+          "ownerAddress": {
+            "type": "string",
+            "description": "A field representing the owner address of the ENS domain. Provided as a 40-character hexadecimal string prefixed with 0x. <br/> <strong style='color: red;'>*</strong> The owner address indicates the owner of the domain and may differ from the address the domain is linked to. For asset transfers, please refer to resolvedAddress in the resolver field."
+          },
+          "resolver": {
+            "type": "object",
+            "description": "A field representing the Resolver information of the domain."
+          },
+          "registration": {
+            "type": "object",
+            "description": "A field representing the registration information of the domain."
+          },
+          "nameWrapper": {
+            "type": "object",
+            "description": "A field representing the wrapped domain information. For wrapped domains, the ownerAddress field displays the wrapping contract address. Please refer to the wrappedOwnerAddress field to verify the actual owner address."
+          }
+        }
+      },
+      "getEnsNameByAddress__evm__Req": {
+        "type": "object",
+        "required": [
+          "address"
+        ],
+        "properties": {
+          "address": {
+            "type": "string",
+            "description": "Parameter specifying the account address to query. Can be entered as a 40-character hexadecimal string starting with 0x.",
+            "pattern": "^0[xX][0-9a-fA-F]{40}$",
+            "example": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+          }
+        },
+        "example": {
+          "address": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+        }
+      },
+      "getEnsNameByAddress__evm__Res": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The ENS domain name mapped to the address. Returns null if no ENS domain is mapped to the address. If domain renewal or new registration does not occur after the expiry date, the previous domain name is displayed."
+          },
+          "expiryDate": {
+            "type": "string",
+            "description": "Indicates the expiry date of the ENS domain. If domain renewal or new registration does not occur after the expiry date, the previous expiry date is returned."
+          }
+        }
+      },
+      "getAddressByEnsName__evm__Res": {
+        "type": "object",
+        "properties": {
+          "address": {
+            "type": "string",
+            "description": "The address that the ENS domain points to. Returns null if the domain does not exist. If domain renewal or new registration does not occur after the expiry date, the address previously pointed to by the domain is returned.",
+            "default": null
+          },
+          "expiryDate": {
+            "type": "string",
+            "description": "Indicates the expiry date of the ENS domain. If domain renewal or new registration does not occur after the expiry date, the previous expiry date is returned."
+          }
+        }
+      },
+      "getAssetTransfersById__tron__Req": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "assetId"
+            ],
+            "properties": {
+              "assetId": {
+                "type": "integer",
+                "description": "Enter the Asset ID to query. Asset ID must be an integer greater than 0.",
+                "example": 1004777
+              },
+              "fromBlock": {
+                "type": "string",
+                "description": "Parameter specifying the starting point for the query. You can enter block number, block hash, or block tag. Default is 0.\n- block number: Enter as a decimal string.\n- block hash: Enter as a 64-character hexadecimal string, excluding the 0x prefix.\n- block tag: You can enter \"earliest\" for fromBlock.\n\nNotes:\n- If only fromBlock is provided without toBlock, results are queried from fromBlock to the most recent block.\n- fromBlock's block number must be less than or equal to toBlock's block number.\n- If toBlock and fromBlock have the same value, only that single block's results are queried.\n- \"latest\" cannot be entered for fromBlock.\n",
+                "pattern": "^[0-9]+$|^[0-9a-fA-F]{64}|latest|earliest",
+                "default": "earliest",
+                "example": "80453005"
+              },
+              "toBlock": {
+                "type": "string",
+                "description": "Parameter specifying the ending point for the query. You can enter block number, block hash, or block tag. Default is \"latest\".\n- block number: Enter as a decimal string.\n- block hash: Enter as a 64-character hexadecimal string, excluding the 0x prefix.\n- block tag: You can enter \"latest\".\n\nNotes:\n- The blockNumber for toBlock must be greater than or equal to the blockNumber for fromBlock.\n- If toBlock and fromBlock have the same value, only that single block's results are queried.\n- If only toBlock is provided without fromBlock, results are queried from genesis block to the time specified in toBlock.\n- \"earliest\" cannot be entered for toBlock.",
+                "pattern": "^[0-9]+$|^[0-9a-fA-F]{64}|latest|earliest",
+                "default": "latest",
+                "example": "80453006"
+              },
+              "fromDate": {
+                "type": "string",
+                "description": "Parameter specifying the start date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without toDate, results are queried from this date to the latest block.\n- fromDate value must be equal to or earlier than toDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-01T00:00:00+00:00"
+              },
+              "toDate": {
+                "type": "string",
+                "description": "Parameter specifying the end date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without fromDate, results are queried from genesis block to this date.\n- toDate value must be equal to or later than fromDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-31T00:00:00+00:00"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "integer",
+                "description": "The page parameter specifies the data page to query. It accepts values up to 100; for pages exceeding 100, use the cursor pagination method.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used.",
+                "pattern": "^(?:[1-9][0-9]?|100)$"
+              },
+              "rpp": {
+                "type": "integer",
+                "description": "rpp stands for results per page and specifies the page size. You can specify a number greater than 0 and up to 100.",
+                "pattern": "^(?:[1-9][0-9]{0,2}?|100)$"
+              },
+              "cursor": {
+                "type": "string",
+                "description": "The cursor parameter supports pagination and data navigation between pages. Provide the cursor value from the previous page in the next request to load the next page of data.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used."
+              },
+              "withCount": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the count field in the response. The count field indicates the total number of requested data items. When set to true, the count field is included and response speed may be slower.",
+                "default": false
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "withZeroValue": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include results with value 0 in the response. Set to true for faster responses.",
+                "default": false
+              }
+            }
+          }
+        ],
+        "example": {
+          "assetId": 1002357,
+          "page": 1,
+          "rpp": 10,
+          "withCount": false,
+          "fromDate": "2026-01-01T00:00:00Z",
+          "toDate": "2026-02-01T00:00:00Z"
+        }
+      },
+      "getAssetMetadataByIssuer__tron__Req": {
+        "type": "object",
+        "required": [
+          "issuer"
+        ],
+        "properties": {
+          "issuer": {
+            "type": "string",
+            "description": "Parameter specifying the issuer address to query. This field uses a 34-character base58 string format starting with \"T\".",
+            "pattern": "^T[1-9A-HJ-NP-Za-km-z]{33}$",
+            "example": "TTzC9cm1vbsyBzhC8n4z3k6eAVkryDyKU8"
+          }
+        },
+        "example": {
+          "issuer": "TTzC9cm1vbsyBzhC8n4z3k6eAVkryDyKU8"
+        }
+      },
+      "getAssetMetadataByIssuer__tron__Res": {
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "symbol",
+          "totalSupply",
+          "decimals",
+          "startTime",
+          "endTime",
+          "description",
+          "url",
+          "blockNumber",
+          "blockTimestamp",
+          "transactionHash",
+          "deployer",
+          "trxNum",
+          "num"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "Represents the unique ID of the TRC10 token. This ID is used to identify a specific TRC10 asset issued on the TRON network."
+          },
+          "name": {
+            "type": "string",
+            "description": "Represents the name of the contract. Returns an empty string if the contract does not follow the standard or if the name (\"name\") was not provided during contract creation."
+          },
+          "symbol": {
+            "type": "string",
+            "description": "Represents the symbol of the contract. Returns an empty string if the contract does not follow the standard or if the symbol (\"symbol\") was not provided during contract creation."
+          },
+          "totalSupply": {
+            "type": "string",
+            "description": "Represents the total supply of the contract. This value is the total token issuance and is displayed as a decimal string."
+          },
+          "decimals": {
+            "type": "integer",
+            "description": "Represents the number of decimal places for the token. Before the TIP10 standard was introduced, the \"precision\" value was set to 0."
+          },
+          "startTime": {
+            "type": "integer",
+            "description": "Represents the ICO (Initial Coin Offering) start time. This value is recorded as a UNIX timestamp in milliseconds."
+          },
+          "endTime": {
+            "type": "integer",
+            "description": "Represents the ICO end time. This value is also recorded as a UNIX timestamp in milliseconds."
+          },
+          "description": {
+            "type": "string",
+            "description": "Represents the description of the TRC10 token. This value is set by the issuer and may be subject to change."
+          },
+          "url": {
+            "type": "string",
+            "description": "Represents the URL for the TRC10 token. This value is also set by the issuer and may be subject to change."
+          },
+          "blockNumber": {
+            "type": "integer",
+            "description": "Represents the block number in which the TRC10 token was created. This is the block number containing the token creation transaction, used to trace the transaction on the blockchain."
+          },
+          "blockTimestamp": {
+            "type": "integer",
+            "description": "Represents when the TRC10 token was created. Recorded as a UNIX timestamp in milliseconds, used to determine when the asset was created."
+          },
+          "transactionHash": {
+            "type": "string",
+            "description": "Represents the hash of the transaction that issued the TRC10 token. Used to identify and query information about the specific TRC10 issuance transaction."
+          },
+          "deployer": {
+            "type": "string",
+            "description": "Represents the account or address that issued the TRC10 token. Identifies the issuer's owning account and serves as the basis for all related asset management and information queries."
+          },
+          "trxNum": {
+            "type": "integer",
+            "description": "Represents the quantity of TRX used to determine the value of the TRC10 asset. This value is calculated as the \"trx_num/num\" ratio, with the unit in sun."
+          },
+          "num": {
+            "type": "integer",
+            "description": "Represents the quantity of TRC10 used to determine the value of the TRC10 asset. The TRC10 asset value is calculated as the \"trx_num/num\" ratio."
+          }
+        }
+      },
+      "getAssetMetadataByIds__tron__Req": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "assetIds"
+            ],
+            "properties": {
+              "assetIds": {
+                "type": "array",
+                "description": "Enter the list of Asset IDs to query. Each Asset ID must be an integer greater than 0.",
+                "items": {
+                  "type": "integer"
+                },
+                "example": [
+                  1002000,
+                  1002357,
+                  1004777
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "integer",
+                "description": "The page parameter specifies the data page to query. It accepts values up to 100; for pages exceeding 100, use the cursor pagination method.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used.",
+                "pattern": "^(?:[1-9][0-9]?|100)$"
+              },
+              "rpp": {
+                "type": "integer",
+                "description": "rpp stands for results per page and specifies the page size. You can specify a number greater than 0 and up to 100.",
+                "pattern": "^(?:[1-9][0-9]{0,2}?|100)$"
+              },
+              "cursor": {
+                "type": "string",
+                "description": "The cursor parameter supports pagination and data navigation between pages. Provide the cursor value from the previous page in the next request to load the next page of data.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used."
+              },
+              "withCount": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the count field in the response. The count field indicates the total number of requested data items. When set to true, the count field is included and response speed may be slower.",
+                "default": false
+              }
+            }
+          }
+        ],
+        "example": {
+          "assetIds": [
+            1002357,
+            1004777
+          ],
+          "page": 1,
+          "rpp": 10,
+          "withCount": false
+        }
+      },
+      "getAssetMetadataByIds__tron__Res": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "required": [
+            "id",
+            "name",
+            "symbol",
+            "totalSupply",
+            "decimals",
+            "startTime",
+            "endTime",
+            "description",
+            "url",
+            "blockNumber",
+            "blockTimestamp",
+            "transactionHash",
+            "deployer",
+            "trxNum",
+            "num"
+          ],
+          "properties": {
+            "id": {
+              "type": "integer",
+              "description": "Represents the unique ID of the TRC10 token. This ID is used to identify a specific TRC10 asset issued on the TRON network."
+            },
+            "name": {
+              "type": "string",
+              "description": "Represents the name of the contract. Returns an empty string if the contract does not follow the standard or if the name (\"name\") was not provided during contract creation."
+            },
+            "symbol": {
+              "type": "string",
+              "description": "Represents the symbol of the contract. Returns an empty string if the contract does not follow the standard or if the symbol (\"symbol\") was not provided during contract creation."
+            },
+            "totalSupply": {
+              "type": "string",
+              "description": "Represents the total supply of the contract. This value is the total token issuance and is displayed as a decimal string."
+            },
+            "decimals": {
+              "type": "integer",
+              "description": "Represents the number of decimal places for the token. Before the TIP10 standard was introduced, the \"precision\" value was set to 0."
+            },
+            "startTime": {
+              "type": "integer",
+              "description": "Represents the ICO (Initial Coin Offering) start time. This value is recorded as a UNIX timestamp in milliseconds."
+            },
+            "endTime": {
+              "type": "integer",
+              "description": "Represents the ICO end time. This value is also recorded as a UNIX timestamp in milliseconds."
+            },
+            "description": {
+              "type": "string",
+              "description": "Represents the description of the TRC10 token. This value is set by the issuer and may be subject to change."
+            },
+            "url": {
+              "type": "string",
+              "description": "Represents the URL for the TRC10 token. This value is also set by the issuer and may be subject to change."
+            },
+            "blockNumber": {
+              "type": "integer",
+              "description": "Represents the block number in which the TRC10 token was created. This is the block number containing the token creation transaction, used to trace the transaction on the blockchain."
+            },
+            "blockTimestamp": {
+              "type": "integer",
+              "description": "Represents when the TRC10 token was created. Recorded as a UNIX timestamp in milliseconds, used to determine when the asset was created."
+            },
+            "transactionHash": {
+              "type": "string",
+              "description": "Represents the hash of the transaction that issued the TRC10 token. Used to identify and query information about the specific TRC10 issuance transaction."
+            },
+            "deployer": {
+              "type": "string",
+              "description": "Represents the account or address that issued the TRC10 token. Identifies the issuer's owning account and serves as the basis for all related asset management and information queries."
+            },
+            "trxNum": {
+              "type": "integer",
+              "description": "Represents the quantity of TRX used to determine the value of the TRC10 asset. This value is calculated as the \"trx_num/num\" ratio, with the unit in sun."
+            },
+            "num": {
+              "type": "integer",
+              "description": "Represents the quantity of TRC10 used to determine the value of the TRC10 asset. The TRC10 asset value is calculated as the \"trx_num/num\" ratio."
+            }
+          }
+        }
+      },
+      "getAssetTransfersWithinRange__tron__Req": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "fromBlock": {
+                "type": "string",
+                "description": "Parameter specifying the starting point for the query. You can enter block number, block hash, or block tag. Default is 0.\n- block number: Enter as a decimal string.\n- block hash: Enter as a 64-character hexadecimal string, excluding the 0x prefix.\n- block tag: You can enter \"earliest\" for fromBlock.\n\nNotes:\n- If only fromBlock is provided without toBlock, results are queried from fromBlock to the most recent block.\n- fromBlock's block number must be less than or equal to toBlock's block number.\n- If toBlock and fromBlock have the same value, only that single block's results are queried.\n- \"latest\" cannot be entered for fromBlock.\n",
+                "pattern": "^[0-9]+$|^[0-9a-fA-F]{64}|latest|earliest",
+                "default": "earliest",
+                "example": "80453005"
+              },
+              "toBlock": {
+                "type": "string",
+                "description": "Parameter specifying the ending point for the query. You can enter block number, block hash, or block tag. Default is \"latest\".\n- block number: Enter as a decimal string.\n- block hash: Enter as a 64-character hexadecimal string, excluding the 0x prefix.\n- block tag: You can enter \"latest\".\n\nNotes:\n- The blockNumber for toBlock must be greater than or equal to the blockNumber for fromBlock.\n- If toBlock and fromBlock have the same value, only that single block's results are queried.\n- If only toBlock is provided without fromBlock, results are queried from genesis block to the time specified in toBlock.\n- \"earliest\" cannot be entered for toBlock.",
+                "pattern": "^[0-9]+$|^[0-9a-fA-F]{64}|latest|earliest",
+                "default": "latest",
+                "example": "80453006"
+              },
+              "fromDate": {
+                "type": "string",
+                "description": "Parameter specifying the start date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without toDate, results are queried from this date to the latest block.\n- fromDate value must be equal to or earlier than toDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-01T00:00:00+00:00"
+              },
+              "toDate": {
+                "type": "string",
+                "description": "Parameter specifying the end date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without fromDate, results are queried from genesis block to this date.\n- toDate value must be equal to or later than fromDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-31T00:00:00+00:00"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "integer",
+                "description": "The page parameter specifies the data page to query. It accepts values up to 100; for pages exceeding 100, use the cursor pagination method.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used.",
+                "pattern": "^(?:[1-9][0-9]?|100)$"
+              },
+              "rpp": {
+                "type": "integer",
+                "description": "rpp stands for results per page and specifies the page size. You can specify a number greater than 0 and up to 100.",
+                "pattern": "^(?:[1-9][0-9]{0,2}?|100)$"
+              },
+              "cursor": {
+                "type": "string",
+                "description": "The cursor parameter supports pagination and data navigation between pages. Provide the cursor value from the previous page in the next request to load the next page of data.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used."
+              },
+              "withCount": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the count field in the response. The count field indicates the total number of requested data items. When set to true, the count field is included and response speed may be slower.",
+                "default": false
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "withZeroValue": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include results with value 0 in the response. Set to true for faster responses.",
+                "default": false
+              }
+            }
+          }
+        ],
+        "example": {
+          "page": 1,
+          "rpp": 10,
+          "withCount": false,
+          "withZeroValue": false,
+          "fromDate": "2026-01-01T00:00:00Z",
+          "toDate": "2026-02-01T00:00:00Z"
+        }
+      },
+      "searchAssetMetadataByKeyword__tron__Req": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "keyword"
+            ],
+            "properties": {
+              "keyword": {
+                "type": "string",
+                "description": "Parameter specifying the name or symbol of the token to query.",
+                "example": "USDT"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "integer",
+                "description": "The page parameter specifies the data page to query. It accepts values up to 100; for pages exceeding 100, use the cursor pagination method.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used.",
+                "pattern": "^(?:[1-9][0-9]?|100)$"
+              },
+              "rpp": {
+                "type": "integer",
+                "description": "rpp stands for results per page and specifies the page size. You can specify a number greater than 0 and up to 100.",
+                "pattern": "^(?:[1-9][0-9]{0,2}?|100)$"
+              },
+              "cursor": {
+                "type": "string",
+                "description": "The cursor parameter supports pagination and data navigation between pages. Provide the cursor value from the previous page in the next request to load the next page of data.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used."
+              },
+              "withCount": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the count field in the response. The count field indicates the total number of requested data items. When set to true, the count field is included and response speed may be slower.",
+                "default": false
+              }
+            }
+          }
+        ],
+        "example": {
+          "keyword": "USDT",
+          "page": 1,
+          "rpp": 10,
+          "withCount": false
+        }
+      },
+      "getAssetTransfersByAccount__tron__Req": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "accountAddress"
+            ],
+            "properties": {
+              "accountAddress": {
+                "type": "string",
+                "description": "Parameter specifying the account address to query. This field uses a 34-character base58 string format starting with \"T\".",
+                "pattern": "^T[1-9A-HJ-NP-Za-km-z]{33}$",
+                "example": "TPswDDCAWhJAZGdHPidFg5nEf8TkNToDX1"
+              },
+              "assetIds": {
+                "type": "array",
+                "description": "Enter the list of Asset IDs to query. Each Asset ID must be an integer greater than 0.",
+                "items": {
+                  "type": "integer"
+                },
+                "example": [
+                  1002000,
+                  1002357,
+                  1004777
+                ]
+              },
+              "fromBlock": {
+                "type": "string",
+                "description": "Parameter specifying the starting point for the query. You can enter block number, block hash, or block tag. Default is 0.\n- block number: Enter as a decimal string.\n- block hash: Enter as a 64-character hexadecimal string, excluding the 0x prefix.\n- block tag: You can enter \"earliest\" for fromBlock.\n\nNotes:\n- If only fromBlock is provided without toBlock, results are queried from fromBlock to the most recent block.\n- fromBlock's block number must be less than or equal to toBlock's block number.\n- If toBlock and fromBlock have the same value, only that single block's results are queried.\n- \"latest\" cannot be entered for fromBlock.\n",
+                "pattern": "^[0-9]+$|^[0-9a-fA-F]{64}|latest|earliest",
+                "default": "earliest",
+                "example": "80453005"
+              },
+              "toBlock": {
+                "type": "string",
+                "description": "Parameter specifying the ending point for the query. You can enter block number, block hash, or block tag. Default is \"latest\".\n- block number: Enter as a decimal string.\n- block hash: Enter as a 64-character hexadecimal string, excluding the 0x prefix.\n- block tag: You can enter \"latest\".\n\nNotes:\n- The blockNumber for toBlock must be greater than or equal to the blockNumber for fromBlock.\n- If toBlock and fromBlock have the same value, only that single block's results are queried.\n- If only toBlock is provided without fromBlock, results are queried from genesis block to the time specified in toBlock.\n- \"earliest\" cannot be entered for toBlock.",
+                "pattern": "^[0-9]+$|^[0-9a-fA-F]{64}|latest|earliest",
+                "default": "latest",
+                "example": "80453006"
+              },
+              "fromDate": {
+                "type": "string",
+                "description": "Parameter specifying the start date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without toDate, results are queried from this date to the latest block.\n- fromDate value must be equal to or earlier than toDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-01T00:00:00+00:00"
+              },
+              "toDate": {
+                "type": "string",
+                "description": "Parameter specifying the end date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without fromDate, results are queried from genesis block to this date.\n- toDate value must be equal to or later than fromDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-31T00:00:00+00:00"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "integer",
+                "description": "The page parameter specifies the data page to query. It accepts values up to 100; for pages exceeding 100, use the cursor pagination method.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used.",
+                "pattern": "^(?:[1-9][0-9]?|100)$"
+              },
+              "rpp": {
+                "type": "integer",
+                "description": "rpp stands for results per page and specifies the page size. You can specify a number greater than 0 and up to 100.",
+                "pattern": "^(?:[1-9][0-9]{0,2}?|100)$"
+              },
+              "cursor": {
+                "type": "string",
+                "description": "The cursor parameter supports pagination and data navigation between pages. Provide the cursor value from the previous page in the next request to load the next page of data.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used."
+              },
+              "withCount": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the count field in the response. The count field indicates the total number of requested data items. When set to true, the count field is included and response speed may be slower.",
+                "default": false
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "withZeroValue": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include results with value 0 in the response. Set to true for faster responses.",
+                "default": false
+              }
+            }
+          }
+        ],
+        "example": {
+          "accountAddress": "TGEj7Eawpj8xnPm82FVHeWYvBRKQzdBoVQ",
+          "assetIds": [
+            1002357,
+            1004777
+          ],
+          "page": 1,
+          "rpp": 10,
+          "withCount": false
+        }
+      },
+      "getAssetHoldersById__tron__Req": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "assetId"
+            ],
+            "properties": {
+              "assetId": {
+                "type": "integer",
+                "description": "Enter the Asset ID to query. Asset ID must be an integer greater than 0.",
+                "example": 1004777
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "integer",
+                "description": "The page parameter specifies the data page to query. It accepts values up to 100; for pages exceeding 100, use the cursor pagination method.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used.",
+                "pattern": "^(?:[1-9][0-9]?|100)$"
+              },
+              "rpp": {
+                "type": "integer",
+                "description": "rpp stands for results per page and specifies the page size. You can specify a number greater than 0 and up to 100.",
+                "pattern": "^(?:[1-9][0-9]{0,2}?|100)$"
+              },
+              "cursor": {
+                "type": "string",
+                "description": "The cursor parameter supports pagination and data navigation between pages. Provide the cursor value from the previous page in the next request to load the next page of data.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used."
+              },
+              "withCount": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the count field in the response. The count field indicates the total number of requested data items. When set to true, the count field is included and response speed may be slower.",
+                "default": false
+              }
+            }
+          }
+        ],
+        "example": {
+          "assetId": 1002357,
+          "page": 1,
+          "rpp": 10,
+          "withCount": false
+        }
+      },
+      "getAssetsOwnedByAccount__tron__Req": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "accountAddress"
+            ],
+            "properties": {
+              "accountAddress": {
+                "type": "string",
+                "description": "Parameter specifying the account address to query. This field uses a 34-character base58 string format starting with \"T\".",
+                "pattern": "^T[1-9A-HJ-NP-Za-km-z]{33}$",
+                "example": "TPswDDCAWhJAZGdHPidFg5nEf8TkNToDX1"
+              },
+              "assetIds": {
+                "type": "array",
+                "description": "Enter the list of Asset IDs to query. Each Asset ID must be an integer greater than 0.",
+                "items": {
+                  "type": "integer"
+                },
+                "example": [
+                  1002000,
+                  1002357,
+                  1004777
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "integer",
+                "description": "The page parameter specifies the data page to query. It accepts values up to 100; for pages exceeding 100, use the cursor pagination method.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used.",
+                "pattern": "^(?:[1-9][0-9]?|100)$"
+              },
+              "rpp": {
+                "type": "integer",
+                "description": "rpp stands for results per page and specifies the page size. You can specify a number greater than 0 and up to 100.",
+                "pattern": "^(?:[1-9][0-9]{0,2}?|100)$"
+              },
+              "cursor": {
+                "type": "string",
+                "description": "The cursor parameter supports pagination and data navigation between pages. Provide the cursor value from the previous page in the next request to load the next page of data.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used."
+              },
+              "withCount": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the count field in the response. The count field indicates the total number of requested data items. When set to true, the count field is included and response speed may be slower.",
+                "default": false
+              }
+            }
+          }
+        ],
+        "example": {
+          "accountAddress": "TGEj7Eawpj8xnPm82FVHeWYvBRKQzdBoVQ",
+          "assetIds": [
+            1002357,
+            1004777
+          ],
+          "page": 1,
+          "rpp": 10,
+          "withCount": false
+        }
+      },
+      "getNativeTransfersByAccount__evm__Req": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "accountAddress": {
+                "type": "string",
+                "description": "Parameter specifying the account address to query. Can be entered as a 40-character hexadecimal string starting with 0x.",
+                "pattern": "^0[xX][0-9a-fA-F]{40}$",
+                "example": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+              },
+              "relation": {
+                "type": "string",
+                "description": "Parameter for filtering transactions where the queried account address is the sender or recipient.\n- from: Filter by sender only.\n- to: Filter by recipient only.\n- both (default): Returns all transactions where the queried address appears in from or to.",
+                "enum": [
+                  "from",
+                  "to",
+                  "both"
+                ],
+                "pattern": "from|to|both",
+                "default": "both"
+              },
+              "fromBlock": {
+                "type": "string",
+                "description": "Parameter specifying the starting block for the query. You can enter one of the following formats:\n- block number: Enter block number as a decimal string.\n- block hash: 64-character hexadecimal (including \"0x\").\n- block tag: Use \"earliest\" or \"latest\" to specify the first block or the most recent block.\n\nNotes:\n- This field cannot be used together with `fromDate` and `toDate`.\n- If provided without fromBlock, results are queried from genesis block to this block.\n- toBlock value cannot be less than fromBlock value.\n- If fromBlock and toBlock have the same value, only that block is queried.\n- \"earliest\" for toBlock is only allowed when fromBlock is \"earliest\".\n- If `fromBlock` and `toBlock` are not provided, the API queries data from the latest 30 days.\n",
+                "pattern": "^[0-9]+$|^0[xX][0-9a-fA-F]{64}|latest|earliest"
+              },
+              "toBlock": {
+                "type": "string",
+                "description": "Parameter specifying the ending block for the query. You can enter one of the following formats:\n- block number: Enter block number as a decimal string.\n- block hash: 64-character hexadecimal (including \"0x\").\n- block tag: Use \"earliest\" or \"latest\" to specify the first block or the most recent block.\n\nNotes:\n- This field cannot be used together with `fromDate` and `toDate`.\n- If provided without fromBlock, results are queried from genesis block to this block.\n- toBlock value cannot be less than fromBlock value.\n- If fromBlock and toBlock have the same value, only that block is queried.\n- \"earliest\" for toBlock is only allowed when fromBlock is \"earliest\".\n- If `fromBlock` and `toBlock` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]+$|^0[xX][0-9a-fA-F]{64}|latest|earliest"
+              },
+              "fromDate": {
+                "type": "string",
+                "description": "Parameter specifying the start date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without toDate, results are queried from this date to the latest block.\n- fromDate value must be equal to or earlier than toDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-01T00:00:00+00:00"
+              },
+              "toDate": {
+                "type": "string",
+                "description": "Parameter specifying the end date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without fromDate, results are queried from genesis block to this date.\n- toDate value must be equal to or later than fromDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-31T00:00:00+00:00"
+              }
+            },
+            "required": [
+              "accountAddress"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "integer",
+                "description": "The page parameter specifies the data page to query. It accepts values up to 100; for pages exceeding 100, use the cursor pagination method.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used.",
+                "pattern": "^(?:[1-9][0-9]?|100)$"
+              },
+              "rpp": {
+                "type": "integer",
+                "description": "rpp stands for results per page and specifies the page size. You can specify a number greater than 0 and up to 100.",
+                "pattern": "^(?:[1-9][0-9]{0,2}?|100)$"
+              },
+              "cursor": {
+                "type": "string",
+                "description": "The cursor parameter supports pagination and data navigation between pages. Provide the cursor value from the previous page in the next request to load the next page of data.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used."
+              },
+              "withCount": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the count field in the response. The count field indicates the total number of requested data items. When set to true, the count field is included and response speed may be slower.",
+                "default": false
+              }
+            }
+          }
+        ],
+        "example": {
+          "accountAddress": "0x742d35Cc6634C0532925a3b844Bc454e4438f44e",
+          "fromDate": "2026-01-01T00:00:00Z",
+          "toDate": "2026-02-01T00:00:00Z",
+          "page": 1,
+          "rpp": 10
+        }
+      },
+      "getNativeTransfersByAccount__tron__Req": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "accountAddress": {
+                "type": "string",
+                "description": "Parameter specifying the account address to query. This field uses a 34-character base58 string format starting with \"T\".",
+                "pattern": "^T[1-9A-HJ-NP-Za-km-z]{33}$",
+                "example": "TPswDDCAWhJAZGdHPidFg5nEf8TkNToDX1"
+              },
+              "relation": {
+                "type": "string",
+                "description": "Parameter for filtering transactions where the queried account address is the sender or recipient.\n- from: Filter by sender only.\n- to: Filter by recipient only.\n- both (default): Returns all transactions where the queried address appears in from or to.",
+                "enum": [
+                  "from",
+                  "to",
+                  "both"
+                ],
+                "pattern": "from|to|both",
+                "default": "both"
+              },
+              "fromBlock": {
+                "type": "string",
+                "description": "Parameter specifying the starting point for the query. You can enter block number, block hash, or block tag. Default is 0.\n- block number: Enter as a decimal string.\n- block hash: Enter as a 64-character hexadecimal string, excluding the 0x prefix.\n- block tag: You can enter \"earliest\" for fromBlock.\n\nNotes:\n- If only fromBlock is provided without toBlock, results are queried from fromBlock to the most recent block.\n- fromBlock's block number must be less than or equal to toBlock's block number.\n- If toBlock and fromBlock have the same value, only that single block's results are queried.\n- \"latest\" cannot be entered for fromBlock.\n",
+                "pattern": "^[0-9]+$|^[0-9a-fA-F]{64}|latest|earliest",
+                "default": "earliest",
+                "example": "80453005"
+              },
+              "toBlock": {
+                "type": "string",
+                "description": "Parameter specifying the ending point for the query. You can enter block number, block hash, or block tag. Default is \"latest\".\n- block number: Enter as a decimal string.\n- block hash: Enter as a 64-character hexadecimal string, excluding the 0x prefix.\n- block tag: You can enter \"latest\".\n\nNotes:\n- The blockNumber for toBlock must be greater than or equal to the blockNumber for fromBlock.\n- If toBlock and fromBlock have the same value, only that single block's results are queried.\n- If only toBlock is provided without fromBlock, results are queried from genesis block to the time specified in toBlock.\n- \"earliest\" cannot be entered for toBlock.",
+                "pattern": "^[0-9]+$|^[0-9a-fA-F]{64}|latest|earliest",
+                "default": "latest",
+                "example": "80453006"
+              },
+              "fromDate": {
+                "type": "string",
+                "description": "Parameter specifying the start date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without toDate, results are queried from this date to the latest block.\n- fromDate value must be equal to or earlier than toDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-01T00:00:00+00:00"
+              },
+              "toDate": {
+                "type": "string",
+                "description": "Parameter specifying the end date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without fromDate, results are queried from genesis block to this date.\n- toDate value must be equal to or later than fromDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-31T00:00:00+00:00"
+              }
+            },
+            "required": [
+              "accountAddress"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "integer",
+                "description": "The page parameter specifies the data page to query. It accepts values up to 100; for pages exceeding 100, use the cursor pagination method.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used.",
+                "pattern": "^(?:[1-9][0-9]?|100)$"
+              },
+              "rpp": {
+                "type": "integer",
+                "description": "rpp stands for results per page and specifies the page size. You can specify a number greater than 0 and up to 100.",
+                "pattern": "^(?:[1-9][0-9]{0,2}?|100)$"
+              },
+              "cursor": {
+                "type": "string",
+                "description": "The cursor parameter supports pagination and data navigation between pages. Provide the cursor value from the previous page in the next request to load the next page of data.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used."
+              },
+              "withCount": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the count field in the response. The count field indicates the total number of requested data items. When set to true, the count field is included and response speed may be slower.",
+                "default": false
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "withZeroValue": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include results with value 0 in the response. Set to true for faster responses.",
+                "default": false
+              }
+            }
+          }
+        ],
+        "example": {
+          "accountAddress": "TPswDDCAWhJAZGdHPidFg5nEf8TkNToDX1",
+          "fromDate": "2026-01-01T00:00:00Z",
+          "toDate": "2026-02-01T00:00:00Z",
+          "page": 1,
+          "rpp": 10
+        }
+      },
+      "getNativeBalanceByAccount__evm__Req": {
+        "type": "object",
+        "required": [
+          "accountAddress"
+        ],
+        "properties": {
+          "accountAddress": {
+            "type": "string",
+            "description": "Parameter specifying the account address to query. Can be entered as a 40-character hexadecimal string starting with 0x.",
+            "pattern": "^0[xX][0-9a-fA-F]{40}$",
+            "example": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+          }
+        },
+        "example": {
+          "accountAddress": "0x742d35Cc6634C0532925a3b844Bc454e4438f44e"
+        }
+      },
+      "getNativeBalanceByAccount__tron__Req": {
+        "type": "object",
+        "required": [
+          "accountAddress"
+        ],
+        "properties": {
+          "accountAddress": {
+            "type": "string",
+            "description": "Parameter specifying the account address to query. This field uses a 34-character base58 string format starting with \"T\".",
+            "pattern": "^T[1-9A-HJ-NP-Za-km-z]{33}$",
+            "example": "TPswDDCAWhJAZGdHPidFg5nEf8TkNToDX1"
+          }
+        },
+        "example": {
+          "accountAddress": "TPswDDCAWhJAZGdHPidFg5nEf8TkNToDX1"
+        }
+      },
+      "nativeBalance__common__Res": {
+        "type": "object",
+        "required": [
+          "ownerAddress",
+          "balance"
+        ],
+        "properties": {
+          "ownerAddress": {
+            "type": "string",
+            "description": "A field representing the owner address."
+          },
+          "balance": {
+            "type": "string",
+            "description": "A field representing the balance."
+          }
+        }
+      },
+      "getNativeBalanceByAccount__tron__Res": {
+        "type": "object",
+        "required": [
+          "ownerAddress",
+          "balance"
+        ],
+        "properties": {
+          "ownerAddress": {
+            "type": "string",
+            "description": "TRON address of the account owner. The address is a 34-character Base58 string format starting with \"T\"."
+          },
+          "balance": {
+            "type": "string",
+            "description": "Represents the current balance of the account. The value is a decimal string in SUN, the smallest unit of TRX (1 TRX = 1,000,000 SUN)."
+          }
+        }
+      },
+      "getNativeTokenBalanceChangesByAccount__xrpl__Req": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "accountAddress"
+            ],
+            "properties": {
+              "accountAddress": {
+                "type": "string",
+                "description": "Parameter specifying the account address for balance query. It is a Base58-encoded string of 25-35 characters, always starting with \"r\".",
+                "pattern": "^r[1-9A-HJ-NP-Za-km-z]{25,35}$"
+              },
+              "fromLedger": {
+                "type": "string",
+                "description": "Parameter specifying the starting ledger for the query. You can enter one of the following formats:\n- **ledger index**: Enter ledger number as a decimal string\n- **ledger hash**: 64-character hexadecimal string (excluding 0x prefix)\n- **ledger tag**: Enter \"earliest\" or \"latest\" (oldest or most recent ledger)\n\nNotes:\n- If provided without toLedger, results are queried from this ledger to the latest ledger.\n- fromLedger value cannot be greater than toLedger value.\n- If fromLedger and toLedger have the same value, only that ledger is queried.\n- \"latest\" for fromLedger is only allowed when toLedger is \"latest\".",
+                "pattern": "^[0-9]+$|^0[xX][0-9a-fA-F]{64}|latest|earliest"
+              },
+              "toLedger": {
+                "type": "string",
+                "description": "Parameter specifying the ending ledger for the query. You can enter one of the following formats:\n- **ledger index**: Enter ledger number as a decimal string\n- **ledger hash**: 64-character hexadecimal string (excluding 0x prefix)\n- **ledger tag**: Enter \"earliest\" or \"latest\" (oldest or most recent ledger)\n\nNotes:\n- If provided without fromLedger, results are queried from genesis ledger to this ledger.\n- toLedger value cannot be less than fromLedger value.\n- If fromLedger and toLedger have the same value, only that ledger is queried.\n- \"earliest\" for toLedger is only allowed when fromLedger is \"earliest\".",
+                "pattern": "^[0-9]+$|^0[xX][0-9a-fA-F]{64}|latest|earliest"
+              },
+              "fromDate": {
+                "type": "string",
+                "description": "Parameter specifying the start date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without toDate, results are queried from this date to the latest ledger.\n- fromDate value must be equal to or earlier than toDate value.\n- If fromDate and toDate are the same, only ledgers from that date are queried.\n- This field cannot be used together with fromLedger and toLedger.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "default": "2025-01-01T00:00:00+00:00"
+              },
+              "toDate": {
+                "type": "string",
+                "description": "Parameter specifying the end date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without fromDate, results are queried from genesis ledger creation to this date.\n- toDate value must be equal to or later than fromDate value.\n- If fromDate and toDate are the same, only ledgers from that date are queried.\n- This field cannot be used together with fromLedger and toLedger.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "default": "2025-01-31T00:00:00+00:00"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "integer",
+                "description": "The page parameter specifies the data page to query. It accepts values up to 100; for pages exceeding 100, use the cursor pagination method.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used.",
+                "pattern": "^(?:[1-9][0-9]?|100)$"
+              },
+              "rpp": {
+                "type": "integer",
+                "description": "rpp stands for results per page and specifies the page size. You can specify a number greater than 0 and up to 100.",
+                "pattern": "^(?:[1-9][0-9]{0,2}?|100)$"
+              },
+              "cursor": {
+                "type": "string",
+                "description": "The cursor parameter supports pagination and data navigation between pages. Provide the cursor value from the previous page in the next request to load the next page of data.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used."
+              },
+              "withCount": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the count field in the response. The count field indicates the total number of requested data items. When set to true, the count field is included and response speed may be slower.",
+                "default": false
+              }
+            }
+          }
+        ],
+        "example": {
+          "accountAddress": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+          "fromDate": "2026-01-01T00:00:00Z",
+          "toDate": "2026-02-01T00:00:00Z",
+          "page": 1,
+          "rpp": 10
+        }
+      },
+      "accountAddress__utxo__Req": {
+        "type": "object",
+        "required": [
+          "accountAddress"
+        ],
+        "properties": {
+          "accountAddress": {
+            "type": "string",
+            "description": "Parameter specifying the account address to query.",
+            "pattern": "^(1[a-km-zA-HJ-NP-Z1-9]{25,33}|3[a-km-zA-HJ-NP-Z1-9]{25,33}|bc1q[a-z0-9]{38,59}|bc1p[a-z0-9]{58})$",
+            "example": "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq"
+          }
+        },
+        "example": {
+          "accountAddress": "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa"
+        }
+      },
+      "getNativeTokenBalanceByAccount__xrpl__Req": {
+        "type": "object",
+        "required": [
+          "accountAddress"
+        ],
+        "properties": {
+          "accountAddress": {
+            "type": "string",
+            "description": "Parameter specifying the account address for balance query. It is a Base58-encoded string of 25-35 characters, always starting with \"r\".",
+            "pattern": "^r[1-9A-HJ-NP-Za-km-z]{25,35}$"
+          }
+        },
+        "example": {
+          "accountAddress": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn"
+        }
+      },
+      "getNativeTokenBalanceByAccount__xrpl__Res": {
+        "type": "object",
+        "required": [
+          "ownerAddress",
+          "balance"
+        ],
+        "properties": {
+          "ownerAddress": {
+            "type": "string",
+            "description": "Required response field that returns the address of the account that owns the balance, a Base58-encoded string 25-35 characters in length, always starting with \"r\"."
+          },
+          "balance": {
+            "type": "string",
+            "description": "Required response field indicating the total balance held by the account, providing the value in standard XRP units (1 XRP = 1,000,000 drops) instead of drops, the smallest XRP unit."
+          }
+        }
+      },
+      "blockRangePaged__evm__Req": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "fromBlock": {
+                "type": "string",
+                "description": "Parameter specifying the starting block for the query. You can enter one of the following formats:\n- block number: Enter block number as a decimal string.\n- block hash: 64-character hexadecimal (including \"0x\").\n- block tag: Use \"earliest\" or \"latest\" to specify the first block or the most recent block.\n\nNotes:\n- This field cannot be used together with `fromDate` and `toDate`.\n- If provided without fromBlock, results are queried from genesis block to this block.\n- toBlock value cannot be less than fromBlock value.\n- If fromBlock and toBlock have the same value, only that block is queried.\n- \"earliest\" for toBlock is only allowed when fromBlock is \"earliest\".\n- If `fromBlock` and `toBlock` are not provided, the API queries data from the latest 30 days.\n",
+                "pattern": "^[0-9]+$|^0[xX][0-9a-fA-F]{64}|latest|earliest"
+              },
+              "toBlock": {
+                "type": "string",
+                "description": "Parameter specifying the ending block for the query. You can enter one of the following formats:\n- block number: Enter block number as a decimal string.\n- block hash: 64-character hexadecimal (including \"0x\").\n- block tag: Use \"earliest\" or \"latest\" to specify the first block or the most recent block.\n\nNotes:\n- This field cannot be used together with `fromDate` and `toDate`.\n- If provided without fromBlock, results are queried from genesis block to this block.\n- toBlock value cannot be less than fromBlock value.\n- If fromBlock and toBlock have the same value, only that block is queried.\n- \"earliest\" for toBlock is only allowed when fromBlock is \"earliest\".\n- If `fromBlock` and `toBlock` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]+$|^0[xX][0-9a-fA-F]{64}|latest|earliest"
+              },
+              "fromDate": {
+                "type": "string",
+                "description": "Parameter specifying the start date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without toDate, results are queried from this date to the latest block.\n- fromDate value must be equal to or earlier than toDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-01T00:00:00+00:00"
+              },
+              "toDate": {
+                "type": "string",
+                "description": "Parameter specifying the end date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without fromDate, results are queried from genesis block to this date.\n- toDate value must be equal to or later than fromDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-31T00:00:00+00:00"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "integer",
+                "description": "The page parameter specifies the data page to query. It accepts values up to 100; for pages exceeding 100, use the cursor pagination method.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used.",
+                "pattern": "^(?:[1-9][0-9]?|100)$"
+              },
+              "rpp": {
+                "type": "integer",
+                "description": "rpp stands for results per page and specifies the page size. You can specify a number greater than 0 and up to 100.",
+                "pattern": "^(?:[1-9][0-9]{0,2}?|100)$"
+              },
+              "cursor": {
+                "type": "string",
+                "description": "The cursor parameter supports pagination and data navigation between pages. Provide the cursor value from the previous page in the next request to load the next page of data.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used."
+              },
+              "withCount": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the count field in the response. The count field indicates the total number of requested data items. When set to true, the count field is included and response speed may be slower.",
+                "default": false
+              }
+            }
+          }
+        ],
+        "example": {
+          "fromDate": "2026-01-01T00:00:00Z",
+          "toDate": "2026-02-01T00:00:00Z",
+          "page": 1,
+          "rpp": 10
+        }
+      },
+      "getNativeHolders__tron__Req": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "integer",
+                "description": "The page parameter specifies the data page to query. It accepts values up to 100; for pages exceeding 100, use the cursor pagination method.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used.",
+                "pattern": "^(?:[1-9][0-9]?|100)$"
+              },
+              "rpp": {
+                "type": "integer",
+                "description": "rpp stands for results per page and specifies the page size. You can specify a number greater than 0 and up to 100.",
+                "pattern": "^(?:[1-9][0-9]{0,2}?|100)$"
+              },
+              "cursor": {
+                "type": "string",
+                "description": "The cursor parameter supports pagination and data navigation between pages. Provide the cursor value from the previous page in the next request to load the next page of data.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used."
+              },
+              "withCount": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the count field in the response. The count field indicates the total number of requested data items. When set to true, the count field is included and response speed may be slower.",
+                "default": false
+              }
+            }
+          }
+        ],
+        "example": {
+          "page": 1,
+          "rpp": 10
+        }
+      },
+      "getNativeTokenTransfersByAccount__utxo__Req": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "accountAddress"
+            ],
+            "properties": {
+              "accountAddress": {
+                "type": "string",
+                "description": "Parameter specifying the account address to query.",
+                "pattern": "^(1[a-km-zA-HJ-NP-Z1-9]{25,33}|3[a-km-zA-HJ-NP-Z1-9]{25,33}|bc1q[a-z0-9]{38,59}|bc1p[a-z0-9]{58})$",
+                "example": "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq"
+              },
+              "relation": {
+                "type": "string",
+                "description": "Parameter for filtering transactions where the queried account address is the sender or recipient.\n- from: Filter by sender only.\n- to: Filter by recipient only.\n- both (default): Returns all transactions where the queried address appears in from or to.",
+                "enum": [
+                  "from",
+                  "to",
+                  "both"
+                ],
+                "pattern": "from|to|both",
+                "default": "both"
+              },
+              "fromBlock": {
+                "type": "string",
+                "description": "Parameter specifying the starting block for the query. You can enter one of the following formats:\n- block number: Enter block number as a decimal string.\n- block hash: 64-character hexadecimal (excluding \"0x\").\n- block tag: Use \"earliest\" or \"latest\" to specify the first block or the most recent block.\n\nNotes:\n- This field cannot be used together with `fromDate` and `toDate`.\n- If provided without fromBlock, results are queried from genesis block to this block.\n- toBlock value cannot be less than fromBlock value.\n- If fromBlock and toBlock have the same value, only that block is queried.\n- \"earliest\" for toBlock is only allowed when fromBlock is \"earliest\".\n- If `fromBlock` and `toBlock` are not provided, the API queries data from the latest 30 days.\n",
+                "pattern": "^[0-9]+$|^[0-9a-fA-F]{64}|latest|earliest"
+              },
+              "toBlock": {
+                "type": "string",
+                "description": "Parameter specifying the ending block for the query. You can enter one of the following formats:\n- block number: Enter block number as a decimal string.\n- block hash: 64-character hexadecimal (excluding \"0x\").\n- block tag: Use \"earliest\" or \"latest\" to specify the first block or the most recent block.\n\nNotes:\n- This field cannot be used together with `fromDate` and `toDate`.\n- If provided without fromBlock, results are queried from genesis block to this block.\n- toBlock value cannot be less than fromBlock value.\n- If fromBlock and toBlock have the same value, only that block is queried.\n- \"earliest\" for toBlock is only allowed when fromBlock is \"earliest\".\n- If `fromBlock` and `toBlock` are not provided, the API queries data from the latest 30 days.\n",
+                "pattern": "^[0-9]+$|^[0-9a-fA-F]{64}|latest|earliest"
+              },
+              "fromDate": {
+                "type": "string",
+                "description": "Parameter specifying the start date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without toDate, results are queried from this date to the latest block.\n- fromDate value must be equal to or earlier than toDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-01T00:00:00+00:00"
+              },
+              "toDate": {
+                "type": "string",
+                "description": "Parameter specifying the end date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without fromDate, results are queried from genesis block to this date.\n- toDate value must be equal to or later than fromDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-31T00:00:00+00:00"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "integer",
+                "description": "The page parameter specifies the data page to query. It accepts values up to 100; for pages exceeding 100, use the cursor pagination method.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used.",
+                "pattern": "^(?:[1-9][0-9]?|100)$"
+              },
+              "rpp": {
+                "type": "integer",
+                "description": "rpp stands for results per page and specifies the page size. You can specify a number greater than 0 and up to 100.",
+                "pattern": "^(?:[1-9][0-9]{0,2}?|100)$"
+              },
+              "cursor": {
+                "type": "string",
+                "description": "The cursor parameter supports pagination and data navigation between pages. Provide the cursor value from the previous page in the next request to load the next page of data.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used."
+              },
+              "withCount": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the count field in the response. The count field indicates the total number of requested data items. When set to true, the count field is included and response speed may be slower.",
+                "default": false
+              }
+            }
+          }
+        ],
+        "example": {
+          "accountAddress": "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa",
+          "fromDate": "2026-01-01T00:00:00Z",
+          "toDate": "2026-02-01T00:00:00Z",
+          "page": 1,
+          "rpp": 10
+        }
+      },
+      "syncNftMetadata__evm__Res": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "Returns a result message for the sync request."
+          }
+        }
+      },
+      "getNftMetadataByTokenIds__evm__Req": {
+        "type": "object",
+        "required": [
+          "tokens"
+        ],
+        "properties": {
+          "tokens": {
+            "type": "array",
+            "description": "List of NFTs to query. Up to 100 NFTs can be queried.",
+            "items": {
+              "type": "object",
+              "required": [
+                "contractAddress",
+                "tokenId"
+              ],
+              "properties": {
+                "contractAddress": {
+                  "type": "string",
+                  "description": "Parameter specifying the contract address to query. Can be entered as a 40-character hexadecimal string starting with 0x.",
+                  "pattern": "^0[xX][0-9a-fA-F]{40}$"
+                },
+                "tokenId": {
+                  "type": "string",
+                  "description": "Parameter specifying the NFT token ID to query. Can be entered as a decimal string.",
+                  "pattern": "^[0-9]+$"
+                }
+              }
+            }
+          }
+        },
+        "example": {
+          "tokens": [
+            {
+              "contractAddress": "0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D",
+              "tokenId": "1"
+            },
+            {
+              "contractAddress": "0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D",
+              "tokenId": "2"
+            }
+          ]
+        }
+      },
+      "getNftMetadataByTokenIds__evm__Res": {
+        "type": "array",
+        "items": {
+          "allOf": [
+            {
+              "type": "object",
+              "required": [
+                "tokenId",
+                "tokenUri",
+                "tokenUriSyncedAt",
+                "rawMetadata",
+                "metadataSyncedAt"
+              ],
+              "properties": {
+                "tokenId": {
+                  "type": "string",
+                  "description": "A field representing the unique ID of the NFT token. This ID is used to identify the NFT."
+                },
+                "tokenUri": {
+                  "type": "string",
+                  "description": "A field representing the URI where the original metadata of the NFT is located. Format may vary by contract implementation, but is typically provided as an IPFS address or web URL."
+                },
+                "tokenUriSyncedAt": {
+                  "type": "string",
+                  "description": "A field representing when the tokenUri of the NFT was synchronized."
+                },
+                "rawMetadata": {
+                  "type": "string",
+                  "description": "A field representing the rawMetadata of the NFT."
+                },
+                "metadataSyncedAt": {
+                  "type": "string",
+                  "description": "A field representing when the metadata of the NFT was synchronized."
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "contract": {
+                  "type": "object"
+                }
+              }
+            }
+          ]
+        }
+      },
+      "getNftTransfersByContract__evm__Req": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "contractAddress"
+            ],
+            "properties": {
+              "contractAddress": {
+                "type": "string",
+                "description": "Parameter specifying the contract address to query. Can be entered as a 40-character hexadecimal string starting with 0x.",
+                "pattern": "^0[xX][0-9a-fA-F]{40}$"
+              },
+              "fromBlock": {
+                "type": "string",
+                "description": "Parameter specifying the starting block for the query. You can enter one of the following formats:\n- block number: Enter block number as a decimal string.\n- block hash: 64-character hexadecimal (including \"0x\").\n- block tag: Use \"earliest\" or \"latest\" to specify the first block or the most recent block.\n\nNotes:\n- This field cannot be used together with `fromDate` and `toDate`.\n- If provided without fromBlock, results are queried from genesis block to this block.\n- toBlock value cannot be less than fromBlock value.\n- If fromBlock and toBlock have the same value, only that block is queried.\n- \"earliest\" for toBlock is only allowed when fromBlock is \"earliest\".\n- If `fromBlock` and `toBlock` are not provided, the API queries data from the latest 30 days.\n",
+                "pattern": "^[0-9]+$|^0[xX][0-9a-fA-F]{64}|latest|earliest"
+              },
+              "toBlock": {
+                "type": "string",
+                "description": "Parameter specifying the ending block for the query. You can enter one of the following formats:\n- block number: Enter block number as a decimal string.\n- block hash: 64-character hexadecimal (including \"0x\").\n- block tag: Use \"earliest\" or \"latest\" to specify the first block or the most recent block.\n\nNotes:\n- This field cannot be used together with `fromDate` and `toDate`.\n- If provided without fromBlock, results are queried from genesis block to this block.\n- toBlock value cannot be less than fromBlock value.\n- If fromBlock and toBlock have the same value, only that block is queried.\n- \"earliest\" for toBlock is only allowed when fromBlock is \"earliest\".\n- If `fromBlock` and `toBlock` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]+$|^0[xX][0-9a-fA-F]{64}|latest|earliest"
+              },
+              "fromDate": {
+                "type": "string",
+                "description": "Parameter specifying the start date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without toDate, results are queried from this date to the latest block.\n- fromDate value must be equal to or earlier than toDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-01T00:00:00+00:00"
+              },
+              "toDate": {
+                "type": "string",
+                "description": "Parameter specifying the end date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without fromDate, results are queried from genesis block to this date.\n- toDate value must be equal to or later than fromDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-31T00:00:00+00:00"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "integer",
+                "description": "The page parameter specifies the data page to query. It accepts values up to 100; for pages exceeding 100, use the cursor pagination method.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used.",
+                "pattern": "^(?:[1-9][0-9]?|100)$"
+              },
+              "rpp": {
+                "type": "integer",
+                "description": "rpp stands for results per page and specifies the page size. You can specify a number greater than 0 and up to 100.",
+                "pattern": "^(?:[1-9][0-9]{0,2}?|100)$"
+              },
+              "cursor": {
+                "type": "string",
+                "description": "The cursor parameter supports pagination and data navigation between pages. Provide the cursor value from the previous page in the next request to load the next page of data.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used."
+              },
+              "withCount": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the count field in the response. The count field indicates the total number of requested data items. When set to true, the count field is included and response speed may be slower.",
+                "default": false
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "withMetadata": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include NFT token metadata fields (rawMetadata, metadataSyncedAt) in the response. Response speed may be slower when set to true.",
+                "default": false
+              },
+              "withZeroValue": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include results with value 0 in the response. Set to true for faster responses.",
+                "default": false
+              },
+              "withFunction": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the function field in the response. Response speed may be slower when set to true.",
+                "default": false
+              }
+            }
+          }
+        ],
+        "example": {
+          "contractAddress": "0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D",
+          "fromDate": "2026-01-01T00:00:00Z",
+          "toDate": "2026-02-01T00:00:00Z",
+          "page": 1,
+          "rpp": 10
+        }
+      },
+      "getNftTransfersByContract__kaia__Req": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "contractAddress"
+            ],
+            "properties": {
+              "contractAddress": {
+                "type": "string",
+                "description": "Parameter specifying the contract address to query. Can be entered as a 40-character hexadecimal string starting with 0x.",
+                "pattern": "^0[xX][0-9a-fA-F]{40}$"
+              },
+              "fromBlock": {
+                "type": "string",
+                "description": "Parameter specifying the starting block for the query. You can enter one of the following formats:\n- block number: Enter block number as a decimal string.\n- block hash: 64-character hexadecimal (including \"0x\").\n- block tag: Use \"earliest\" or \"latest\" to specify the first block or the most recent block.\n\nNotes:\n- This field cannot be used together with `fromDate` and `toDate`.\n- If provided without fromBlock, results are queried from genesis block to this block.\n- toBlock value cannot be less than fromBlock value.\n- If fromBlock and toBlock have the same value, only that block is queried.\n- \"earliest\" for toBlock is only allowed when fromBlock is \"earliest\".\n- If `fromBlock` and `toBlock` are not provided, the API queries data from the latest 30 days.\n\nFor Kaia, entering \"earliest\" queries the block at the Kaia hardfork point.\n- Mainnet: 162,900,480 (Aug 29, 2024 11:08:01 UTC+9)\n- Kairos(Testnet): 156,660,000 (June 13, 2024 10:15:19 UTC+9)\n\n",
+                "pattern": "^[0-9]+$|^0[xX][0-9a-fA-F]{64}|latest|earliest"
+              },
+              "toBlock": {
+                "type": "string",
+                "description": "Parameter specifying the ending block for the query. You can enter one of the following formats:\n- block number: Enter block number as a decimal string.\n- block hash: 64-character hexadecimal (including \"0x\").\n- block tag: Use \"earliest\" or \"latest\" to specify the first block or the most recent block.\n\nNotes:\n- This field cannot be used together with `fromDate` and `toDate`.\n- If provided without fromBlock, results are queried from genesis block to this block.\n- toBlock value cannot be less than fromBlock value.\n- If fromBlock and toBlock have the same value, only that block is queried.\n- \"earliest\" for toBlock is only allowed when fromBlock is \"earliest\".\n- If `fromBlock` and `toBlock` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]+$|^0[xX][0-9a-fA-F]{64}|latest|earliest"
+              },
+              "fromDate": {
+                "type": "string",
+                "description": "Parameter specifying the start date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without toDate, results are queried from this date to the latest block.\n- fromDate value must be equal to or earlier than toDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-01T00:00:00+00:00"
+              },
+              "toDate": {
+                "type": "string",
+                "description": "Parameter specifying the end date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without fromDate, results are queried from genesis block to this date.\n- toDate value must be equal to or later than fromDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-31T00:00:00+00:00"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "integer",
+                "description": "The page parameter specifies the data page to query. It accepts values up to 100; for pages exceeding 100, use the cursor pagination method.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used.",
+                "pattern": "^(?:[1-9][0-9]?|100)$"
+              },
+              "rpp": {
+                "type": "integer",
+                "description": "rpp stands for results per page and specifies the page size. You can specify a number greater than 0 and up to 100.",
+                "pattern": "^(?:[1-9][0-9]{0,2}?|100)$"
+              },
+              "cursor": {
+                "type": "string",
+                "description": "The cursor parameter supports pagination and data navigation between pages. Provide the cursor value from the previous page in the next request to load the next page of data.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used."
+              },
+              "withCount": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the count field in the response. The count field indicates the total number of requested data items. When set to true, the count field is included and response speed may be slower.",
+                "default": false
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "withMetadata": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include NFT token metadata fields (rawMetadata, metadataSyncedAt) in the response. Response speed may be slower when set to true.",
+                "default": false
+              },
+              "withZeroValue": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include results with value 0 in the response. Set to true for faster responses.",
+                "default": false
+              },
+              "withFunction": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the function field in the response. Response speed may be slower when set to true.",
+                "default": false
+              }
+            }
+          }
+        ],
+        "example": {
+          "contractAddress": "0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D",
+          "fromDate": "2026-01-01T00:00:00Z",
+          "toDate": "2026-02-01T00:00:00Z",
+          "page": 1,
+          "rpp": 10
+        }
+      },
+      "searchNftContractMetadataByKeyword__evm__Req": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "keyword"
+            ],
+            "properties": {
+              "keyword": {
+                "type": "string",
+                "description": "Parameter specifying the name or symbol of the token to query."
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "integer",
+                "description": "The page parameter specifies the data page to query. It accepts values up to 100; for pages exceeding 100, use the cursor pagination method.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used.",
+                "pattern": "^(?:[1-9][0-9]?|100)$"
+              },
+              "rpp": {
+                "type": "integer",
+                "description": "rpp stands for results per page and specifies the page size. You can specify a number greater than 0 and up to 100.",
+                "pattern": "^(?:[1-9][0-9]{0,2}?|100)$"
+              },
+              "cursor": {
+                "type": "string",
+                "description": "The cursor parameter supports pagination and data navigation between pages. Provide the cursor value from the previous page in the next request to load the next page of data.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used."
+              },
+              "withCount": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the count field in the response. The count field indicates the total number of requested data items. When set to true, the count field is included and response speed may be slower.",
+                "default": false
+              }
+            }
+          }
+        ],
+        "example": {
+          "keyword": "BAYC",
+          "page": 1,
+          "rpp": 10
+        }
+      },
+      "getNftTransfersByAccount__evm__Req": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "accountAddress"
+            ],
+            "properties": {
+              "accountAddress": {
+                "type": "string",
+                "description": "Parameter specifying the account address to query. Can be entered as a 40-character hexadecimal string starting with 0x.",
+                "pattern": "^0[xX][0-9a-fA-F]{40}$",
+                "example": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+              },
+              "relation": {
+                "type": "string",
+                "description": "Parameter for filtering transactions where the queried account address is the sender or recipient.\n- from: Filter by sender only.\n- to: Filter by recipient only.\n- both (default): Returns all transactions where the queried address appears in from or to.",
+                "enum": [
+                  "from",
+                  "to",
+                  "both"
+                ],
+                "pattern": "from|to|both",
+                "default": "both"
+              },
+              "contractAddresses": {
+                "type": "array",
+                "description": "Parameter specifying an array of contract addresses to query. Contract addresses can be entered as 40-character hexadecimal strings starting with 0x.",
+                "items": {
+                  "type": "string",
+                  "description": "Parameter specifying the contract address to query. Can be entered as a 40-character hexadecimal string starting with 0x.",
+                  "pattern": "^0[xX][0-9a-fA-F]{40}$"
+                }
+              },
+              "fromBlock": {
+                "type": "string",
+                "description": "Parameter specifying the starting block for the query. You can enter one of the following formats:\n- block number: Enter block number as a decimal string.\n- block hash: 64-character hexadecimal (including \"0x\").\n- block tag: Use \"earliest\" or \"latest\" to specify the first block or the most recent block.\n\nNotes:\n- This field cannot be used together with `fromDate` and `toDate`.\n- If provided without fromBlock, results are queried from genesis block to this block.\n- toBlock value cannot be less than fromBlock value.\n- If fromBlock and toBlock have the same value, only that block is queried.\n- \"earliest\" for toBlock is only allowed when fromBlock is \"earliest\".\n- If `fromBlock` and `toBlock` are not provided, the API queries data from the latest 30 days.\n",
+                "pattern": "^[0-9]+$|^0[xX][0-9a-fA-F]{64}|latest|earliest"
+              },
+              "toBlock": {
+                "type": "string",
+                "description": "Parameter specifying the ending block for the query. You can enter one of the following formats:\n- block number: Enter block number as a decimal string.\n- block hash: 64-character hexadecimal (including \"0x\").\n- block tag: Use \"earliest\" or \"latest\" to specify the first block or the most recent block.\n\nNotes:\n- This field cannot be used together with `fromDate` and `toDate`.\n- If provided without fromBlock, results are queried from genesis block to this block.\n- toBlock value cannot be less than fromBlock value.\n- If fromBlock and toBlock have the same value, only that block is queried.\n- \"earliest\" for toBlock is only allowed when fromBlock is \"earliest\".\n- If `fromBlock` and `toBlock` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]+$|^0[xX][0-9a-fA-F]{64}|latest|earliest"
+              },
+              "fromDate": {
+                "type": "string",
+                "description": "Parameter specifying the start date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without toDate, results are queried from this date to the latest block.\n- fromDate value must be equal to or earlier than toDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-01T00:00:00+00:00"
+              },
+              "toDate": {
+                "type": "string",
+                "description": "Parameter specifying the end date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without fromDate, results are queried from genesis block to this date.\n- toDate value must be equal to or later than fromDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-31T00:00:00+00:00"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "integer",
+                "description": "The page parameter specifies the data page to query. It accepts values up to 100; for pages exceeding 100, use the cursor pagination method.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used.",
+                "pattern": "^(?:[1-9][0-9]?|100)$"
+              },
+              "rpp": {
+                "type": "integer",
+                "description": "rpp stands for results per page and specifies the page size. You can specify a number greater than 0 and up to 100.",
+                "pattern": "^(?:[1-9][0-9]{0,2}?|100)$"
+              },
+              "cursor": {
+                "type": "string",
+                "description": "The cursor parameter supports pagination and data navigation between pages. Provide the cursor value from the previous page in the next request to load the next page of data.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used."
+              },
+              "withCount": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the count field in the response. The count field indicates the total number of requested data items. When set to true, the count field is included and response speed may be slower.",
+                "default": false
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "withMetadata": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include NFT token metadata fields (rawMetadata, metadataSyncedAt) in the response. Response speed may be slower when set to true.",
+                "default": false
+              },
+              "withZeroValue": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include results with value 0 in the response. Set to true for faster responses.",
+                "default": false
+              },
+              "withFunction": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the function field in the response. Response speed may be slower when set to true.",
+                "default": false
+              }
+            }
+          }
+        ],
+        "example": {
+          "accountAddress": "0x742d35Cc6634C0532925a3b844Bc454e4438f44e",
+          "fromDate": "2026-01-01T00:00:00Z",
+          "toDate": "2026-02-01T00:00:00Z",
+          "page": 1,
+          "rpp": 10
+        }
+      },
+      "getNftTransfersByAccount__kaia__Req": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "accountAddress"
+            ],
+            "properties": {
+              "accountAddress": {
+                "type": "string",
+                "description": "Parameter specifying the account address to query. Can be entered as a 40-character hexadecimal string starting with 0x.",
+                "pattern": "^0[xX][0-9a-fA-F]{40}$",
+                "example": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+              },
+              "relation": {
+                "type": "string",
+                "description": "Parameter for filtering transactions where the queried account address is the sender or recipient.\n- from: Filter by sender only.\n- to: Filter by recipient only.\n- both (default): Returns all transactions where the queried address appears in from or to.",
+                "enum": [
+                  "from",
+                  "to",
+                  "both"
+                ],
+                "pattern": "from|to|both",
+                "default": "both"
+              },
+              "contractAddresses": {
+                "type": "array",
+                "description": "Parameter specifying an array of contract addresses to query. Contract addresses can be entered as 40-character hexadecimal strings starting with 0x.",
+                "items": {
+                  "type": "string",
+                  "description": "Parameter specifying the contract address to query. Can be entered as a 40-character hexadecimal string starting with 0x.",
+                  "pattern": "^0[xX][0-9a-fA-F]{40}$"
+                }
+              },
+              "fromBlock": {
+                "type": "string",
+                "description": "Parameter specifying the starting block for the query. You can enter one of the following formats:\n- block number: Enter block number as a decimal string.\n- block hash: 64-character hexadecimal (including \"0x\").\n- block tag: Use \"earliest\" or \"latest\" to specify the first block or the most recent block.\n\nNotes:\n- This field cannot be used together with `fromDate` and `toDate`.\n- If provided without fromBlock, results are queried from genesis block to this block.\n- toBlock value cannot be less than fromBlock value.\n- If fromBlock and toBlock have the same value, only that block is queried.\n- \"earliest\" for toBlock is only allowed when fromBlock is \"earliest\".\n- If `fromBlock` and `toBlock` are not provided, the API queries data from the latest 30 days.\n\nFor Kaia, entering \"earliest\" queries the block at the Kaia hardfork point.\n- Mainnet: 162,900,480 (Aug 29, 2024 11:08:01 UTC+9)\n- Kairos(Testnet): 156,660,000 (June 13, 2024 10:15:19 UTC+9)\n\n",
+                "pattern": "^[0-9]+$|^0[xX][0-9a-fA-F]{64}|latest|earliest"
+              },
+              "toBlock": {
+                "type": "string",
+                "description": "Parameter specifying the ending block for the query. You can enter one of the following formats:\n- block number: Enter block number as a decimal string.\n- block hash: 64-character hexadecimal (including \"0x\").\n- block tag: Use \"earliest\" or \"latest\" to specify the first block or the most recent block.\n\nNotes:\n- This field cannot be used together with `fromDate` and `toDate`.\n- If provided without fromBlock, results are queried from genesis block to this block.\n- toBlock value cannot be less than fromBlock value.\n- If fromBlock and toBlock have the same value, only that block is queried.\n- \"earliest\" for toBlock is only allowed when fromBlock is \"earliest\".\n- If `fromBlock` and `toBlock` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]+$|^0[xX][0-9a-fA-F]{64}|latest|earliest"
+              },
+              "fromDate": {
+                "type": "string",
+                "description": "Parameter specifying the start date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without toDate, results are queried from this date to the latest block.\n- fromDate value must be equal to or earlier than toDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-01T00:00:00+00:00"
+              },
+              "toDate": {
+                "type": "string",
+                "description": "Parameter specifying the end date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without fromDate, results are queried from genesis block to this date.\n- toDate value must be equal to or later than fromDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-31T00:00:00+00:00"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "integer",
+                "description": "The page parameter specifies the data page to query. It accepts values up to 100; for pages exceeding 100, use the cursor pagination method.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used.",
+                "pattern": "^(?:[1-9][0-9]?|100)$"
+              },
+              "rpp": {
+                "type": "integer",
+                "description": "rpp stands for results per page and specifies the page size. You can specify a number greater than 0 and up to 100.",
+                "pattern": "^(?:[1-9][0-9]{0,2}?|100)$"
+              },
+              "cursor": {
+                "type": "string",
+                "description": "The cursor parameter supports pagination and data navigation between pages. Provide the cursor value from the previous page in the next request to load the next page of data.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used."
+              },
+              "withCount": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the count field in the response. The count field indicates the total number of requested data items. When set to true, the count field is included and response speed may be slower.",
+                "default": false
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "withMetadata": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include NFT token metadata fields (rawMetadata, metadataSyncedAt) in the response. Response speed may be slower when set to true.",
+                "default": false
+              },
+              "withZeroValue": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include results with value 0 in the response. Set to true for faster responses.",
+                "default": false
+              },
+              "withFunction": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the function field in the response. Response speed may be slower when set to true.",
+                "default": false
+              }
+            }
+          }
+        ],
+        "example": {
+          "accountAddress": "0x742d35Cc6634C0532925a3b844Bc454e4438f44e",
+          "fromDate": "2026-01-01T00:00:00Z",
+          "toDate": "2026-02-01T00:00:00Z",
+          "page": 1,
+          "rpp": 10
+        }
+      },
+      "getNftsOwnedByAccount__evm__Req": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "accountAddress"
+            ],
+            "properties": {
+              "accountAddress": {
+                "type": "string",
+                "description": "Parameter specifying the account address to query. Can be entered as a 40-character hexadecimal string starting with 0x.",
+                "pattern": "^0[xX][0-9a-fA-F]{40}$",
+                "example": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+              },
+              "contractAddresses": {
+                "type": "array",
+                "description": "Parameter specifying an array of contract addresses to query. Contract addresses can be entered as 40-character hexadecimal strings starting with 0x.",
+                "items": {
+                  "type": "string",
+                  "description": "Parameter specifying the contract address to query. Can be entered as a 40-character hexadecimal string starting with 0x.",
+                  "pattern": "^0[xX][0-9a-fA-F]{40}$"
+                }
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "integer",
+                "description": "The page parameter specifies the data page to query. It accepts values up to 100; for pages exceeding 100, use the cursor pagination method.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used.",
+                "pattern": "^(?:[1-9][0-9]?|100)$"
+              },
+              "rpp": {
+                "type": "integer",
+                "description": "rpp stands for results per page and specifies the page size. You can specify a number greater than 0 and up to 100.",
+                "pattern": "^(?:[1-9][0-9]{0,2}?|100)$"
+              },
+              "cursor": {
+                "type": "string",
+                "description": "The cursor parameter supports pagination and data navigation between pages. Provide the cursor value from the previous page in the next request to load the next page of data.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used."
+              },
+              "withCount": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the count field in the response. The count field indicates the total number of requested data items. When set to true, the count field is included and response speed may be slower.",
+                "default": false
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "withMetadata": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include NFT token metadata fields (rawMetadata, metadataSyncedAt) in the response. Response speed may be slower when set to true.",
+                "default": false
+              }
+            }
+          }
+        ],
+        "example": {
+          "accountAddress": "0x742d35Cc6634C0532925a3b844Bc454e4438f44e",
+          "page": 1,
+          "rpp": 10
+        }
+      },
+      "getNftTransfersByTokenId__evm__Req": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "contractAddress",
+              "tokenId"
+            ],
+            "properties": {
+              "contractAddress": {
+                "type": "string",
+                "description": "Parameter specifying the contract address to query. Can be entered as a 40-character hexadecimal string starting with 0x.",
+                "pattern": "^0[xX][0-9a-fA-F]{40}$"
+              },
+              "tokenId": {
+                "type": "string",
+                "description": "Parameter specifying the NFT token ID to query. Can be entered as a decimal string.",
+                "pattern": "^[0-9]+$"
+              },
+              "fromBlock": {
+                "type": "string",
+                "description": "Parameter specifying the starting block for the query. You can enter one of the following formats:\n- block number: Enter block number as a decimal string.\n- block hash: 64-character hexadecimal (including \"0x\").\n- block tag: Use \"earliest\" or \"latest\" to specify the first block or the most recent block.\n\nNotes:\n- This field cannot be used together with `fromDate` and `toDate`.\n- If provided without fromBlock, results are queried from genesis block to this block.\n- toBlock value cannot be less than fromBlock value.\n- If fromBlock and toBlock have the same value, only that block is queried.\n- \"earliest\" for toBlock is only allowed when fromBlock is \"earliest\".\n- If `fromBlock` and `toBlock` are not provided, the API queries data from the latest 30 days.\n",
+                "pattern": "^[0-9]+$|^0[xX][0-9a-fA-F]{64}|latest|earliest"
+              },
+              "toBlock": {
+                "type": "string",
+                "description": "Parameter specifying the ending block for the query. You can enter one of the following formats:\n- block number: Enter block number as a decimal string.\n- block hash: 64-character hexadecimal (including \"0x\").\n- block tag: Use \"earliest\" or \"latest\" to specify the first block or the most recent block.\n\nNotes:\n- This field cannot be used together with `fromDate` and `toDate`.\n- If provided without fromBlock, results are queried from genesis block to this block.\n- toBlock value cannot be less than fromBlock value.\n- If fromBlock and toBlock have the same value, only that block is queried.\n- \"earliest\" for toBlock is only allowed when fromBlock is \"earliest\".\n- If `fromBlock` and `toBlock` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]+$|^0[xX][0-9a-fA-F]{64}|latest|earliest"
+              },
+              "fromDate": {
+                "type": "string",
+                "description": "Parameter specifying the start date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without toDate, results are queried from this date to the latest block.\n- fromDate value must be equal to or earlier than toDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-01T00:00:00+00:00"
+              },
+              "toDate": {
+                "type": "string",
+                "description": "Parameter specifying the end date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without fromDate, results are queried from genesis block to this date.\n- toDate value must be equal to or later than fromDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-31T00:00:00+00:00"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "integer",
+                "description": "The page parameter specifies the data page to query. It accepts values up to 100; for pages exceeding 100, use the cursor pagination method.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used.",
+                "pattern": "^(?:[1-9][0-9]?|100)$"
+              },
+              "rpp": {
+                "type": "integer",
+                "description": "rpp stands for results per page and specifies the page size. You can specify a number greater than 0 and up to 100.",
+                "pattern": "^(?:[1-9][0-9]{0,2}?|100)$"
+              },
+              "cursor": {
+                "type": "string",
+                "description": "The cursor parameter supports pagination and data navigation between pages. Provide the cursor value from the previous page in the next request to load the next page of data.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used."
+              },
+              "withCount": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the count field in the response. The count field indicates the total number of requested data items. When set to true, the count field is included and response speed may be slower.",
+                "default": false
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "withMetadata": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include NFT token metadata fields (rawMetadata, metadataSyncedAt) in the response. Response speed may be slower when set to true.",
+                "default": false
+              },
+              "withZeroValue": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include results with value 0 in the response. Set to true for faster responses.",
+                "default": false
+              },
+              "withFunction": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the function field in the response. Response speed may be slower when set to true.",
+                "default": false
+              }
+            }
+          }
+        ],
+        "example": {
+          "contractAddress": "0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D",
+          "tokenId": "1",
+          "fromDate": "2026-01-01T00:00:00Z",
+          "toDate": "2026-02-01T00:00:00Z",
+          "page": 1,
+          "rpp": 10
+        }
+      },
+      "getNftTransfersByTokenId__kaia__Req": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "contractAddress",
+              "tokenId"
+            ],
+            "properties": {
+              "contractAddress": {
+                "type": "string",
+                "description": "Parameter specifying the contract address to query. Can be entered as a 40-character hexadecimal string starting with 0x.",
+                "pattern": "^0[xX][0-9a-fA-F]{40}$"
+              },
+              "tokenId": {
+                "type": "string",
+                "description": "Parameter specifying the NFT token ID to query. Can be entered as a decimal string.",
+                "pattern": "^[0-9]+$"
+              },
+              "fromBlock": {
+                "type": "string",
+                "description": "Parameter specifying the starting block for the query. You can enter one of the following formats:\n- block number: Enter block number as a decimal string.\n- block hash: 64-character hexadecimal (including \"0x\").\n- block tag: Use \"earliest\" or \"latest\" to specify the first block or the most recent block.\n\nNotes:\n- This field cannot be used together with `fromDate` and `toDate`.\n- If provided without fromBlock, results are queried from genesis block to this block.\n- toBlock value cannot be less than fromBlock value.\n- If fromBlock and toBlock have the same value, only that block is queried.\n- \"earliest\" for toBlock is only allowed when fromBlock is \"earliest\".\n- If `fromBlock` and `toBlock` are not provided, the API queries data from the latest 30 days.\n\nFor Kaia, entering \"earliest\" queries the block at the Kaia hardfork point.\n- Mainnet: 162,900,480 (Aug 29, 2024 11:08:01 UTC+9)\n- Kairos(Testnet): 156,660,000 (June 13, 2024 10:15:19 UTC+9)\n\n",
+                "pattern": "^[0-9]+$|^0[xX][0-9a-fA-F]{64}|latest|earliest"
+              },
+              "toBlock": {
+                "type": "string",
+                "description": "Parameter specifying the ending block for the query. You can enter one of the following formats:\n- block number: Enter block number as a decimal string.\n- block hash: 64-character hexadecimal (including \"0x\").\n- block tag: Use \"earliest\" or \"latest\" to specify the first block or the most recent block.\n\nNotes:\n- This field cannot be used together with `fromDate` and `toDate`.\n- If provided without fromBlock, results are queried from genesis block to this block.\n- toBlock value cannot be less than fromBlock value.\n- If fromBlock and toBlock have the same value, only that block is queried.\n- \"earliest\" for toBlock is only allowed when fromBlock is \"earliest\".\n- If `fromBlock` and `toBlock` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]+$|^0[xX][0-9a-fA-F]{64}|latest|earliest"
+              },
+              "fromDate": {
+                "type": "string",
+                "description": "Parameter specifying the start date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without toDate, results are queried from this date to the latest block.\n- fromDate value must be equal to or earlier than toDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-01T00:00:00+00:00"
+              },
+              "toDate": {
+                "type": "string",
+                "description": "Parameter specifying the end date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without fromDate, results are queried from genesis block to this date.\n- toDate value must be equal to or later than fromDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-31T00:00:00+00:00"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "integer",
+                "description": "The page parameter specifies the data page to query. It accepts values up to 100; for pages exceeding 100, use the cursor pagination method.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used.",
+                "pattern": "^(?:[1-9][0-9]?|100)$"
+              },
+              "rpp": {
+                "type": "integer",
+                "description": "rpp stands for results per page and specifies the page size. You can specify a number greater than 0 and up to 100.",
+                "pattern": "^(?:[1-9][0-9]{0,2}?|100)$"
+              },
+              "cursor": {
+                "type": "string",
+                "description": "The cursor parameter supports pagination and data navigation between pages. Provide the cursor value from the previous page in the next request to load the next page of data.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used."
+              },
+              "withCount": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the count field in the response. The count field indicates the total number of requested data items. When set to true, the count field is included and response speed may be slower.",
+                "default": false
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "withMetadata": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include NFT token metadata fields (rawMetadata, metadataSyncedAt) in the response. Response speed may be slower when set to true.",
+                "default": false
+              },
+              "withZeroValue": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include results with value 0 in the response. Set to true for faster responses.",
+                "default": false
+              },
+              "withFunction": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the function field in the response. Response speed may be slower when set to true.",
+                "default": false
+              }
+            }
+          }
+        ],
+        "example": {
+          "contractAddress": "0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D",
+          "tokenId": "1",
+          "fromDate": "2026-01-01T00:00:00Z",
+          "toDate": "2026-02-01T00:00:00Z",
+          "page": 1,
+          "rpp": 10
+        }
+      },
+      "getNftHoldersByTokenId__evm__Req": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "contractAddress",
+              "tokenId"
+            ],
+            "properties": {
+              "contractAddress": {
+                "type": "string",
+                "description": "Parameter specifying the contract address to query. Can be entered as a 40-character hexadecimal string starting with 0x.",
+                "pattern": "^0[xX][0-9a-fA-F]{40}$"
+              },
+              "tokenId": {
+                "type": "string",
+                "description": "Parameter specifying the NFT token ID to query. Can be entered as a decimal string.",
+                "pattern": "^[0-9]+$"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "integer",
+                "description": "The page parameter specifies the data page to query. It accepts values up to 100; for pages exceeding 100, use the cursor pagination method.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used.",
+                "pattern": "^(?:[1-9][0-9]?|100)$"
+              },
+              "rpp": {
+                "type": "integer",
+                "description": "rpp stands for results per page and specifies the page size. You can specify a number greater than 0 and up to 100.",
+                "pattern": "^(?:[1-9][0-9]{0,2}?|100)$"
+              },
+              "cursor": {
+                "type": "string",
+                "description": "The cursor parameter supports pagination and data navigation between pages. Provide the cursor value from the previous page in the next request to load the next page of data.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used."
+              },
+              "withCount": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the count field in the response. The count field indicates the total number of requested data items. When set to true, the count field is included and response speed may be slower.",
+                "default": false
+              }
+            }
+          }
+        ],
+        "example": {
+          "contractAddress": "0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D",
+          "tokenId": "1",
+          "page": 1,
+          "rpp": 10
+        }
+      },
+      "getNftTransfersWithinRange__evm__Req": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "fromBlock": {
+                "type": "string",
+                "description": "Parameter specifying the starting block for the query. You can enter one of the following formats:\n- block number: Enter block number as a decimal string.\n- block hash: 64-character hexadecimal (including \"0x\").\n- block tag: Use \"earliest\" or \"latest\" to specify the first block or the most recent block.\n\nNotes:\n- This field cannot be used together with `fromDate` and `toDate`.\n- If provided without fromBlock, results are queried from genesis block to this block.\n- toBlock value cannot be less than fromBlock value.\n- If fromBlock and toBlock have the same value, only that block is queried.\n- \"earliest\" for toBlock is only allowed when fromBlock is \"earliest\".\n- If `fromBlock` and `toBlock` are not provided, the API queries data from the latest 30 days.\n",
+                "pattern": "^[0-9]+$|^0[xX][0-9a-fA-F]{64}|latest|earliest"
+              },
+              "toBlock": {
+                "type": "string",
+                "description": "Parameter specifying the ending block for the query. You can enter one of the following formats:\n- block number: Enter block number as a decimal string.\n- block hash: 64-character hexadecimal (including \"0x\").\n- block tag: Use \"earliest\" or \"latest\" to specify the first block or the most recent block.\n\nNotes:\n- This field cannot be used together with `fromDate` and `toDate`.\n- If provided without fromBlock, results are queried from genesis block to this block.\n- toBlock value cannot be less than fromBlock value.\n- If fromBlock and toBlock have the same value, only that block is queried.\n- \"earliest\" for toBlock is only allowed when fromBlock is \"earliest\".\n- If `fromBlock` and `toBlock` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]+$|^0[xX][0-9a-fA-F]{64}|latest|earliest"
+              },
+              "fromDate": {
+                "type": "string",
+                "description": "Parameter specifying the start date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without toDate, results are queried from this date to the latest block.\n- fromDate value must be equal to or earlier than toDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-01T00:00:00+00:00"
+              },
+              "toDate": {
+                "type": "string",
+                "description": "Parameter specifying the end date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without fromDate, results are queried from genesis block to this date.\n- toDate value must be equal to or later than fromDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-31T00:00:00+00:00"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "integer",
+                "description": "The page parameter specifies the data page to query. It accepts values up to 100; for pages exceeding 100, use the cursor pagination method.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used.",
+                "pattern": "^(?:[1-9][0-9]?|100)$"
+              },
+              "rpp": {
+                "type": "integer",
+                "description": "rpp stands for results per page and specifies the page size. You can specify a number greater than 0 and up to 100.",
+                "pattern": "^(?:[1-9][0-9]{0,2}?|100)$"
+              },
+              "cursor": {
+                "type": "string",
+                "description": "The cursor parameter supports pagination and data navigation between pages. Provide the cursor value from the previous page in the next request to load the next page of data.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used."
+              },
+              "withCount": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the count field in the response. The count field indicates the total number of requested data items. When set to true, the count field is included and response speed may be slower.",
+                "default": false
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "withMetadata": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include NFT token metadata fields (rawMetadata, metadataSyncedAt) in the response. Response speed may be slower when set to true.",
+                "default": false
+              },
+              "withZeroValue": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include results with value 0 in the response. Set to true for faster responses.",
+                "default": false
+              },
+              "withFunction": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the function field in the response. Response speed may be slower when set to true.",
+                "default": false
+              }
+            }
+          }
+        ],
+        "example": {
+          "fromDate": "2026-01-01T00:00:00Z",
+          "toDate": "2026-02-01T00:00:00Z",
+          "page": 1,
+          "rpp": 10
+        }
+      },
+      "getNftTransfersWithinRange__kaia__Req": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "fromBlock": {
+                "type": "string",
+                "description": "Parameter specifying the starting block for the query. You can enter one of the following formats:\n- block number: Enter block number as a decimal string.\n- block hash: 64-character hexadecimal (including \"0x\").\n- block tag: Use \"earliest\" or \"latest\" to specify the first block or the most recent block.\n\nNotes:\n- This field cannot be used together with `fromDate` and `toDate`.\n- If provided without fromBlock, results are queried from genesis block to this block.\n- toBlock value cannot be less than fromBlock value.\n- If fromBlock and toBlock have the same value, only that block is queried.\n- \"earliest\" for toBlock is only allowed when fromBlock is \"earliest\".\n- If `fromBlock` and `toBlock` are not provided, the API queries data from the latest 30 days.\n\nFor Kaia, entering \"earliest\" queries the block at the Kaia hardfork point.\n- Mainnet: 162,900,480 (Aug 29, 2024 11:08:01 UTC+9)\n- Kairos(Testnet): 156,660,000 (June 13, 2024 10:15:19 UTC+9)\n\n",
+                "pattern": "^[0-9]+$|^0[xX][0-9a-fA-F]{64}|latest|earliest"
+              },
+              "toBlock": {
+                "type": "string",
+                "description": "Parameter specifying the ending block for the query. You can enter one of the following formats:\n- block number: Enter block number as a decimal string.\n- block hash: 64-character hexadecimal (including \"0x\").\n- block tag: Use \"earliest\" or \"latest\" to specify the first block or the most recent block.\n\nNotes:\n- This field cannot be used together with `fromDate` and `toDate`.\n- If provided without fromBlock, results are queried from genesis block to this block.\n- toBlock value cannot be less than fromBlock value.\n- If fromBlock and toBlock have the same value, only that block is queried.\n- \"earliest\" for toBlock is only allowed when fromBlock is \"earliest\".\n- If `fromBlock` and `toBlock` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]+$|^0[xX][0-9a-fA-F]{64}|latest|earliest"
+              },
+              "fromDate": {
+                "type": "string",
+                "description": "Parameter specifying the start date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without toDate, results are queried from this date to the latest block.\n- fromDate value must be equal to or earlier than toDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-01T00:00:00+00:00"
+              },
+              "toDate": {
+                "type": "string",
+                "description": "Parameter specifying the end date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without fromDate, results are queried from genesis block to this date.\n- toDate value must be equal to or later than fromDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-31T00:00:00+00:00"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "integer",
+                "description": "The page parameter specifies the data page to query. It accepts values up to 100; for pages exceeding 100, use the cursor pagination method.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used.",
+                "pattern": "^(?:[1-9][0-9]?|100)$"
+              },
+              "rpp": {
+                "type": "integer",
+                "description": "rpp stands for results per page and specifies the page size. You can specify a number greater than 0 and up to 100.",
+                "pattern": "^(?:[1-9][0-9]{0,2}?|100)$"
+              },
+              "cursor": {
+                "type": "string",
+                "description": "The cursor parameter supports pagination and data navigation between pages. Provide the cursor value from the previous page in the next request to load the next page of data.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used."
+              },
+              "withCount": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the count field in the response. The count field indicates the total number of requested data items. When set to true, the count field is included and response speed may be slower.",
+                "default": false
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "withMetadata": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include NFT token metadata fields (rawMetadata, metadataSyncedAt) in the response. Response speed may be slower when set to true.",
+                "default": false
+              },
+              "withZeroValue": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include results with value 0 in the response. Set to true for faster responses.",
+                "default": false
+              },
+              "withFunction": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the function field in the response. Response speed may be slower when set to true.",
+                "default": false
+              }
+            }
+          }
+        ],
+        "example": {
+          "fromDate": "2026-01-01T00:00:00Z",
+          "toDate": "2026-02-01T00:00:00Z",
+          "page": 1,
+          "rpp": 10
+        }
+      },
+      "getNftContractsByAccount__evm__Req": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "accountAddress"
+            ],
+            "properties": {
+              "accountAddress": {
+                "type": "string",
+                "description": "Parameter specifying the account address to query. Can be entered as a 40-character hexadecimal string starting with 0x.",
+                "pattern": "^0[xX][0-9a-fA-F]{40}$",
+                "example": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+              },
+              "contractAddresses": {
+                "type": "array",
+                "description": "Parameter specifying an array of contract addresses to query. Contract addresses can be entered as 40-character hexadecimal strings starting with 0x.",
+                "items": {
+                  "type": "string",
+                  "description": "Parameter specifying the contract address to query. Can be entered as a 40-character hexadecimal string starting with 0x.",
+                  "pattern": "^0[xX][0-9a-fA-F]{40}$"
+                }
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "integer",
+                "description": "The page parameter specifies the data page to query. It accepts values up to 100; for pages exceeding 100, use the cursor pagination method.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used.",
+                "pattern": "^(?:[1-9][0-9]?|100)$"
+              },
+              "rpp": {
+                "type": "integer",
+                "description": "rpp stands for results per page and specifies the page size. You can specify a number greater than 0 and up to 100.",
+                "pattern": "^(?:[1-9][0-9]{0,2}?|100)$"
+              },
+              "cursor": {
+                "type": "string",
+                "description": "The cursor parameter supports pagination and data navigation between pages. Provide the cursor value from the previous page in the next request to load the next page of data.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used."
+              },
+              "withCount": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the count field in the response. The count field indicates the total number of requested data items. When set to true, the count field is included and response speed may be slower.",
+                "default": false
+              }
+            }
+          }
+        ],
+        "example": {
+          "accountAddress": "0x742d35Cc6634C0532925a3b844Bc454e4438f44e",
+          "page": 1,
+          "rpp": 10
+        }
+      },
+      "getBlocksWithinRange__aptos__Req": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "fromBlock": {
+                "type": "string",
+                "description": "Parameter specifying the starting block for the query. You can enter one of the following formats:\n- block number: Enter block number as a decimal string.\n- block hash: 64-character hexadecimal (including \"0x\").\n- block tag: Use \"earliest\" or \"latest\" to specify the first block or the most recent block.\n\nNotes:\n- This field cannot be used together with `fromDate` and `toDate`.\n- If provided without fromBlock, results are queried from genesis block to this block.\n- toBlock value cannot be less than fromBlock value.\n- If fromBlock and toBlock have the same value, only that block is queried.\n- \"earliest\" for toBlock is only allowed when fromBlock is \"earliest\".\n- If `fromBlock` and `toBlock` are not provided, the API queries data from the latest 30 days.\n",
+                "pattern": "^[0-9]+$|^0[xX][0-9a-fA-F]{64}|latest|earliest",
+                "default": "earliest"
+              },
+              "toBlock": {
+                "type": "string",
+                "description": "Parameter specifying the ending block for the query. You can enter one of the following formats:\n- block number: Enter block number as a decimal string.\n- block hash: 64-character hexadecimal (including \"0x\").\n- block tag: Use \"earliest\" or \"latest\" to specify the first block or the most recent block.\n\nNotes:\n- This field cannot be used together with `fromDate` and `toDate`.\n- If provided without fromBlock, results are queried from genesis block to this block.\n- toBlock value cannot be less than fromBlock value.\n- If fromBlock and toBlock have the same value, only that block is queried.\n- \"earliest\" for toBlock is only allowed when fromBlock is \"earliest\".\n- If `fromBlock` and `toBlock` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]+$|^0[xX][0-9a-fA-F]{64}|latest|earliest"
+              },
+              "fromDate": {
+                "type": "string",
+                "description": "Parameter specifying the start date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without toDate, results are queried from this date to the latest block.\n- fromDate value must be equal to or earlier than toDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-01T00:00:00+00:00"
+              },
+              "toDate": {
+                "type": "string",
+                "description": "Parameter specifying the end date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without fromDate, results are queried from genesis block to this date.\n- toDate value must be equal to or later than fromDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-31T00:00:00+00:00"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "integer",
+                "description": "The page parameter specifies the data page to query. It accepts values up to 100; for pages exceeding 100, use the cursor pagination method.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used.",
+                "pattern": "^(?:[1-9][0-9]?|100)$"
+              },
+              "rpp": {
+                "type": "integer",
+                "description": "rpp stands for results per page and specifies the page size. You can specify a number greater than 0 and up to 100.",
+                "pattern": "^(?:[1-9][0-9]{0,2}?|100)$"
+              },
+              "cursor": {
+                "type": "string",
+                "description": "The cursor parameter supports pagination and data navigation between pages. Provide the cursor value from the previous page in the next request to load the next page of data.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used."
+              },
+              "withCount": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the count field in the response. The count field indicates the total number of requested data items. When set to true, the count field is included and response speed may be slower.",
+                "default": false
+              }
+            }
+          }
+        ],
+        "example": {
+          "page": 1,
+          "rpp": 10,
+          "fromDate": "2026-01-01T00:00:00Z",
+          "toDate": "2026-02-01T00:00:00Z"
+        }
+      },
+      "getBlocksWithinRange__kaia__Req": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "fromBlock": {
+                "type": "string",
+                "description": "Parameter specifying the starting block for the query. You can enter one of the following formats:\n- block number: Enter block number as a decimal string.\n- block hash: 64-character hexadecimal (including \"0x\").\n- block tag: Use \"earliest\" or \"latest\" to specify the first block or the most recent block.\n\nNotes:\n- This field cannot be used together with `fromDate` and `toDate`.\n- If provided without fromBlock, results are queried from genesis block to this block.\n- toBlock value cannot be less than fromBlock value.\n- If fromBlock and toBlock have the same value, only that block is queried.\n- \"earliest\" for toBlock is only allowed when fromBlock is \"earliest\".\n- If `fromBlock` and `toBlock` are not provided, the API queries data from the latest 30 days.\n\nFor Kaia, entering \"earliest\" queries the block at the Kaia hardfork point.\n- Mainnet: 162,900,480 (Aug 29, 2024 11:08:01 UTC+9)\n- Kairos(Testnet): 156,660,000 (June 13, 2024 10:15:19 UTC+9)\n\n",
+                "pattern": "^[0-9]+$|^0[xX][0-9a-fA-F]{64}|latest|earliest"
+              },
+              "toBlock": {
+                "type": "string",
+                "description": "Parameter specifying the ending block for the query. You can enter one of the following formats:\n- block number: Enter block number as a decimal string.\n- block hash: 64-character hexadecimal (including \"0x\").\n- block tag: Use \"earliest\" or \"latest\" to specify the first block or the most recent block.\n\nNotes:\n- If provided without fromBlock, results are queried from the Kaia hardfork block to this block.\n- toBlock value cannot be less than fromBlock value.\n- If fromBlock and toBlock have the same value, only that block is queried.\n- \"earliest\" for toBlock is only allowed when fromBlock is \"earliest\".\n\nFor Kaia, entering \"earliest\" queries the block at the Kaia hardfork point.\n- Mainnet: 162,900,480 (Aug 29, 2024 11:08:01 UTC+9)\n- Kairos(Testnet): 156,660,000 (June 13, 2024 10:15:19 UTC+9)\n",
+                "pattern": "^[0-9]+$|^0[xX][0-9a-fA-F]{64}|latest|earliest"
+              },
+              "fromDate": {
+                "type": "string",
+                "description": "Parameter specifying the start date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without toDate, results are queried from this date to the latest block.\n- fromDate value must be equal to or earlier than toDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-01T00:00:00+00:00"
+              },
+              "toDate": {
+                "type": "string",
+                "description": "Parameter specifying the end date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without fromDate, results are queried from genesis block to this date.\n- toDate value must be equal to or later than fromDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-31T00:00:00+00:00"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "integer",
+                "description": "The page parameter specifies the data page to query. It accepts values up to 100; for pages exceeding 100, use the cursor pagination method.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used.",
+                "pattern": "^(?:[1-9][0-9]?|100)$"
+              },
+              "rpp": {
+                "type": "integer",
+                "description": "rpp stands for results per page and specifies the page size. You can specify a number greater than 0 and up to 100.",
+                "pattern": "^(?:[1-9][0-9]{0,2}?|100)$"
+              },
+              "cursor": {
+                "type": "string",
+                "description": "The cursor parameter supports pagination and data navigation between pages. Provide the cursor value from the previous page in the next request to load the next page of data.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used."
+              },
+              "withCount": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the count field in the response. The count field indicates the total number of requested data items. When set to true, the count field is included and response speed may be slower.",
+                "default": false
+              }
+            }
+          }
+        ],
+        "example": {
+          "page": 1,
+          "rpp": 10,
+          "fromDate": "2026-01-01T00:00:00Z",
+          "toDate": "2026-02-01T00:00:00Z"
+        }
+      },
+      "getTransactionsByVersions__aptos__Req": {
+        "type": "object",
+        "required": [
+          "transactionVersions"
+        ],
+        "properties": {
+          "transactionVersions": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "description": "Parameter specifying the transaction version to query. The transaction version must be entered as a positive integer.",
+              "pattern": "^[-+]?[0-9]+$"
+            },
+            "minItems": 1,
+            "maxItems": 1000,
+            "description": "Enter the transaction versions to query as an array."
+          },
+          "withBalanceChanges": {
+            "type": "boolean",
+            "description": "Parameter specifying whether to include the balanceChanges field in the response.\n\n- balanceChanges is a field containing balance changes for Native token (APT) and Tokens.\n- Response speed may be slower when true is set for this parameter.",
+            "default": false
+          }
+        },
+        "example": {
+          "transactionVersions": [
+            3102207414,
+            3102479727
+          ],
+          "withBalanceChanges": false
+        }
+      },
+      "transactionList__aptos__Res": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "required": [
+            "transactionHash",
+            "transactionVersion",
+            "blockHeight",
+            "blockTimestamp",
+            "expirationTimestampSecs",
+            "gasUnitPrice",
+            "gasUsed",
+            "maxGasAmount",
+            "secondarySigners",
+            "sender",
+            "sequenceNumber",
+            "success",
+            "vmStatus",
+            "events",
+            "balanceInAccounts",
+            "balanceOutAccounts",
+            "balanceChangedTokens"
+          ],
+          "properties": {
+            "transactionHash": {
+              "type": "string",
+              "description": "A field that represents the unique identifier of the transaction.\nA cryptographic hash computed from all transaction data (signed payload), provided as a 64-character hexadecimal string prefixed with 0x.\nUsed to verify transaction integrity and to uniquely identify the transaction.\n"
+            },
+            "transactionVersion": {
+              "type": "integer",
+              "description": "A field that represents the version of the transaction.\nA unique sequence ID indicating the order of the transaction on the chain, incrementing sequentially from 0.\nUsed to ensure transaction execution order and to query the state of a specific transaction.\n"
+            },
+            "blockHeight": {
+              "type": "integer",
+              "description": "A field that represents the height of the block containing the transaction.\nProvided as an integer that increments sequentially from the genesis block (0).\nUsed to identify which block the transaction was included in and to verify if the transaction has been finalized.\n"
+            },
+            "blockTimestamp": {
+              "type": "integer",
+              "description": "A field that represents the creation time of the block containing the transaction.\nProvided as a UNIX timestamp; this value means both when the block was created and when the transactions in that block were processed.\n"
+            },
+            "expirationTimestampSecs": {
+              "type": "integer",
+              "description": "A field that represents the expiration time of the transaction.\nProvided as a UNIX timestamp in seconds; the transaction cannot be included in the chain after this time.\nSets the validity period of the transaction to prevent old transactions from being processed.\n"
+            },
+            "gasUnitPrice": {
+              "type": "string",
+              "description": "A field that represents the gas unit price of the transaction.\nProvided in Octas (1 APT = 10^8 Octas); indicates the amount to pay per gas unit.\nUsed to determine transaction processing priority and to calculate transaction fees.\n"
+            },
+            "gasUsed": {
+              "type": "string",
+              "description": "A field that represents the amount of gas actually consumed during transaction execution.\nA unit that measures the amount of computing resources consumed for transaction processing.\nActual transaction fee is calculated as gasUsed * gasUnitPrice.\n"
+            },
+            "maxGasAmount": {
+              "type": "string",
+              "description": "A field that represents the maximum amount of gas available for the transaction.\nThe transaction fails if this value is exceeded during execution; serves as a cap on gas cost.\nPrevents users from paying unexpectedly high fees.\n"
+            },
+            "secondarySigners": {
+              "type": "array",
+              "description": "A field that represents the list of addresses of additional signers in a multi-signature transaction.\nContains the addresses of accounts that signed the transaction in addition to the primary signer (sender).\nUsed for complex permission management or transactions requiring multiple approvals.\n",
+              "items": {
+                "type": "string"
+              }
+            },
+            "sender": {
+              "type": "string",
+              "description": "A field that represents the address of the account that initiated the transaction.\nProvided as a 64-character hexadecimal string prefixed with 0x; identifies the principal of the transaction.\nThe account against which transaction fee payment and sequence number management are applied.\n"
+            },
+            "sequenceNumber": {
+              "type": "integer",
+              "description": "A field that represents the current sequence number of the sender account.\nStarts at 0 and increments by 1 per transaction per account; prevents replay attacks and ensures transaction order.\nTransactions with the same sequence number cannot be executed redundantly.\n"
+            },
+            "success": {
+              "type": "boolean",
+              "description": "A field that indicates whether the transaction executed successfully.\ntrue means the transaction was executed successfully; false means an error occurred during execution.\n"
+            },
+            "vmStatus": {
+              "type": "string",
+              "description": "A field that represents the execution result status of the transaction.\nReturns 'Executed successfully' on success; includes specific error messages on failure.\nHelps analyze the cause of transaction failures and troubleshoot issues.\n"
+            },
+            "events": {
+              "type": "array",
+              "description": "A field that represents the list of events emitted during transaction execution.\nEach event records state changes or important operations caused by the transaction.\nProvides information to track transaction impact and for integration with external systems.\n",
+              "items": {
+                "type": "object"
+              }
+            },
+            "balanceInAccounts": {
+              "type": "array",
+              "description": "A field that represents the list of addresses of accounts that received assets in the transaction.\nContains addresses of accounts with positive values (deposits) in balanceChanges.\nUsed to track asset transfer recipients and analyze deposit history.\n",
+              "items": {
+                "type": "string"
+              }
+            },
+            "balanceOutAccounts": {
+              "type": "array",
+              "description": "A field that represents the list of addresses of accounts that sent assets in the transaction.\nContains addresses of accounts with negative values (withdrawals) in balanceChanges.\nUsed to track asset transfer senders and analyze withdrawal history.\n",
+              "items": {
+                "type": "string"
+              }
+            },
+            "balanceChangedTokens": {
+              "type": "array",
+              "description": "A field that represents the list of token types whose balances changed due to the transaction.\nEach token is provided in 'moduleAddress::moduleName::structName' format.\nUsed to identify the types of assets affected by the transaction and to track changes per asset.\n",
+              "items": {
+                "type": "string"
+              }
+            },
+            "balanceChanges": {
+              "type": "array",
+              "description": "A field that represents the asset change history that occurred in the transaction.\nOnly provided when withBalance=true is included in the request.\n",
+              "items": {
+                "type": "object"
+              }
+            },
+            "payload": {
+              "description": "A field that represents the transaction payload.\nContains the execution content of the transaction, such as entry function calls or script executions.\nOnly provided when the payload type is entry_function_payload.\n",
+              "type": "object"
+            },
+            "entryFunctionContractAddress": {
+              "type": "string",
+              "description": "A field that represents the module address of the called entry function.\nOnly provided when the payload type is entry_function_payload.\n"
+            },
+            "entryFunctionIdStr": {
+              "type": "string",
+              "description": "A field that represents the full identifier of the called entry function.\nProvided in 'moduleAddress::moduleName::functionName' format.\nOnly provided when the payload type is entry_function_payload.\n"
+            },
+            "entryFunctionModuleName": {
+              "type": "string",
+              "description": "A field that represents the module name of the called entry function.\nOnly provided when the payload type is entry_function_payload.\n"
+            },
+            "entryFunctionName": {
+              "type": "string",
+              "description": "A field that represents the name of the called entry function.\nOnly provided when the payload type is entry_function_payload.\n"
+            }
+          }
+        }
+      },
+      "getTransactionsByTransactionIds__utxo__Req": {
+        "type": "object",
+        "required": [
+          "transactionIds"
+        ],
+        "properties": {
+          "transactionIds": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "description": "Parameter specifying the transaction ID to query. Can be entered as a 64-character hexadecimal string (excluding 0x).",
+              "pattern": "^[0-9a-fA-F]{64}$"
+            },
+            "minItems": 1,
+            "maxItems": 1000,
+            "description": "Enter the transaction IDs to query as an array."
+          }
+        },
+        "example": {
+          "transactionIds": [
+            "b3554fe6689fddb99446c78a3bb1d08f59cfa479505e87e9b948e14b42ea9aef",
+            "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"
+          ]
+        }
+      },
+      "getTransactionsByTransactionIds__utxo__Res": {
+        "type": "array",
+        "items": {
+          "allOf": [
+            {
+              "type": "object",
+              "required": [
+                "id",
+                "index",
+                "hash",
+                "version",
+                "lockTime",
+                "size",
+                "vsize",
+                "weight",
+                "fee",
+                "vinCount",
+                "voutCount",
+                "blockHeight",
+                "blockHash",
+                "blockTimestamp"
+              ],
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "description": "Unique identifier of the transaction; a value that uniquely identifies each transaction."
+                },
+                "index": {
+                  "type": "integer",
+                  "description": "Indicates the index of the transaction within the block. Starts at 0; represents the order of transactions included in the block."
+                },
+                "hash": {
+                  "type": "string",
+                  "description": "Hash value of the transaction; a unique identifier calculated from the transaction data. Computed including SegWit data."
+                },
+                "version": {
+                  "type": "integer",
+                  "description": "Value indicating the transaction version; defines the transaction format."
+                },
+                "lockTime": {
+                  "type": "integer",
+                  "description": "Lock time of the transaction; indicates the condition (block height or UNIX timestamp) under which the transaction becomes valid. A value of `0` means the transaction is immediately valid."
+                },
+                "size": {
+                  "type": "integer",
+                  "description": "Actual size of the transaction in bytes; represents the length of the transaction data."
+                },
+                "vsize": {
+                  "type": "integer",
+                  "description": "Virtual size of the transaction in bytes; represents the effective size of the transaction as included in a block when SegWit data is included. Calculated by dividing weight by 4 and rounding up, per BIP-141."
+                },
+                "weight": {
+                  "type": "integer",
+                  "description": "Weight of the transaction; represents the network cost of the transaction as calculated per BIP-141. Calculated as `(non-witness size * 3) + total size`."
+                },
+                "fee": {
+                  "type": "integer",
+                  "description": "Transaction fee (in BTC units); the remainder when output value is subtracted from input value."
+                },
+                "vinCount": {
+                  "type": "integer",
+                  "description": "Indicates the number of input (Vin) transactions."
+                },
+                "voutCount": {
+                  "type": "integer",
+                  "description": "Indicates the number of output (Vout) transactions."
+                },
+                "blockHeight": {
+                  "type": "integer",
+                  "description": "Indicates the height of the block containing the transaction."
+                },
+                "blockHash": {
+                  "type": "string",
+                  "description": "Hash of the block containing the transaction."
+                },
+                "blockTimestamp": {
+                  "type": "integer",
+                  "description": "Indicates when the block containing the transaction was created; displayed in UNIX timestamp format."
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "vin": {
+                  "type": "object"
+                },
+                "vout": {
+                  "type": "object"
+                }
+              }
+            }
+          ]
+        }
+      },
+      "getTransactionsByHashes__aptos__Req": {
+        "type": "object",
+        "required": [
+          "transactionHashes"
+        ],
+        "properties": {
+          "transactionHashes": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "description": "Parameter specifying the transaction hash to query. The transaction hash must be entered as a 64-character hexadecimal string (including \"0x\").",
+              "pattern": "^0[xX][0-9a-fA-F]{64}"
+            }
+          },
+          "withBalanceChanges": {
+            "type": "boolean",
+            "description": "Parameter specifying whether to include the balanceChanges field in the response.\n\n- balanceChanges is a field containing balance changes for Native token (APT) and Tokens.\n- Response speed may be slower when true is set for this parameter.",
+            "default": false
+          }
+        },
+        "example": {
+          "transactionHashes": [
+            "0xda067ac1f6ab166745a7d4c3824275b8b7a2f97eeb947028283e17aff8b1fe45",
+            "0x2483964711e2041a9c8bdf3e3c2dc3eec19e968646d938c13813dc82255794d1"
+          ],
+          "withBalanceChanges": false
+        }
+      },
+      "getTransactionsByHashes__evm__Req": {
+        "type": "object",
+        "required": [
+          "transactionHashes"
+        ],
+        "properties": {
+          "transactionHashes": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "description": "Parameter specifying the transaction hash to query. Can be entered as a 64-character hexadecimal string starting with 0x.",
+              "pattern": "^0[xX][0-9a-fA-F]{64}$"
+            }
+          },
+          "withLogs": {
+            "type": "boolean",
+            "description": "Parameter specifying whether to include the logs field in the response. Response speed may be slower when set to true.",
+            "default": false
+          },
+          "withDecode": {
+            "type": "boolean",
+            "description": "Parameter specifying whether to include decodedInput and decodedLog fields in the response. Response speed may be slower when set to true.\n\ndecodedLog is part of logs, so it is not included when withLogs is false even if withDecode is true.\ndecodedInput interprets the transaction input field and provides the result. However, different functions may use the same function selector, so the result may not match the actually called function. Additional verification is recommended for non-standard ERC functions.",
+            "default": false
+          }
+        },
+        "example": {
+          "transactionHashes": [
+            "0x45d5ca108b4bf1e11e2ca6e92c6ee34911cd458726400ebb9810a4e2a51eaa98",
+            "0x57703b1e8e372ae1d84362d6687102237199604ef72a27b9127ca307ea746c18"
+          ],
+          "withLogs": false,
+          "withDecode": false
+        }
+      },
+      "getTransactionsByHashes__tron__Req": {
+        "type": "object",
+        "required": [
+          "transactionHashes"
+        ],
+        "properties": {
+          "transactionHashes": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "description": "Parameter for entering the transaction hash. Can be entered as a 64-character hexadecimal string.",
+              "pattern": "[0-9a-fA-F]{64}$",
+              "example": "ac3621457c57046ea1f558b95a567a5a125421dd80c5b137cb3c02e87d56f6ad"
+            }
+          },
+          "withLogs": {
+            "type": "boolean",
+            "description": "Parameter specifying whether to include the logs field in the response. Response speed may be slower when set to true.",
+            "default": false
+          },
+          "withDecode": {
+            "type": "boolean",
+            "description": "Parameter specifying whether to include decodedInput and decodedLog fields in the response. Response speed may be slower when set to true.\n\ndecodedLog is part of logs, so it is not included when withLogs is false even if withDecode is true.\ndecodedInput interprets the transaction input field and provides the result. However, different functions may use the same function selector, so the result may not match the actually called function. Additional verification is recommended for non-standard ERC functions.",
+            "default": false
+          }
+        },
+        "example": {
+          "transactionHashes": [
+            "7dedf74e3f0faaf03385292020a8f3b6c82c1886f3bd45edb2edaea4d0dc29a1",
+            "8cb2673b89baba29cce93d21c75099e639f11a4d950728bb4ea2ddf2a741be97"
+          ],
+          "withLogs": false,
+          "withDecode": false
+        }
+      },
+      "getTransactionsByHashes__xrpl__Req": {
+        "type": "object",
+        "required": [
+          "transactionHashes"
+        ],
+        "properties": {
+          "transactionHashes": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "description": "Parameter for entering the unique transaction hash. Uses a 64-character hexadecimal string.",
+              "pattern": "[0-9a-fA-F]{64}$"
+            }
+          },
+          "withBalanceChanges": {
+            "type": "boolean",
+            "description": "Optional parameter determining whether to include the balanceChanges field in the response. balanceChanges contains balance change details for native token (XRP) and IOU tokens. Response speed may be slower when set to true.",
+            "default": false
+          },
+          "withTokenTransfers": {
+            "type": "boolean",
+            "description": "Optional parameter determining whether to include the tokenTransfers field in the response. tokenTransfers contains IOU token transfer history. Response speed may be slower when set to true.",
+            "default": false
+          }
+        },
+        "example": {
+          "transactionHashes": [
+            "C466ACB9B54128A433E7FC9EFA49030A547AA06F40A3508BA90EF9D5984BADC3",
+            "A14DE85FA752026D5EE591BE0C99B5BC2814CD8FBE744A07EC0BC430254C34DA"
+          ],
+          "withBalanceChanges": false,
+          "withTokenTransfers": false
+        }
+      },
+      "getTransactionsByHashes__evm__Res": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "required": [
+            "transactionHash",
+            "transactionIndex",
+            "blockHash",
+            "blockNumber",
+            "from",
+            "to",
+            "value",
+            "input",
+            "functionSelector",
+            "nonce",
+            "gas",
+            "gasPrice",
+            "gasUsed",
+            "cumulativeGasUsed",
+            "contractAddress",
+            "logsBloom"
+          ],
+          "properties": {
+            "transactionHash": {
+              "type": "string",
+              "description": "A field representing the hash of the transaction. Provided as a 64-character hexadecimal string prefixed with 0x."
+            },
+            "transactionIndex": {
+              "type": "integer",
+              "description": "A field representing the index of the transaction. Indicates the order within the block. Provided in decimal string format."
+            },
+            "blockHash": {
+              "type": "string",
+              "description": "A field representing the hash of the block. Provided as a 64-character hexadecimal string prefixed with 0x."
+            },
+            "blockNumber": {
+              "type": "integer",
+              "description": "A field representing the block number."
+            },
+            "from": {
+              "type": "string",
+              "description": "A field representing the address that initiated the transaction. Provided as a 40-character hexadecimal string prefixed with 0x."
+            },
+            "to": {
+              "type": "string",
+              "description": "A field representing the recipient address of the transaction. For contract creation transactions, this field returns null. Provided as a 40-character hexadecimal string prefixed with 0x."
+            },
+            "value": {
+              "type": "string",
+              "description": "A field representing the amount of tokens transferred in the transaction. Provided in decimal string format."
+            },
+            "input": {
+              "type": "string",
+              "description": "A field representing the data of the transaction. For Native Token (ETH, MATIC, etc.) transfers, this field is empty. Provided as a hexadecimal string prefixed with 0x. "
+            },
+            "decodedInput": {
+              "type": "object",
+              "description": "A field representing the decoded result of the transaction input. Included in the response only when the withDecode parameter is set to true, providing function data executed based on the decoded input. This field is not provided even when withDecode is true if the function cannot be identified."
+            },
+            "functionSelector": {
+              "type": "string",
+              "description": "A 4-byte function selector value that identifies the called function. The function selector is the first 4 bytes of the Keccak-256 hash of the function signature. Provided as an 8-character hexadecimal string prefixed with 0x."
+            },
+            "nonce": {
+              "type": "string",
+              "description": "A field representing the nonce value of the transaction. Used for transaction deduplication and ordering. Provided in decimal string format."
+            },
+            "gas": {
+              "type": "string",
+              "description": "A field representing the maximum amount of gas the user intends to allocate for transaction execution. Provided in decimal string format."
+            },
+            "gasPrice": {
+              "type": "string",
+              "description": "A field representing the amount the user is willing to pay per unit of gas. Used in the transaction model before EIP-1559 (London Hard fork) with fixed fees; users can manually set the price based on network congestion. Provided in decimal string format."
+            },
+            "maxFeePerGas": {
+              "type": "string",
+              "description": "A field representing the maximum fee the user is willing to pay per unit of gas. Must be greater than or equal to the sum of baseFeePerGas and maxPriorityFeePerGas. Part of the variable fee model introduced in EIP-1559 (London Hard fork). This field is not provided for transactions before this introduction. Provided in decimal string format."
+            },
+            "maxPriorityFeePerGas": {
+              "type": "string",
+              "description": "The maximum fee per unit of gas that the user wants to pay directly to the block builder. Higher values cause the block builder to prioritize the transaction. Part of the variable fee model introduced in EIP-1559 (London Hard fork). This field is not provided for transactions before this introduction. Provided in decimal string format."
+            },
+            "gasUsed": {
+              "type": "string",
+              "description": "A field representing the amount of gas actually used in transaction execution. Provided in decimal string format."
+            },
+            "cumulativeGasUsed": {
+              "type": "string",
+              "description": "A field representing the total gas used by all transactions in the block up to and including the current transaction. Provided in decimal string format."
+            },
+            "effectiveGasPrice": {
+              "type": "string",
+              "description": "A field representing the average price actually paid per unit of gas by the transaction. For transactions before EIP-1559 (London Hard fork), this field returns the same value as gasPrice. Provided in decimal string format."
+            },
+            "contractAddress": {
+              "type": "string",
+              "description": "A field representing the created contract address when the transaction is a contract creation transaction. Provided as a 40-character hexadecimal string prefixed with 0x."
+            },
+            "type": {
+              "type": "string",
+              "description": "A field representing the type of the transaction. This field may not be provided depending on the block context. Provided in decimal string format.\n0: Represents a standard Ethereum transaction. This is the traditional transaction format before EIP-2718.\n1: Represents the 'Access List' transaction introduced in EIP-2930. This type includes an access list for specific addresses and storage slots to optimize gas costs.\n2: Represents the 'Fee Market' transaction introduced in EIP-1559. This type uses a variable gas cost model and includes maxFeePerGas and maxPriorityFeePerGas fields.\n3: Represents the 'Blob Transaction' introduced in EIP-4844. This type includes additional blob data separate from the body, improving data availability and supporting scalability in conjunction with Layer2 solutions such as Rollups.\n4: An extended transaction type introduced in EIP-7702, containing an authorizationList field with signature/authorization information. Used when multi-signature or additional authentication procedures are required.\n"
+            },
+            "status": {
+              "type": "string",
+              "description": "A field representing the status of the transaction. 1 indicates success; 0 indicates failure. This field is not provided for transactions before the Byzantium Hard Fork. Provided in decimal string format."
+            },
+            "logsBloom": {
+              "type": "string",
+              "description": "A field representing all logs bloom of the transaction. Provided as a 512-character hexadecimal string prefixed with 0x."
+            },
+            "accessList": {
+              "type": "array",
+              "description": "A field representing the access list of the transaction.",
+              "items": {
+                "type": "object"
+              }
+            },
+            "timestamp": {
+              "type": "integer",
+              "description": "A field representing when the transaction was created. This field is provided as a UNIX timestamp."
+            },
+            "authorizationList": {
+              "type": "array",
+              "description": "This field is a list containing the transaction's signature and authorization information. Each item includes chain ID, nonce, signature values, etc. required for signature verification. Provided after EIP-7702. Support and adoption may vary by network, and this field may not be present depending on the transaction type (e.g., type 4 or higher).",
+              "items": {
+                "type": "object"
+              }
+            },
+            "logs": {
+              "type": "array",
+              "description": "A field representing the list of logs included in the transaction. Provided only when the withLogs parameter is true.",
+              "items": {
+                "type": "object"
+              }
+            }
+          }
+        }
+      },
+      "getTransactionsByHashes__tron__Res": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "required": [
+            "transactionHash",
+            "transactionIndex",
+            "transactionTimestamp",
+            "blockNumber",
+            "blockTimestamp",
+            "refBlockBytes",
+            "refBlockHash",
+            "type",
+            "typeUrl",
+            "isMultiSig",
+            "from",
+            "to",
+            "value",
+            "assetId",
+            "input",
+            "functionSelector",
+            "result",
+            "contractRet",
+            "resMessage",
+            "fee",
+            "feeLimit",
+            "netFee",
+            "netUsage",
+            "energyFee",
+            "energyUsage",
+            "originEnergyUsage",
+            "energyUsageTotal",
+            "energyPenaltyTotal"
+          ],
+          "properties": {
+            "transactionHash": {
+              "type": "string",
+              "description": "Unique hash value that identifies the transaction. This field has a 64-character hexadecimal string format excluding the prefix (0x)."
+            },
+            "transactionIndex": {
+              "type": "integer",
+              "description": "Order in which the transaction was included within a specific block; indicates the execution order of the transaction."
+            },
+            "transactionTimestamp": {
+              "type": "integer",
+              "description": "Indicates when the transaction was created in milliseconds. The time when the transaction was created may differ from when it was included in a block; the actual state change is applied at the block timestamp when the transaction is included in the block."
+            },
+            "blockNumber": {
+              "type": "integer",
+              "description": "Unique number of the block. This number indicates the order in which the block was created on the blockchain."
+            },
+            "blockTimestamp": {
+              "type": "integer",
+              "description": "Timestamp of when the block was created, provided in milliseconds. Stored in Unix timestamp format."
+            },
+            "refBlockBytes": {
+              "type": "string",
+              "description": "Indicates the block referenced by the transaction. This field uses the 6th to 7th bytes of the reference block number, totaling 2 bytes. The reference block is the most recently finalized block; this value is embedded in the transaction to prevent transaction replay."
+            },
+            "refBlockHash": {
+              "type": "string",
+              "description": "Indicates the block referenced by the transaction. This field uses the 8th to 15th bytes of the reference block hash, totaling 8 bytes. The reference block is the most recently finalized block; this value is embedded in the transaction to prevent transaction replay."
+            },
+            "type": {
+              "type": "string",
+              "description": "Indicates the type of transaction. This field specifies the specific action performed by the transaction so the network can process it accordingly. Values include TransferContract, TriggerSmartContract, etc., defining operations such as TRX transfer and smart contract execution."
+            },
+            "typeUrl": {
+              "type": "string",
+              "description": "Field that specifies the specific path of the transaction type. This field is used to identify transaction types defined in chain buffer format. "
+            },
+            "isMultiSig": {
+              "type": "boolean",
+              "description": "Field indicating whether the transaction is a multi-signature transaction. Multi-sig requires signatures from multiple accounts and is used to enhance security."
+            },
+            "from": {
+              "type": "string",
+              "description": "Represents the sender address that created the transaction. That is, the account address from which the transaction originates. This field has a 34-character base58 string format starting with \"T\"."
+            },
+            "to": {
+              "type": "string",
+              "description": "Represents the recipient address that will receive the transaction. Depending on the transaction type, this may mean the address receiving the transferred TRX or the smart contract being invoked. This field has a 34-character base58 string format starting with \"T\"."
+            },
+            "value": {
+              "type": "string",
+              "description": "Represents the amount of assets transferred in the transaction. These assets include TRX or TRC10 tokens. \n\n<strong style='color: red;'>*</strong> The type of asset transferred depends on the \"assetId\" field value. When \"assetId\" is 0, it represents the TRX amount; when non-zero, it represents the amount of a specific TRC10 token. The amount is expressed in the smallest unit (e.g., sun for TRX) as a decimal string."
+            },
+            "assetId": {
+              "type": "integer",
+              "description": "Identifier for the token being transferred (TRX, TRC10). \n\n<strong style='color: red;'>*</strong> When the \"assetId\" field is 0, it means TRX; when non-zero, it means a specific TRC10 token."
+            },
+            "input": {
+              "type": "string",
+              "description": "Represents the data or input value passed when invoking a smart contract. Primarily used as parameter values for smart contract functions, specifying the actions the contract should perform."
+            },
+            "functionSelector": {
+              "type": "string",
+              "description": "Represents the unique identifier of the function executed in the transaction. For example, the signature of the transfer(address,uint256) function generates a specific hash through Keccak-256 hashing, and the first 4 bytes of this hash are used as the function selector."
+            },
+            "result": {
+              "type": "string",
+              "description": "Indicates the final status of the transaction execution. Provides the overall result of whether the entire transaction was processed successfully, allowing users to easily verify if the transaction completed successfully. Status values are SUCCESS and FAILED.\n\n<strong style='color: red;'>*</strong> Even if smart contract execution fails, the transaction itself is considered successful if it was recorded on the blockchain."
+            },
+            "contractRet": {
+              "type": "string",
+              "description": "Indicates the smart contract execution result, providing more detailed information about the transaction success or failure.\n- Examples: SUCCESS, REVERT, BAD_JUMP_DESTINATION, OUT_OF_MEMORY, PRECOMPILED_CONTRACT, ..."
+            },
+            "resMessage": {
+              "type": "string",
+              "description": "When transaction execution fails, represents the failure reason or error message. Returns an empty string for successful transactions."
+            },
+            "fee": {
+              "type": "string",
+              "description": "Total TRX cost consumed during transaction execution. When the bandwidth and energy of the account that created the transaction are insufficient, the shortfall is covered in TRX. This field represents that shortfall and is the sum of netFee and energyFee. For example, if bandwidth and energy are sufficient, fee is 0. Otherwise, it indicates the amount of TRX consumed to cover the shortfall. The unit of this field is \"sun\", and 1 TRX = 1,000,000 sun."
+            },
+            "feeLimit": {
+              "type": "string",
+              "description": "Maximum fee limit set by the user when creating the transaction; specifies the upper limit of fees that can be consumed when the transaction is executed. If the actual fee used exceeds feeLimit, the transaction fails. This allows users to prevent unexpected high fees in advance. The unit of this field is \"sun\", and 1 TRX = 1,000,000 sun."
+            },
+            "netFee": {
+              "type": "string",
+              "description": "Cost paid in TRX when the bandwidth of the transaction creator's account is insufficient. If available bandwidth is sufficient, no netFee is incurred. The unit of this field is \"sun\", and 1 TRX = 1,000,000 sun."
+            },
+            "netUsage": {
+              "type": "string",
+              "description": "Amount of bandwidth actually used in the transaction. When the transaction creator's remaining bandwidth is insufficient, the shortfall is paid in TRX, and the amount paid is recorded in netFee."
+            },
+            "energyFee": {
+              "type": "string",
+              "description": "Represents the cost paid in TRX when the energy of the transaction creator's account is insufficient. Only incurred when the energy required for smart contract execution exceeds the creator's available balance. The unit of this field is \"sun\", and 1 TRX = 1,000,000 sun."
+            },
+            "energyUsage": {
+              "type": "string",
+              "description": "Amount of energy used from the transaction creator's account. "
+            },
+            "originEnergyUsage": {
+              "type": "string",
+              "description": "Represents the amount of energy used from the account that deployed the smart contract. In certain situations, the contract deployer may bear some of the energy cost."
+            },
+            "energyUsageTotal": {
+              "type": "string",
+              "description": "Total amount of energy consumed in the transaction. Sum of energy consumed by the transaction creator (energyUsage) and energy consumed by the deployed smart contract (originEnergyUsage), representing the total energy usage for transaction execution."
+            },
+            "energyPenaltyTotal": {
+              "type": "string",
+              "description": "Additional energy amount that must be paid when calling certain popular smart contracts. Because TRON network resources (bandwidth and energy) are limited, penalties are applied to prevent excessive resource usage by specific popular smart contracts."
+            },
+            "permissionId": {
+              "type": "integer",
+              "description": "Field that specifies the permission to use for the transaction.\n- 0: Indicates Owner permission.\n- 1: Indicates Witness permission. Related to block production; cannot be used for transaction signing.\n- 2 or higher: Indicates Active permission groups. Specifies the user group that can execute transactions."
+            },
+            "assetIssueId": {
+              "type": "integer",
+              "description": "Value that identifies the TRC10 issued by the transaction. Returns the TRC10 asset ID when the transaction type is AssetIssueContract; returns null for other transaction types."
+            },
+            "withdrawAmount": {
+              "type": "string",
+              "description": "Represents the amount of rewards withdrawn, in sun. For reward withdrawal and unfreeze transactions, voting rewards are withdrawn to the account. The unit of this field is \"sun\", and 1 TRX = 1,000,000 sun."
+            },
+            "withdrawExpireAmount": {
+              "type": "string",
+              "description": "In the Stake2.0 phase, represents the amount of TRX withdrawn to the account for the following transactions. The unit of this field is \"sun\", and 1 TRX = 1,000,000 sun.\n1. Unstaking transaction\n2. Transaction that withdraws unfrozen balance to the account\n3. Transaction that cancels all unstaking requests"
+            },
+            "unfreezeAmount": {
+              "type": "string",
+              "description": "In the Stake1.0 phase, for unstaking transactions, this field returns the amount of unstaked TRX. The unit of this field is \"sun\", and 1 TRX = 1,000,000 sun."
+            },
+            "cancelUnfreezeV2Amount": {
+              "type": "object",
+              "description": "Amount of TRX used to re-stake the cancelled unstaking principal to obtain various resources such as BANDWIDTH, ENERGY, or TRON POWER."
+            },
+            "exchangeId": {
+              "type": "integer",
+              "description": "Unique ID that identifies a swap transaction on the decentralized exchange (DEX) provided by the TRON network. This ID distinguishes specific swap transactions and tracks which asset pair was traded."
+            },
+            "exchangeReceivedAmount": {
+              "type": "string",
+              "description": "Represents the final amount of assets received through a swap transaction on the decentralized exchange (DEX) provided by the TRON network."
+            },
+            "exchangeInjectAnotherAmount": {
+              "type": "string",
+              "description": "Amount of the other asset additionally injected during a swap transaction on the decentralized exchange (DEX) provided by the TRON network."
+            },
+            "exchangeWithdrawAnotherAmount": {
+              "type": "string",
+              "description": "Represents the amount withdrawn in another asset after a swap transaction on the decentralized exchange (DEX) provided by the TRON network."
+            },
+            "decodedInput": {
+              "type": "object",
+              "description": "Value decoded from the input data based on ABI when calling a smart contract. For regular transfers such as native token (TRX) transfers that are not smart contract calls, no input data exists, so this field is not provided.\n<strong style='color: red;'>*</strong> This field is only provided when withDecode is true."
+            }
+          }
+        }
+      },
+      "getTransactionsByHashes__xrpl__Res": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "required": [
+            "ledgerIndex",
+            "ledgerTimestamp",
+            "transactionIndex",
+            "transactionHash",
+            "transactionType",
+            "transactionResult",
+            "account",
+            "sequence",
+            "signingPubKey",
+            "fee",
+            "transactionCategory"
+          ],
+          "properties": {
+            "ledgerIndex": {
+              "type": "integer",
+              "description": "Sequence number of the ledger that contains the transaction. Used to identify which ledger the transaction was recorded in."
+            },
+            "ledgerTimestamp": {
+              "type": "integer",
+              "description": "Returns the close time of the ledger containing this transaction as a Unix timestamp. In the XRP Ledger, close time is recorded in seconds since the Ripple Epoch (January 1, 2000 00:00 UTC). Standard Unix timestamps use the Unix Epoch (January 1, 1970 00:00 UTC); the difference between them is 946,684,800 seconds. Thus ledgerTimestamp is the recorded close time plus 946,684,800 seconds."
+            },
+            "transactionIndex": {
+              "type": "integer",
+              "description": "Index indicating the processing order of the transaction within the ledger. Used to determine the order of transactions in the ledger."
+            },
+            "transactionHash": {
+              "type": "string",
+              "description": "A 256-bit (64-digit hexadecimal) cryptographic hash that uniquely identifies the transaction. Used for transaction data integrity and identification."
+            },
+            "transactionType": {
+              "type": "string",
+              "description": "String indicating the transaction type. Distinguishes various types such as Payment, OfferCreate, EscrowCreate, and is classified by processing method."
+            },
+            "transactionResult": {
+              "type": "string",
+              "description": "String indicating the transaction processing result, displayed as a result code such as 'tesSUCCESS'. Used to verify whether the transaction succeeded."
+            },
+            "account": {
+              "type": "string",
+              "description": "Account address that initiated the transaction. The account address is a Base58-encoded string 25-35 characters in length, starting with 'r'."
+            },
+            "sequence": {
+              "type": "integer",
+              "description": "Sequential number of transactions issued by the account, used to prevent duplicate submissions and replay attacks."
+            },
+            "lastLedgerSequence": {
+              "type": "integer",
+              "description": "Sequence number of the last ledger in which the transaction is valid. The transaction will not be processed in ledgers after this value."
+            },
+            "ticketSequence": {
+              "type": "integer",
+              "description": "For ticket-based transactions, the ticket number. Only present for transactions that use tickets."
+            },
+            "signingPubKey": {
+              "type": "string",
+              "description": "Public key used for the transaction signature, typically expressed as a 33-byte (66-digit hexadecimal) compressed public key."
+            },
+            "txnSignature": {
+              "type": "string",
+              "description": "Transaction signature value generated with signingPubKey. Used for transaction verification and authentication."
+            },
+            "fee": {
+              "type": "string",
+              "description": "Transaction processing fee, expressed as an XRP amount (in XRP units) as a string. In XRP units where 1 XRP equals 1,000,000 drops."
+            },
+            "flags": {
+              "type": "string",
+              "description": "Flag values applied to the transaction. Each bit controls a specific option or behavior; the default is often 0."
+            },
+            "accountTxnId": {
+              "type": "string",
+              "description": "256-bit hash identifying another transaction. If set, this transaction is valid only when it matches the sending account's most recent transaction ID. Used to prevent duplicate transaction submission or to verify that account state has not changed since a previous transaction."
+            },
+            "sourceTag": {
+              "type": "integer",
+              "description": "32-bit unsigned integer that the sender may specify when sending a transaction. Primarily used to identify the sending user from shared addresses (e.g. exchange or hosted wallet). Provides additional information so the receiver can determine \"who sent it\"."
+            },
+            "signers": {
+              "type": "array",
+              "description": "For multi-signed transactions, an array of objects containing each signer's information. Each object includes signer account, signing public key, signature value, etc.",
+              "items": {
+                "type": "object"
+              }
+            },
+            "memos": {
+              "type": "array",
+              "description": "Array of objects containing memo data attached to the transaction. Each memo object provides additional information such as memo content and format.",
+              "items": {
+                "type": "object"
+              }
+            },
+            "transactionCategory": {
+              "type": "string",
+              "description": "Enumeration string indicating the transaction category. Possible values include AMM, Check, Escrow, Offer, Payment, Payment Channel; each category is defined by the corresponding transaction type (e.g. Payment, OfferCreate)."
+            },
+            "transactionDetails": {
+              "type": "object",
+              "description": "Object containing details related to the transaction. May include additional data and fields required for transaction processing."
+            },
+            "balanceChanges": {
+              "type": "object"
+            },
+            "tokenTransfers": {
+              "type": "object"
+            },
+            "balanceOutAccounts": {
+              "type": "array",
+              "description": "List of account addresses whose final net balance change is less than zero (decreased) after summing all sends and receives in the transaction. Reflects both XRP and IOU token balance changes.",
+              "items": {
+                "type": "string",
+                "description": "Account address with a confirmed balance decrease"
+              }
+            },
+            "balanceInAccounts": {
+              "type": "array",
+              "description": "List of account addresses whose final net balance change is greater than zero (increased) after summing all sends and receives in the transaction. Reflects both XRP and IOU token balance changes.",
+              "items": {
+                "type": "string",
+                "description": "Account address with a confirmed balance increase"
+              }
+            },
+            "balanceChangedTokens": {
+              "type": "array",
+              "description": "List of token identifiers with non-zero final net balance change when summing the entire transaction. Each item follows the 'currency-issuer' format.",
+              "items": {
+                "type": "string",
+                "description": "Token identifier in 'currency-issuer' format"
+              }
+            }
+          }
+        }
+      },
+      "getTotalTransactionCountByAccount__aptos__Req": {
+        "type": "object",
+        "required": [
+          "accountAddress"
+        ],
+        "properties": {
+          "accountAddress": {
+            "type": "string",
+            "description": "Parameter specifying the account address to query. The account address must be entered as a 64-character hexadecimal string (including \"0x\").",
+            "pattern": "^0[xX][0-9a-fA-F]{64}",
+            "example": "0xd91c64b777e51395c6ea9dec562ed79a4afa0cd6dad5a87b187c37198a1f855a"
+          }
+        },
+        "example": {
+          "accountAddress": "0xd91c64b777e51395c6ea9dec562ed79a4afa0cd6dad5a87b187c37198a1f855a"
+        }
+      },
+      "getTotalTransactionCountByAccount__evm__Req": {
+        "type": "object",
+        "required": [
+          "accountAddress"
+        ],
+        "properties": {
+          "accountAddress": {
+            "type": "string",
+            "description": "Parameter specifying the account address to query. Can be entered as a 40-character hexadecimal string starting with 0x.",
+            "pattern": "^0[xX][0-9a-fA-F]{40}$",
+            "example": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+          }
+        },
+        "example": {
+          "accountAddress": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+        }
+      },
+      "getTotalTransactionCountByAccount__tron__Req": {
+        "type": "object",
+        "required": [
+          "accountAddress"
+        ],
+        "properties": {
+          "accountAddress": {
+            "type": "string",
+            "description": "Parameter specifying the account address to query. This field uses a 34-character base58 string format starting with \"T\".",
+            "pattern": "^T[1-9A-HJ-NP-Za-km-z]{33}$",
+            "example": "TPswDDCAWhJAZGdHPidFg5nEf8TkNToDX1"
+          }
+        }
+      },
+      "getTotalTransactionCountByAccount__xrpl__Req": {
+        "type": "object",
+        "required": [
+          "accountAddress"
+        ],
+        "properties": {
+          "accountAddress": {
+            "type": "string",
+            "description": "Parameter specifying the account address for balance query. It is a Base58-encoded string of 25-35 characters, always starting with \"r\".",
+            "pattern": "^r[1-9A-HJ-NP-Za-km-z]{25,35}$"
+          }
+        },
+        "example": {
+          "accountAddress": "r9cZA1mLK5R5Am25ArfXFmqgNQW4tU1K8"
+        }
+      },
+      "getTotalTransactionCountByAccount___shared__Res": {
+        "type": "object",
+        "properties": {
+          "transactionCount": {
+            "type": "integer",
+            "description": "Indicates the total count of transactions in which the account participated as sender or recipient. For XRPL and Aptos, it indicates the total count of transactions created by the specific account."
+          }
+        }
+      },
+      "getInternalTransactionsByTransactionHash__evm__Req": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "transactionHash"
+            ],
+            "properties": {
+              "transactionHash": {
+                "type": "string",
+                "description": "Parameter specifying the transaction hash to query. Can be entered as a 64-character hexadecimal string starting with 0x.",
+                "pattern": "^0[xX][0-9a-fA-F]{64}$"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "integer",
+                "description": "The page parameter specifies the data page to query. It accepts values up to 100; for pages exceeding 100, use the cursor pagination method.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used.",
+                "pattern": "^(?:[1-9][0-9]?|100)$"
+              },
+              "rpp": {
+                "type": "integer",
+                "description": "rpp stands for results per page and specifies the page size. You can specify a number greater than 0 and up to 100.",
+                "pattern": "^(?:[1-9][0-9]{0,2}?|100)$"
+              },
+              "cursor": {
+                "type": "string",
+                "description": "The cursor parameter supports pagination and data navigation between pages. Provide the cursor value from the previous page in the next request to load the next page of data.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used."
+              },
+              "withCount": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the count field in the response. The count field indicates the total number of requested data items. When set to true, the count field is included and response speed may be slower.",
+                "default": false
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "withZeroValue": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include results with value 0 in the response. Set to true for faster responses.",
+                "default": false
+              },
+              "withExternalTransaction": {
+                "type": "boolean",
+                "description": "Parameter determining whether to include external transactions in the response. External transactions are returned in the same format as internal transactions with trace index 0. When set to true, external transactions are included and response speed may be slower.",
+                "default": false
+              }
+            }
+          }
+        ],
+        "example": {
+          "page": 1,
+          "rpp": 10,
+          "transactionHash": "0xdcfd39025f4c17b2633b42a3592cda9e0b783ee01acad8ee1a3a5130991692ff",
+          "withZeroValue": false,
+          "withExternalTransaction": false
+        }
+      },
+      "getInternalTransactionsByTransactionHash__tron__Req": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "transactionHash"
+            ],
+            "properties": {
+              "transactionHash": {
+                "type": "string",
+                "description": "Parameter for entering the transaction hash. Can be entered as a 64-character hexadecimal string.",
+                "pattern": "[0-9a-fA-F]{64}$",
+                "example": "ac3621457c57046ea1f558b95a567a5a125421dd80c5b137cb3c02e87d56f6ad"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "integer",
+                "description": "The page parameter specifies the data page to query. It accepts values up to 100; for pages exceeding 100, use the cursor pagination method.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used.",
+                "pattern": "^(?:[1-9][0-9]?|100)$"
+              },
+              "rpp": {
+                "type": "integer",
+                "description": "rpp stands for results per page and specifies the page size. You can specify a number greater than 0 and up to 100.",
+                "pattern": "^(?:[1-9][0-9]{0,2}?|100)$"
+              },
+              "cursor": {
+                "type": "string",
+                "description": "The cursor parameter supports pagination and data navigation between pages. Provide the cursor value from the previous page in the next request to load the next page of data.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used."
+              },
+              "withCount": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the count field in the response. The count field indicates the total number of requested data items. When set to true, the count field is included and response speed may be slower.",
+                "default": false
+              }
+            }
+          }
+        ],
+        "example": {
+          "page": 1,
+          "rpp": 10,
+          "transactionHash": "ac3621457c57046ea1f558b95a567a5a125421dd80c5b137cb3c02e87d56f6ad",
+          "withZeroValue": false,
+          "withExternalTransaction": false
+        }
+      },
+      "getTransactionsInBlock__evm__Req": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "block"
+            ],
+            "properties": {
+              "block": {
+                "type": "string",
+                "description": "Parameter specifying the block to query. The default value is latest. You can input block number (decimal string), block hash (64-character hexadecimal string starting with 0x), or block tag (earliest, latest). \"earliest\" refers to the first block, \"latest\" refers to the most recent block.\n\n",
+                "pattern": "^[0-9]+$|^0[xX][0-9a-fA-F]{64}|latest|earliest",
+                "default": "latest"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "integer",
+                "description": "The page parameter specifies the data page to query. It accepts values up to 100; for pages exceeding 100, use the cursor pagination method.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used.",
+                "pattern": "^(?:[1-9][0-9]?|100)$"
+              },
+              "rpp": {
+                "type": "integer",
+                "description": "rpp stands for results per page and specifies the page size. You can specify a number greater than 0 and up to 100.",
+                "pattern": "^(?:[1-9][0-9]{0,2}?|100)$"
+              },
+              "cursor": {
+                "type": "string",
+                "description": "The cursor parameter supports pagination and data navigation between pages. Provide the cursor value from the previous page in the next request to load the next page of data.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used."
+              },
+              "withCount": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the count field in the response. The count field indicates the total number of requested data items. When set to true, the count field is included and response speed may be slower.",
+                "default": false
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "withLogs": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the logs field in the response. Response speed may be slower when set to true.",
+                "default": false
+              },
+              "withDecode": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include decodedInput and decodedLog fields in the response. Response speed may be slower when set to true.\n\ndecodedLog is part of logs, so it is not included when withLogs is false even if withDecode is true.\ndecodedInput interprets the transaction input field and provides the result. However, different functions may use the same function selector, so the result may not match the actually called function. Additional verification is recommended for non-standard ERC functions.",
+                "default": false
+              }
+            }
+          }
+        ],
+        "example": {
+          "block": "17530000",
+          "withLogs": false,
+          "withDecode": false
+        }
+      },
+      "getTransactionsInBlock__aptos__Req": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "block"
+            ],
+            "properties": {
+              "block": {
+                "type": "string",
+                "description": "Parameter specifying the block to query. The default value is latest. You can input block number (decimal string), block hash (64-character hexadecimal string starting with 0x), or block tag (earliest, latest). \"earliest\" refers to the first block, \"latest\" refers to the most recent block.",
+                "pattern": "^[0-9]+$|^0[xX][0-9a-fA-F]{64}|latest|earliest",
+                "default": "latest"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "integer",
+                "description": "The page parameter specifies the data page to query. It accepts values up to 100; for pages exceeding 100, use the cursor pagination method.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used.",
+                "pattern": "^(?:[1-9][0-9]?|100)$"
+              },
+              "rpp": {
+                "type": "integer",
+                "description": "rpp stands for results per page and specifies the page size. You can specify a number greater than 0 and up to 100.",
+                "pattern": "^(?:[1-9][0-9]{0,2}?|100)$"
+              },
+              "cursor": {
+                "type": "string",
+                "description": "The cursor parameter supports pagination and data navigation between pages. Provide the cursor value from the previous page in the next request to load the next page of data.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used."
+              },
+              "withCount": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the count field in the response. The count field indicates the total number of requested data items. When set to true, the count field is included and response speed may be slower.",
+                "default": false
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "withBalanceChanges": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the balanceChanges field in the response.\n\n- balanceChanges is a field containing balance changes for Native token (APT) and Tokens.\n- Response speed may be slower when true is set for this parameter.",
+                "default": false
+              }
+            }
+          }
+        ],
+        "example": {
+          "block": "17530000",
+          "withBalanceChanges": false
+        }
+      },
+      "getTransactionsInBlock__tron__Req": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "block"
+            ],
+            "properties": {
+              "block": {
+                "type": "string",
+                "description": "Parameter specifying the point in time for balance query. You can enter block hash, block number, or block tag.\n- block number: Enter as a decimal string.\n- block hash: Enter as a 64-character hexadecimal string, excluding the 0x prefix.\n- block tag: Enter \"earliest\" or \"latest\"; \"latest\" queries the balance of the most recent block.",
+                "pattern": "^[0-9]+$|^[0-9a-fA-F]{64}|latest|earliest",
+                "default": "latest",
+                "example": "latest"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "integer",
+                "description": "The page parameter specifies the data page to query. It accepts values up to 100; for pages exceeding 100, use the cursor pagination method.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used.",
+                "pattern": "^(?:[1-9][0-9]?|100)$"
+              },
+              "rpp": {
+                "type": "integer",
+                "description": "rpp stands for results per page and specifies the page size. You can specify a number greater than 0 and up to 100.",
+                "pattern": "^(?:[1-9][0-9]{0,2}?|100)$"
+              },
+              "cursor": {
+                "type": "string",
+                "description": "The cursor parameter supports pagination and data navigation between pages. Provide the cursor value from the previous page in the next request to load the next page of data.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used."
+              },
+              "withCount": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the count field in the response. The count field indicates the total number of requested data items. When set to true, the count field is included and response speed may be slower.",
+                "default": false
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "withLogs": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the logs field in the response. Response speed may be slower when set to true.",
+                "default": false
+              },
+              "withDecode": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include decodedInput and decodedLog fields in the response. Response speed may be slower when set to true.\n\ndecodedLog is part of logs, so it is not included when withLogs is false even if withDecode is true.\ndecodedInput interprets the transaction input field and provides the result. However, different functions may use the same function selector, so the result may not match the actually called function. Additional verification is recommended for non-standard ERC functions.",
+                "default": false
+              }
+            }
+          }
+        ],
+        "example": {
+          "block": "17530000",
+          "withLogs": false,
+          "withDecode": false
+        }
+      },
+      "getEventsByType__aptos__Req": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "eventType"
+            ],
+            "properties": {
+              "eventType": {
+                "type": "string",
+                "description": "Parameter specifying the event type to query. Event type refers to the name of the event struct defined in the module. This field must be entered in the format `module_address::module_name::event_name`.",
+                "pattern": "^0[xX]?[0-9a-fA-F]{0,64}$::^0x[0-9a-zA-Z:_<>]+$::^[a-zA-Z0-9_-]+$"
+              },
+              "fromBlock": {
+                "type": "string",
+                "description": "Parameter specifying the starting block for the query. You can enter one of the following formats:\n- block number: Enter block number as a decimal string.\n- block hash: 64-character hexadecimal (including \"0x\").\n- block tag: Use \"earliest\" or \"latest\" to specify the first block or the most recent block.\n\nNotes:\n- This field cannot be used together with `fromDate` and `toDate`.\n- If provided without fromBlock, results are queried from genesis block to this block.\n- toBlock value cannot be less than fromBlock value.\n- If fromBlock and toBlock have the same value, only that block is queried.\n- \"earliest\" for toBlock is only allowed when fromBlock is \"earliest\".\n- If `fromBlock` and `toBlock` are not provided, the API queries data from the latest 30 days.\n",
+                "pattern": "^[0-9]+$|^0[xX][0-9a-fA-F]{64}|latest|earliest",
+                "default": "earliest"
+              },
+              "toBlock": {
+                "type": "string",
+                "description": "Parameter specifying the ending block for the query. You can enter one of the following formats:\n- block number: Enter block number as a decimal string.\n- block hash: 64-character hexadecimal (including \"0x\").\n- block tag: Use \"earliest\" or \"latest\" to specify the first block or the most recent block.\n\nNotes:\n- This field cannot be used together with `fromDate` and `toDate`.\n- If provided without fromBlock, results are queried from genesis block to this block.\n- toBlock value cannot be less than fromBlock value.\n- If fromBlock and toBlock have the same value, only that block is queried.\n- \"earliest\" for toBlock is only allowed when fromBlock is \"earliest\".\n- If `fromBlock` and `toBlock` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]+$|^0[xX][0-9a-fA-F]{64}|latest|earliest"
+              },
+              "fromDate": {
+                "type": "string",
+                "description": "Parameter specifying the start date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without toDate, results are queried from this date to the latest block.\n- fromDate value must be equal to or earlier than toDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-01T00:00:00+00:00"
+              },
+              "toDate": {
+                "type": "string",
+                "description": "Parameter specifying the end date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without fromDate, results are queried from genesis block to this date.\n- toDate value must be equal to or later than fromDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-31T00:00:00+00:00"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "integer",
+                "description": "The page parameter specifies the data page to query. It accepts values up to 100; for pages exceeding 100, use the cursor pagination method.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used.",
+                "pattern": "^(?:[1-9][0-9]?|100)$"
+              },
+              "rpp": {
+                "type": "integer",
+                "description": "rpp stands for results per page and specifies the page size. You can specify a number greater than 0 and up to 100.",
+                "pattern": "^(?:[1-9][0-9]{0,2}?|100)$"
+              },
+              "cursor": {
+                "type": "string",
+                "description": "The cursor parameter supports pagination and data navigation between pages. Provide the cursor value from the previous page in the next request to load the next page of data.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used."
+              },
+              "withCount": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the count field in the response. The count field indicates the total number of requested data items. When set to true, the count field is included and response speed may be slower.",
+                "default": false
+              }
+            }
+          }
+        ]
+      },
+      "getTransactionByHash__aptos__Req": {
+        "type": "object",
+        "required": [
+          "transactionHash"
+        ],
+        "properties": {
+          "transactionHash": {
+            "type": "string",
+            "description": "Parameter specifying the transaction hash to query. The transaction hash must be entered as a 64-character hexadecimal string (including \"0x\").",
+            "pattern": "^0[xX][0-9a-fA-F]{64}"
+          },
+          "withBalanceChanges": {
+            "type": "boolean",
+            "description": "Parameter specifying whether to include the balanceChanges field in the response.\n\n- balanceChanges is a field containing balance changes for Native token (APT) and Tokens.\n- Response speed may be slower when true is set for this parameter.",
+            "default": false
+          }
+        },
+        "example": {
+          "transactionHash": "0xda067ac1f6ab166745a7d4c3824275b8b7a2f97eeb947028283e17aff8b1fe45",
+          "withBalanceChanges": false
+        }
+      },
+      "getTransactionByHash__evm__Req": {
+        "type": "object",
+        "required": [
+          "transactionHash"
+        ],
+        "properties": {
+          "transactionHash": {
+            "type": "string",
+            "description": "Parameter specifying the transaction hash to query. Can be entered as a 64-character hexadecimal string starting with 0x.",
+            "pattern": "^0[xX][0-9a-fA-F]{64}$"
+          },
+          "withLogs": {
+            "type": "boolean",
+            "description": "Parameter specifying whether to include the logs field in the response. Response speed may be slower when set to true.",
+            "default": false
+          },
+          "withDecode": {
+            "type": "boolean",
+            "description": "Parameter specifying whether to include decodedInput and decodedLog fields in the response. Response speed may be slower when set to true.\n\ndecodedLog is part of logs, so it is not included when withLogs is false even if withDecode is true.\ndecodedInput interprets the transaction input field and provides the result. However, different functions may use the same function selector, so the result may not match the actually called function. Additional verification is recommended for non-standard ERC functions.",
+            "default": false
+          }
+        },
+        "example": {
+          "transactionHash": "0x45d5ca108b4bf1e11e2ca6e92c6ee34911cd458726400ebb9810a4e2a51eaa98",
+          "withLogs": false,
+          "withDecode": false
+        }
+      },
+      "getTransactionByHash__xrpl__Req": {
+        "type": "object",
+        "required": [
+          "transactionHash"
+        ],
+        "properties": {
+          "transactionHash": {
+            "type": "string",
+            "description": "Parameter for entering the unique transaction hash. Uses a 64-character hexadecimal string.",
+            "pattern": "[0-9a-fA-F]{64}$"
+          },
+          "withBalanceChanges": {
+            "type": "boolean",
+            "description": "Optional parameter determining whether to include the balanceChanges field in the response. balanceChanges contains balance change details for native token (XRP) and IOU tokens. Response speed may be slower when set to true.",
+            "default": false
+          },
+          "withTokenTransfers": {
+            "type": "boolean",
+            "description": "Optional parameter determining whether to include the tokenTransfers field in the response. tokenTransfers contains IOU token transfer history. Response speed may be slower when set to true.",
+            "default": false
+          }
+        },
+        "example": {
+          "transactionHash": "C466ACB9B54128A433E7FC9EFA49030A547AA06F40A3508BA90EF9D5984BADC3",
+          "withBalanceChanges": false,
+          "withTokenTransfers": false
+        }
+      },
+      "getTransactionByHash__evm__Res": {
+        "type": "object",
+        "required": [
+          "transactionHash",
+          "transactionIndex",
+          "blockHash",
+          "blockNumber",
+          "from",
+          "to",
+          "value",
+          "input",
+          "functionSelector",
+          "nonce",
+          "gas",
+          "gasPrice",
+          "gasUsed",
+          "cumulativeGasUsed",
+          "contractAddress",
+          "logsBloom"
+        ],
+        "properties": {
+          "transactionHash": {
+            "type": "string",
+            "description": "A field representing the hash of the transaction. Provided as a 64-character hexadecimal string prefixed with 0x."
+          },
+          "transactionIndex": {
+            "type": "integer",
+            "description": "A field representing the index of the transaction. Indicates the order within the block. Provided in decimal string format."
+          },
+          "blockHash": {
+            "type": "string",
+            "description": "A field representing the hash of the block. Provided as a 64-character hexadecimal string prefixed with 0x."
+          },
+          "blockNumber": {
+            "type": "integer",
+            "description": "A field representing the block number."
+          },
+          "from": {
+            "type": "string",
+            "description": "A field representing the address that initiated the transaction. Provided as a 40-character hexadecimal string prefixed with 0x."
+          },
+          "to": {
+            "type": "string",
+            "description": "A field representing the recipient address of the transaction. For contract creation transactions, this field returns null. Provided as a 40-character hexadecimal string prefixed with 0x."
+          },
+          "value": {
+            "type": "string",
+            "description": "A field representing the amount of tokens transferred in the transaction. Provided in decimal string format."
+          },
+          "input": {
+            "type": "string",
+            "description": "A field representing the data of the transaction. For Native Token (ETH, MATIC, etc.) transfers, this field is empty. Provided as a hexadecimal string prefixed with 0x. "
+          },
+          "decodedInput": {
+            "type": "object",
+            "description": "A field representing the decoded result of the transaction input. Included in the response only when the withDecode parameter is set to true, providing function data executed based on the decoded input. This field is not provided even when withDecode is true if the function cannot be identified."
+          },
+          "functionSelector": {
+            "type": "string",
+            "description": "A 4-byte function selector value that identifies the called function. The function selector is the first 4 bytes of the Keccak-256 hash of the function signature. Provided as an 8-character hexadecimal string prefixed with 0x."
+          },
+          "nonce": {
+            "type": "string",
+            "description": "A field representing the nonce value of the transaction. Used for transaction deduplication and ordering. Provided in decimal string format."
+          },
+          "gas": {
+            "type": "string",
+            "description": "A field representing the maximum amount of gas the user intends to allocate for transaction execution. Provided in decimal string format."
+          },
+          "gasPrice": {
+            "type": "string",
+            "description": "A field representing the amount the user is willing to pay per unit of gas. Used in the transaction model before EIP-1559 (London Hard fork) with fixed fees; users can manually set the price based on network congestion. Provided in decimal string format."
+          },
+          "maxFeePerGas": {
+            "type": "string",
+            "description": "A field representing the maximum fee the user is willing to pay per unit of gas. Must be greater than or equal to the sum of baseFeePerGas and maxPriorityFeePerGas. Part of the variable fee model introduced in EIP-1559 (London Hard fork). This field is not provided for transactions before this introduction. Provided in decimal string format."
+          },
+          "maxPriorityFeePerGas": {
+            "type": "string",
+            "description": "The maximum fee per unit of gas that the user wants to pay directly to the block builder. Higher values cause the block builder to prioritize the transaction. Part of the variable fee model introduced in EIP-1559 (London Hard fork). This field is not provided for transactions before this introduction. Provided in decimal string format."
+          },
+          "gasUsed": {
+            "type": "string",
+            "description": "A field representing the amount of gas actually used in transaction execution. Provided in decimal string format."
+          },
+          "cumulativeGasUsed": {
+            "type": "string",
+            "description": "A field representing the total gas used by all transactions in the block up to and including the current transaction. Provided in decimal string format."
+          },
+          "effectiveGasPrice": {
+            "type": "string",
+            "description": "A field representing the average price actually paid per unit of gas by the transaction. For transactions before EIP-1559 (London Hard fork), this field returns the same value as gasPrice. Provided in decimal string format."
+          },
+          "contractAddress": {
+            "type": "string",
+            "description": "A field representing the created contract address when the transaction is a contract creation transaction. Provided as a 40-character hexadecimal string prefixed with 0x."
+          },
+          "type": {
+            "type": "string",
+            "description": "A field representing the type of the transaction. This field may not be provided depending on the block context. Provided in decimal string format.\n0: Represents a standard Ethereum transaction. This is the traditional transaction format before EIP-2718.\n1: Represents the 'Access List' transaction introduced in EIP-2930. This type includes an access list for specific addresses and storage slots to optimize gas costs.\n2: Represents the 'Fee Market' transaction introduced in EIP-1559. This type uses a variable gas cost model and includes maxFeePerGas and maxPriorityFeePerGas fields.\n3: Represents the 'Blob Transaction' introduced in EIP-4844. This type includes additional blob data separate from the body, improving data availability and supporting scalability in conjunction with Layer2 solutions such as Rollups.\n4: An extended transaction type introduced in EIP-7702, containing an authorizationList field with signature/authorization information. Used when multi-signature or additional authentication procedures are required.\n"
+          },
+          "status": {
+            "type": "string",
+            "description": "A field representing the status of the transaction. 1 indicates success; 0 indicates failure. This field is not provided for transactions before the Byzantium Hard Fork. Provided in decimal string format."
+          },
+          "logsBloom": {
+            "type": "string",
+            "description": "A field representing all logs bloom of the transaction. Provided as a 512-character hexadecimal string prefixed with 0x."
+          },
+          "accessList": {
+            "type": "array",
+            "description": "A field representing the access list of the transaction.",
+            "items": {
+              "type": "object"
+            }
+          },
+          "timestamp": {
+            "type": "integer",
+            "description": "A field representing when the transaction was created. This field is provided as a UNIX timestamp."
+          },
+          "authorizationList": {
+            "type": "array",
+            "description": "This field is a list containing the transaction's signature and authorization information. Each item includes chain ID, nonce, signature values, etc. required for signature verification. Provided after EIP-7702. Support and adoption may vary by network, and this field may not be present depending on the transaction type (e.g., type 4 or higher).",
+            "items": {
+              "type": "object"
+            }
+          },
+          "logs": {
+            "type": "array",
+            "description": "A field representing the list of logs included in the transaction. Provided only when the withLogs parameter is true.",
+            "items": {
+              "type": "object"
+            }
+          }
+        }
+      },
+      "transaction__aptos__Res": {
+        "type": "object",
+        "required": [
+          "transactionHash",
+          "transactionVersion",
+          "blockHeight",
+          "blockTimestamp",
+          "expirationTimestampSecs",
+          "gasUnitPrice",
+          "gasUsed",
+          "maxGasAmount",
+          "secondarySigners",
+          "sender",
+          "sequenceNumber",
+          "success",
+          "vmStatus",
+          "events",
+          "balanceInAccounts",
+          "balanceOutAccounts",
+          "balanceChangedTokens"
+        ],
+        "properties": {
+          "transactionHash": {
+            "type": "string",
+            "description": "A field that represents the unique identifier of the transaction.\nA cryptographic hash computed from all transaction data (signed payload), provided as a 64-character hexadecimal string prefixed with 0x.\nUsed to verify transaction integrity and to uniquely identify the transaction.\n"
+          },
+          "transactionVersion": {
+            "type": "integer",
+            "description": "A field that represents the version of the transaction.\nA unique sequence ID indicating the order of the transaction on the chain, incrementing sequentially from 0.\nUsed to ensure transaction execution order and to query the state of a specific transaction.\n"
+          },
+          "blockHeight": {
+            "type": "integer",
+            "description": "A field that represents the height of the block containing the transaction.\nProvided as an integer that increments sequentially from the genesis block (0).\nUsed to identify which block the transaction was included in and to verify if the transaction has been finalized.\n"
+          },
+          "blockTimestamp": {
+            "type": "integer",
+            "description": "A field that represents the creation time of the block containing the transaction.\nProvided as a UNIX timestamp; this value means both when the block was created and when the transactions in that block were processed.\n"
+          },
+          "expirationTimestampSecs": {
+            "type": "integer",
+            "description": "A field that represents the expiration time of the transaction.\nProvided as a UNIX timestamp in seconds; the transaction cannot be included in the chain after this time.\nSets the validity period of the transaction to prevent old transactions from being processed.\n"
+          },
+          "gasUnitPrice": {
+            "type": "string",
+            "description": "A field that represents the gas unit price of the transaction.\nProvided in Octas (1 APT = 10^8 Octas); indicates the amount to pay per gas unit.\nUsed to determine transaction processing priority and to calculate transaction fees.\n"
+          },
+          "gasUsed": {
+            "type": "string",
+            "description": "A field that represents the amount of gas actually consumed during transaction execution.\nA unit that measures the amount of computing resources consumed for transaction processing.\nActual transaction fee is calculated as gasUsed * gasUnitPrice.\n"
+          },
+          "maxGasAmount": {
+            "type": "string",
+            "description": "A field that represents the maximum amount of gas available for the transaction.\nThe transaction fails if this value is exceeded during execution; serves as a cap on gas cost.\nPrevents users from paying unexpectedly high fees.\n"
+          },
+          "secondarySigners": {
+            "type": "array",
+            "description": "A field that represents the list of addresses of additional signers in a multi-signature transaction.\nContains the addresses of accounts that signed the transaction in addition to the primary signer (sender).\nUsed for complex permission management or transactions requiring multiple approvals.\n",
+            "items": {
+              "type": "string"
+            }
+          },
+          "sender": {
+            "type": "string",
+            "description": "A field that represents the address of the account that initiated the transaction.\nProvided as a 64-character hexadecimal string prefixed with 0x; identifies the principal of the transaction.\nThe account against which transaction fee payment and sequence number management are applied.\n"
+          },
+          "sequenceNumber": {
+            "type": "integer",
+            "description": "A field that represents the current sequence number of the sender account.\nStarts at 0 and increments by 1 per transaction per account; prevents replay attacks and ensures transaction order.\nTransactions with the same sequence number cannot be executed redundantly.\n"
+          },
+          "success": {
+            "type": "boolean",
+            "description": "A field that indicates whether the transaction executed successfully.\ntrue means the transaction was executed successfully; false means an error occurred during execution.\n"
+          },
+          "vmStatus": {
+            "type": "string",
+            "description": "A field that represents the execution result status of the transaction.\nReturns 'Executed successfully' on success; includes specific error messages on failure.\nHelps analyze the cause of transaction failures and troubleshoot issues.\n"
+          },
+          "events": {
+            "type": "array",
+            "description": "A field that represents the list of events emitted during transaction execution.\nEach event records state changes or important operations caused by the transaction.\nProvides information to track transaction impact and for integration with external systems.\n",
+            "items": {
+              "type": "object"
+            }
+          },
+          "balanceInAccounts": {
+            "type": "array",
+            "description": "A field that represents the list of addresses of accounts that received assets in the transaction.\nContains addresses of accounts with positive values (deposits) in balanceChanges.\nUsed to track asset transfer recipients and analyze deposit history.\n",
+            "items": {
+              "type": "string"
+            }
+          },
+          "balanceOutAccounts": {
+            "type": "array",
+            "description": "A field that represents the list of addresses of accounts that sent assets in the transaction.\nContains addresses of accounts with negative values (withdrawals) in balanceChanges.\nUsed to track asset transfer senders and analyze withdrawal history.\n",
+            "items": {
+              "type": "string"
+            }
+          },
+          "balanceChangedTokens": {
+            "type": "array",
+            "description": "A field that represents the list of token types whose balances changed due to the transaction.\nEach token is provided in 'moduleAddress::moduleName::structName' format.\nUsed to identify the types of assets affected by the transaction and to track changes per asset.\n",
+            "items": {
+              "type": "string"
+            }
+          },
+          "balanceChanges": {
+            "type": "array",
+            "description": "A field that represents the asset change history that occurred in the transaction.\nOnly provided when withBalance=true is included in the request.\n",
+            "items": {
+              "type": "object"
+            }
+          },
+          "payload": {
+            "description": "A field that represents the transaction payload.\nContains the execution content of the transaction, such as entry function calls or script executions.\nOnly provided when the payload type is entry_function_payload.\n",
+            "type": "object"
+          },
+          "entryFunctionContractAddress": {
+            "type": "string",
+            "description": "A field that represents the module address of the called entry function.\nOnly provided when the payload type is entry_function_payload.\n"
+          },
+          "entryFunctionIdStr": {
+            "type": "string",
+            "description": "A field that represents the full identifier of the called entry function.\nProvided in 'moduleAddress::moduleName::functionName' format.\nOnly provided when the payload type is entry_function_payload.\n"
+          },
+          "entryFunctionModuleName": {
+            "type": "string",
+            "description": "A field that represents the module name of the called entry function.\nOnly provided when the payload type is entry_function_payload.\n"
+          },
+          "entryFunctionName": {
+            "type": "string",
+            "description": "A field that represents the name of the called entry function.\nOnly provided when the payload type is entry_function_payload.\n"
+          }
+        }
+      },
+      "getTransactionByHash__xrpl__Res": {
+        "type": "object",
+        "required": [
+          "ledgerIndex",
+          "ledgerTimestamp",
+          "transactionIndex",
+          "transactionHash",
+          "transactionType",
+          "transactionResult",
+          "account",
+          "sequence",
+          "signingPubKey",
+          "fee",
+          "transactionCategory"
+        ],
+        "properties": {
+          "ledgerIndex": {
+            "type": "integer",
+            "description": "Sequence number of the ledger that contains the transaction. Used to identify which ledger the transaction was recorded in."
+          },
+          "ledgerTimestamp": {
+            "type": "integer",
+            "description": "Returns the close time of the ledger containing this transaction as a Unix timestamp. In the XRP Ledger, close time is recorded in seconds since the Ripple Epoch (January 1, 2000 00:00 UTC). Standard Unix timestamps use the Unix Epoch (January 1, 1970 00:00 UTC); the difference between them is 946,684,800 seconds. Thus ledgerTimestamp is the recorded close time plus 946,684,800 seconds."
+          },
+          "transactionIndex": {
+            "type": "integer",
+            "description": "Index indicating the processing order of the transaction within the ledger. Used to determine the order of transactions in the ledger."
+          },
+          "transactionHash": {
+            "type": "string",
+            "description": "A 256-bit (64-digit hexadecimal) cryptographic hash that uniquely identifies the transaction. Used for transaction data integrity and identification."
+          },
+          "transactionType": {
+            "type": "string",
+            "description": "String indicating the transaction type. Distinguishes various types such as Payment, OfferCreate, EscrowCreate, and is classified by processing method."
+          },
+          "transactionResult": {
+            "type": "string",
+            "description": "String indicating the transaction processing result, displayed as a result code such as 'tesSUCCESS'. Used to verify whether the transaction succeeded."
+          },
+          "account": {
+            "type": "string",
+            "description": "Account address that initiated the transaction. The account address is a Base58-encoded string 25-35 characters in length, starting with 'r'."
+          },
+          "sequence": {
+            "type": "integer",
+            "description": "Sequential number of transactions issued by the account, used to prevent duplicate submissions and replay attacks."
+          },
+          "lastLedgerSequence": {
+            "type": "integer",
+            "description": "Sequence number of the last ledger in which the transaction is valid. The transaction will not be processed in ledgers after this value."
+          },
+          "ticketSequence": {
+            "type": "integer",
+            "description": "For ticket-based transactions, the ticket number. Only present for transactions that use tickets."
+          },
+          "signingPubKey": {
+            "type": "string",
+            "description": "Public key used for the transaction signature, typically expressed as a 33-byte (66-digit hexadecimal) compressed public key."
+          },
+          "txnSignature": {
+            "type": "string",
+            "description": "Transaction signature value generated with signingPubKey. Used for transaction verification and authentication."
+          },
+          "fee": {
+            "type": "string",
+            "description": "Transaction processing fee, expressed as an XRP amount (in XRP units) as a string. In XRP units where 1 XRP equals 1,000,000 drops."
+          },
+          "flags": {
+            "type": "string",
+            "description": "Flag values applied to the transaction. Each bit controls a specific option or behavior; the default is often 0."
+          },
+          "accountTxnId": {
+            "type": "string",
+            "description": "256-bit hash identifying another transaction. If set, this transaction is valid only when it matches the sending account's most recent transaction ID. Used to prevent duplicate transaction submission or to verify that account state has not changed since a previous transaction."
+          },
+          "sourceTag": {
+            "type": "integer",
+            "description": "32-bit unsigned integer that the sender may specify when sending a transaction. Primarily used to identify the sending user from shared addresses (e.g. exchange or hosted wallet). Provides additional information so the receiver can determine \"who sent it\"."
+          },
+          "signers": {
+            "type": "array",
+            "description": "For multi-signed transactions, an array of objects containing each signer's information. Each object includes signer account, signing public key, signature value, etc.",
+            "items": {
+              "type": "object"
+            }
+          },
+          "memos": {
+            "type": "array",
+            "description": "Array of objects containing memo data attached to the transaction. Each memo object provides additional information such as memo content and format.",
+            "items": {
+              "type": "object"
+            }
+          },
+          "transactionCategory": {
+            "type": "string",
+            "description": "Enumeration string indicating the transaction category. Possible values include AMM, Check, Escrow, Offer, Payment, Payment Channel; each category is defined by the corresponding transaction type (e.g. Payment, OfferCreate)."
+          },
+          "transactionDetails": {
+            "type": "object",
+            "description": "Object containing details related to the transaction. May include additional data and fields required for transaction processing."
+          },
+          "balanceChanges": {
+            "type": "object"
+          },
+          "tokenTransfers": {
+            "type": "object"
+          },
+          "balanceOutAccounts": {
+            "type": "array",
+            "description": "List of account addresses whose final net balance change is less than zero (decreased) after summing all sends and receives in the transaction. Reflects both XRP and IOU token balance changes.",
+            "items": {
+              "type": "string",
+              "description": "Account address with a confirmed balance decrease"
+            }
+          },
+          "balanceInAccounts": {
+            "type": "array",
+            "description": "List of account addresses whose final net balance change is greater than zero (increased) after summing all sends and receives in the transaction. Reflects both XRP and IOU token balance changes.",
+            "items": {
+              "type": "string",
+              "description": "Account address with a confirmed balance increase"
+            }
+          },
+          "balanceChangedTokens": {
+            "type": "array",
+            "description": "List of token identifiers with non-zero final net balance change when summing the entire transaction. Each item follows the 'currency-issuer' format.",
+            "items": {
+              "type": "string",
+              "description": "Token identifier in 'currency-issuer' format"
+            }
+          }
+        }
+      },
+      "address__evm__Req": {
+        "type": "object",
+        "required": [
+          "address"
+        ],
+        "properties": {
+          "address": {
+            "type": "string",
+            "description": "Parameter specifying the address to query. Can be entered as a 40-character hexadecimal string starting with 0x.",
+            "pattern": "^0[xX][0-9a-fA-F]{40}$"
+          }
+        },
+        "example": {
+          "address": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+        }
+      },
+      "address__tron__Req": {
+        "type": "object",
+        "required": [
+          "address"
+        ],
+        "properties": {
+          "address": {
+            "type": "string",
+            "description": "Parameter specifying the account address to query. This field uses a 34-character base58 string format starting with \"T\".",
+            "pattern": "^T[1-9A-HJ-NP-Za-km-z]{33}$",
+            "example": "TPswDDCAWhJAZGdHPidFg5nEf8TkNToDX1"
+          }
+        }
+      },
+      "isContract___shared__Res": {
+        "type": "object",
+        "properties": {
+          "result": {
+            "type": "boolean",
+            "description": "Returns true if the input address is a contract, false otherwise."
+          }
+        }
+      },
+      "getTransactionsInLedger__xrpl__Req": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "ledger"
+            ],
+            "properties": {
+              "ledger": {
+                "type": "string",
+                "description": "Parameter specifying the ledger to query. You can enter one of the following formats:\n- ledger index: Ledger number as a decimal string\n- ledger hash: 64-character hexadecimal string (excluding 0x prefix)\n- ledger tag: \"earliest\" or \"latest\" (oldest or most recent ledger)\n",
+                "pattern": "^[0-9]+$|^[0-9a-fA-F]{64}|latest|earliest",
+                "default": "latest"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "integer",
+                "description": "The page parameter specifies the data page to query. It accepts values up to 100; for pages exceeding 100, use the cursor pagination method.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used.",
+                "pattern": "^(?:[1-9][0-9]?|100)$"
+              },
+              "rpp": {
+                "type": "integer",
+                "description": "rpp stands for results per page and specifies the page size. You can specify a number greater than 0 and up to 100.",
+                "pattern": "^(?:[1-9][0-9]{0,2}?|100)$"
+              },
+              "cursor": {
+                "type": "string",
+                "description": "The cursor parameter supports pagination and data navigation between pages. Provide the cursor value from the previous page in the next request to load the next page of data.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used."
+              },
+              "withCount": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the count field in the response. The count field indicates the total number of requested data items. When set to true, the count field is included and response speed may be slower.",
+                "default": false
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "withBalanceChanges": {
+                "type": "boolean",
+                "description": "Optional parameter determining whether to include the balanceChanges field in the response. balanceChanges contains balance change details for native token (XRP) and IOU tokens. Response speed may be slower when set to true.",
+                "default": false
+              },
+              "withTokenTransfers": {
+                "type": "boolean",
+                "description": "Optional parameter determining whether to include the tokenTransfers field in the response. tokenTransfers contains IOU token transfer history. Response speed may be slower when set to true.",
+                "default": false
+              }
+            }
+          }
+        ],
+        "example": {
+          "ledger": "latest",
+          "withBalanceChanges": false,
+          "withTokenTransfers": false
+        }
+      },
+      "getNextNonceByAccount__evm__Req": {
+        "type": "object",
+        "required": [
+          "accountAddress"
+        ],
+        "properties": {
+          "accountAddress": {
+            "type": "string",
+            "description": "Parameter specifying the account address to query. Can be entered as a 40-character hexadecimal string starting with 0x.",
+            "pattern": "^0[xX][0-9a-fA-F]{40}$",
+            "example": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+          }
+        },
+        "example": {
+          "accountAddress": "0x1234567890123456789012345678901234567890"
+        }
+      },
+      "getNextNonceByAccount__evm__Res": {
+        "type": "object",
+        "required": [
+          "nonce"
+        ],
+        "properties": {
+          "nonce": {
+            "type": "string",
+            "description": "Returns the next nonce value for the queried account. \nThis value increases by 1 each time a transaction is created; before creating a new transaction, check this value to set the transaction's nonce."
+          }
+        }
+      },
+      "getLedgersWithinRange__xrpl__Req": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "fromLedger",
+              "toLedger"
+            ],
+            "properties": {
+              "fromLedger": {
+                "type": "string",
+                "description": "Parameter specifying the starting ledger for the query. You can enter one of the following formats:\n- **ledger index**: Enter ledger number as a decimal string\n- **ledger hash**: 64-character hexadecimal string (excluding 0x prefix)\n- **ledger tag**: Enter \"earliest\" or \"latest\" (oldest or most recent ledger)\n\nNotes:\n- If provided without toLedger, results are queried from this ledger to the latest ledger.\n- fromLedger value cannot be greater than toLedger value.\n- If fromLedger and toLedger have the same value, only that ledger is queried.\n- \"latest\" for fromLedger is only allowed when toLedger is \"latest\".",
+                "pattern": "^[0-9]+$|^0[xX][0-9a-fA-F]{64}|latest|earliest"
+              },
+              "toLedger": {
+                "type": "string",
+                "description": "Parameter specifying the ending ledger for the query. You can enter one of the following formats:\n- **ledger index**: Enter ledger number as a decimal string\n- **ledger hash**: 64-character hexadecimal string (excluding 0x prefix)\n- **ledger tag**: Enter \"earliest\" or \"latest\" (oldest or most recent ledger)\n\nNotes:\n- If provided without fromLedger, results are queried from genesis ledger to this ledger.\n- toLedger value cannot be less than fromLedger value.\n- If fromLedger and toLedger have the same value, only that ledger is queried.\n- \"earliest\" for toLedger is only allowed when fromLedger is \"earliest\".",
+                "pattern": "^[0-9]+$|^0[xX][0-9a-fA-F]{64}|latest|earliest"
+              },
+              "fromDate": {
+                "type": "string",
+                "description": "Parameter specifying the start date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without toDate, results are queried from this date to the latest block.\n- fromDate value must be equal to or earlier than toDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-01T00:00:00+00:00"
+              },
+              "toDate": {
+                "type": "string",
+                "description": "Parameter specifying the end date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without fromDate, results are queried from genesis block to this date.\n- toDate value must be equal to or later than fromDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-31T00:00:00+00:00"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "integer",
+                "description": "The page parameter specifies the data page to query. It accepts values up to 100; for pages exceeding 100, use the cursor pagination method.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used.",
+                "pattern": "^(?:[1-9][0-9]?|100)$"
+              },
+              "rpp": {
+                "type": "integer",
+                "description": "rpp stands for results per page and specifies the page size. You can specify a number greater than 0 and up to 100.",
+                "pattern": "^(?:[1-9][0-9]{0,2}?|100)$"
+              },
+              "cursor": {
+                "type": "string",
+                "description": "The cursor parameter supports pagination and data navigation between pages. Provide the cursor value from the previous page in the next request to load the next page of data.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used."
+              },
+              "withCount": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the count field in the response. The count field indicates the total number of requested data items. When set to true, the count field is included and response speed may be slower.",
+                "default": false
+              }
+            }
+          }
+        ]
+      },
+      "getUnspentTransactionOutputsByAccount__utxo__Req": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "accountAddress"
+            ],
+            "properties": {
+              "accountAddress": {
+                "type": "string",
+                "description": "Parameter specifying the account address to query.",
+                "pattern": "^(1[a-km-zA-HJ-NP-Z1-9]{25,33}|3[a-km-zA-HJ-NP-Z1-9]{25,33}|bc1q[a-z0-9]{38,59}|bc1p[a-z0-9]{58})$",
+                "example": "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "integer",
+                "description": "The page parameter specifies the data page to query. It accepts values up to 100; for pages exceeding 100, use the cursor pagination method.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used.",
+                "pattern": "^(?:[1-9][0-9]?|100)$"
+              },
+              "rpp": {
+                "type": "integer",
+                "description": "rpp stands for results per page and specifies the page size. You can specify a number greater than 0 and up to 100.",
+                "pattern": "^(?:[1-9][0-9]{0,2}?|100)$"
+              },
+              "cursor": {
+                "type": "string",
+                "description": "The cursor parameter supports pagination and data navigation between pages. Provide the cursor value from the previous page in the next request to load the next page of data.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used."
+              },
+              "withCount": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the count field in the response. The count field indicates the total number of requested data items. When set to true, the count field is included and response speed may be slower.",
+                "default": false
+              }
+            }
+          }
+        ],
+        "example": {
+          "accountAddress": "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa"
+        }
+      },
+      "getEventsByAccount__aptos__Req": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "accountAddress"
+            ],
+            "properties": {
+              "accountAddress": {
+                "type": "string",
+                "description": "Parameter specifying the account address to query. The account address must be entered as a 64-character hexadecimal string (including \"0x\").",
+                "pattern": "^0[xX][0-9a-fA-F]{64}",
+                "example": "0xd91c64b777e51395c6ea9dec562ed79a4afa0cd6dad5a87b187c37198a1f855a"
+              },
+              "eventTypes": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "description": "Parameter specifying the event type to query. Event type refers to the name of the event struct defined in the module. This field must be entered in the format `module_address::module_name::event_name`.",
+                  "pattern": "^0[xX]?[0-9a-fA-F]{0,64}$::^0x[0-9a-zA-Z:_<>]+$::^[a-zA-Z0-9_-]+$"
+                }
+              },
+              "fromBlock": {
+                "type": "string",
+                "description": "Parameter specifying the starting block for the query. You can enter one of the following formats:\n- block number: Enter block number as a decimal string.\n- block hash: 64-character hexadecimal (including \"0x\").\n- block tag: Use \"earliest\" or \"latest\" to specify the first block or the most recent block.\n\nNotes:\n- This field cannot be used together with `fromDate` and `toDate`.\n- If provided without fromBlock, results are queried from genesis block to this block.\n- toBlock value cannot be less than fromBlock value.\n- If fromBlock and toBlock have the same value, only that block is queried.\n- \"earliest\" for toBlock is only allowed when fromBlock is \"earliest\".\n- If `fromBlock` and `toBlock` are not provided, the API queries data from the latest 30 days.\n",
+                "pattern": "^[0-9]+$|^0[xX][0-9a-fA-F]{64}|latest|earliest",
+                "default": "earliest"
+              },
+              "toBlock": {
+                "type": "string",
+                "description": "Parameter specifying the ending block for the query. You can enter one of the following formats:\n- block number: Enter block number as a decimal string.\n- block hash: 64-character hexadecimal (including \"0x\").\n- block tag: Use \"earliest\" or \"latest\" to specify the first block or the most recent block.\n\nNotes:\n- This field cannot be used together with `fromDate` and `toDate`.\n- If provided without fromBlock, results are queried from genesis block to this block.\n- toBlock value cannot be less than fromBlock value.\n- If fromBlock and toBlock have the same value, only that block is queried.\n- \"earliest\" for toBlock is only allowed when fromBlock is \"earliest\".\n- If `fromBlock` and `toBlock` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]+$|^0[xX][0-9a-fA-F]{64}|latest|earliest"
+              },
+              "fromDate": {
+                "type": "string",
+                "description": "Parameter specifying the start date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without toDate, results are queried from this date to the latest block.\n- fromDate value must be equal to or earlier than toDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-01T00:00:00+00:00"
+              },
+              "toDate": {
+                "type": "string",
+                "description": "Parameter specifying the end date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without fromDate, results are queried from genesis block to this date.\n- toDate value must be equal to or later than fromDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-31T00:00:00+00:00"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "integer",
+                "description": "The page parameter specifies the data page to query. It accepts values up to 100; for pages exceeding 100, use the cursor pagination method.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used.",
+                "pattern": "^(?:[1-9][0-9]?|100)$"
+              },
+              "rpp": {
+                "type": "integer",
+                "description": "rpp stands for results per page and specifies the page size. You can specify a number greater than 0 and up to 100.",
+                "pattern": "^(?:[1-9][0-9]{0,2}?|100)$"
+              },
+              "cursor": {
+                "type": "string",
+                "description": "The cursor parameter supports pagination and data navigation between pages. Provide the cursor value from the previous page in the next request to load the next page of data.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used."
+              },
+              "withCount": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the count field in the response. The count field indicates the total number of requested data items. When set to true, the count field is included and response speed may be slower.",
+                "default": false
+              }
+            }
+          }
+        ],
+        "example": {
+          "accountAddress": "0x51c6abe562e755582d268340b2cf0e2d8895a155dc9b7a7fb5465000d62d770b",
+          "fromDate": "2026-01-01T00:00:00Z",
+          "toDate": "2026-02-01T00:00:00Z",
+          "page": 1,
+          "rpp": 10
+        }
+      },
+      "getTransactionByTransactionId__utxo__Req": {
+        "type": "object",
+        "required": [
+          "transactionId"
+        ],
+        "properties": {
+          "transactionId": {
+            "type": "string",
+            "description": "Parameter specifying the transaction ID to query. Can be entered as a 64-character hexadecimal string (excluding 0x).",
+            "pattern": "^[0-9a-fA-F]{64}$"
+          }
+        }
+      },
+      "getTransactionByTransactionId__utxo__Res": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "id",
+              "index",
+              "hash",
+              "version",
+              "lockTime",
+              "size",
+              "vsize",
+              "weight",
+              "fee",
+              "vinCount",
+              "voutCount",
+              "blockHeight",
+              "blockHash",
+              "blockTimestamp"
+            ],
+            "properties": {
+              "id": {
+                "type": "string",
+                "description": "Unique identifier of the transaction; a value that uniquely identifies each transaction."
+              },
+              "index": {
+                "type": "integer",
+                "description": "Indicates the index of the transaction within the block. Starts at 0; represents the order of transactions included in the block."
+              },
+              "hash": {
+                "type": "string",
+                "description": "Hash value of the transaction; a unique identifier calculated from the transaction data. Computed including SegWit data."
+              },
+              "version": {
+                "type": "integer",
+                "description": "Value indicating the transaction version; defines the transaction format."
+              },
+              "lockTime": {
+                "type": "integer",
+                "description": "Lock time of the transaction; indicates the condition (block height or UNIX timestamp) under which the transaction becomes valid. A value of `0` means the transaction is immediately valid."
+              },
+              "size": {
+                "type": "integer",
+                "description": "Actual size of the transaction in bytes; represents the length of the transaction data."
+              },
+              "vsize": {
+                "type": "integer",
+                "description": "Virtual size of the transaction in bytes; represents the effective size of the transaction as included in a block when SegWit data is included. Calculated by dividing weight by 4 and rounding up, per BIP-141."
+              },
+              "weight": {
+                "type": "integer",
+                "description": "Weight of the transaction; represents the network cost of the transaction as calculated per BIP-141. Calculated as `(non-witness size * 3) + total size`."
+              },
+              "fee": {
+                "type": "integer",
+                "description": "Transaction fee (in BTC units); the remainder when output value is subtracted from input value."
+              },
+              "vinCount": {
+                "type": "integer",
+                "description": "Indicates the number of input (Vin) transactions."
+              },
+              "voutCount": {
+                "type": "integer",
+                "description": "Indicates the number of output (Vout) transactions."
+              },
+              "blockHeight": {
+                "type": "integer",
+                "description": "Indicates the height of the block containing the transaction."
+              },
+              "blockHash": {
+                "type": "string",
+                "description": "Hash of the block containing the transaction."
+              },
+              "blockTimestamp": {
+                "type": "integer",
+                "description": "Indicates when the block containing the transaction was created; displayed in UNIX timestamp format."
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "vin": {
+                "type": "object"
+              },
+              "vout": {
+                "type": "object"
+              }
+            }
+          }
+        ]
+      },
+      "searchEvents__evm__Req": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "contractAddress",
+              "eventNames",
+              "abi"
+            ],
+            "properties": {
+              "contractAddress": {
+                "type": "string",
+                "description": "Parameter specifying the contract address to query. Can be entered as a 40-character hexadecimal string starting with 0x.",
+                "pattern": "^0[xX][0-9a-fA-F]{40}$"
+              },
+              "eventNames": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "description": "Parameter specifying the name of the event to query."
+                }
+              },
+              "abi": {
+                "type": "string",
+                "format": "json",
+                "description": "Parameter specifying the ABI of the contract to query. Can be entered as a JSON-formatted ABI string."
+              },
+              "fromBlock": {
+                "type": "string",
+                "description": "Parameter specifying the starting block for the query. You can enter one of the following formats:\n- block number: Enter block number as a decimal string.\n- block hash: 64-character hexadecimal (including \"0x\").\n- block tag: Use \"earliest\" or \"latest\" to specify the first block or the most recent block.\n\nNotes:\n- This field cannot be used together with `fromDate` and `toDate`.\n- If provided without fromBlock, results are queried from genesis block to this block.\n- toBlock value cannot be less than fromBlock value.\n- If fromBlock and toBlock have the same value, only that block is queried.\n- \"earliest\" for toBlock is only allowed when fromBlock is \"earliest\".\n- If `fromBlock` and `toBlock` are not provided, the API queries data from the latest 30 days.\n",
+                "pattern": "^[0-9]+$|^0[xX][0-9a-fA-F]{64}|latest|earliest"
+              },
+              "toBlock": {
+                "type": "string",
+                "description": "Parameter specifying the ending block for the query. You can enter one of the following formats:\n- block number: Enter block number as a decimal string.\n- block hash: 64-character hexadecimal (including \"0x\").\n- block tag: Use \"earliest\" or \"latest\" to specify the first block or the most recent block.\n\nNotes:\n- This field cannot be used together with `fromDate` and `toDate`.\n- If provided without fromBlock, results are queried from genesis block to this block.\n- toBlock value cannot be less than fromBlock value.\n- If fromBlock and toBlock have the same value, only that block is queried.\n- \"earliest\" for toBlock is only allowed when fromBlock is \"earliest\".\n- If `fromBlock` and `toBlock` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]+$|^0[xX][0-9a-fA-F]{64}|latest|earliest"
+              },
+              "fromDate": {
+                "type": "string",
+                "description": "Parameter specifying the start date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without toDate, results are queried from this date to the latest block.\n- fromDate value must be equal to or earlier than toDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-01T00:00:00+00:00"
+              },
+              "toDate": {
+                "type": "string",
+                "description": "Parameter specifying the end date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without fromDate, results are queried from genesis block to this date.\n- toDate value must be equal to or later than fromDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-31T00:00:00+00:00"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "integer",
+                "description": "The page parameter specifies the data page to query. It accepts values up to 100; for pages exceeding 100, use the cursor pagination method.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used.",
+                "pattern": "^(?:[1-9][0-9]?|100)$"
+              },
+              "rpp": {
+                "type": "integer",
+                "description": "rpp stands for results per page and specifies the page size. You can specify a number greater than 0 and up to 100.",
+                "pattern": "^(?:[1-9][0-9]{0,2}?|100)$"
+              },
+              "cursor": {
+                "type": "string",
+                "description": "The cursor parameter supports pagination and data navigation between pages. Provide the cursor value from the previous page in the next request to load the next page of data.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used."
+              },
+              "withCount": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the count field in the response. The count field indicates the total number of requested data items. When set to true, the count field is included and response speed may be slower.",
+                "default": false
+              }
+            }
+          }
+        ],
+        "example": {
+          "contractAddress": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
+          "eventNames": [
+            "Transfer"
+          ],
+          "abi": "0x1234567890123456789012345678901234567890",
+          "fromDate": "2026-01-01T00:00:00Z",
+          "toDate": "2026-02-01T00:00:00Z"
+        }
+      },
+      "searchEvents__kaia__Req": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "contractAddress",
+              "eventNames",
+              "abi"
+            ],
+            "properties": {
+              "contractAddress": {
+                "type": "string",
+                "description": "Parameter specifying the contract address to query. Can be entered as a 40-character hexadecimal string starting with 0x.",
+                "pattern": "^0[xX][0-9a-fA-F]{40}$"
+              },
+              "eventNames": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "description": "Parameter specifying the name of the event to query."
+                }
+              },
+              "abi": {
+                "type": "string",
+                "format": "json",
+                "description": "Parameter specifying the ABI of the contract to query. Can be entered as a JSON-formatted ABI string."
+              },
+              "fromBlock": {
+                "type": "string",
+                "description": "Parameter specifying the starting block for the query. You can enter one of the following formats:\n- block number: Enter block number as a decimal string.\n- block hash: 64-character hexadecimal (including \"0x\").\n- block tag: Use \"earliest\" or \"latest\" to specify the first block or the most recent block.\n\nNotes:\n- This field cannot be used together with `fromDate` and `toDate`.\n- If provided without fromBlock, results are queried from genesis block to this block.\n- toBlock value cannot be less than fromBlock value.\n- If fromBlock and toBlock have the same value, only that block is queried.\n- \"earliest\" for toBlock is only allowed when fromBlock is \"earliest\".\n- If `fromBlock` and `toBlock` are not provided, the API queries data from the latest 30 days.\n\nFor Kaia, entering \"earliest\" queries the block at the Kaia hardfork point.\n- Mainnet: 162,900,480 (Aug 29, 2024 11:08:01 UTC+9)\n- Kairos(Testnet): 156,660,000 (June 13, 2024 10:15:19 UTC+9)\n\n",
+                "pattern": "^[0-9]+$|^0[xX][0-9a-fA-F]{64}|latest|earliest"
+              },
+              "toBlock": {
+                "type": "string",
+                "description": "Parameter specifying the ending block for the query. You can enter one of the following formats:\n- block number: Enter block number as a decimal string.\n- block hash: 64-character hexadecimal (including \"0x\").\n- block tag: Use \"earliest\" or \"latest\" to specify the first block or the most recent block.\n\nNotes:\n- If provided without fromBlock, results are queried from the Kaia hardfork block to this block.\n- toBlock value cannot be less than fromBlock value.\n- If fromBlock and toBlock have the same value, only that block is queried.\n- \"earliest\" for toBlock is only allowed when fromBlock is \"earliest\".\n\nFor Kaia, entering \"earliest\" queries the block at the Kaia hardfork point.\n- Mainnet: 162,900,480 (Aug 29, 2024 11:08:01 UTC+9)\n- Kairos(Testnet): 156,660,000 (June 13, 2024 10:15:19 UTC+9)\n",
+                "pattern": "^[0-9]+$|^0[xX][0-9a-fA-F]{64}|latest|earliest"
+              },
+              "fromDate": {
+                "type": "string",
+                "description": "Parameter specifying the start date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without toDate, results are queried from this date to the latest block.\n- fromDate value must be equal to or earlier than toDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-01T00:00:00+00:00"
+              },
+              "toDate": {
+                "type": "string",
+                "description": "Parameter specifying the end date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without fromDate, results are queried from genesis block to this date.\n- toDate value must be equal to or later than fromDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-31T00:00:00+00:00"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "integer",
+                "description": "The page parameter specifies the data page to query. It accepts values up to 100; for pages exceeding 100, use the cursor pagination method.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used.",
+                "pattern": "^(?:[1-9][0-9]?|100)$"
+              },
+              "rpp": {
+                "type": "integer",
+                "description": "rpp stands for results per page and specifies the page size. You can specify a number greater than 0 and up to 100.",
+                "pattern": "^(?:[1-9][0-9]{0,2}?|100)$"
+              },
+              "cursor": {
+                "type": "string",
+                "description": "The cursor parameter supports pagination and data navigation between pages. Provide the cursor value from the previous page in the next request to load the next page of data.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used."
+              },
+              "withCount": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the count field in the response. The count field indicates the total number of requested data items. When set to true, the count field is included and response speed may be slower.",
+                "default": false
+              }
+            }
+          }
+        ]
+      },
+      "getLedgerByHashOrIndex__xrpl__Req": {
+        "type": "object",
+        "required": [
+          "ledger"
+        ],
+        "properties": {
+          "ledger": {
+            "type": "string",
+            "description": "Parameter specifying the ledger to query. You can enter one of the following formats:\n- ledger index: Ledger number as a decimal string\n- ledger hash: 64-character hexadecimal string (excluding 0x prefix)\n- ledger tag: \"earliest\" or \"latest\" (oldest or most recent ledger)\n",
+            "pattern": "^[0-9]+$|^[0-9a-fA-F]{64}|latest|earliest",
+            "default": "latest"
+          }
+        },
+        "example": {
+          "ledger": "latest"
+        }
+      },
+      "getLedgerByHashOrIndex__xrpl__Res": {
+        "type": "object",
+        "required": [
+          "ledgerHash",
+          "ledgerIndex",
+          "ledgerIndex",
+          "ledgerTimestamp",
+          "parentLedgerHash",
+          "accountHash",
+          "totalCoins",
+          "transactionHash",
+          "transactionCount",
+          "transactions"
+        ],
+        "properties": {
+          "ledgerHash": {
+            "type": "string",
+            "description": "Unique identifier of the current ledger, a 256-bit (64-digit hexadecimal) cryptographic hash. Used for ledger data integrity verification and identification."
+          },
+          "ledgerIndex": {
+            "type": "integer",
+            "description": "Integer value indicating the creation order of the ledger, used to identify its position (sequence number) on the network."
+          },
+          "ledgerTimestamp": {
+            "type": "integer",
+            "description": "The ledger's close time converted to a Unix timestamp. The close time recorded in the ledger header is expressed in seconds since the Ripple Epoch (January 1, 2000 00:00 UTC), which differs from the Unix Epoch (January 1, 1970 00:00 UTC) by 946,684,800 seconds. Thus ledgerTimestamp is the recorded close time plus 946,684,800 seconds."
+          },
+          "parentLedgerHash": {
+            "type": "string",
+            "description": "256-bit (64-digit hexadecimal) hash identifying the ledger immediately preceding the current ledger. References the previous ledger's hash to maintain chain integrity."
+          },
+          "accountHash": {
+            "type": "string",
+            "description": "256-bit (64-digit hexadecimal) hash summarizing all account state information recorded in the ledger. Used to verify consistency and integrity of account data."
+          },
+          "totalCoins": {
+            "type": "string",
+            "description": "Total quantity of XRP (in XRP units) owned by accounts recorded in the ledger. This value excludes XRP burned as transaction fees. The actual circulating XRP may be lower than this value because some accounts may be in a \"black hole\" state (accounts with no key)."
+          },
+          "transactionHash": {
+            "type": "string",
+            "description": "256-bit (64-digit hexadecimal) Merkle tree root hash summarizing all transaction data included in the ledger. Used for transaction history integrity verification."
+          },
+          "transactionCount": {
+            "type": "integer",
+            "description": "Integer value indicating the total number of transactions included in the ledger. Used to assess the scale and activity of ledger transaction history."
+          },
+          "transactions": {
+            "type": "array",
+            "description": "Array of transaction hashes included in the ledger. Each hash is a 256-bit (64-digit hexadecimal) cryptographic hash uniquely identifying a transaction, used for transaction data integrity and identification.",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "getTransactionsByAccount__aptos__Req": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "accountAddress"
+            ],
+            "properties": {
+              "accountAddress": {
+                "type": "string",
+                "description": "Parameter specifying the account address to query. The account address must be entered as a 64-character hexadecimal string (including \"0x\").",
+                "pattern": "^0[xX][0-9a-fA-F]{64}",
+                "example": "0xd91c64b777e51395c6ea9dec562ed79a4afa0cd6dad5a87b187c37198a1f855a"
+              },
+              "relation": {
+                "type": "string",
+                "description": "Parameter for filtering transactions where the queried account address belongs to from or to.\n\nThree options are available: from, to, and both. The default value for this parameter is both.\n- from: Returns results where the queried address is included in balanceOutAccounts.\n- to: Returns results where the queried address is included in balanceInAccounts.\n- both: Returns results where the queried address is included in all balance changes.",
+                "enum": [
+                  "from",
+                  "to",
+                  "both"
+                ],
+                "pattern": "from|to|both",
+                "default": "both"
+              },
+              "fromBlock": {
+                "type": "string",
+                "description": "Parameter specifying the starting block for the query. You can enter one of the following formats:\n- block number: Enter block number as a decimal string.\n- block hash: 64-character hexadecimal (including \"0x\").\n- block tag: Use \"earliest\" or \"latest\" to specify the first block or the most recent block.\n\nNotes:\n- This field cannot be used together with `fromDate` and `toDate`.\n- If provided without fromBlock, results are queried from genesis block to this block.\n- toBlock value cannot be less than fromBlock value.\n- If fromBlock and toBlock have the same value, only that block is queried.\n- \"earliest\" for toBlock is only allowed when fromBlock is \"earliest\".\n- If `fromBlock` and `toBlock` are not provided, the API queries data from the latest 30 days.\n",
+                "pattern": "^[0-9]+$|^0[xX][0-9a-fA-F]{64}|latest|earliest",
+                "default": "earliest"
+              },
+              "toBlock": {
+                "type": "string",
+                "description": "Parameter specifying the ending block for the query. You can enter one of the following formats:\n- block number: Enter block number as a decimal string.\n- block hash: 64-character hexadecimal (including \"0x\").\n- block tag: Use \"earliest\" or \"latest\" to specify the first block or the most recent block.\n\nNotes:\n- This field cannot be used together with `fromDate` and `toDate`.\n- If provided without fromBlock, results are queried from genesis block to this block.\n- toBlock value cannot be less than fromBlock value.\n- If fromBlock and toBlock have the same value, only that block is queried.\n- \"earliest\" for toBlock is only allowed when fromBlock is \"earliest\".\n- If `fromBlock` and `toBlock` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]+$|^0[xX][0-9a-fA-F]{64}|latest|earliest"
+              },
+              "fromDate": {
+                "type": "string",
+                "description": "Parameter specifying the start date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without toDate, results are queried from this date to the latest block.\n- fromDate value must be equal to or earlier than toDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-01T00:00:00+00:00"
+              },
+              "toDate": {
+                "type": "string",
+                "description": "Parameter specifying the end date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without fromDate, results are queried from genesis block to this date.\n- toDate value must be equal to or later than fromDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-31T00:00:00+00:00"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "integer",
+                "description": "The page parameter specifies the data page to query. It accepts values up to 100; for pages exceeding 100, use the cursor pagination method.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used.",
+                "pattern": "^(?:[1-9][0-9]?|100)$"
+              },
+              "rpp": {
+                "type": "integer",
+                "description": "rpp stands for results per page and specifies the page size. You can specify a number greater than 0 and up to 100.",
+                "pattern": "^(?:[1-9][0-9]{0,2}?|100)$"
+              },
+              "cursor": {
+                "type": "string",
+                "description": "The cursor parameter supports pagination and data navigation between pages. Provide the cursor value from the previous page in the next request to load the next page of data.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used."
+              },
+              "withCount": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the count field in the response. The count field indicates the total number of requested data items. When set to true, the count field is included and response speed may be slower.",
+                "default": false
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "withBalanceChanges": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the balanceChanges field in the response.\n\n- balanceChanges is a field containing balance changes for Native token (APT) and Tokens.\n- Response speed may be slower when true is set for this parameter.",
+                "default": false
+              }
+            }
+          }
+        ],
+        "example": {
+          "accountAddress": "0xd91c64b777e51395c6ea9dec562ed79a4afa0cd6dad5a87b187c37198a1f855a",
+          "relation": "both",
+          "fromDate": "2026-01-01T00:00:00Z",
+          "toDate": "2026-02-01T00:00:00Z"
+        }
+      },
+      "getTransactionsByAccount__evm__Req": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "accountAddress"
+            ],
+            "properties": {
+              "accountAddress": {
+                "type": "string",
+                "description": "Parameter specifying the account address to query. Can be entered as a 40-character hexadecimal string starting with 0x.",
+                "pattern": "^0[xX][0-9a-fA-F]{40}$",
+                "example": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+              },
+              "relation": {
+                "type": "string",
+                "description": "Parameter for filtering transactions where the queried account address is the sender or recipient.\n- from: Filter by sender only.\n- to: Filter by recipient only.\n- both (default): Returns all transactions where the queried address appears in from or to.",
+                "enum": [
+                  "from",
+                  "to",
+                  "both"
+                ],
+                "pattern": "from|to|both",
+                "default": "both"
+              },
+              "fromBlock": {
+                "type": "string",
+                "description": "Parameter specifying the starting block for the query. You can enter one of the following formats:\n- block number: Enter block number as a decimal string.\n- block hash: 64-character hexadecimal (including \"0x\").\n- block tag: Use \"earliest\" or \"latest\" to specify the first block or the most recent block.\n\nNotes:\n- This field cannot be used together with `fromDate` and `toDate`.\n- If provided without fromBlock, results are queried from genesis block to this block.\n- toBlock value cannot be less than fromBlock value.\n- If fromBlock and toBlock have the same value, only that block is queried.\n- \"earliest\" for toBlock is only allowed when fromBlock is \"earliest\".\n- If `fromBlock` and `toBlock` are not provided, the API queries data from the latest 30 days.\n",
+                "pattern": "^[0-9]+$|^0[xX][0-9a-fA-F]{64}|latest|earliest"
+              },
+              "toBlock": {
+                "type": "string",
+                "description": "Parameter specifying the ending block for the query. You can enter one of the following formats:\n- block number: Enter block number as a decimal string.\n- block hash: 64-character hexadecimal (including \"0x\").\n- block tag: Use \"earliest\" or \"latest\" to specify the first block or the most recent block.\n\nNotes:\n- This field cannot be used together with `fromDate` and `toDate`.\n- If provided without fromBlock, results are queried from genesis block to this block.\n- toBlock value cannot be less than fromBlock value.\n- If fromBlock and toBlock have the same value, only that block is queried.\n- \"earliest\" for toBlock is only allowed when fromBlock is \"earliest\".\n- If `fromBlock` and `toBlock` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]+$|^0[xX][0-9a-fA-F]{64}|latest|earliest"
+              },
+              "fromDate": {
+                "type": "string",
+                "description": "Parameter specifying the start date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without toDate, results are queried from this date to the latest block.\n- fromDate value must be equal to or earlier than toDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-01T00:00:00+00:00"
+              },
+              "toDate": {
+                "type": "string",
+                "description": "Parameter specifying the end date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without fromDate, results are queried from genesis block to this date.\n- toDate value must be equal to or later than fromDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-31T00:00:00+00:00"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "integer",
+                "description": "The page parameter specifies the data page to query. It accepts values up to 100; for pages exceeding 100, use the cursor pagination method.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used.",
+                "pattern": "^(?:[1-9][0-9]?|100)$"
+              },
+              "rpp": {
+                "type": "integer",
+                "description": "rpp stands for results per page and specifies the page size. You can specify a number greater than 0 and up to 100.",
+                "pattern": "^(?:[1-9][0-9]{0,2}?|100)$"
+              },
+              "cursor": {
+                "type": "string",
+                "description": "The cursor parameter supports pagination and data navigation between pages. Provide the cursor value from the previous page in the next request to load the next page of data.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used."
+              },
+              "withCount": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the count field in the response. The count field indicates the total number of requested data items. When set to true, the count field is included and response speed may be slower.",
+                "default": false
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "withLogs": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the logs field in the response. Response speed may be slower when set to true.",
+                "default": false
+              },
+              "withDecode": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include decodedInput and decodedLog fields in the response. Response speed may be slower when set to true.\n\ndecodedLog is part of logs, so it is not included when withLogs is false even if withDecode is true.\ndecodedInput interprets the transaction input field and provides the result. However, different functions may use the same function selector, so the result may not match the actually called function. Additional verification is recommended for non-standard ERC functions.",
+                "default": false
+              }
+            }
+          }
+        ],
+        "example": {
+          "accountAddress": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
+          "relation": "both",
+          "fromDate": "2026-01-01T00:00:00Z",
+          "toDate": "2026-02-01T00:00:00Z"
+        }
+      },
+      "getTransactionsByAccount__kaia__Req": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "accountAddress"
+            ],
+            "properties": {
+              "accountAddress": {
+                "type": "string",
+                "description": "Parameter specifying the account address to query. Can be entered as a 40-character hexadecimal string starting with 0x.",
+                "pattern": "^0[xX][0-9a-fA-F]{40}$",
+                "example": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+              },
+              "relation": {
+                "type": "string",
+                "description": "Parameter for filtering transactions where the queried account address is the sender or recipient.\n- from: Filter by sender only.\n- to: Filter by recipient only.\n- both (default): Returns all transactions where the queried address appears in from or to.",
+                "enum": [
+                  "from",
+                  "to",
+                  "both"
+                ],
+                "pattern": "from|to|both",
+                "default": "both"
+              },
+              "fromBlock": {
+                "type": "string",
+                "description": "Parameter specifying the starting block for the query. You can enter one of the following formats:\n- block number: Enter block number as a decimal string.\n- block hash: 64-character hexadecimal (including \"0x\").\n- block tag: Use \"earliest\" or \"latest\" to specify the first block or the most recent block.\n\nNotes:\n- This field cannot be used together with `fromDate` and `toDate`.\n- If provided without fromBlock, results are queried from genesis block to this block.\n- toBlock value cannot be less than fromBlock value.\n- If fromBlock and toBlock have the same value, only that block is queried.\n- \"earliest\" for toBlock is only allowed when fromBlock is \"earliest\".\n- If `fromBlock` and `toBlock` are not provided, the API queries data from the latest 30 days.\n\nFor Kaia, entering \"earliest\" queries the block at the Kaia hardfork point.\n- Mainnet: 162,900,480 (Aug 29, 2024 11:08:01 UTC+9)\n- Kairos(Testnet): 156,660,000 (June 13, 2024 10:15:19 UTC+9)\n\n",
+                "pattern": "^[0-9]+$|^0[xX][0-9a-fA-F]{64}|latest|earliest"
+              },
+              "toBlock": {
+                "type": "string",
+                "description": "Parameter specifying the ending block for the query. You can enter one of the following formats:\n- block number: Enter block number as a decimal string.\n- block hash: 64-character hexadecimal (including \"0x\").\n- block tag: Use \"earliest\" or \"latest\" to specify the first block or the most recent block.\n\nNotes:\n- If provided without fromBlock, results are queried from the Kaia hardfork block to this block.\n- toBlock value cannot be less than fromBlock value.\n- If fromBlock and toBlock have the same value, only that block is queried.\n- \"earliest\" for toBlock is only allowed when fromBlock is \"earliest\".\n\nFor Kaia, entering \"earliest\" queries the block at the Kaia hardfork point.\n- Mainnet: 162,900,480 (Aug 29, 2024 11:08:01 UTC+9)\n- Kairos(Testnet): 156,660,000 (June 13, 2024 10:15:19 UTC+9)\n",
+                "pattern": "^[0-9]+$|^0[xX][0-9a-fA-F]{64}|latest|earliest"
+              },
+              "fromDate": {
+                "type": "string",
+                "description": "Parameter specifying the start date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without toDate, results are queried from this date to the latest block.\n- fromDate value must be equal to or earlier than toDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-01T00:00:00+00:00"
+              },
+              "toDate": {
+                "type": "string",
+                "description": "Parameter specifying the end date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without fromDate, results are queried from genesis block to this date.\n- toDate value must be equal to or later than fromDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-31T00:00:00+00:00"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "integer",
+                "description": "The page parameter specifies the data page to query. It accepts values up to 100; for pages exceeding 100, use the cursor pagination method.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used.",
+                "pattern": "^(?:[1-9][0-9]?|100)$"
+              },
+              "rpp": {
+                "type": "integer",
+                "description": "rpp stands for results per page and specifies the page size. You can specify a number greater than 0 and up to 100.",
+                "pattern": "^(?:[1-9][0-9]{0,2}?|100)$"
+              },
+              "cursor": {
+                "type": "string",
+                "description": "The cursor parameter supports pagination and data navigation between pages. Provide the cursor value from the previous page in the next request to load the next page of data.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used."
+              },
+              "withCount": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the count field in the response. The count field indicates the total number of requested data items. When set to true, the count field is included and response speed may be slower.",
+                "default": false
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "withLogs": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the logs field in the response. Response speed may be slower when set to true.",
+                "default": false
+              },
+              "withDecode": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include decodedInput and decodedLog fields in the response. Response speed may be slower when set to true.\n\ndecodedLog is part of logs, so it is not included when withLogs is false even if withDecode is true.\ndecodedInput interprets the transaction input field and provides the result. However, different functions may use the same function selector, so the result may not match the actually called function. Additional verification is recommended for non-standard ERC functions.",
+                "default": false
+              }
+            }
+          }
+        ],
+        "example": {
+          "accountAddress": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
+          "relation": "both",
+          "fromDate": "2026-01-01T00:00:00Z",
+          "toDate": "2026-02-01T00:00:00Z"
+        }
+      },
+      "getTransactionsByAccount__utxo__Req": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "accountAddress"
+            ],
+            "properties": {
+              "accountAddress": {
+                "type": "string",
+                "description": "Parameter specifying the account address to query.",
+                "pattern": "^(1[a-km-zA-HJ-NP-Z1-9]{25,33}|3[a-km-zA-HJ-NP-Z1-9]{25,33}|bc1q[a-z0-9]{38,59}|bc1p[a-z0-9]{58})$",
+                "example": "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq"
+              },
+              "relation": {
+                "type": "string",
+                "description": "Parameter for filtering transactions where the queried account address is the sender or recipient.\n- from: Filter by sender only.\n- to: Filter by recipient only.\n- both (default): Returns all transactions where the queried address appears in from or to.",
+                "enum": [
+                  "from",
+                  "to",
+                  "both"
+                ],
+                "pattern": "from|to|both",
+                "default": "both"
+              },
+              "fromBlock": {
+                "type": "string",
+                "description": "Parameter specifying the starting block for the query. You can enter one of the following formats:\n- block number: Enter block number as a decimal string.\n- block hash: 64-character hexadecimal (excluding \"0x\").\n- block tag: Use \"earliest\" or \"latest\" to specify the first block or the most recent block.\n\nNotes:\n- This field cannot be used together with `fromDate` and `toDate`.\n- If provided without fromBlock, results are queried from genesis block to this block.\n- toBlock value cannot be less than fromBlock value.\n- If fromBlock and toBlock have the same value, only that block is queried.\n- \"earliest\" for toBlock is only allowed when fromBlock is \"earliest\".\n- If `fromBlock` and `toBlock` are not provided, the API queries data from the latest 30 days.\n",
+                "pattern": "^[0-9]+$|^[0-9a-fA-F]{64}|latest|earliest"
+              },
+              "toBlock": {
+                "type": "string",
+                "description": "Parameter specifying the ending block for the query. You can enter one of the following formats:\n- block number: Enter block number as a decimal string.\n- block hash: 64-character hexadecimal (excluding \"0x\").\n- block tag: Use \"earliest\" or \"latest\" to specify the first block or the most recent block.\n\nNotes:\n- This field cannot be used together with `fromDate` and `toDate`.\n- If provided without fromBlock, results are queried from genesis block to this block.\n- toBlock value cannot be less than fromBlock value.\n- If fromBlock and toBlock have the same value, only that block is queried.\n- \"earliest\" for toBlock is only allowed when fromBlock is \"earliest\".\n- If `fromBlock` and `toBlock` are not provided, the API queries data from the latest 30 days.\n",
+                "pattern": "^[0-9]+$|^[0-9a-fA-F]{64}|latest|earliest"
+              },
+              "fromDate": {
+                "type": "string",
+                "description": "Parameter specifying the start date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without toDate, results are queried from this date to the latest block.\n- fromDate value must be equal to or earlier than toDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-01T00:00:00+00:00"
+              },
+              "toDate": {
+                "type": "string",
+                "description": "Parameter specifying the end date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without fromDate, results are queried from genesis block to this date.\n- toDate value must be equal to or later than fromDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-31T00:00:00+00:00"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "integer",
+                "description": "The page parameter specifies the data page to query. It accepts values up to 100; for pages exceeding 100, use the cursor pagination method.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used.",
+                "pattern": "^(?:[1-9][0-9]?|100)$"
+              },
+              "rpp": {
+                "type": "integer",
+                "description": "rpp stands for results per page and specifies the page size. You can specify a number greater than 0 and up to 100.",
+                "pattern": "^(?:[1-9][0-9]{0,2}?|100)$"
+              },
+              "cursor": {
+                "type": "string",
+                "description": "The cursor parameter supports pagination and data navigation between pages. Provide the cursor value from the previous page in the next request to load the next page of data.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used."
+              },
+              "withCount": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the count field in the response. The count field indicates the total number of requested data items. When set to true, the count field is included and response speed may be slower.",
+                "default": false
+              }
+            }
+          }
+        ],
+        "example": {
+          "accountAddress": "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq",
+          "relation": "both",
+          "fromDate": "2026-01-01T00:00:00Z",
+          "toDate": "2026-02-01T00:00:00Z"
+        }
+      },
+      "getTransactionsByAccount__tron__Req": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "accountAddress"
+            ],
+            "properties": {
+              "accountAddress": {
+                "type": "string",
+                "description": "Parameter specifying the account address to query. This field uses a 34-character base58 string format starting with \"T\".",
+                "pattern": "^T[1-9A-HJ-NP-Za-km-z]{33}$",
+                "example": "TPswDDCAWhJAZGdHPidFg5nEf8TkNToDX1"
+              },
+              "relation": {
+                "type": "string",
+                "description": "Parameter for filtering transactions where the queried account address is the sender or recipient.\n- from: Filter by sender only.\n- to: Filter by recipient only.\n- both (default): Returns all transactions where the queried address appears in from or to.",
+                "enum": [
+                  "from",
+                  "to",
+                  "both"
+                ],
+                "pattern": "from|to|both",
+                "default": "both"
+              },
+              "fromBlock": {
+                "type": "string",
+                "description": "Parameter specifying the starting point for the query. You can enter block number, block hash, or block tag. Default is 0.\n- block number: Enter as a decimal string.\n- block hash: Enter as a 64-character hexadecimal string, excluding the 0x prefix.\n- block tag: You can enter \"earliest\" for fromBlock.\n\nNotes:\n- If only fromBlock is provided without toBlock, results are queried from fromBlock to the most recent block.\n- fromBlock's block number must be less than or equal to toBlock's block number.\n- If toBlock and fromBlock have the same value, only that single block's results are queried.\n- \"latest\" cannot be entered for fromBlock.\n",
+                "pattern": "^[0-9]+$|^[0-9a-fA-F]{64}|latest|earliest",
+                "default": "earliest",
+                "example": "80453005"
+              },
+              "toBlock": {
+                "type": "string",
+                "description": "Parameter specifying the ending point for the query. You can enter block number, block hash, or block tag. Default is \"latest\".\n- block number: Enter as a decimal string.\n- block hash: Enter as a 64-character hexadecimal string, excluding the 0x prefix.\n- block tag: You can enter \"latest\".\n\nNotes:\n- The blockNumber for toBlock must be greater than or equal to the blockNumber for fromBlock.\n- If toBlock and fromBlock have the same value, only that single block's results are queried.\n- If only toBlock is provided without fromBlock, results are queried from genesis block to the time specified in toBlock.\n- \"earliest\" cannot be entered for toBlock.",
+                "pattern": "^[0-9]+$|^[0-9a-fA-F]{64}|latest|earliest",
+                "default": "latest",
+                "example": "80453006"
+              },
+              "fromDate": {
+                "type": "string",
+                "description": "Parameter specifying the start date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without toDate, results are queried from this date to the latest block.\n- fromDate value must be equal to or earlier than toDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-01T00:00:00+00:00"
+              },
+              "toDate": {
+                "type": "string",
+                "description": "Parameter specifying the end date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without fromDate, results are queried from genesis block to this date.\n- toDate value must be equal to or later than fromDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-31T00:00:00+00:00"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "integer",
+                "description": "The page parameter specifies the data page to query. It accepts values up to 100; for pages exceeding 100, use the cursor pagination method.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used.",
+                "pattern": "^(?:[1-9][0-9]?|100)$"
+              },
+              "rpp": {
+                "type": "integer",
+                "description": "rpp stands for results per page and specifies the page size. You can specify a number greater than 0 and up to 100.",
+                "pattern": "^(?:[1-9][0-9]{0,2}?|100)$"
+              },
+              "cursor": {
+                "type": "string",
+                "description": "The cursor parameter supports pagination and data navigation between pages. Provide the cursor value from the previous page in the next request to load the next page of data.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used."
+              },
+              "withCount": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the count field in the response. The count field indicates the total number of requested data items. When set to true, the count field is included and response speed may be slower.",
+                "default": false
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "withLogs": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the logs field in the response. Response speed may be slower when set to true.",
+                "default": false
+              },
+              "withDecode": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include decodedInput and decodedLog fields in the response. Response speed may be slower when set to true.\n\ndecodedLog is part of logs, so it is not included when withLogs is false even if withDecode is true.\ndecodedInput interprets the transaction input field and provides the result. However, different functions may use the same function selector, so the result may not match the actually called function. Additional verification is recommended for non-standard ERC functions.",
+                "default": false
+              }
+            }
+          }
+        ]
+      },
+      "getTransactionsByAccount__xrpl__Req": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "accountAddress"
+            ],
+            "properties": {
+              "accountAddress": {
+                "type": "string",
+                "description": "Parameter specifying the account address for balance query. It is a Base58-encoded string of 25-35 characters, always starting with \"r\".",
+                "pattern": "^r[1-9A-HJ-NP-Za-km-z]{25,35}$"
+              },
+              "relation": {
+                "type": "string",
+                "description": "Parameter for filtering transactions where the queried account address is the sender or recipient.\n- from: Filter by sender only.\n- to: Filter by recipient only.\n- both (default): Returns all transactions where the queried address appears in from or to.",
+                "enum": [
+                  "from",
+                  "to",
+                  "both"
+                ],
+                "pattern": "from|to|both",
+                "default": "both"
+              },
+              "fromLedger": {
+                "type": "string",
+                "description": "Parameter specifying the starting ledger for the query. You can enter one of the following formats:\n- **ledger index**: Enter ledger number as a decimal string\n- **ledger hash**: 64-character hexadecimal string (excluding 0x prefix)\n- **ledger tag**: Enter \"earliest\" or \"latest\" (oldest or most recent ledger)\n\nNotes:\n- If provided without toLedger, results are queried from this ledger to the latest ledger.\n- fromLedger value cannot be greater than toLedger value.\n- If fromLedger and toLedger have the same value, only that ledger is queried.\n- \"latest\" for fromLedger is only allowed when toLedger is \"latest\".",
+                "pattern": "^[0-9]+$|^0[xX][0-9a-fA-F]{64}|latest|earliest"
+              },
+              "toLedger": {
+                "type": "string",
+                "description": "Parameter specifying the ending ledger for the query. You can enter one of the following formats:\n- **ledger index**: Enter ledger number as a decimal string\n- **ledger hash**: 64-character hexadecimal string (excluding 0x prefix)\n- **ledger tag**: Enter \"earliest\" or \"latest\" (oldest or most recent ledger)\n\nNotes:\n- If provided without fromLedger, results are queried from genesis ledger to this ledger.\n- toLedger value cannot be less than fromLedger value.\n- If fromLedger and toLedger have the same value, only that ledger is queried.\n- \"earliest\" for toLedger is only allowed when fromLedger is \"earliest\".",
+                "pattern": "^[0-9]+$|^0[xX][0-9a-fA-F]{64}|latest|earliest"
+              },
+              "fromDate": {
+                "type": "string",
+                "description": "Parameter specifying the start date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without toDate, results are queried from this date to the latest block.\n- fromDate value must be equal to or earlier than toDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-01T00:00:00+00:00"
+              },
+              "toDate": {
+                "type": "string",
+                "description": "Parameter specifying the end date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without fromDate, results are queried from genesis block to this date.\n- toDate value must be equal to or later than fromDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-31T00:00:00+00:00"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "integer",
+                "description": "The page parameter specifies the data page to query. It accepts values up to 100; for pages exceeding 100, use the cursor pagination method.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used.",
+                "pattern": "^(?:[1-9][0-9]?|100)$"
+              },
+              "rpp": {
+                "type": "integer",
+                "description": "rpp stands for results per page and specifies the page size. You can specify a number greater than 0 and up to 100.",
+                "pattern": "^(?:[1-9][0-9]{0,2}?|100)$"
+              },
+              "cursor": {
+                "type": "string",
+                "description": "The cursor parameter supports pagination and data navigation between pages. Provide the cursor value from the previous page in the next request to load the next page of data.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used."
+              },
+              "withCount": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the count field in the response. The count field indicates the total number of requested data items. When set to true, the count field is included and response speed may be slower.",
+                "default": false
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "withBalanceChanges": {
+                "type": "boolean",
+                "description": "Optional parameter determining whether to include the balanceChanges field in the response. balanceChanges contains balance change details for native token (XRP) and IOU tokens. Response speed may be slower when set to true.",
+                "default": false
+              },
+              "withTokenTransfers": {
+                "type": "boolean",
+                "description": "Optional parameter determining whether to include the tokenTransfers field in the response. tokenTransfers contains IOU token transfer history. Response speed may be slower when set to true.",
+                "default": false
+              }
+            }
+          }
+        ],
+        "example": {
+          "accountAddress": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+          "relation": "both",
+          "fromDate": "2026-01-01T00:00:00Z",
+          "toDate": "2026-02-01T00:00:00Z"
+        }
+      },
+      "getTransactionByVersion__aptos__Req": {
+        "type": "object",
+        "required": [
+          "transactionVersion"
+        ],
+        "properties": {
+          "transactionVersion": {
+            "type": "integer",
+            "description": "Parameter specifying the transaction version to query. The transaction version must be entered as a positive integer.",
+            "pattern": "^[-+]?[0-9]+$"
+          },
+          "withBalanceChanges": {
+            "type": "boolean",
+            "description": "Parameter specifying whether to include the balanceChanges field in the response.\n\n- balanceChanges is a field containing balance changes for Native token (APT) and Tokens.\n- Response speed may be slower when true is set for this parameter.",
+            "default": false
+          }
+        }
+      },
+      "getGasPrice__evm__Res": {
+        "type": "object",
+        "required": [
+          "high",
+          "average",
+          "low",
+          "latestBlock",
+          "baseFee"
+        ],
+        "properties": {
+          "high": {
+            "type": "string",
+            "description": "Indicates the highest price of the current Gas Price. Provided as a decimal string."
+          },
+          "average": {
+            "type": "string",
+            "description": "Indicates the average price of the current Gas Price. Provided as a decimal string."
+          },
+          "low": {
+            "type": "string",
+            "description": "Indicates the lowest price of the current Gas Price. Provided as a decimal string."
+          },
+          "latestBlock": {
+            "type": "string",
+            "description": "Indicates the latest block. Provided as a decimal string."
+          },
+          "baseFee": {
+            "type": "string",
+            "description": "Indicates the base fee of the latest block. Provided as a decimal string."
+          }
+        }
+      },
+      "getInternalTransactionsByAccount__evm__Req": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "accountAddress"
+            ],
+            "properties": {
+              "accountAddress": {
+                "type": "string",
+                "description": "Parameter specifying the account address to query. Can be entered as a 40-character hexadecimal string starting with 0x.",
+                "pattern": "^0[xX][0-9a-fA-F]{40}$",
+                "example": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+              },
+              "relation": {
+                "type": "string",
+                "description": "Parameter for filtering transactions where the queried account address is the sender or recipient.\n- from: Filter by sender only.\n- to: Filter by recipient only.\n- both (default): Returns all transactions where the queried address appears in from or to.",
+                "enum": [
+                  "from",
+                  "to",
+                  "both"
+                ],
+                "pattern": "from|to|both",
+                "default": "both"
+              },
+              "fromBlock": {
+                "type": "string",
+                "description": "Parameter specifying the starting block for the query. You can enter one of the following formats:\n- block number: Enter block number as a decimal string.\n- block hash: 64-character hexadecimal (including \"0x\").\n- block tag: Use \"earliest\" or \"latest\" to specify the first block or the most recent block.\n\nNotes:\n- This field cannot be used together with `fromDate` and `toDate`.\n- If provided without fromBlock, results are queried from genesis block to this block.\n- toBlock value cannot be less than fromBlock value.\n- If fromBlock and toBlock have the same value, only that block is queried.\n- \"earliest\" for toBlock is only allowed when fromBlock is \"earliest\".\n- If `fromBlock` and `toBlock` are not provided, the API queries data from the latest 30 days.\n",
+                "pattern": "^[0-9]+$|^0[xX][0-9a-fA-F]{64}|latest|earliest"
+              },
+              "toBlock": {
+                "type": "string",
+                "description": "Parameter specifying the ending block for the query. You can enter one of the following formats:\n- block number: Enter block number as a decimal string.\n- block hash: 64-character hexadecimal (including \"0x\").\n- block tag: Use \"earliest\" or \"latest\" to specify the first block or the most recent block.\n\nNotes:\n- This field cannot be used together with `fromDate` and `toDate`.\n- If provided without fromBlock, results are queried from genesis block to this block.\n- toBlock value cannot be less than fromBlock value.\n- If fromBlock and toBlock have the same value, only that block is queried.\n- \"earliest\" for toBlock is only allowed when fromBlock is \"earliest\".\n- If `fromBlock` and `toBlock` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]+$|^0[xX][0-9a-fA-F]{64}|latest|earliest"
+              },
+              "fromDate": {
+                "type": "string",
+                "description": "Parameter specifying the start date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without toDate, results are queried from this date to the latest block.\n- fromDate value must be equal to or earlier than toDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-01T00:00:00+00:00"
+              },
+              "toDate": {
+                "type": "string",
+                "description": "Parameter specifying the end date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without fromDate, results are queried from genesis block to this date.\n- toDate value must be equal to or later than fromDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-31T00:00:00+00:00"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "integer",
+                "description": "The page parameter specifies the data page to query. It accepts values up to 100; for pages exceeding 100, use the cursor pagination method.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used.",
+                "pattern": "^(?:[1-9][0-9]?|100)$"
+              },
+              "rpp": {
+                "type": "integer",
+                "description": "rpp stands for results per page and specifies the page size. You can specify a number greater than 0 and up to 100.",
+                "pattern": "^(?:[1-9][0-9]{0,2}?|100)$"
+              },
+              "cursor": {
+                "type": "string",
+                "description": "The cursor parameter supports pagination and data navigation between pages. Provide the cursor value from the previous page in the next request to load the next page of data.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used."
+              },
+              "withCount": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the count field in the response. The count field indicates the total number of requested data items. When set to true, the count field is included and response speed may be slower.",
+                "default": false
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "withZeroValue": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include results with value 0 in the response. Set to true for faster responses.",
+                "default": false
+              },
+              "withExternalTransaction": {
+                "type": "boolean",
+                "description": "Parameter determining whether to include external transactions in the response. External transactions are returned in the same format as internal transactions with trace index 0. When set to true, external transactions are included and response speed may be slower.",
+                "default": false
+              }
+            }
+          }
+        ],
+        "example": {
+          "accountAddress": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
+          "relation": "both",
+          "fromDate": "2026-01-01T00:00:00Z",
+          "toDate": "2026-02-01T00:00:00Z",
+          "withZeroValue": false,
+          "withExternalTransaction": false
+        }
+      },
+      "getInternalTransactionsByAccount__tron__Req": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "accountAddress"
+            ],
+            "properties": {
+              "accountAddress": {
+                "type": "string",
+                "description": "Parameter specifying the account address to query. This field uses a 34-character base58 string format starting with \"T\".",
+                "pattern": "^T[1-9A-HJ-NP-Za-km-z]{33}$",
+                "example": "TPswDDCAWhJAZGdHPidFg5nEf8TkNToDX1"
+              },
+              "relation": {
+                "type": "string",
+                "description": "Parameter for filtering transactions where the queried account address is the sender or recipient.\n- from: Filter by sender only.\n- to: Filter by recipient only.\n- both (default): Returns all transactions where the queried address appears in from or to.",
+                "enum": [
+                  "from",
+                  "to",
+                  "both"
+                ],
+                "pattern": "from|to|both",
+                "default": "both"
+              },
+              "fromBlock": {
+                "type": "string",
+                "description": "Parameter specifying the starting point for the query. You can enter block number, block hash, or block tag. Default is 0.\n- block number: Enter as a decimal string.\n- block hash: Enter as a 64-character hexadecimal string, excluding the 0x prefix.\n- block tag: You can enter \"earliest\" for fromBlock.\n\nNotes:\n- If only fromBlock is provided without toBlock, results are queried from fromBlock to the most recent block.\n- fromBlock's block number must be less than or equal to toBlock's block number.\n- If toBlock and fromBlock have the same value, only that single block's results are queried.\n- \"latest\" cannot be entered for fromBlock.\n",
+                "pattern": "^[0-9]+$|^[0-9a-fA-F]{64}|latest|earliest",
+                "default": "earliest",
+                "example": "80453005"
+              },
+              "toBlock": {
+                "type": "string",
+                "description": "Parameter specifying the ending point for the query. You can enter block number, block hash, or block tag. Default is \"latest\".\n- block number: Enter as a decimal string.\n- block hash: Enter as a 64-character hexadecimal string, excluding the 0x prefix.\n- block tag: You can enter \"latest\".\n\nNotes:\n- The blockNumber for toBlock must be greater than or equal to the blockNumber for fromBlock.\n- If toBlock and fromBlock have the same value, only that single block's results are queried.\n- If only toBlock is provided without fromBlock, results are queried from genesis block to the time specified in toBlock.\n- \"earliest\" cannot be entered for toBlock.",
+                "pattern": "^[0-9]+$|^[0-9a-fA-F]{64}|latest|earliest",
+                "default": "latest",
+                "example": "80453006"
+              },
+              "fromDate": {
+                "type": "string",
+                "description": "Parameter specifying the start date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without toDate, results are queried from this date to the latest block.\n- fromDate value must be equal to or earlier than toDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-01T00:00:00+00:00"
+              },
+              "toDate": {
+                "type": "string",
+                "description": "Parameter specifying the end date for the query. Date must follow ISO 8601 format (YYYY-MM-DDThh:mm:ss{time zone}) including seconds.\n\nNotes:\n- If provided without fromDate, results are queried from genesis block to this date.\n- toDate value must be equal to or later than fromDate value.\n- If fromDate and toDate have the same value, only blocks from that date are queried.\n- This field cannot be used together with fromBlock and toBlock.  \n- If `fromDate` and `toDate` are not provided, the API queries data from the latest 30 days.",
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,3})?(?:Z|[+-][0-9]{2}:[0-9]{2})$",
+                "example": "2025-01-31T00:00:00+00:00"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "integer",
+                "description": "The page parameter specifies the data page to query. It accepts values up to 100; for pages exceeding 100, use the cursor pagination method.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used.",
+                "pattern": "^(?:[1-9][0-9]?|100)$"
+              },
+              "rpp": {
+                "type": "integer",
+                "description": "rpp stands for results per page and specifies the page size. You can specify a number greater than 0 and up to 100.",
+                "pattern": "^(?:[1-9][0-9]{0,2}?|100)$"
+              },
+              "cursor": {
+                "type": "string",
+                "description": "The cursor parameter supports pagination and data navigation between pages. Provide the cursor value from the previous page in the next request to load the next page of data.\n\nThe page and cursor parameters cannot be used together. If both page and cursor are empty, cursor pagination is used."
+              },
+              "withCount": {
+                "type": "boolean",
+                "description": "Parameter specifying whether to include the count field in the response. The count field indicates the total number of requested data items. When set to true, the count field is included and response speed may be slower.",
+                "default": false
+              }
+            }
+          }
+        ]
+      },
+      "getBlockByHashOrNumber__aptos__Req": {
+        "type": "object",
+        "required": [
+          "block"
+        ],
+        "properties": {
+          "block": {
+            "type": "string",
+            "description": "Parameter specifying the block to query. The default value is latest. You can input block number (decimal string), block hash (64-character hexadecimal string starting with 0x), or block tag (earliest, latest). \"earliest\" refers to the first block, \"latest\" refers to the most recent block.",
+            "pattern": "^[0-9]+$|^0[xX][0-9a-fA-F]{64}|latest|earliest",
+            "default": "latest"
+          }
+        },
+        "example": {
+          "block": "latest"
+        }
+      },
+      "getBlockByHashOrNumber__evm__Req": {
+        "type": "object",
+        "required": [
+          "block"
+        ],
+        "properties": {
+          "block": {
+            "type": "string",
+            "description": "Parameter specifying the block to query. The default value is latest. You can input block number (decimal string), block hash (64-character hexadecimal string starting with 0x), or block tag (earliest, latest). \"earliest\" refers to the first block, \"latest\" refers to the most recent block.\n\n",
+            "pattern": "^[0-9]+$|^0[xX][0-9a-fA-F]{64}|latest|earliest",
+            "default": "latest"
+          }
+        },
+        "example": {
+          "block": "latest"
+        }
+      },
+      "getBlockByHashOrNumber__kaia__Req": {
+        "type": "object",
+        "required": [
+          "block"
+        ],
+        "properties": {
+          "block": {
+            "type": "string",
+            "description": "Parameter specifying the block to query. The default value is latest. You can input block number (decimal string), block hash (64-character hexadecimal string starting with 0x), or block tag (earliest, latest). \"earliest\" refers to the first block, \"latest\" refers to the most recent block.\n\nFor Kaia, entering \"earliest\" queries the block at the Kaia hardfork point.\n- Mainnet: 162,900,480 (Aug 29, 2024 11:08:01 UTC+9)\n- Kairos(Testnet): 156,660,000 (June 13, 2024 10:15:19 UTC+9)\n\n",
+            "pattern": "^[0-9]+$|^0[xX][0-9a-fA-F]{64}|latest|earliest",
+            "default": "latest"
+          }
+        },
+        "example": {
+          "block": "latest"
+        }
+      },
+      "getBlockByHashOrNumber__utxo__Req": {
+        "type": "object",
+        "required": [
+          "block"
+        ],
+        "properties": {
+          "block": {
+            "type": "string",
+            "description": "Parameter specifying the point in time for balance query. You can enter one of the following formats:\n- block hash: 64-character hexadecimal string (256-bit). Queries based on the specified block hash.\n- block number: Decimal string. Queries based on the specified block height.\n- block tag: Enter \"earliest\" or \"latest\" to query the first block or the most recent block.",
+            "pattern": "^[0-9]+$|^[0-9a-fA-F]{64}|latest|earliest",
+            "default": "latest"
+          }
+        },
+        "example": {
+          "block": "latest"
+        }
+      },
+      "getBlockByHashOrNumber__aptos__Res": {
+        "type": "object",
+        "required": [
+          "hash",
+          "height",
+          "timestamp",
+          "firstVersion",
+          "lastVersion",
+          "transactionsCount",
+          "transactions"
+        ],
+        "properties": {
+          "hash": {
+            "type": "string",
+            "description": "A field that represents the unique hash identifier of the block.\nIt is a cryptographic hash computed from all data of the block, provided as a 64-character hexadecimal string prefixed with 0x.\n"
+          },
+          "height": {
+            "type": "integer",
+            "description": "A field that represents the block height.\nAn integer that increments sequentially starting from the genesis block (0), used as an indicator for the blockchain length and the position of a specific block.\n"
+          },
+          "timestamp": {
+            "type": "integer",
+            "description": "A field that represents when the block was created.\nProvided as a UNIX timestamp, used for block creation order and time tracking.\nBlock timestamps are used to ensure transaction order and measure inter-block creation intervals.\n"
+          },
+          "firstVersion": {
+            "type": "integer",
+            "description": "A field that represents the version number of the first transaction processed in the block.\nIn Aptos, each transaction has a unique version number that indicates the global execution order of the transaction.\nfirstVersion and lastVersion allow you to determine the version range of transactions within the block.\n"
+          },
+          "lastVersion": {
+            "type": "integer",
+            "description": "A field that represents the version number of the last transaction processed in the block.\nTogether with firstVersion, it defines the version range of transactions within the block; this enables sequential retrieval of all transactions in the block.\n"
+          },
+          "transactionsCount": {
+            "type": "integer",
+            "description": "A field that represents the total number of transactions included in the block.\nAn important indicator for understanding block size and throughput; it includes all transaction types (user transactions, system transactions, etc.).\nThis value equals lastVersion - firstVersion + 1.\n"
+          },
+          "transactions": {
+            "type": "array",
+            "description": "A field that represents the list of version numbers for all transactions included in the block.\nEach version number serves as a unique identifier for the transaction, sorted sequentially from firstVersion to lastVersion.\nThis list enables retrieval of detailed information for individual transactions in the block.\n",
+            "items": {
+              "type": "integer"
+            }
+          }
+        }
+      },
+      "getBlockByHashOrNumber__evm__Res": {
+        "type": "object",
+        "required": [
+          "hash",
+          "number",
+          "timestamp",
+          "parentHash",
+          "nonce",
+          "stateRoot",
+          "receiptsRoot",
+          "transactionsRoot",
+          "miner",
+          "difficulty",
+          "totalDifficulty",
+          "mixHash",
+          "gasLimit",
+          "gasUsed",
+          "size",
+          "logsBloom",
+          "extraData",
+          "sha3Uncles",
+          "transactionsCount",
+          "transactions"
+        ],
+        "properties": {
+          "hash": {
+            "type": "string",
+            "description": "A field representing the block hash. Provided as a 64-character hexadecimal string prefixed with 0x."
+          },
+          "number": {
+            "type": "integer",
+            "description": "A field representing the block number or block height. Provided as a decimal string."
+          },
+          "timestamp": {
+            "type": "integer",
+            "description": "A field representing the time when the block was created. This field is provided as a UNIX timestamp."
+          },
+          "parentHash": {
+            "type": "string",
+            "description": "A field representing the hash of the parent block. Provided as a 64-character hexadecimal string prefixed with 0x."
+          },
+          "nonce": {
+            "type": "string",
+            "description": "A value used to prove block validity in Proof of Work (PoW). Returns 0x0000000000000000 for blocks after the transition to Proof of Stake (PoS)."
+          },
+          "stateRoot": {
+            "type": "string",
+            "description": "A field representing the root hash of the block state. Provided as a 64-character hexadecimal string prefixed with 0x."
+          },
+          "receiptsRoot": {
+            "type": "string",
+            "description": "A field representing the root hash of all transaction receipts in the block. Provided as a 64-character hexadecimal string prefixed with 0x."
+          },
+          "transactionsRoot": {
+            "type": "string",
+            "description": "A field representing the root hash of all transactions in the block. Provided as a 64-character hexadecimal string prefixed with 0x."
+          },
+          "miner": {
+            "type": "string",
+            "description": "A field representing the address of the miner who created the block. Provided as a 40-character hexadecimal string prefixed with 0x."
+          },
+          "difficulty": {
+            "type": "string",
+            "description": "A field representing the block creation difficulty. Returns the difficulty value for Proof of Work (PoW), and 0 for blocks after the transition to Proof of Stake (PoS)."
+          },
+          "totalDifficulty": {
+            "type": "string",
+            "description": "A field representing the cumulative block creation difficulty. Returns the sum of difficulty from block 0 to the current block. Provided as a hexadecimal string prefixed with 0x."
+          },
+          "mixHash": {
+            "type": "string",
+            "description": "A value used to prove block validity in Proof of Work (PoW). Provided as a 64-character hexadecimal string prefixed with 0x."
+          },
+          "gasLimit": {
+            "type": "string",
+            "description": "A field representing the maximum gas allowed for the block. The sum of gas used by all transactions in the block must be less than this value. Provided as a hexadecimal string prefixed with 0x."
+          },
+          "gasUsed": {
+            "type": "string",
+            "description": "A field representing the total gas used by all transactions in the block. Provided as a hexadecimal string prefixed with 0x."
+          },
+          "baseFeePerGas": {
+            "type": "string",
+            "description": "A field representing the block base gas fee. Part of the variable fee model introduced in EIP-1559 (London Hard fork). This field is not provided for blocks before this introduction. Provided as a hexadecimal string prefixed with 0x."
+          },
+          "size": {
+            "type": "string",
+            "description": "A field representing the size of the block in bytes. Provided as a hexadecimal string prefixed with 0x."
+          },
+          "logsBloom": {
+            "type": "string",
+            "description": "A field representing the logs bloom of all transactions in the block. Provided as a 512-character hexadecimal string prefixed with 0x."
+          },
+          "extraData": {
+            "type": "string",
+            "description": "A field representing additional data added by the block creator. Returns 0x when no value was added. Provided as a hexadecimal string prefixed with 0x."
+          },
+          "sha3Uncles": {
+            "type": "string",
+            "description": "A field representing the hash of all uncle blocks in the block. Provided as a 64-character hexadecimal string prefixed with 0x."
+          },
+          "transactionsCount": {
+            "type": "integer",
+            "description": "A field representing the number of transactions in the block."
+          },
+          "transactions": {
+            "type": "array",
+            "description": "A field representing the list of transactions in the block.",
+            "items": {
+              "type": "string",
+              "description": "A field representing the hash of a transaction in the block. Provided as a 64-character hexadecimal string prefixed with 0x."
+            }
+          },
+          "withdrawalsRoot": {
+            "type": "string",
+            "description": "A field representing the root hash of all withdrawal transactions in the block. Provided as a 64-character hexadecimal string prefixed with 0x."
+          },
+          "withdrawals": {
+            "type": "array",
+            "description": "A field representing the list of withdrawals of staked assets by validators.",
+            "items": {
+              "type": "object"
+            }
+          },
+          "requestsHash": {
+            "type": "string",
+            "description": "A field in the block header that is a cryptographic commitment of the order and content of all requests in the block. This allows verification of the integrity of the request list within the block without downloading the full data."
+          },
+          "withdrawalsCount": {
+            "type": "integer",
+            "description": "A field representing the number of withdrawal transactions included in the block."
+          }
+        }
+      },
+      "getBlockByHashOrNumber__utxo__Res": {
+        "type": "object",
+        "required": [
+          "hash",
+          "height",
+          "version",
+          "timestamp",
+          "nonce",
+          "bits",
+          "difficulty",
+          "merkleRoot",
+          "transactionCount",
+          "size",
+          "weight",
+          "previousBlockHash",
+          "nextBlockHash",
+          "medianTime",
+          "strippedSize",
+          "transactions"
+        ],
+        "properties": {
+          "hash": {
+            "type": "string",
+            "description": "SHA-256 hash value that uniquely identifies the block. Generated by combining block header information; serves as a unique identifier within the blockchain with no duplicates."
+          },
+          "height": {
+            "type": "integer",
+            "description": "Number indicating the position of the block in the blockchain. The genesis block starts at 0, and subsequent blocks increment by 1."
+          },
+          "version": {
+            "type": "integer",
+            "description": "Block version number, used to identify the block validation rules used by the network. Updated when new features are added."
+          },
+          "timestamp": {
+            "type": "integer",
+            "description": "Represents when the block was created, displayed as a UNIX timestamp."
+          },
+          "nonce": {
+            "type": "integer",
+            "description": "Value used in the Proof-of-Work algorithm; a variable that is changed multiple times to find a valid block hash."
+          },
+          "bits": {
+            "type": "string",
+            "description": "Compressed 32-bit hexadecimal value representing the difficulty target that the block hash must satisfy. This value varies according to the network's mining difficulty."
+          },
+          "difficulty": {
+            "type": "string",
+            "description": "Represents the difficulty of the block, calculated as the ratio between the initial target value and the current target value. Reflects the relative difficulty of mining."
+          },
+          "merkleRoot": {
+            "type": "string",
+            "description": "Root hash value calculated by constructing a Merkle tree from the hashes of all transactions included in the block. Used to verify data integrity."
+          },
+          "transactionCount": {
+            "type": "integer",
+            "description": "Indicates the total number of transactions included in the block. Used to check the volume of transactions in a mined block."
+          },
+          "size": {
+            "type": "integer",
+            "description": "Total size of the block including header and transaction data, in bytes. Represents the actual disk space required to store the block data."
+          },
+          "weight": {
+            "type": "integer",
+            "description": "Block weight calculated according to BIP-141, taking SegWit data into account."
+          },
+          "previousBlockHash": {
+            "type": "string",
+            "description": "Hash of the previous block; maintains the linkage between blocks in the blockchain. Null for the genesis block."
+          },
+          "nextBlockHash": {
+            "type": "string",
+            "description": "Hash of the next block; null for the most recent block. Indicates the end of the chain."
+          },
+          "medianTime": {
+            "type": "integer",
+            "description": "Median of the timestamps of the most recent 11 blocks. Used to reduce time volatility and provide a more stable block time."
+          },
+          "strippedSize": {
+            "type": "integer",
+            "description": "Size of the block excluding SegWit data. Measured in bytes; represents the raw transaction data and header size."
+          },
+          "transactions": {
+            "type": "array",
+            "description": "Array of transaction hash values included in the block. Each transaction is identified by its unique hash.",
+            "items": {
+              "type": "string",
+              "description": "SHA-256 hash value that uniquely identifies each transaction."
+            }
+          }
+        }
+      },
+      "getBlockByHashOrNumber__bitcoincash__Res": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "hash",
+              "height",
+              "version",
+              "timestamp",
+              "nonce",
+              "bits",
+              "difficulty",
+              "merkleRoot",
+              "transactionCount",
+              "size",
+              "weight",
+              "previousBlockHash",
+              "nextBlockHash",
+              "medianTime",
+              "strippedSize",
+              "transactions"
+            ],
+            "properties": {
+              "hash": {
+                "type": "string",
+                "description": "SHA-256 hash value that uniquely identifies the block. Generated by combining block header information; serves as a unique identifier within the blockchain with no duplicates."
+              },
+              "height": {
+                "type": "integer",
+                "description": "Number indicating the position of the block in the blockchain. The genesis block starts at 0, and subsequent blocks increment by 1."
+              },
+              "version": {
+                "type": "integer",
+                "description": "Block version number, used to identify the block validation rules used by the network. Updated when new features are added."
+              },
+              "timestamp": {
+                "type": "integer",
+                "description": "Represents when the block was created, displayed as a UNIX timestamp."
+              },
+              "nonce": {
+                "type": "integer",
+                "description": "Value used in the Proof-of-Work algorithm; a variable that is changed multiple times to find a valid block hash."
+              },
+              "bits": {
+                "type": "string",
+                "description": "Compressed 32-bit hexadecimal value representing the difficulty target that the block hash must satisfy. This value varies according to the network's mining difficulty."
+              },
+              "difficulty": {
+                "type": "string",
+                "description": "Represents the difficulty of the block, calculated as the ratio between the initial target value and the current target value. Reflects the relative difficulty of mining."
+              },
+              "merkleRoot": {
+                "type": "string",
+                "description": "Root hash value calculated by constructing a Merkle tree from the hashes of all transactions included in the block. Used to verify data integrity."
+              },
+              "transactionCount": {
+                "type": "integer",
+                "description": "Indicates the total number of transactions included in the block. Used to check the volume of transactions in a mined block."
+              },
+              "size": {
+                "type": "integer",
+                "description": "Total size of the block including header and transaction data, in bytes. Represents the actual disk space required to store the block data."
+              },
+              "weight": {
+                "type": "integer",
+                "description": "Block weight calculated according to BIP-141, taking SegWit data into account."
+              },
+              "previousBlockHash": {
+                "type": "string",
+                "description": "Hash of the previous block; maintains the linkage between blocks in the blockchain. Null for the genesis block."
+              },
+              "nextBlockHash": {
+                "type": "string",
+                "description": "Hash of the next block; null for the most recent block. Indicates the end of the chain."
+              },
+              "medianTime": {
+                "type": "integer",
+                "description": "Median of the timestamps of the most recent 11 blocks. Used to reduce time volatility and provide a more stable block time."
+              },
+              "strippedSize": {
+                "type": "integer",
+                "description": "Size of the block excluding SegWit data. Measured in bytes; represents the raw transaction data and header size."
+              },
+              "transactions": {
+                "type": "array",
+                "description": "Array of transaction hash values included in the block. Each transaction is identified by its unique hash.",
+                "items": {
+                  "type": "string",
+                  "description": "SHA-256 hash value that uniquely identifies each transaction."
+                }
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "ablastate": {
+                "type": "object",
+                "description": "ABLA (Adaptive Block Limit Algorithm) state values. Provided only for blocks after ABLA activation. When provided, all internal fields exist."
+              }
+            }
+          }
+        ]
+      },
+      "dailyStatsRange__evm__Req": {
+        "type": "object",
+        "required": [
+          "startDate",
+          "endDate"
+        ],
+        "properties": {
+          "startDate": {
+            "type": "string",
+            "description": "Parameter specifying the start date for the query. Data can be queried for up to 100 days from start to end date. Supports YYYY-MM-DD format.",
+            "pattern": "^[0-9]{4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])$",
+            "example": "2026-01-01"
+          },
+          "endDate": {
+            "type": "string",
+            "description": "Parameter specifying the end date for the query. Data can be queried for up to 100 days from start to end date. Supports YYYY-MM-DD format.",
+            "pattern": "^[0-9]{4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])$",
+            "example": "2026-01-01"
+          }
+        },
+        "example": {
+          "startDate": "2026-01-01",
+          "endDate": "2026-02-01"
+        }
+      },
+      "statsItems__evm__Res": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "items"
+            ],
+            "properties": {
+              "count": {
+                "type": "integer",
+                "description": "Field representing the total count of requested data. This field is only included in the response when true is set for the withCount parameter."
+              },
+              "items": {
+                "type": "array",
+                "description": "Field representing the list of queried data."
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "items": {
+                "type": "array",
+                "items": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "dailyStatsByContract__evm__Req": {
+        "type": "object",
+        "required": [
+          "contractAddress",
+          "startDate",
+          "endDate"
+        ],
+        "properties": {
+          "contractAddress": {
+            "type": "string",
+            "description": "Parameter specifying the contract address to query. Can be entered as a 40-character hexadecimal string starting with 0x.",
+            "pattern": "^0[xX][0-9a-fA-F]{40}$"
+          },
+          "startDate": {
+            "type": "string",
+            "description": "Parameter specifying the start date for the query. Data can be queried for up to 100 days from start to end date. Supports YYYY-MM-DD format.",
+            "pattern": "^[0-9]{4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])$",
+            "example": "2026-01-01"
+          },
+          "endDate": {
+            "type": "string",
+            "description": "Parameter specifying the end date for the query. Data can be queried for up to 100 days from start to end date. Supports YYYY-MM-DD format.",
+            "pattern": "^[0-9]{4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])$",
+            "example": "2026-01-01"
+          }
+        },
+        "example": {
+          "contractAddress": "0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D",
+          "startDate": "2026-01-01",
+          "endDate": "2026-02-01"
+        }
+      },
+      "getAccountStats__aptos__Req": {
+        "type": "object",
+        "required": [
+          "address"
+        ],
+        "properties": {
+          "address": {
+            "type": "string",
+            "description": "Parameter specifying the account address to query. The account address must be entered as a 64-character hexadecimal string (including \"0x\").",
+            "pattern": "^0[xX][0-9a-fA-F]{64}",
+            "example": "0xd91c64b777e51395c6ea9dec562ed79a4afa0cd6dad5a87b187c37198a1f855a"
+          }
+        }
+      },
+      "getAccountStats__evm__Res": {
+        "type": "object",
+        "properties": {
+          "transactionCounts": {
+            "type": "object",
+            "description": "Object containing transaction count information associated with the queried address."
+          },
+          "transferCounts": {
+            "type": "object",
+            "description": "Object containing transfer event count information associated with the queried address."
+          },
+          "assets": {
+            "type": "object",
+            "description": "Object containing asset information owned by the queried address."
+          }
+        },
+        "required": [
+          "transactionCounts",
+          "transferCounts",
+          "assets"
+        ]
+      },
+      "getAccountStats__tron__Res": {
+        "type": "object",
+        "properties": {
+          "transactionCounts": {
+            "type": "object",
+            "description": "Object containing transaction count information associated with the queried address."
+          },
+          "transferCounts": {
+            "type": "object",
+            "description": "Object containing transfer event count information associated with the queried address."
+          },
+          "assets": {
+            "type": "object",
+            "description": "Object containing asset information owned by the queried address."
+          }
+        }
+      },
+      "getAccountStats__aptos__Res": {
+        "type": "object",
+        "required": [
+          "transactionCounts",
+          "balanceChangesCounts",
+          "assets"
+        ],
+        "properties": {
+          "transactionCounts": {
+            "type": "integer",
+            "description": "A field that represents the number of transactions created by the account.\nRefers to transactions where this account is included as the sender.\n"
+          },
+          "balanceChangesCounts": {
+            "type": "object"
+          },
+          "assets": {
+            "type": "object"
+          }
+        }
+      },
+      "hourlyStatsRange__evm__Req": {
+        "type": "object",
+        "required": [
+          "startDateTime",
+          "endDateTime"
+        ],
+        "properties": {
+          "startDateTime": {
+            "type": "string",
+            "description": "Parameter specifying the start date and time for the query. Data can be queried for up to 2400 hours from start to end datetime. Supports YYYY-MM-DD-HH format.",
+            "pattern": "^[0-9]{4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])-([01][0-9]|2[0-3])$",
+            "example": "2026-01-01-00"
+          },
+          "endDateTime": {
+            "type": "string",
+            "description": "Parameter specifying the end date and time for the query. Data can be queried for up to 2400 hours from start to end datetime. Supports YYYY-MM-DD-HH format.",
+            "pattern": "^[0-9]{4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])-([01][0-9]|2[0-3])$",
+            "example": "2026-01-01-00"
+          }
+        },
+        "example": {
+          "startDateTime": "2026-01-01-00",
+          "endDateTime": "2026-02-01-00"
+        }
+      },
+      "hourlyStatsByContract__evm__Req": {
+        "type": "object",
+        "required": [
+          "contractAddress",
+          "startDateTime",
+          "endDateTime"
+        ],
+        "properties": {
+          "contractAddress": {
+            "type": "string",
+            "description": "Parameter specifying the contract address to query. Can be entered as a 40-character hexadecimal string starting with 0x.",
+            "pattern": "^0[xX][0-9a-fA-F]{40}$"
+          },
+          "startDateTime": {
+            "type": "string",
+            "description": "Parameter specifying the start date and time for the query. Data can be queried for up to 2400 hours from start to end datetime. Supports YYYY-MM-DD-HH format.",
+            "pattern": "^[0-9]{4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])-([01][0-9]|2[0-3])$",
+            "example": "2026-01-01-00"
+          },
+          "endDateTime": {
+            "type": "string",
+            "description": "Parameter specifying the end date and time for the query. Data can be queried for up to 2400 hours from start to end datetime. Supports YYYY-MM-DD-HH format.",
+            "pattern": "^[0-9]{4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])-([01][0-9]|2[0-3])$",
+            "example": "2026-01-01-00"
+          }
+        },
+        "example": {
+          "contractAddress": "0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D",
+          "startDateTime": "2026-01-01-00",
+          "endDateTime": "2026-02-01-00"
+        }
+      },
+      "syncNftMetadata__evm__Req": {
+        "type": "object",
+        "required": [
+          "tokens"
+        ],
+        "properties": {
+          "tokens": {
+            "type": "array",
+            "description": "List of NFTs to synchronize. Up to 100 NFTs can be synchronized.",
+            "items": {
+              "type": "object",
+              "required": [
+                "contractAddress",
+                "tokenId"
+              ],
+              "properties": {
+                "contractAddress": {
+                  "type": "string",
+                  "description": "Parameter specifying the contract address to query. Can be entered as a 40-character hexadecimal string starting with 0x.",
+                  "pattern": "^0[xX][0-9a-fA-F]{40}$"
+                },
+                "tokenId": {
+                  "type": "string",
+                  "description": "Parameter specifying the NFT token ID to query. Can be entered as a decimal string.",
+                  "pattern": "^[0-9]+$"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "JWT",
+        "description": "Account-scope JWT issued by `/auth`. Used on payment (Credit/PPU) and history-lookup paths. Pay-Per-Use also allows unauthenticated calls."
+      }
+    }
+  },
+  "security": [
+    {
+      "bearerAuth": []
+    }
+  ]
+}


### PR DESCRIPTION
Adds the **Nodit** provider under `providers/lambda256/nodit/`.

Nodit exposes on-chain access via the x402 payment protocol across EVM chains, Solana, Bitcoin, Aptos, Sui, and more — raw JSON-RPC (Node API) plus indexed Web3 data (balances, transfers, holders, NFT/asset metadata, transactions, blocks, events, gas, ENS, stats).

- Category: `data`
- Service URL: https://x402.nodit.io
- Payment: x402 Pay-Per-Use (from 0.001 USDC/request) and Credit modes

`pay catalog check` passes locally.