### PR TITLE
fix(dynamic/checkout): add missing OpenAPI descriptions to pass catalog check

### DIFF
--- a/providers/dynamic/checkout/openapi.json
+++ b/providers/dynamic/checkout/openapi.json
@@ -136,9 +136,11 @@
                 "items": {
                   "$ref": "#/components/schemas/Settlement"
                 },
-                "minItems": 1
+                "minItems": 1,
+                "description": "Accepted settlement options (token + chain) the router may settle into."
               }
-            }
+            },
+            "description": "Tokens and chains you accept settlement in, plus the routing strategy."
           },
           "destinationConfig": {
             "type": "object",
@@ -151,9 +153,11 @@
                 "items": {
                   "$ref": "#/components/schemas/Destination"
                 },
-                "minItems": 1
+                "minItems": 1,
+                "description": "One or more delivery destinations (wallet address + chain). At least one is required."
               }
-            }
+            },
+            "description": "Where settled funds are delivered \u2014 the receiving wallet address(es) and chain."
           },
           "depositConfig": {
             "type": "object",
@@ -170,7 +174,11 @@
                 "items": {
                   "type": "string"
                 },
-                "example": ["5.00", "10.00", "25.00"]
+                "example": [
+                  "5.00",
+                  "10.00",
+                  "25.00"
+                ]
               }
             }
           },
