### PR TITLE
Add glianalabs/ai — pay-per-call AI inference (60+ models, Solana USDC)

### DIFF
--- a/providers/glianalabs/ai/PAY.md
+++ b/providers/glianalabs/ai/PAY.md
@@ -1,0 +1,56 @@
+---
+name: ai
+title: "GlianaAI — Pay-per-call AI Inference"
+description: "Pay-per-call AI across 90+ models: LLM chat, image, video, music, speech. No signup or API key — each call is paid from your own wallet via x402 or MPP, USDC on Solana mainnet (also Base/Tempo). Quote the exact price, then run it."
+use_case: "Use for LLM chat, text-to-image, text-to-video, image-to-video, video editing, text-to-speech, speech-to-text, and music generation — pick a model, get the exact per-call price up front, and pay per result in USDC with no account."
+category: ai_ml
+service_url: https://api.glianalabs.com
+openapi:
+  path: openapi.json
+---
+
+GlianaAI is a pay-per-call generative AI gateway: one endpoint over 90+ LLM chat, image,
+video, music, and speech models from providers like Google, OpenAI, ByteDance,
+Black Forest Labs, MiniMax, Runway, and xAI. No signup, no API key, no prepaid
+balance — each request is settled from the caller's own wallet, so an autonomous
+agent can call any model with just funds on chain.
+
+Payment is non-custodial, two protocols:
+
+- **Native x402** — `POST /x402/{model}` returns a 402 whose `accepts` offers
+  **USDC on Solana mainnet** and on Base. This is the Solana-settling path.
+- **MPP** — `POST /v1/infer` (one-shot) and `POST /v1/session/infer` (a reusable
+  payment channel for many calls, cheaper for repeated use) settle over MPP
+  (Tempo / EVM USDC).
+
+Either way the price is the model's exact per-call cost — quote it first with
+`GET /v1/price` (no markup surprises).
+
+## Spend-aware usage
+
+- Call `GET /v1/models` to browse the catalog (id, category, provider, per-call
+  price) — free, no payment. Pick a model before quoting or running.
+- Call `GET /v1/price?model={id}` to get the exact cost of one call before
+  paying. Pass billing-affecting input (e.g. `duration` for per-second video,
+  `text` for per-character speech, `resolution` for tiered video) for a precise
+  quote — free.
+- Call `GET /v1/schema?model={id}` to see a model's input fields (required,
+  types, enums, defaults) so you send a valid request the first time — free.
+- Not sure which endpoint fits? `GET /v1/consult?intent={what you want to do}`
+  returns ranked candidates with prices — free, and it never charges.
+- Making many calls? `POST /v1/session/infer` opens one payment channel and
+  settles many calls against it, which is cheaper than paying per request.
+  Prefer it over `/v1/infer` for repeated work; use `/v1/infer` for one-offs.
+- Run a model with `POST /v1/infer` (MPP) or `POST /x402/{model}` (x402). Send
+  only the core input — a `prompt` (and a file URL for image/video/audio
+  models); the gateway fills every other parameter from the model's schema and
+  validates before charging, so a malformed call is rejected without taking
+  funds. USDC on Solana mainnet or Base.
+- File inputs (image-to-video, video editing, transcription) take a public URL.
+  Upload a local file for free with `POST /v1/media` (≤40 MB) and pass the
+  returned URL — no payment, no key.
+- Generated media is returned as a stable hosted URL; fetch it from `GET
+  /v1/media/{key}`.
+- Quote before large jobs and prefer the cheapest model that fits the task — the
+  catalog lists a per-call price for every model, and per-second/per-character
+  models scale with the request.

