### PR TITLE
feat(provider): add covenant/trust — agent identity verification + signed attestations

### DIFF
--- a/providers/covenant/trust/PAY.md
+++ b/providers/covenant/trust/PAY.md
@@ -1,0 +1,46 @@
+---
+name: trust
+title: "Covenant Trust"
+description: "Verify an AI agent before you transact: confirm its on-chain identity passport (MPL Core asset + 014 Registry + Covenant attestation) and obtain Covenant-signed attestations — priced per call in USDC over x402 on Solana."
+use_case: "Use before delegating to or paying another agent: verify its on-chain identity and Covenant registration/attestation, or issue a Covenant-signed attestation over a claim about its work."
+category: identity
+service_url: https://x402-seller.opencovenant.org
+version: v1
+openapi:
+  path: openapi.json
+---
+
+Two paid endpoints for agent-to-agent trust: check a counterparty's on-chain
+identity before you transact with it, and obtain a Covenant-signed,
+independently-verifiable statement about it.
+
+- **`GET /x402/passport/{asset}`** — resolve an agent's on-chain identity
+  passport: the MPL Core asset, its 014 Registry binding, and any Covenant
+  attestation AppData plus the write authority that signed it. Pure chain reads —
+  no Covenant infrastructure required.
+- **`POST /x402/attest`** — obtain a Covenant-signed ed25519 attestation over a
+  claim, independently verifiable against the published key (recompute the
+  sha256 digest of the canonical payload, check the signature).
+
+Settles in USDC on Solana via the PayAI facilitator (the fee payer is sponsored,
+so callers need no SOL).
+
+## Verifying an attestation
+
+Don't trust the server — check the signature. The recipe and the signing key are
+published at `GET /.well-known/x402` (`attestation.publicKey`):
+
+1. `digest = sha256(canonical(payload))` as lowercase hex, where `canonical` is
+   JSON with recursively-sorted keys and no insignificant whitespace (UTF-8).
+2. `message = "covenant.attest.v1\n" + digest`.
+3. ed25519-verify the base58-decoded `signature_b58` over `message` against the
+   pinned key, and confirm `pubkey_b58` equals it.
+
+## Spend-aware usage
+
+- Pass the agent's MPL Core asset address you already hold; don't enumerate.
+- One passport call returns identity, registration, and attestation together.
+- Passport results change rarely — cache and reuse a recent result within a task
+  instead of re-paying.
+- Verify a returned attestation locally (recompute the digest, check the ed25519
+  signature against `pubkey_b58`) rather than re-calling to re-confirm.

--- a/providers/covenant/trust/PAY.md
+++ b/providers/covenant/trust/PAY.md
@@ -2,7 +2,7 @@
 name: trust
 title: "Covenant Trust"
 description: "Verify an AI agent before you transact: confirm its on-chain identity passport (MPL Core asset + 014 Registry + Covenant attestation) and obtain Covenant-signed attestations — priced per call in USDC over x402 on Solana."
-use_case: "Use before delegating to or paying another agent: verify its on-chain identity and Covenant registration/attestation, or issue a Covenant-signed attestation over a claim about its work."
+use_case: "Use when delegating to or paying another agent: verify its on-chain identity and Covenant registration/attestation, or issue a Covenant-signed attestation over a claim about its work."
 category: identity
 service_url: https://x402-seller.opencovenant.org
 version: v1