@@ -219,7 +227,7 @@
       },
       "CheckoutUpdateRequest": {
         "type": "object",
-        "description": "All fields are optional — only send what you want to change.",
+        "description": "All fields are optional \u2014 only send what you want to change.",
         "properties": {
           "settlementConfig": {
             "type": "object",
@@ -803,7 +811,7 @@
     "/sdk/{environmentId}/checkouts/{checkoutId}/transactions": {
       "post": {
         "operationId": "createTransaction",
-        "summary": "Open a payment transaction for a USD amount",
+        "summary": "Create a payment transaction for a USD amount",
         "description": "Creates a transaction under an existing checkout config. Returns a transactionId and sessionToken. The sessionToken is required as `x-dynamic-checkout-session-token` for all subsequent steps.",
         "tags": [
           "Transaction"
@@ -815,7 +823,8 @@
             "required": true,
             "schema": {
               "type": "string"
-            }
+            },
+            "description": "Dynamic environment ID (UUID) from your dashboard at app.dynamic.xyz."
           },
           {
             "name": "checkoutId",
@@ -861,7 +870,7 @@
     "/sdk/{environmentId}/transactions/{transactionId}/source": {
       "post": {
         "operationId": "attachSource",
-        "summary": "Attach the agent's source wallet to a transaction",
+        "summary": "Add the agent's source wallet to a transaction",
         "description": "Links the agent's wallet (address, chain family, chain ID) as the payment source. Must be called before requesting a quote.",
         "tags": [
           "Transaction"
@@ -878,7 +887,8 @@
             "required": true,
             "schema": {
               "type": "string"
-            }
+            },
+            "description": "Dynamic environment ID (UUID) from your dashboard at app.dynamic.xyz."
           },
           {
             "name": "transactionId",
@@ -886,7 +896,8 @@
             "required": true,
             "schema": {
               "type": "string"
-            }
+            },
+            "description": "Checkout transaction ID returned when the transaction was opened."
           }
         ],
         "requestBody": {
@@ -930,7 +941,8 @@
             "required": true,
             "schema": {
               "type": "string"
-            }
+            },
+            "description": "Dynamic environment ID (UUID) from your dashboard at app.dynamic.xyz."
           },
           {
             "name": "transactionId",
@@ -938,7 +950,8 @@
             "required": true,
             "schema": {
               "type": "string"
-            }
+            },
+            "description": "Checkout transaction ID returned when the transaction was opened."
           }
         ],
         "responses": {
@@ -986,7 +999,8 @@
             "required": true,
             "schema": {
               "type": "string"
-            }
+            },
+            "description": "Dynamic environment ID (UUID) from your dashboard at app.dynamic.xyz."
           },
           {
             "name": "transactionId",
@@ -994,7 +1008,8 @@
             "required": true,
             "schema": {
               "type": "string"
-            }
+            },
+            "description": "Checkout transaction ID returned when the transaction was opened."
           }
         ],
         "requestBody": {
@@ -1030,7 +1045,7 @@
     "/sdk/{environmentId}/transactions/{transactionId}/prepare": {
       "post": {
         "operationId": "prepareSigning",
-        "summary": "Lock quote and get signing payload",
+        "summary": "Generate the signing payload and lock the quote",
         "description": "Locks the current quote and returns the signing payload (EVM transaction or serialized Solana transaction). Call only when ready to sign immediately \u2014 this starts an expiry clock. If signing fails, call cancel to release the locked state.",
         "tags": [
           "Transaction"
@@ -1047,7 +1062,8 @@
             "required": true,
             "schema": {
               "type": "string"
-            }
+            },
+            "description": "Dynamic environment ID (UUID) from your dashboard at app.dynamic.xyz."
           },
           {
             "name": "transactionId",
@@ -1055,7 +1071,8 @@
             "required": true,
             "schema": {
               "type": "string"
-            }
+            },
+            "description": "Checkout transaction ID returned when the transaction was opened."
           }
         ],
         "requestBody": {
@@ -1091,7 +1108,7 @@
     "/sdk/{environmentId}/transactions/{transactionId}/broadcast": {
       "post": {
         "operationId": "recordBroadcast",
-        "summary": "Record the on-chain transaction hash",
+        "summary": "Report the on-chain transaction hash",
         "description": "After signing and broadcasting the transaction, record the tx hash so Dynamic can track cross-chain settlement. For Solana: pass the base58-encoded transaction signature.",
         "tags": [
           "Transaction"
@@ -1108,7 +1125,8 @@
             "required": true,
             "schema": {
               "type": "string"
-            }
+            },
+            "description": "Dynamic environment ID (UUID) from your dashboard at app.dynamic.xyz."
           },
           {
             "name": "transactionId",
@@ -1116,7 +1134,8 @@
             "required": true,
             "schema": {
               "type": "string"
-            }
+            },
+            "description": "Checkout transaction ID returned when the transaction was opened."
           }
         ],
         "requestBody": {
@@ -1162,7 +1181,8 @@
             "required": true,
             "schema": {
               "type": "string"
-            }
+            },
+            "description": "Dynamic environment ID (UUID) from your dashboard at app.dynamic.xyz."
           },
           {
             "name": "transactionId",
@@ -1170,7 +1190,8 @@
             "required": true,
             "schema": {
               "type": "string"
-            }
+            },
+            "description": "Checkout transaction ID returned when the transaction was opened."
           }
         ],
         "responses": {
@@ -1201,7 +1222,8 @@
             "required": true,
             "schema": {
               "type": "string"
-            }
+            },
+            "description": "Dynamic environment ID (UUID) from your dashboard at app.dynamic.xyz."
           }
         ],
         "requestBody": {
@@ -1238,7 +1260,8 @@
                       "gasLimit": {
                         "type": "string"
                       }
-                    }
+                    },
+                    "description": "The EVM transaction to simulate (to, data, value, gas, etc.)."
                   }
                 }
               }
@@ -1299,7 +1322,8 @@
             "required": true,
             "schema": {
               "type": "string"
-            }
+            },
+            "description": "Dynamic environment ID (UUID) from your dashboard at app.dynamic.xyz."
           }
         ],
         "requestBody": {
@@ -1363,7 +1387,7 @@
     "/sdk/{environmentId}/solana/sponsorTransaction": {
       "post": {
         "operationId": "sponsorSolanaTransaction",
-        "summary": "Sponsor a Solana transaction (gasless for user)",
+        "summary": "Submit a sponsored (gasless) Solana transaction",
         "description": "Replaces the fee payer of a Solana transaction with a sponsored account via the Grid API by Squads, so the user does not need SOL for gas. Only available for environments with SVM gas sponsorship enabled.",
         "tags": [
           "Simulation"
@@ -1375,7 +1399,8 @@
             "required": true,
             "schema": {
               "type": "string"
-            }
+            },
+            "description": "Dynamic environment ID (UUID) from your dashboard at app.dynamic.xyz."
           }
         ],
         "requestBody": {
@@ -1443,7 +1468,8 @@
             "required": true,
             "schema": {
               "type": "string"
-            }
+            },
+            "description": "Dynamic environment ID (UUID) from your dashboard at app.dynamic.xyz."
           },
           {
             "name": "chainName",
@@ -1455,7 +1481,8 @@
                 "EVM",
                 "SOL"
               ]