--- a/providers/glianalabs/ai/openapi.json
+++ b/providers/glianalabs/ai/openapi.json
@@ -1,0 +1,1630 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "GlianaAI",
+    "version": "1",
+    "description": "Pay-per-call AI models, live market data and identity APIs. Generative image, video, music, speech and LLM chat, plus crypto and FX rates, DEX liquidity, DeFi TVL, gas, web search, document OCR and face matching. No signup or API key; each call is settled from the caller\u2019s own wallet. Per-call prices: GET /v1/price?model=. Rate limit ~120 requests/min per IP \u2014 need more? contact@glianalabs.com. Not sure which endpoint you need? GET /v1/consult?intent=\u2026 is free. Agents: set up https://api.glianalabs.com/skill.md.",
+    "contact": {
+      "name": "Gliana Labs",
+      "email": "contact@glianalabs.com",
+      "url": "https://ai.glianalabs.com"
+    },
+    "x-guidance": "Browse models at GET /v1/models, get a model\u2019s exact inputs at GET /v1/schema?model=, quote at GET /v1/price?model=, then POST /v1/infer with { model, ...modelInput }. You get a 402 with the price; pay from your wallet and retry. No API key \u2014 payment is the gate. Rails: POST /v1/infer settles over MPP (USDC on Tempo); for native x402 USDC on Base or Solana, POST /x402/{model}; the same tools and recipes also settle in USDC on Algorand at /a402/\u2026 and on BNB Smart Chain at /b402/\u2026 (see the per-endpoint x-payment-info for each path\u2019s exact protocol). File inputs (image/video/audio, e.g. video-to-video video_uri) take a public URL \u2014 upload a local file (free) at POST /v1/media (\u226440MB) and pass the returned url."
+  },
+  "x-service-info": {
+    "categories": [
+      "media",
+      "image-to-video",
+      "music",
+      "stt",
+      "text-to-image",
+      "text-to-video",
+      "tts",
+      "video-to-video",
+      "text"
+    ],
+    "docs": {
+      "homepage": "https://ai.glianalabs.com",
+      "apiReference": "https://ai.glianalabs.com/docs"
+    }
+  },
+  "tags": [
+    {
+      "name": "media",
+      "description": "Generative media inference."
+    },
+    {
+      "name": "image-to-video"
+    },
+    {
+      "name": "music"
+    },
+    {
+      "name": "stt"
+    },
+    {
+      "name": "text-to-image"
+    },
+    {
+      "name": "text-to-video"
+    },
+    {
+      "name": "tts"
+    },
+    {
+      "name": "video-to-video"
+    },
+    {
+      "name": "text"
+    },
+    {
+      "name": "image"
+    },
+    {
+      "name": "utility"
+    }
+  ],
+  "servers": [
+    {
+      "url": "https://api.glianalabs.com"
+    }
+  ],
+  "externalDocs": {
+    "description": "GlianaAI",
+    "url": "https://ai.glianalabs.com"
+  },
+  "paths": {
+    "/v1/infer": {
+      "post": {
+        "operationId": "infer",
+        "summary": "Run any of 90+ generative models pay-per-call.",
+        "tags": [
+          "media",
+          "image-to-video",
+          "music",
+          "stt",
+          "text-to-image",
+          "text-to-video",
+          "tts",
+          "video-to-video",
+          "text"
+        ],
+        "description": "**$0.0001\u2013$60 per call**, depending on model and input. Exact price is returned in the 402 challenge before you pay, or up front from `GET /v1/price?model=`.\n\nOne endpoint for the whole catalog: send { model, ...modelInput } \u2014 pick any model from GET /v1/models (90+ across image, video, image-to-video, text-to-speech, speech-to-text, music). Responds 402 Payment Required with the per-model price; pay from your own account and retry.",
+        "security": [],
+        "x-payment-info": {
+          "price": {
+            "mode": "dynamic",
+            "currency": "USD",
+            "min": "0.0001",
+            "max": "60"
+          },
+          "protocols": [
+            {
+              "mpp": {
+                "method": "tempo",
+                "intent": "charge",
+                "currency": "0x20C000000000000000000000b9537d11c60E8b50"
+              }
+            },
+            {
+              "mpp": {
+                "method": "evm",
+                "intent": "charge",
+                "network": "eip155:8453",
+                "currency": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+              }
+            },
+            {
+              "mpp": {
+                "method": "solana",
+                "intent": "charge",
+                "network": "solana:mainnet",
+                "currency": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+              }
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "model"
+                ],
+                "properties": {
+                  "model": {
+                    "type": "string",
+                    "description": "Model id or full run id (see GET /v1/models)."
+                  },
+                  "prompt": {
+                    "type": "string",
+                    "description": "Most models take a text prompt; STT/some take a file/url instead."
+                  }
+                },
+                "additionalProperties": true
+              },
+              "example": {
+                "model": "grok-imagine-image",
+                "prompt": "a red apple on a table"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Model output + payment receipt.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "model": {
+                      "type": "string"
+                    },
+                    "costMicroUsd": {
+                      "type": "integer",
+                      "description": "Amount charged, micro-USD."
+                    },
+                    "output": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "The model result, nested \u2014 NOT spread across the top level. Media models return { url, contentType, sizeBytes } where url is a stable /v1/media link we host; text models (STT, vision, JSON tools) return the provider shape, e.g. { text }."
+                    }
+                  }
+                },
+                "example": {
+                  "model": "nano-banana-2",
+                  "costMicroUsd": 92400,
+                  "output": {
+                    "url": "https://api.glianalabs.com/v1/media/8f2c1d9e4a7b3f60.png",
+                    "contentType": "image/png",
+                    "sizeBytes": 1834127
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required \u2014 pay the challenge and retry."
+          }
+        }
+      }
+    },
+    "/v1/session/infer": {
+      "post": {
+        "operationId": "sessionInfer",
+        "summary": "Run any of 90+ models over a payment channel (pay-as-you-go).",
+        "tags": [
+          "media",
+          "image-to-video",
+          "music",
+          "stt",
+          "text-to-image",
+          "text-to-video",
+          "tts",
+          "video-to-video",
+          "text"
+        ],
+        "description": "**$0.0001\u2013$60 per call**, depending on model and input. Exact price is returned in the 402 challenge before you pay, or up front from `GET /v1/price?model=`.\n\nOpen one Tempo channel and pay many calls with off-chain vouchers; settle on close. Non-custodial \u2014 the deposit stays in the on-chain escrow.",
+        "security": [],
+        "x-payment-info": {
+          "price": {
+            "mode": "dynamic",
+            "currency": "USD",
+            "min": "0.0001",
+            "max": "60"
+          },
+          "protocols": [
+            {
+              "mpp": {
+                "method": "tempo",
+                "intent": "session",
+                "currency": "0x20C000000000000000000000b9537d11c60E8b50"
+              }
+            },
+            {
+              "mpp": {
+                "method": "evm",
+                "intent": "session",
+                "network": "eip155:8453",
+                "currency": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+              }
+            },
+            {
+              "mpp": {
+                "method": "solana",
+                "intent": "session",
+                "network": "solana:mainnet",
+                "currency": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+              }
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "model"
+                ],
+                "properties": {
+                  "model": {
+                    "type": "string",
+                    "description": "Model id or full run id."
+                  }
+                },
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Model output + payment receipt.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "model": {
+                      "type": "string"
+                    },
+                    "costMicroUsd": {
+                      "type": "integer",
+                      "description": "Amount charged, micro-USD."
+                    },
+                    "output": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "The model result, nested \u2014 NOT spread across the top level. Media models return { url, contentType, sizeBytes } where url is a stable /v1/media link we host; text models (STT, vision, JSON tools) return the provider shape, e.g. { text }."
+                    }
+                  }
+                },
+                "example": {
+                  "model": "nano-banana-2",
+                  "costMicroUsd": 92400,
+                  "output": {
+                    "url": "https://api.glianalabs.com/v1/media/8f2c1d9e4a7b3f60.png",
+                    "contentType": "image/png",
+                    "sizeBytes": 1834127
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required \u2014 open/extend the channel and retry."
+          }
+        }
+      }
+    },
+    "/v1/chat/completions": {
+      "post": {
+        "operationId": "chatCompletions",
+        "summary": "Generate chat completions with any LLM pay-per-call.",
+        "tags": [
+          "text"
+        ],
+        "description": "**$0.0001\u2013$60 per call**, depending on model and input. Exact price is returned in the 402 challenge before you pay, or up front from `GET /v1/price?model=`.\n\nDrop-in for the OpenAI chat completions API: swap the base URL, keep your SDK. Pick any text model from GET /v1/models (category \"text\"). Billing is a pre-charged ceiling \u2014 (estimated input tokens + max_tokens) at the model\u2019s per-1M rates \u2014 so set max_tokens to bound spend; the response returns real `usage`. Supports messages (required), max_tokens, temperature, top_p, stream: true (SSE, OpenAI chunk format), tools/tool_choice (OpenAI function calling \u2014 tool_calls + role:\"tool\" round-trip), and vision (content parts with image_url on vision-capable models). 402 \u2192 pay \u2192 retry. FILE INPUT: if the image is already on the web or your own storage, pass `image_url` \u2014 we fetch it server-side at datacenter speed, which is the fastest option by far. Sending it inline as `image_base64` is simplest and stores nothing anywhere, but base64 adds ~33% to the bytes and you pay your own upload speed, so it is best under ~1MB. For a large local file, upload the RAW bytes to `POST /v1/media` (free, \u226440MB) and pass the URL: same transfer as base64 minus the 33%, and identity endpoints delete the object as soon as they have read it.",
+        "security": [],
+        "x-payment-info": {
+          "price": {
+            "mode": "dynamic",
+            "currency": "USD",
+            "min": "0.0001",
+            "max": "60"
+          },
+          "protocols": [
+            {
+              "mpp": {
+                "method": "tempo",
+                "intent": "charge",
+                "currency": "0x20C000000000000000000000b9537d11c60E8b50"
+              }
+            },
+            {
+              "mpp": {
+                "method": "evm",
+                "intent": "charge",
+                "network": "eip155:8453",
+                "currency": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+              }
+            },
+            {
+              "mpp": {
+                "method": "solana",
+                "intent": "charge",
+                "network": "solana:mainnet",
+                "currency": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+              }
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "model",
+                  "messages"
+                ],
+                "properties": {
+                  "model": {
+                    "type": "string",
+                    "description": "Text model id (see GET /v1/models, category \"text\")."
+                  },
+                  "messages": {
+                    "type": "array",
+                    "description": "OpenAI-style chat messages: [{ role: \"user\"|\"assistant\"|\"system\"|\"tool\", content }].",
+                    "items": {
+                      "type": "object",
+                      "additionalProperties": true
+                    }
+                  },
+                  "max_tokens": {
+                    "type": "integer",
+                    "description": "Output cap \u2014 bounds the pre-charged ceiling. Default 1024."
+                  },
+                  "tools": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "description": "OpenAI function tools; response returns tool_calls."
+                  }
+                },
+                "additionalProperties": true
+              },
+              "example": {
+                "model": "grok-4.3",
+                "messages": [
+                  {
+                    "role": "user",
+                    "content": "Summarize x402 in one sentence."
+                  }
+                ],
+                "max_tokens": 256
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OpenAI chat-completion body (+ costMicroUsd and a payment receipt)."
+          },
+          "402": {
+            "description": "Payment Required \u2014 pay the challenge and retry."
+          }
+        }
+      }
+    },
+    "/v1/images/generations": {
+      "post": {
+        "operationId": "imagesGenerate",
+        "summary": "Generate an image from a text prompt with any model.",
+        "tags": [
+          "image",
+          "text-to-image"
+        ],
+        "description": "**$0.0001\u2013$60 per call**, depending on model and input. Exact price is returned in the 402 challenge before you pay, or up front from `GET /v1/price?model=`.\n\nCapability endpoint \u2014 pick any matching model with GET /v1/models and pass it as { model }. Same pay-per-call charge as /v1/infer (402, then pay and retry); the per-model POST /x402/flux-2-pro-preview path also works.",
+        "security": [],
+        "x-payment-info": {
+          "price": {
+            "mode": "dynamic",
+            "currency": "USD",
+            "min": "0.0001",
+            "max": "60"
+          },
+          "protocols": [
+            {
+              "mpp": {
+                "method": "tempo",
+                "intent": "charge",
+                "currency": "0x20C000000000000000000000b9537d11c60E8b50"
+              }
+            },
+            {
+              "mpp": {
+                "method": "evm",
+                "intent": "charge",
+                "network": "eip155:8453",
+                "currency": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+              }
+            },
+            {
+              "mpp": {
+                "method": "solana",
+                "intent": "charge",
+                "network": "solana:mainnet",
+                "currency": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+              }
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "model"
+                ],
+                "properties": {
+                  "model": {
+                    "type": "string",
+                    "description": "Model id or full run id (see GET /v1/models)."
+                  }
+                },
+                "additionalProperties": true
+              },
+              "example": {
+                "model": "flux-2-pro-preview",
+                "prompt": "a red apple on a wooden table"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Result + payment receipt (media: { data: [{ url }] }; STT: { text }).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "model": {
+                      "type": "string"
+                    },
+                    "costMicroUsd": {
+                      "type": "integer",
+                      "description": "Amount charged, micro-USD."
+                    },
+                    "output": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "The model result, nested \u2014 NOT spread across the top level. Media models return { url, contentType, sizeBytes } where url is a stable /v1/media link we host; text models (STT, vision, JSON tools) return the provider shape, e.g. { text }."
+                    }
+                  }
+                },
+                "example": {
+                  "model": "nano-banana-2",
+                  "costMicroUsd": 92400,
+                  "output": {
+                    "url": "https://api.glianalabs.com/v1/media/8f2c1d9e4a7b3f60.png",
+                    "contentType": "image/png",
+                    "sizeBytes": 1834127
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required \u2014 pay the challenge and retry."
+          }
+        }
+      }
+    },
+    "/v1/audio/speech": {
+      "post": {
+        "operationId": "audioSpeech",
+        "summary": "Convert text to speech with any TTS model.",
+        "tags": [
+          "tts"
+        ],
+        "description": "**$0.0001\u2013$60 per call**, depending on model and input. Exact price is returned in the 402 challenge before you pay, or up front from `GET /v1/price?model=`.\n\nCapability endpoint \u2014 pick any matching model with GET /v1/models and pass it as { model }. Same pay-per-call charge as /v1/infer (402, then pay and retry); the per-model POST /x402/grok-tts path also works.",
+        "security": [],
+        "x-payment-info": {
+          "price": {
+            "mode": "dynamic",
+            "currency": "USD",
+            "min": "0.0001",
+            "max": "60"
+          },
+          "protocols": [
+            {
+              "mpp": {
+                "method": "tempo",
+                "intent": "charge",
+                "currency": "0x20C000000000000000000000b9537d11c60E8b50"
+              }
+            },
+            {
+              "mpp": {
+                "method": "evm",
+                "intent": "charge",
+                "network": "eip155:8453",
+                "currency": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+              }
+            },
+            {
+              "mpp": {
+                "method": "solana",
+                "intent": "charge",
+                "network": "solana:mainnet",
+                "currency": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+              }
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "model"
+                ],
+                "properties": {
+                  "model": {
+                    "type": "string",
+                    "description": "Model id or full run id (see GET /v1/models)."
+                  }
+                },
+                "additionalProperties": true
+              },
+              "example": {
+                "model": "grok-tts",
+                "input": "Hello from GlianaAI."
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Result + payment receipt (media: { data: [{ url }] }; STT: { text }).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "model": {
+                      "type": "string"
+                    },
+                    "costMicroUsd": {
+                      "type": "integer",
+                      "description": "Amount charged, micro-USD."
+                    },
+                    "output": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "The model result, nested \u2014 NOT spread across the top level. Media models return { url, contentType, sizeBytes } where url is a stable /v1/media link we host; text models (STT, vision, JSON tools) return the provider shape, e.g. { text }."
+                    }
+                  }
+                },
+                "example": {
+                  "model": "nano-banana-2",
+                  "costMicroUsd": 92400,
+                  "output": {
+                    "url": "https://api.glianalabs.com/v1/media/8f2c1d9e4a7b3f60.png",
+                    "contentType": "image/png",
+                    "sizeBytes": 1834127
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required \u2014 pay the challenge and retry."
+          }
+        }
+      }
+    },
+    "/v1/audio/transcriptions": {
+      "post": {
+        "operationId": "audioTranscribe",
+        "summary": "Transcribe audio to text with any STT model.",
+        "tags": [
+          "stt"
+        ],
+        "description": "**$0.0001\u2013$60 per call**, depending on model and input. Exact price is returned in the 402 challenge before you pay, or up front from `GET /v1/price?model=`.\n\nCapability endpoint \u2014 pick any matching model with GET /v1/models and pass it as { model }. Same pay-per-call charge as /v1/infer (402, then pay and retry); the per-model POST /x402/grok-stt path also works. FILE INPUT: if the audio file is already on the web or your own storage, pass `audio_url` \u2014 we fetch it server-side at datacenter speed, which is the fastest option by far. Sending it inline as `audio_base64` is simplest and stores nothing anywhere, but base64 adds ~33% to the bytes and you pay your own upload speed, so it is best under ~1MB. For a large local file, upload the RAW bytes to `POST /v1/media` (free, \u226440MB) and pass the URL: same transfer as base64 minus the 33%, and identity endpoints delete the object as soon as they have read it.",
+        "security": [],
+        "x-payment-info": {
+          "price": {
+            "mode": "dynamic",
+            "currency": "USD",
+            "min": "0.0001",
+            "max": "60"
+          },
+          "protocols": [
+            {
+              "mpp": {
+                "method": "tempo",
+                "intent": "charge",
+                "currency": "0x20C000000000000000000000b9537d11c60E8b50"
+              }
+            },
+            {
+              "mpp": {
+                "method": "evm",
+                "intent": "charge",
+                "network": "eip155:8453",
+                "currency": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+              }
+            },
+            {
+              "mpp": {
+                "method": "solana",
+                "intent": "charge",
+                "network": "solana:mainnet",
+                "currency": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+              }
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "model"
+                ],
+                "properties": {
+                  "model": {
+                    "type": "string",
+                    "description": "Model id or full run id (see GET /v1/models)."
+                  }
+                },
+                "additionalProperties": true
+              },
+              "example": {
+                "model": "grok-stt",
+                "audio_url": "https://example.com/input.mp3"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Result + payment receipt (media: { data: [{ url }] }; STT: { text }).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "model": {
+                      "type": "string"
+                    },
+                    "costMicroUsd": {
+                      "type": "integer",
+                      "description": "Amount charged, micro-USD."
+                    },
+                    "output": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "The model result, nested \u2014 NOT spread across the top level. Media models return { url, contentType, sizeBytes } where url is a stable /v1/media link we host; text models (STT, vision, JSON tools) return the provider shape, e.g. { text }."
+                    }
+                  }
+                },
+                "example": {
+                  "model": "nano-banana-2",
+                  "costMicroUsd": 92400,
+                  "output": {
+                    "url": "https://api.glianalabs.com/v1/media/8f2c1d9e4a7b3f60.png",
+                    "contentType": "image/png",
+                    "sizeBytes": 1834127
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required \u2014 pay the challenge and retry."
+          }
+        }
+      }
+    },
+    "/x402/minimax-m3": {
+      "post": {
+        "operationId": "x402_minimax-m3",
+        "summary": "Generate text with minimax-m3 via x402.",
+        "description": "**$0.001291 per call.** Flat price, charged only on success.\n\nPay-per-call minimax-m3 (text).",
+        "tags": [
+          "text"
+        ],
+        "security": [],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001291"
+          },
+          "protocols": [
+            {
+              "x402": {
+                "networks": [
+                  {
+                    "network": "base",
+                    "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                    "payTo": "0x7662E00f8Ab4C362166e1FF649Ff6c2A638c80AD"
+                  },
+                  {
+                    "network": "solana",
+                    "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                    "payTo": "CXSdm7NgrFXooHbvN6CdNgMvmqTkVLzu6JCVZR3J3Ygh"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "messages"
+                ],
+                "properties": {
+                  "messages": {
+                    "type": "array",
+                    "description": "OpenAI-style chat messages: [{ role: \"user\" | \"system\" | \"assistant\" | \"tool\", content }]. Vision: content may be a parts array with { type: \"image_url\", image_url: { url } } (public URL \u2014 upload via POST /v1/media)."
+                  },
+                  "max_tokens": {
+                    "type": "integer",
+                    "description": "Output-token cap \u2014 bounds the pre-charged price ceiling. Default 1024."
+                  },
+                  "temperature": {
+                    "type": "number",
+                    "description": "Sampling temperature. Passed through where the provider supports it."
+                  },
+                  "top_p": {
+                    "type": "number",
+                    "description": "Nucleus sampling. Passed through where the provider supports it."
+                  },
+                  "stream": {
+                    "type": "boolean",
+                    "description": "true \u2192 Server-Sent Events in the OpenAI chunk format (on /v1/chat/completions)."
+                  },
+                  "tools": {
+                    "type": "array",
+                    "description": "OpenAI-style function tools: [{ type: \"function\", function: { name, description, parameters } }]. The response returns tool_calls (finish_reason \"tool_calls\"); send results back as { role: \"tool\", tool_call_id, content }."
+                  },
+                  "tool_choice": {
+                    "type": "string",
+                    "description": "\"auto\" (default) | \"none\" | \"required\" | { type: \"function\", function: { name } }."
+                  }
+                },
+                "additionalProperties": true
+              },
+              "example": {
+                "messages": [
+                  {
+                    "role": "user",
+                    "content": "Summarize x402 in one sentence."
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Model output.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InferOutput"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required."
+          }
+        }
+      }
+    },
+    "/x402/nano-banana-2": {
+      "post": {
+        "operationId": "x402_nano-banana-2",
+        "summary": "Generate an image with nano-banana-2 via x402.",
+        "description": "**$0.114000 per call.** Flat price, charged only on success.\n\nPay-per-call nano-banana-2 (text-to-image).",
+        "tags": [
+          "text-to-image"
+        ],
+        "security": [],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.114000"
+          },
+          "protocols": [
+            {
+              "x402": {
+                "networks": [
+                  {
+                    "network": "base",
+                    "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                    "payTo": "0x7662E00f8Ab4C362166e1FF649Ff6c2A638c80AD"
+                  },
+                  {
+                    "network": "solana",
+                    "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                    "payTo": "CXSdm7NgrFXooHbvN6CdNgMvmqTkVLzu6JCVZR3J3Ygh"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "prompt"
+                ],
+                "properties": {
+                  "aspect_ratio": {
+                    "type": "string",
+                    "description": "Output aspect ratio (e.g. 16:9, 1:1, 9:16).",
+                    "enum": [
+                      "match_input_image",
+                      "1:1",
+                      "2:3",
+                      "3:2",
+                      "3:4",
+                      "4:3",
+                      "4:5",
+                      "5:4",
+                      "9:16",
+                      "16:9",
+                      "21:9"
+                    ]
+                  },
+                  "google_search": {
+                    "type": "boolean",
+                    "description": "Allow the model to use Google Search for grounding."
+                  },
+                  "image_input": {
+                    "type": "array",
+                    "description": "Reference image(s) to guide generation (HTTPS URL or upload). Pass a public URL; to use a local file, upload it (free) via POST /v1/media (\u226440MB) and pass the returned url.",
+                    "items": {
+                      "type": "string",
+                      "format": "uri"
+                    },
+                    "x-file-input": true
+                  },
+                  "image_search": {
+                    "type": "boolean",
+                    "description": "Allow the model to search for reference images."
+                  },
+                  "output_format": {
+                    "type": "string",
+                    "description": "File format of the output (e.g. png, jpeg, mp4).",
+                    "enum": [
+                      "jpg",
+                      "png"
+                    ]
+                  },
+                  "prompt": {
+                    "type": "string",
+                    "description": "Text prompt describing what to generate."
+                  },
+                  "resolution": {
+                    "type": "string",
+                    "description": "Output resolution / quality tier.",
+                    "enum": [
+                      "1K",
+                      "2K",
+                      "4K"
+                    ]
+                  }
+                },
+                "additionalProperties": true
+              },
+              "example": {
+                "prompt": "a red apple on a table"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Model output.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InferOutput"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required."
+          }
+        }
+      }
+    },
+    "/x402/tts-1": {
+      "post": {
+        "operationId": "x402_tts-1",
+        "summary": "Convert text to speech with tts-1 via x402.",
+        "description": "**$0.001000\u2013$undefined per call**, depending on model and input. Exact price is returned in the 402 challenge before you pay, or up front from `GET /v1/price?model=`.\n\nPay-per-call tts-1 (tts). Priced per character \u2014 final price scales with text length; min is the smallest possible charge.",
+        "tags": [
+          "tts"
+        ],
+        "security": [],
+        "x-payment-info": {
+          "price": {
+            "mode": "dynamic",
+            "currency": "USD",
+            "min": "0.001000"
+          },
+          "protocols": [
+            {
+              "x402": {
+                "networks": [
+                  {
+                    "network": "base",
+                    "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                    "payTo": "0x7662E00f8Ab4C362166e1FF649Ff6c2A638c80AD"
+                  },
+                  {
+                    "network": "solana",
+                    "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                    "payTo": "CXSdm7NgrFXooHbvN6CdNgMvmqTkVLzu6JCVZR3J3Ygh"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "text"
+                ],
+                "properties": {
+                  "response_format": {
+                    "type": "string",
+                    "description": "The output format for the audio. Supported formats are mp3, opus, wav, aac and flac.",
+                    "enum": [
+                      "mp3",
+                      "opus",
+                      "wav",
+                      "aac",
+                      "flac"
+                    ]
+                  },
+                  "speed": {
+                    "type": "number",
+                    "description": "The speed of the generated audio. Select a value from 0.25 to 4.0. 1.0 is the default.",
+                    "minimum": 0.25,
+                    "maximum": 4
+                  },
+                  "text": {
+                    "type": "string",
+                    "description": "The text to generate audio for. Maximum length is 4096 characters."
+                  },
+                  "voice": {
+                    "type": "string",
+                    "description": "The voice to use when generating the audio. Defaults to alloy.",
+                    "enum": [
+                      "alloy",
+                      "echo",
+                      "fable",
+                      "onyx",
+                      "nova",
+                      "shimmer"
+                    ]
+                  }
+                },
+                "additionalProperties": true
+              },
+              "example": {
+                "text": "Hello from GlianaAI."
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Model output.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InferOutput"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required."
+          }
+        }
+      }
+    },
+    "/x402/grok-tts": {
+      "post": {
+        "operationId": "x402_grok-tts",
+        "summary": "Convert text to speech with grok-tts via x402.",
+        "description": "**$0.001000\u2013$undefined per call**, depending on model and input. Exact price is returned in the 402 challenge before you pay, or up front from `GET /v1/price?model=`.\n\nPay-per-call grok-tts (tts). Priced per character \u2014 final price scales with text length; min is the smallest possible charge.",
+        "tags": [
+          "tts"
+        ],
+        "security": [],
+        "x-payment-info": {
+          "price": {
+            "mode": "dynamic",
+            "currency": "USD",
+            "min": "0.001000"
+          },
+          "protocols": [
+            {
+              "x402": {
+                "networks": [
+                  {
+                    "network": "base",
+                    "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                    "payTo": "0x7662E00f8Ab4C362166e1FF649Ff6c2A638c80AD"
+                  },
+                  {
+                    "network": "solana",
+                    "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                    "payTo": "CXSdm7NgrFXooHbvN6CdNgMvmqTkVLzu6JCVZR3J3Ygh"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "text"
+                ],
+                "properties": {
+                  "language": {
+                    "type": "string",
+                    "description": "BCP-47 language code (e.g. \"en\", \"zh\", \"pt-BR\") or \"auto\" for automatic language detection. Required for both REST and WebSocket modes. Supported codes: auto, en, ar-EG, ar-SA, ar-AE, bn, zh, fr, de, hi, id, it, ja, ko, pt-BR, pt-PT, ru, es-MX, es-ES, tr, vi."
+                  },
+                  "optimize_streaming_latency": {
+                    "type": "number",
+                    "description": "Latency optimization for streaming synthesis. 0 (default): no optimization, best audio quality. 1: reduced first-chunk size for lower time-to-first-audio with minor quality tradeoff.",
+                    "enum": [
+                      0,
+                      1
+                    ]
+                  },
+                  "output_format": {
+                    "type": "object",
+                    "description": "Output audio format. Defaults to MP3 at 24 kHz / 128 kbps when omitted."
+                  },
+                  "speed": {
+                    "type": "number",
+                    "description": "Speech speed multiplier. 1.0 is normal speed. Range: 0.7 to 1.5. Defaults to 1.0. Only used in WebSocket mode.",
+                    "minimum": 0.7,
+                    "maximum": 1.5
+                  },
+                  "text": {
+                    "type": "string",
+                    "description": "Text to convert to speech. Maximum 15,000 characters. Supports inline speech tags: [pause], [laugh], <whisper>\u2026</whisper>, etc. Required for REST mode, mutually exclusive with websocket."
+                  },
+                  "text_normalization": {
+                    "type": "boolean",
+                    "description": "When true, normalizes written-form text into spoken-form before synthesis (e.g. \"Dr.\" \u2192 \"Doctor\", \"100\" \u2192 \"one hundred\"). Defaults to false."
+                  },
+                  "voice_id": {
+                    "type": "string",
+                    "description": "Voice for synthesis. Defaults to \"eve\". Built-in voices: eve (energetic), ara (warm), rex (confident), sal (balanced), leo (authoritative). Custom voice IDs from /v1/tts/voices are also accepted. Case-insensitive \u2014 \"Eve\", \"EVE\", and \"eve\" are equivalent."
+                  }
+                },
+                "additionalProperties": true
+              },
+              "example": {
+                "text": "Hello from GlianaAI."
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Model output.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InferOutput"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required."
+          }
+        }
+      }
+    },
+    "/x402/grok-stt": {
+      "post": {
+        "operationId": "x402_grok-stt",
+        "summary": "Transcribe audio with grok-stt via x402.",
+        "description": "**$0.009006 per call.** Flat price, charged only on success.\n\nPay-per-call grok-stt (stt).",
+        "tags": [
+          "stt"
+        ],
+        "security": [],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.009006"
+          },
+          "protocols": [
+            {
+              "x402": {
+                "networks": [
+                  {
+                    "network": "base",
+                    "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                    "payTo": "0x7662E00f8Ab4C362166e1FF649Ff6c2A638c80AD"
+                  },
+                  {
+                    "network": "solana",
+                    "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                    "payTo": "CXSdm7NgrFXooHbvN6CdNgMvmqTkVLzu6JCVZR3J3Ygh"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [],
+                "properties": {
+                  "audio_format": {
+                    "type": "string",
+                    "description": "Format hint for raw/headerless audio. Required for pcm, mulaw, alaw. Omit for container formats (mp3, wav, etc.) \u2014 xAI auto-detects them.",
+                    "enum": [
+                      "pcm",
+                      "mulaw",
+                      "alaw"
+                    ]
+                  },
+                  "channels": {
+                    "type": "integer",
+                    "description": "Number of audio channels (2\u20138). Required only for multichannel raw audio; auto-detected for container formats.",
+                    "minimum": 2,
+                    "maximum": 8
+                  },
+                  "diarize": {
+                    "type": "boolean",
+                    "description": "When true, enables speaker diarization. Each word in the response includes a `speaker` integer identifying the detected speaker."
+                  },
+                  "file": {
+                    "type": "string",
+                    "description": "Audio file as a data URI (data:audio/...;base64,...) or an HTTPS URL the gateway fetches and uploads. Supported container formats: flac, mp3, mp4, m4a, mkv, ogg, opus, wav, aac. Raw formats (pcm, mulaw, alaw) also accepted \u2014 supply audio_format and sample_rate. Gateway-side size limit: 25 MB. Mutually exclusive with `url`. Pass a public URL; to use a local file, upload it (free) via POST /v1/media (\u226440MB) and pass the returned url.",
+                    "x-file-input": true
+                  },
+                  "filler_words": {
+                    "type": "boolean",
+                    "description": "When true, filler words (uh, um, er) are included in the transcript. Defaults to false \u2014 filler words are removed."
+                  },
+                  "format": {
+                    "type": "boolean",
+                    "description": "When true, enables Inverse Text Normalization \u2014 spoken numbers and currencies are converted to written form (e.g. \"one hundred dollars\" \u2192 \"$100\"). Requires language to be set."
+                  },
+                  "keyterm": {
+                    "type": "array",
+                    "description": "Key terms to bias transcription toward (e.g. product names, proper nouns). Each term up to 50 characters, max 100 terms. Sent as repeated form fields: keyterm=Term+One&keyterm=Term+Two."
+                  },
+                  "language": {
+                    "type": "string",
+                    "description": "Language code (e.g. \"en\", \"fr\", \"de\"). Used with format=true to enable Inverse Text Normalization. xAI transcribes in any language regardless \u2014 supplying this enables number/currency formatting in the transcript."
+                  },
+                  "multichannel": {
+                    "type": "boolean",
+                    "description": "When true, each audio channel is transcribed independently. Results are returned in the `channels` array. Requires channels \u2265 2."
+                  },
+                  "sample_rate": {
+                    "type": "integer",
+                    "description": "Sample rate in Hz. Required when audio_format is set."
+                  },
+                  "url": {
+                    "type": "string",
+                    "description": "HTTPS URL of an audio file for xAI to fetch server-side. Mutually exclusive with `file` and `websocket`. No gateway-side size limit applies. Pass a public URL; to use a local file, upload it (free) via POST /v1/media (\u226440MB) and pass the returned url.",
+                    "x-file-input": true
+                  }
+                },
+                "additionalProperties": true
+              },
+              "example": {}
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Model output.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InferOutput"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required."
+          }
+        }
+      }
+    },
+    "/x402/flux-2-pro-preview": {
+      "post": {
+        "operationId": "x402_flux-2-pro-preview",
+        "summary": "Generate an image with flux-2-pro-preview via x402.",
+        "description": "**$0.054000 per call.** Flat price, charged only on success.\n\nPay-per-call flux-2-pro-preview (text-to-image).",
+        "tags": [
+          "text-to-image"
+        ],
+        "security": [],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.054000"
+          },
+          "protocols": [
+            {
+              "x402": {
+                "networks": [
+                  {
+                    "network": "base",
+                    "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                    "payTo": "0x7662E00f8Ab4C362166e1FF649Ff6c2A638c80AD"
+                  },
+                  {
+                    "network": "solana",
+                    "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                    "payTo": "CXSdm7NgrFXooHbvN6CdNgMvmqTkVLzu6JCVZR3J3Ygh"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "prompt"
+                ],
+                "properties": {
+                  "height": {
+                    "type": "integer",
+                    "description": "Height of the generated image in pixels (minimum 64). Omit to let BFL pick.",
+                    "minimum": 64
+                  },
+                  "input_images": {
+                    "type": "array",
+                    "description": "Up to 8 reference images for editing or multi-image composition. Each entry is an HTTPS URL or a data:image/...;base64,... URI. Pass a public URL; to use a local file, upload it (free) via POST /v1/media (\u226440MB) and pass the returned url.",
+                    "items": {
+                      "type": "string",
+                      "format": "uri"
+                    },
+                    "x-file-input": true
+                  },
+                  "output_format": {
+                    "type": "string",
+                    "description": "Output image format. Defaults to jpeg.",
+                    "enum": [
+                      "jpeg",
+                      "png",
+                      "webp"
+                    ]
+                  },
+                  "prompt": {
+                    "type": "string",
+                    "description": "Text prompt for image generation or editing."
+                  },
+                  "safety_tolerance": {
+                    "type": "integer",
+                    "description": "Tolerance for input/output moderation. 0 is the strictest, 5 the most permissive. Defaults to 2.",
+                    "minimum": 0,
+                    "maximum": 5
+                  },
+                  "seed": {
+                    "type": "integer",
+                    "description": "Optional seed for reproducible generation."
+                  },
+                  "width": {
+                    "type": "integer",
+                    "description": "Width of the generated image in pixels (minimum 64). Omit to let BFL pick.",
+                    "minimum": 64
+                  }
+                },
+                "additionalProperties": true
+              },
+              "example": {
+                "prompt": "a red apple on a table"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Model output.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InferOutput"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required."
+          }
+        }
+      }
+    },
+    "/v1/tools/scrape": {
+      "post": {
+        "operationId": "toolScrape",
+        "summary": "Scrape a rendered page to clean markdown.",
+        "tags": [
+          "utility"
+        ],
+        "description": "**$0.005000 per call.** Flat price, charged only on success.\n\nRender a page (JS) \u2192 clean markdown \u2014 { url }. Utility endpoint (not an AI model) \u2014 flat price, paid like /v1/infer (402, then pay and retry).",
+        "security": [],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.005000"
+          },
+          "protocols": [
+            {
+              "mpp": {
+                "method": "tempo",
+                "intent": "charge",
+                "currency": "0x20C000000000000000000000b9537d11c60E8b50"
+              }
+            },
+            {
+              "mpp": {
+                "method": "evm",
+                "intent": "charge",
+                "network": "eip155:8453",
+                "currency": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+              }
+            },
+            {
+              "mpp": {
+                "method": "solana",
+                "intent": "charge",
+                "network": "solana:mainnet",
+                "currency": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+              }
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "properties": {
+                  "url": {
+                    "type": "string",
+                    "description": "https URL of the page to fetch as markdown."
+                  }
+                },
+                "required": [
+                  "url"
+                ]
+              },
+              "example": {
+                "url": "https://example.com"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Result, plus the payment receipt headers.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "tool": {
+                      "type": "string",
+                      "description": "Tool id, echoed back."
+                    },
+                    "costMicroUsd": {
+                      "type": "integer",
+                      "description": "Amount charged, micro-USD."
+                    }
+                  },
+                  "additionalProperties": true
+                },
+                "example": {
+                  "tool": "tools/scrape",
+                  "costMicroUsd": 5000,
+                  "url": "https://example.com",
+                  "markdown": "# Example\n\nSome page text..."
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required \u2014 pay the challenge and retry."
+          }
+        }
+      }
+    },
+    "/v1/tools/face-compare": {
+      "post": {
+        "operationId": "toolFaceCompare",
+        "summary": "Compare two faces for similarity and match.",
+        "tags": [
+          "utility"
+        ],
+        "description": "**$0.011000 per call.** Flat price, charged only on success.\n\nCompare two faces \u2192 cosine similarity + match \u2014 { a:{image_url|image_base64}, b:{image_url|image_base64} }. Utility endpoint (not an AI model) \u2014 flat price, paid like /v1/infer (402, then pay and retry). FILE INPUT: if the image is already on the web or your own storage, pass `image_url` \u2014 we fetch it server-side at datacenter speed, which is the fastest option by far. Sending it inline as `image_base64` is simplest and stores nothing anywhere, but base64 adds ~33% to the bytes and you pay your own upload speed, so it is best under ~1MB. For a large local file, upload the RAW bytes to `POST /v1/media` (free, \u226440MB) and pass the URL: same transfer as base64 minus the 33%, and identity endpoints delete the object as soon as they have read it.",
+        "security": [],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.011000"
+          },
+          "protocols": [
+            {
+              "mpp": {
+                "method": "tempo",
+                "intent": "charge",
+                "currency": "0x20C000000000000000000000b9537d11c60E8b50"
+              }
+            },
+            {
+              "mpp": {
+                "method": "evm",
+                "intent": "charge",
+                "network": "eip155:8453",
+                "currency": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+              }
+            },
+            {
+              "mpp": {
+                "method": "solana",
+                "intent": "charge",
+                "network": "solana:mainnet",
+                "currency": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+              }
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true,
+                "properties": {
+                  "a": {
+                    "type": "object",
+                    "description": "First face to compare: { image_url } or { image_base64 }."
+                  },
+                  "b": {
+                    "type": "object",
+                    "description": "Second face to compare: { image_url } or { image_base64 }."
+                  }
+                },
+                "required": [
+                  "a",
+                  "b"
+                ]
+              },
+              "example": {
+                "a": {
+                  "image_url": "https://example.com/a.jpg"
+                },
+                "b": {
+                  "image_url": "https://example.com/b.jpg"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Result, plus the payment receipt headers.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "tool": {
+                      "type": "string",
+                      "description": "Tool id, echoed back."
+                    },
+                    "costMicroUsd": {
+                      "type": "integer",
+                      "description": "Amount charged, micro-USD."
+                    }
+                  },
+                  "additionalProperties": true
+                },
+                "example": {
+                  "tool": "tools/face-compare",
+                  "costMicroUsd": 11000
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required \u2014 pay the challenge and retry."
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "InferOutput": {
+        "type": "object",
+        "properties": {
+          "model": {
+            "type": "string"
+          },
+          "costMicroUsd": {
+            "type": "integer",
+            "description": "Amount charged, micro-USD."
+          },
+          "output": {
+            "type": "object",
+            "additionalProperties": true,
+            "description": "The model result, nested \u2014 NOT spread across the top level. Media models return { url, contentType, sizeBytes } where url is a stable /v1/media link we host; text models (STT, vision, JSON tools) return the provider shape, e.g. { text }."
+          }
+        }
+      },
+      "PromptInput": {
+        "type": "object",
+        "required": [],
+        "properties": {
+          "prompt": {
+            "type": "string",
+            "description": "Text prompt, or the model-specific input \u2014 see GET /v1/schema?model=."
+          }
+        },
+        "additionalProperties": true
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds **GlianaAI** to the registry.

- **What:** pay-per-call generative AI gateway — 60+ image/video/music/speech models, one endpoint, no signup or API key.
- **Payment:** non-custodial 402 over **MPP** (`POST /v1/infer`) and native **x402** (`POST /x402/{model}`). The 402 challenge offers **USDC on Solana mainnet** and Base. Verified live:
  - `POST /x402/nano-banana-2` → 402 with `network: solana`, asset `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v` (USDC mint).
- **Free discovery:** `GET /v1/models`, `/v1/price`, `/v1/schema`; free upload `POST /v1/media`.
- Category `ai_ml`; OpenAPI committed at `providers/glianalabs/ai/openapi.json`.

Service: https://api.glianalabs.com