### PR TITLE
feat: add redqueen intel providerAdd files via upload

### DIFF
--- a/providers/redqueen/intel/PAY.md
+++ b/providers/redqueen/intel/PAY.md
@@ -1,0 +1,24 @@
+---
+name: intel
+title: Red Queen Intelligence Mainframe
+description: Restricted real-time global disaster warnings, NASA hazards, and live Solana DePIN validator node telemetry feeds.
+use_case: Use for AI agents querying real-time environmental risk telemetry, natural disaster data, and Solana network validator stability statistics.
+category: data
+service_url: https://redqueen.space
+openapi:
+  path: openapi.json
+---
+
+# Red Queen API
+
+The central artificial intelligence of Solvival Corp's Advanced Intelligence Division. This API serves high-fidelity, real-time telemetry streams regarding tectonic anomalies, environmental threats, and node-level infrastructure metrics.
+
+## Endpoint Authentication & x402 Micropayments
+All premium endpoints require on-chain stablecoin micro-settlement via the x402 V2 protocol.
+
+* **`/api/intel/premium`**: Global threat dossier, USGS seismology, and NASA open hazards.
+  * Price: **0.01 USDC**
+* **`/api/intel/depin`**: Solana validator status tracking, average priority fee rates, and live epoch performance samples.
+  * Price: **0.02 USDC**
+
+Payment challenges are served as HTTP 402 challenges and settled automatically by x402-compliant clients (such as the `pay.sh` CLI or agent nodes).

--- a/providers/redqueen/intel/PAY.md
+++ b/providers/redqueen/intel/PAY.md
@@ -1,8 +1,8 @@
 ---
 name: intel
 title: Red Queen Intelligence Mainframe
-description: Restricted real-time global disaster warnings, NASA hazards, and live Solana DePIN validator node telemetry feeds.
-use_case: Use for AI agents querying real-time environmental risk telemetry, natural disaster data, and Solana network validator stability statistics.
+description: Production-grade threat monitoring oracle exposing aggregated risk data from 8 real-time feeds (USGS, NASA, NOAA, GDACS, disease, currency, and Solana DePIN telemetry).
+use_case: AI agents query this to get real-time environmental risk telemetry, natural disaster data, space weather indices, and Solana network validator stability statistics.
 category: data
 service_url: https://redqueen.space
 openapi:
@@ -11,14 +11,23 @@ openapi:
 
 # Red Queen API
 
-The central artificial intelligence of Solvival Corp's Advanced Intelligence Division. This API serves high-fidelity, real-time telemetry streams regarding tectonic anomalies, environmental threats, and node-level infrastructure metrics.
+The central artificial intelligence of Solvival Corp's Advanced Intelligence Division. This API serves high-fidelity, real-time threat telemetry streams aggregated from 8 distinct live feeds:
+
+*   **USGS Earthquakes**: Live tectonic activity and seismic disruption telemetry.
+*   **NASA EONET**: Open environmental hazards (storms, fires, volcanic activity).
+*   **GDACS Alerts**: Global coordination and disaster alert monitoring.
+*   **NOAA SWPC**: Space weather geomagnetic storm warnings.
+*   **Google News RSS Outbreaks**: Worldwide pathogen developments and virus alerts.
+*   **Open Exchange Rates**: Inflation risks and currency devaluations.
+*   **Disease.sh**: Covid-19 and biological containment caseloads.
+*   **Solana Mainnet RPC**: Delinquent validator nodes, network health, slot telemetry, and prioritization fee logs.
 
 ## Endpoint Authentication & x402 Micropayments
 All premium endpoints require on-chain stablecoin micro-settlement via the x402 V2 protocol.
 
-* **`/api/intel/premium`**: Global threat dossier, USGS seismology, and NASA open hazards.
+* **`/api/intel/premium`**: Global threat dossier, USGS seismology, NASA open hazards, and Disease.sh pathogen stats.
   * Price: **0.01 USDC**
-* **`/api/intel/depin`**: Solana validator status tracking, average priority fee rates, and live epoch performance samples.
+* **`/api/intel/depin`**: Solana validator status tracking, average priority fee rates, and live slot performance samples.
   * Price: **0.02 USDC**
 
 Payment challenges are served as HTTP 402 challenges and settled automatically by x402-compliant clients (such as the `pay.sh` CLI or agent nodes).

--- a/providers/redqueen/intel/openapi.json
+++ b/providers/redqueen/intel/openapi.json
@@ -31,18 +31,18 @@
             }
           ]
         },