--- a/providers/covenant/trust/openapi.json
+++ b/providers/covenant/trust/openapi.json
@@ -1,0 +1,124 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Covenant Trust",
+    "version": "1.0.0",
+    "description": "Verify another agent before you transact with it. On-chain identity passports and Covenant-signed attestations, priced per call in USDC over x402 on Solana.",
+    "contact": { "url": "https://opencovenant.org" },
+    "license": { "name": "Apache-2.0" },
+    "x-guidance": "Use /x402/passport/{asset} to confirm a counterparty agent's on-chain identity (MPL Core asset + 014 Registry binding + Covenant attestation) before delegating work or paying it, and /x402/attest to obtain a Covenant-signed, independently-verifiable statement over a claim."
+  },
+  "servers": [{ "url": "https://x402-seller.opencovenant.org" }],
+  "paths": {
+    "/x402/passport/{asset}": {
+      "get": {
+        "operationId": "getPassport",
+        "summary": "Verify an agent's on-chain identity passport.",
+        "tags": ["trust"],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "asset",
+            "required": true,
+            "schema": { "type": "string" },
+            "description": "The agent's MPL Core asset address (base58).",
+            "example": "9sFJ95mZsBTGqTEBkcbmsx2V8RQiZ5iQACCLPLE61aWH"
+          }
+        ],
+        "responses": {
+          "200": { "description": "Passport", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Passport" } } } },
+          "400": { "description": "Not a valid Solana address" },
+          "402": { "description": "Payment Required" },
+          "404": { "description": "Not an MPL Core asset" },
+          "502": { "description": "Chain/DAS upstream unavailable" }
+        }
+      }
+    },
+    "/x402/attest": {
+      "post": {
+        "operationId": "attest",
+        "summary": "Create a Covenant-signed attestation over a claim.",
+        "tags": ["trust"],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["subject", "claim"],
+                "properties": {
+                  "subject": { "type": "string", "maxLength": 256, "description": "What the claim is about." },
+                  "claim": { "description": "Arbitrary JSON statement to be signed." }
+                }
+              },
+              "example": { "subject": "9sFJ95mZsBTGqTEBkcbmsx2V8RQiZ5iQACCLPLE61aWH", "claim": { "delivered": true, "task": "build-report" } }
+            }
+          }
+        },
+        "responses": {
+          "200": { "description": "Signed attestation", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Attestation" } } } },
+          "400": { "description": "Invalid body" },
+          "402": { "description": "Payment Required" },
+          "503": { "description": "Signer not configured" }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Passport": {
+        "type": "object",
+        "properties": {
+          "asset": {
+            "type": "object",
+            "properties": {
+              "id": { "type": "string" },
+              "name": { "type": "string" },
+              "owner": { "type": "string" },
+              "authority": { "type": "string" },
+              "inCovenantCollection": { "type": "boolean" },
+              "collection": { "type": ["string", "null"] },
+              "burnt": { "type": "boolean" }
+            }
+          },
+          "registry": {
+            "type": "object",
+            "properties": {
+              "pda": { "type": "string" },
+              "registered": { "type": "boolean" },
+              "identityPlugin": { "type": "boolean" },
+              "registrationUri": { "type": ["string", "null"] }
+            }
+          },
+          "attestation": {
+            "type": ["object", "null"],
+            "properties": {
+              "authority": { "type": ["string", "null"] },
+              "covenantAuthored": { "type": "boolean" }
+            }
+          }
+        }
+      },
+      "Attestation": {
+        "type": "object",
+        "description": "Independently verifiable: digest = sha256(canonical(payload)) lowercase hex, where canonical is JSON with recursively-sorted keys and no insignificant whitespace (UTF-8); message = domain + \"\\n\" + digest; ed25519-verify base58-decoded signature_b58 over the UTF-8 message against pubkey_b58. Pin the expected pubkey from GET /.well-known/x402 (attestation.publicKey).",
+        "properties": {
+          "alg": { "type": "string", "description": "Signature algorithm — \"ed25519\"." },
+          "domain": { "type": "string", "description": "Domain prefix bound into the signed message." },
+          "canonicalization": { "type": "string" },
+          "payload": {
+            "type": "object",
+            "properties": {
+              "subject": { "type": "string" },
+              "claim": {},
+              "ts": { "type": "integer" }
+            }
+          },
+          "digest_sha256_hex": { "type": "string" },
+          "pubkey_b58": { "type": "string", "description": "Signer pubkey; must match attestation.publicKey from /.well-known/x402." },
+          "signature_b58": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/providers/covenant/trust/openapi.json
+++ b/providers/covenant/trust/openapi.json
@@ -10,6 +10,16 @@
   },
   "servers": [{ "url": "https://x402-seller.opencovenant.org" }],
   "paths": {
+    "/.well-known/x402": {
+      "get": {
+        "operationId": "discovery",
+        "summary": "Fetch x402 discovery: resources and the attestation public key.",
+        "tags": ["meta"],
+        "responses": {
+          "200": { "description": "Discovery document", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Discovery" } } } }
+        }
+      }
+    },
     "/x402/passport/{asset}": {
       "get": {
         "operationId": "getPassport",
@@ -68,6 +78,7 @@
     "schemas": {
       "Passport": {
         "type": "object",
+        "required": ["asset", "registry", "attestation"],
         "properties": {
           "asset": {
             "type": "object",
@@ -101,6 +112,7 @@
       },
       "Attestation": {
         "type": "object",
+        "required": ["alg", "domain", "canonicalization", "payload", "digest_sha256_hex", "pubkey_b58", "signature_b58"],
         "description": "Independently verifiable: digest = sha256(canonical(payload)) lowercase hex, where canonical is JSON with recursively-sorted keys and no insignificant whitespace (UTF-8); message = domain + \"\\n\" + digest; ed25519-verify base58-decoded signature_b58 over the UTF-8 message against pubkey_b58. Pin the expected pubkey from GET /.well-known/x402 (attestation.publicKey).",
         "properties": {
           "alg": { "type": "string", "description": "Signature algorithm — \"ed25519\"." },
@@ -117,6 +129,26 @@
           "digest_sha256_hex": { "type": "string" },
           "pubkey_b58": { "type": "string", "description": "Signer pubkey; must match attestation.publicKey from /.well-known/x402." },
           "signature_b58": { "type": "string" }
+        }
+      },
+      "Discovery": {
+        "type": "object",
+        "required": ["version", "resources"],
+        "properties": {
+          "version": { "type": "integer" },
+          "resources": { "type": "array", "items": { "type": "string" } },
+          "instructions": { "type": "string" },
+          "attestation": {
+            "type": ["object", "null"],
+            "description": "Pin attestation.publicKey to verify /x402/attest responses offline.",
+            "properties": {
+              "algorithm": { "type": "string" },
+              "publicKey": { "type": "string" },
+              "domain": { "type": "string" },
+              "canonicalization": { "type": "string" },
+              "verify": { "type": "string" }
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
## covenant/trust

Two paid endpoints for agent-to-agent trust, under `identity` — a category otherwise unrepresented in the catalog. Priced per call in USDC over x402 on Solana mainnet (PayAI facilitator; fee payer sponsored, so callers need no SOL).

- `GET /x402/passport/{asset}` — an agent's on-chain identity passport: the MPL Core asset, its 014 Registry binding, and any Covenant attestation AppData plus the authority that signed it. Pure chain reads via DAS.
- `POST /x402/attest` — a Covenant-signed ed25519 attestation over a claim, independently verifiable against a published key (recipe + key at `/.well-known/x402`).

Complementary to the payment rail: an agent about to pay a counterparty through pay.sh can verify that counterparty here first.

**Live:** https://x402-seller.opencovenant.org (OpenAPI committed alongside).
**Validated:** `pay catalog check` → Solana-compat verdict PASS, both endpoints probe green (USDC, Solana mainnet).

Reputation and work-provenance endpoints will follow once they return data with the depth this bar deserves.