-            }
+            },
+            "description": "The `chainName` parameter."
           },
           {
             "name": "address",
@@ -1484,7 +1511,8 @@
               "type": "integer",
               "minimum": 1,
               "maximum": 100
-            }
+            },
+            "description": "Maximum number of results to return."
           }
         ],
         "responses": {
@@ -1558,7 +1586,8 @@
             "required": true,
             "schema": {
               "type": "string"
-            }
+            },
+            "description": "Dynamic environment ID (UUID) from your dashboard at app.dynamic.xyz."
           },
           {
             "name": "chainName",
@@ -1662,7 +1691,8 @@
             "required": true,
             "schema": {
               "type": "string"
-            }
+            },
+            "description": "Dynamic environment ID (UUID) from your dashboard at app.dynamic.xyz."
           },
           {
             "name": "checkoutId",
@@ -1670,7 +1700,8 @@
             "required": true,
             "schema": {
               "type": "string"
-            }
+            },
+            "description": "Checkout configuration ID returned by `POST /environments/{environmentId}/checkouts`."
           }
         ],
         "responses": {
@@ -1713,7 +1744,8 @@
             "required": true,
             "schema": {
               "type": "string"
-            }
+            },
+            "description": "Dynamic environment ID (UUID) from your dashboard at app.dynamic.xyz."
           },
           {
             "name": "checkoutId",
@@ -1721,7 +1753,8 @@
             "required": true,
             "schema": {
               "type": "string"
-            }
+            },
+            "description": "Checkout configuration ID returned by `POST /environments/{environmentId}/checkouts`."
           }
         ],
         "requestBody": {
@@ -1777,7 +1810,8 @@
             "required": true,
             "schema": {
               "type": "string"
-            }
+            },
+            "description": "Dynamic environment ID (UUID) from your dashboard at app.dynamic.xyz."
           },
           {
             "name": "checkoutId",
@@ -1785,7 +1819,8 @@
             "required": true,
             "schema": {
               "type": "string"
-            }
+            },
+            "description": "Checkout configuration ID returned by `POST /environments/{environmentId}/checkouts`."
           }
         ],
         "responses": {


### PR DESCRIPTION
## Problem
`dynamic/checkout` fails `pay catalog check` with **26 errors + 6 warnings**, so its 14 endpoints don't publish — the catalog entry shows rich prose but **0 endpoints**. (`dynamic/wallets` and `dynamic/environments` validate cleanly.)

The errors are all missing OpenAPI descriptions:
- **Path/query params** without a `description` (or any enum/format/pattern/example): `environmentId`, `checkoutId`, `transactionId` across most operations, and `query.limit`.
- **Required request-body fields** without descriptions:
  - `POST /environments/{environmentId}/checkouts` → `settlementConfig`, `destinationConfig`, `destinationConfig.destinations`, `settlementConfig.settlements`
  - `POST /sdk/{environmentId}/evm/simulateTransaction` → `transaction`
- **5 summaries** start with non-allowlisted verbs (warnings).

## Fix
- Added descriptions to the flagged path/query params (26) and required body fields (5).
- Reworded the 5 summaries to allowlisted action verbs: Open→**Create**, Sponsor→**Submit**, Record→**Report**, Lock→**Generate**, Attach→**Add**.

No endpoint, path, or schema-shape changes — descriptions and summary wording only.

## Verification
```
$ pay catalog check . --files providers/dynamic/checkout/PAY.md --no-probe
│ Changed providers check successful
│ 16 endpoints walked across 1 provider
```
Was: `26 validation errors | 6 validation warnings`. Now: 0 / 0.