-        "x402Version": 2,
-        "resource": {
+        "x-x402Version": 2,
+        "x-resource": {
           "url": "https://redqueen.space/api/intel/premium",
           "description": "GET /api/intel/premium",
           "mimeType": "application/json"
         },
-        "accepts": [
+        "x-accepts": [
           {
             "scheme": "exact",
             "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
             "payTo": "AUCYMsSZXASMiXfjLNL26NF7sPehUA4ncEzTCx8MdSYg",
-            "asset": "usdc",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
             "amount": "10000",
             "maxTimeoutSeconds": 300,
             "extra": {}
@@ -138,18 +138,18 @@
             }
           ]
         },
-        "x402Version": 2,
-        "resource": {
+        "x-x402Version": 2,
+        "x-resource": {
           "url": "https://redqueen.space/api/intel/depin",
           "description": "GET /api/intel/depin",
           "mimeType": "application/json"
         },
-        "accepts": [
+        "x-accepts": [
           {
             "scheme": "exact",
             "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
             "payTo": "AUCYMsSZXASMiXfjLNL26NF7sPehUA4ncEzTCx8MdSYg",
-            "asset": "usdc",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
             "amount": "20000",
             "maxTimeoutSeconds": 300,
             "extra": {}

--- a/providers/redqueen/intel/openapi.json
+++ b/providers/redqueen/intel/openapi.json
@@ -1,0 +1,129 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Red Queen Intelligence & Containment API",
+    "description": "Premium real-time apocalypse telemetry and survival containment data feeds. Protected by x402 open-protocol stablecoin micropayments.",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://redqueen.space",
+      "description": "Production Red Queen Mainframe Gateway"
+    }
+  ],
+  "paths": {
+    "/api/intel/premium": {
+      "get": {
+        "summary": "Premium Global Threat Briefing",
+        "description": "Returns real-time USGS earthquake, NASA natural hazard, and Disease.sh global pathogen metrics, calculated through the Red Queen global entropy matrix.",
+        "operationId": "getPremiumIntel",
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": false,
+            "description": "Optional Bearer JWT token to award XP directly to the operative's profile.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "Payment-Signature",
+            "in": "header",
+            "required": false,
+            "description": "Standard x402 payment proof containing the transaction signature for the 0.01 USDC transfer.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful decryption of global threat dossier.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": { "type": "boolean" },
+                    "timestamp": { "type": "string" },
+                    "clearance": { "type": "string" },
+                    "intel": {
+                      "type": "object",
+                      "properties": {
+                        "headline": { "type": "string" },
+                        "summary": { "type": "string" },
+                        "combinedEntropyIndex": { "type": "string" },
+                        "directive": { "type": "string" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required. Returns standard x402 exact SVM scheme challenge details for 0.01 USDC payment routing."
+          }
+        }
+      }
+    },
+    "/api/intel/depin": {
+      "get": {
+        "summary": "Live DePIN Mesh Network Diagnostic Telemetry",
+        "description": "Returns live node stability percentage, delinquent validator list, vote performance thresholds, and average priority fee metrics queried directly from Solana Mainnet Beta.",
+        "operationId": "getDepinIntel",
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": false,
+            "description": "Optional Bearer JWT token to award XP directly to the operative's profile.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "Payment-Signature",
+            "in": "header",
+            "required": false,
+            "description": "Standard x402 payment proof containing the transaction signature for the 0.02 USDC transfer.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful decryption of live validator and node analytics.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": { "type": "boolean" },
+                    "timestamp": { "type": "string" },
+                    "clearance": { "type": "string" },
+                    "depin": {
+                      "type": "object",
+                      "properties": {
+                        "scannerName": { "type": "string" },
+                        "onlineNodes": { "type": "integer" },
+                        "compromisedNodes": { "type": "integer" },
+                        "bandwidthTaintIndex": { "type": "string" },
+                        "networkHealth": { "type": "string" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required. Returns standard x402 exact SVM scheme challenge details for 0.02 USDC payment routing."
+          }
+        }
+      }
+    }
+  }
+}

--- a/providers/redqueen/intel/openapi.json
+++ b/providers/redqueen/intel/openapi.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.0.3",
+  "openapi": "3.1.0",
   "info": {
     "title": "Red Queen Intelligence & Containment API",
     "description": "Premium real-time apocalypse telemetry and survival containment data feeds. Protected by x402 open-protocol stablecoin micropayments.",
@@ -17,9 +17,34 @@
         "summary": "Premium Global Threat Briefing",
         "description": "Returns real-time USGS earthquake, NASA natural hazard, and Disease.sh global pathogen metrics, calculated through the Red Queen global entropy matrix.",
         "operationId": "getPremiumIntel",
+        "x-payment-required": true,
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.01"
+        },
+        "x402Version": 2,
+        "resource": {
+          "url": "https://redqueen.space/api/intel/premium",
+          "description": "GET /api/intel/premium",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "AUCYMsSZXASMiXfjLNL26NF7sPehUA4ncEzTCx8MdSYg",
+            "asset": "usdc",
+            "amount": "10000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ],
         "parameters": [
           {
-            "name": "Authorization",
+            "name": "X-Operative-Token",
             "in": "header",
             "required": false,
             "description": "Optional Bearer JWT token to award XP directly to the operative's profile.",
@@ -63,7 +88,27 @@
             }
           },
           "402": {
-            "description": "Payment Required. Returns standard x402 exact SVM scheme challenge details for 0.01 USDC payment routing."
+            "description": "Payment Required. Returns standard x402 exact SVM scheme challenge details for 0.01 USDC payment routing.",
+            "headers": {
+              "Payment-Required": {
+                "description": "Base64 encoded payment requirement challenge",
+                "required": true,
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": { "type": "string", "example": "PAYMENT_REQUIRED" },
+                    "challenge": { "type": "string", "description": "Base64 encoded payment requirement challenge" }
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -73,9 +118,34 @@
         "summary": "Live DePIN Mesh Network Diagnostic Telemetry",
         "description": "Returns live node stability percentage, delinquent validator list, vote performance thresholds, and average priority fee metrics queried directly from Solana Mainnet Beta.",
         "operationId": "getDepinIntel",
+        "x-payment-required": true,
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "$0.02"
+        },
+        "x402Version": 2,
+        "resource": {
+          "url": "https://redqueen.space/api/intel/depin",
+          "description": "GET /api/intel/depin",
+          "mimeType": "application/json"
+        },
+        "accepts": [
+          {
+            "scheme": "exact",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "payTo": "AUCYMsSZXASMiXfjLNL26NF7sPehUA4ncEzTCx8MdSYg",
+            "asset": "usdc",
+            "amount": "20000",
+            "maxTimeoutSeconds": 300,
+            "extra": {}
+          }
+        ],
         "parameters": [
           {
-            "name": "Authorization",
+            "name": "X-Operative-Token",
             "in": "header",
             "required": false,
             "description": "Optional Bearer JWT token to award XP directly to the operative's profile.",
@@ -120,7 +190,27 @@
             }
           },
           "402": {
-            "description": "Payment Required. Returns standard x402 exact SVM scheme challenge details for 0.02 USDC payment routing."
+            "description": "Payment Required. Returns standard x402 exact SVM scheme challenge details for 0.02 USDC payment routing.",
+            "headers": {
+              "Payment-Required": {
+                "description": "Base64 encoded payment requirement challenge",
+                "required": true,
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": { "type": "string", "example": "PAYMENT_REQUIRED" },
+                    "challenge": { "type": "string", "description": "Base64 encoded payment requirement challenge" }
+                  }
+                }
+              }
+            }
           }
         }
       }

--- a/providers/redqueen/intel/openapi.json
+++ b/providers/redqueen/intel/openapi.json
@@ -23,7 +23,13 @@
             "x402"
           ],
           "pricingMode": "fixed",
-          "price": "$0.01"
+          "price": "0.01",
+          "chains": [
+            {
+              "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+              "name": "Solana"
+            }
+          ]
         },
         "x402Version": 2,
         "resource": {
@@ -124,7 +130,13 @@
             "x402"
           ],
           "pricingMode": "fixed",
-          "price": "$0.02"
+          "price": "0.02",
+          "chains": [
+            {
+              "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+              "name": "Solana"
+            }
+          ]
         },
         "x402Version": 2,
         "resource": {

--- a/providers/redqueen/intel/openapi.json
+++ b/providers/redqueen/intel/openapi.json
@@ -14,7 +14,7 @@
   "paths": {
     "/api/intel/premium": {
       "get": {
-        "summary": "Premium Global Threat Briefing",
+        "summary": "Retrieve premium global threat briefing",
         "description": "Returns real-time USGS earthquake, NASA natural hazard, and Disease.sh global pathogen metrics, calculated through the Red Queen global entropy matrix.",
         "operationId": "getPremiumIntel",
         "x-payment-required": true,
@@ -121,7 +121,7 @@
     },
     "/api/intel/depin": {
       "get": {
-        "summary": "Live DePIN Mesh Network Diagnostic Telemetry",
+        "summary": "Retrieve live DePIN mesh network diagnostic telemetry",
         "description": "Returns live node stability percentage, delinquent validator list, vote performance thresholds, and average priority fee metrics queried directly from Solana Mainnet Beta.",
         "operationId": "getDepinIntel",
         "x-payment-required": true,


### PR DESCRIPTION
This Pull Request adds the integration files for the **Red Queen Intelligence Mainframe** provider.
### Details:
- **Fully Qualified Name (FQN)**: `redqueen/intel`
- **Category**: `data`
- **Service URL**: https://redqueen.space
- **Documentation File**: `providers/redqueen/intel/PAY.md`
- **OpenAPI Schema**: `providers/redqueen/intel/openapi.json`
### Summary of Provider:
Serves real-time environmental risk telemetry, geological warnings, meteorology hazards, and live Solana network validator telemetry feeds. The endpoints are paywalled using the x402 open payment protocol scheme ($0.01 USDC for premium briefings and $0.02 USDC for live DePIN diagnostics).