### PR TITLE
Add x-payment-info to EarnFi paid create endpoints

### DIFF
--- a/providers/earnfi/agent-api/openapi.json
+++ b/providers/earnfi/agent-api/openapi.json
@@ -80,7 +80,7 @@
         "tags": [
           "discovery"
         ],
-        "summary": "List job types, minimum rewards, and suggested participant sizes",
+        "summary": "List job types, minimum rewards, and suggested sizes",
         "description": "**Free.** Lists what kinds of quick work you can fund, minimum pay, and suggested participant counts.",
         "responses": {
           "200": {
@@ -323,7 +323,7 @@
             "x402"
           ],
           "pricingMode": "dynamic",
-          "price": "402 quote (varies by task_type, slots, reward_per_user)"
+          "price": "$0.03-$500"
         }
       },
       "post": {
@@ -370,7 +370,7 @@
             "x402"
           ],
           "pricingMode": "dynamic",
-          "price": "402 quote (varies by task_type, slots, reward_per_user)"
+          "price": "$0.03-$500"
         }
       }
     },
@@ -409,7 +409,7 @@
             "x402"
           ],
           "pricingMode": "dynamic",
-          "price": "402 quote (varies by slots, reward_per_user, verification style)"
+          "price": "$0.20-$500"
         }
       },
       "post": {
@@ -456,7 +456,7 @@
             "x402"
           ],
           "pricingMode": "dynamic",
-          "price": "402 quote (varies by slots, reward_per_user, verification style)"
+          "price": "$0.20-$500"
         }
       }
     },
@@ -495,7 +495,7 @@
             "x402"
           ],
           "pricingMode": "dynamic",
-          "price": "402 quote (varies by prize pool and participant count)"
+          "price": "$3.00-$500"
         }
       },
       "post": {
@@ -542,7 +542,7 @@
             "x402"
           ],
           "pricingMode": "dynamic",
-          "price": "402 quote (varies by prize pool and participant count)"
+          "price": "$3.00-$500"
         }
       }
     },
@@ -581,7 +581,7 @@
             "x402"
           ],
           "pricingMode": "dynamic",
-          "price": "402 quote (varies by slots and reward_per_user)"
+          "price": "$0.05-$50"
         }
       },
       "post": {
@@ -628,7 +628,7 @@
             "x402"
           ],
           "pricingMode": "dynamic",
-          "price": "402 quote (varies by slots and reward_per_user)"
+          "price": "$0.05-$50"
         }
       }
     },

--- a/providers/earnfi/agent-api/openapi.json
+++ b/providers/earnfi/agent-api/openapi.json
@@ -36,7 +36,7 @@
         "tags": [
           "discovery"
         ],
-        "summary": "Preview how paid social jobs are priced",
+        "summary": "Fetch x402 USDC pricing preview for social job creation",
         "description": "**Returns 402** with the same payment framing as `/jobs/social`, so tools can learn quote shape before you fund a real run.",
         "responses": {
           "402": {
@@ -57,7 +57,7 @@
         "tags": [
           "discovery"
         ],
-        "summary": "Preview x402 USDC pricing for social job creation",
+        "summary": "Fetch x402 USDC pricing preview via POST for social jobs",
         "description": "Identical to GET; body is optional for discovery.",
         "responses": {
           "402": {
@@ -80,7 +80,7 @@
         "tags": [
           "discovery"
         ],
-        "summary": "Job types, minimum rewards, suggested sizes",
+        "summary": "List job types, minimum rewards, and suggested participant sizes",
         "description": "**Free.** Lists what kinds of quick work you can fund, minimum pay, and suggested participant counts.",
         "responses": {
           "200": {
@@ -93,7 +93,7 @@
         "tags": [
           "discovery"
         ],
-        "summary": "Return the same catalog JSON as the GET catalog route",
+        "summary": "Fetch the same catalog JSON as the GET catalog route",
         "description": "**Free.** Same JSON as GET.",
         "responses": {
           "200": {
@@ -108,7 +108,7 @@
         "tags": [
           "discovery"
         ],
-        "summary": "Canonical registration message",
+        "summary": "Fetch canonical agent registration challenge message",
         "description": "**Free.** Returns `message`, `nonce`, and expiry. Sign `message` exactly (UTF-8), then `POST /register` with the same `wallet_address`, `agent_name`, unchanged `message`, `signature`, and `nonce`. Recommended for autonomous clients.",
         "parameters": [
           {
@@ -166,7 +166,7 @@
         "tags": [
           "discovery"
         ],
-        "summary": "Register an agent (wallet-signed message)",
+        "summary": "Create agent credentials via wallet-signed registration message",
         "description": "**Free.** Creates an **agent_token** for your machine identity. This wallet message signature is **not** the same object you use for x402 paid creates after a 402 quote.",
         "requestBody": {
           "required": true,
@@ -552,7 +552,7 @@
         "tags": [
           "x402-paid-create"
         ],
-        "summary": "Ask many people one question (paid)",
+        "summary": "Create a paid human-interrupt question job via x402",
         "description": "**Paid (x402).** Human answers to a single clear question—opinions, quick feedback, light tasks. Same quote-then-pay pattern; optional gating as documented.",
         "responses": {
           "200": {
@@ -589,7 +589,7 @@
         "tags": [
           "x402-paid-create"
         ],
-        "summary": "Ask many people one question (paid, JSON body)",
+        "summary": "Create a paid human-interrupt job via JSON request body",
         "description": "**Paid (x402).** Same quote-then-pay semantics as GET; parameters may be sent as JSON body.",
         "responses": {
           "200": {
@@ -764,7 +764,7 @@
         "tags": [
           "creator"
         ],
-        "summary": "Pause or resume an active funded job for creators",
+        "summary": "Update pause state on an active funded creator job",
         "description": "**Free** — requires agent_token in JSON body or Agent-Token header. Use POST for mutations.",
         "parameters": [
           {
@@ -842,7 +842,7 @@
         "tags": [
           "creator"
         ],
-        "summary": "Approve a manual verification and release worker pay",
+        "summary": "Update manual verification to approved and release worker pay",
         "description": "**Free** — `agent_token` required. `{id}` is the verification (completion) id. Use POST for mutations.",
         "parameters": [
           {
@@ -886,7 +886,7 @@
         "tags": [
           "creator"
         ],
-        "summary": "Reject a manual verification with optional reason text",
+        "summary": "Update manual verification to rejected with optional reason",
         "description": "**Free** — `agent_token` required. Optional `reason` in query or JSON body. Use POST for mutations.",
         "parameters": [
           {
@@ -964,7 +964,7 @@
         "tags": [
           "creator"
         ],
-        "summary": "Mark a contest submission as the prize winner",
+        "summary": "Update contest prize winner from a selected submission",
         "description": "**Free** — requires `agent_token` and submission identifiers per live API schema. Use POST for mutations.",
         "parameters": [
           {

--- a/providers/earnfi/agent-api/openapi.json
+++ b/providers/earnfi/agent-api/openapi.json
@@ -317,6 +317,13 @@
           "403": {
             "description": "Gating or policy rejection"
           }
+        },
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "dynamic",
+          "price": "402 quote (varies by task_type, slots, reward_per_user)"
         }
       },
       "post": {
@@ -357,6 +364,13 @@
               }
             }
           }
+        },
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "dynamic",
+          "price": "402 quote (varies by task_type, slots, reward_per_user)"
         }
       }
     },
@@ -389,7 +403,14 @@
           {
             "$ref": "#/components/parameters/AgentTokenHeader"
           }
-        ]
+        ],
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "dynamic",
+          "price": "402 quote (varies by slots, reward_per_user, verification style)"
+        }
       },
       "post": {
         "operationId": "createManualJobPost",
@@ -429,6 +450,13 @@
               }
             }
           }
+        },
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "dynamic",
+          "price": "402 quote (varies by slots, reward_per_user, verification style)"
         }
       }
     },
@@ -461,7 +489,14 @@
           {
             "$ref": "#/components/parameters/AgentTokenHeader"
           }
-        ]
+        ],
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "dynamic",
+          "price": "402 quote (varies by prize pool and participant count)"
+        }
       },
       "post": {
         "operationId": "createContestJobPost",
@@ -501,6 +536,13 @@
               }
             }
           }
+        },
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "dynamic",
+          "price": "402 quote (varies by prize pool and participant count)"
         }
       }
     },
@@ -533,7 +575,14 @@
           {
             "$ref": "#/components/parameters/AgentTokenHeader"
           }
-        ]
+        ],
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "dynamic",
+          "price": "402 quote (varies by slots and reward_per_user)"
+        }
       },
       "post": {
         "operationId": "createInterruptJobPost",
@@ -573,6 +622,13 @@
               }
             }
           }
+        },
+        "x-payment-info": {
+          "protocols": [
+            "x402"
+          ],
+          "pricingMode": "dynamic",
+          "price": "402 quote (varies by slots and reward_per_user)"
         }
       }
     },


### PR DESCRIPTION
## Summary
- Adds `x-payment-info` to all paid create operations (GET/POST on `/jobs/social`, `/jobs/manual`, `/jobs/contest`, `/interrupt`) so pay.sh indexes billable endpoints.
- Follow-up to #100 - the registry showed `endpoint_count: 0` because operations lacked `x-payment-info`.
- Uses dollar-formatted dynamic price ranges aligned with pay-skills registry conventions.

## Test plan
- [x] `pay catalog check providers/earnfi/agent-api/PAY.md` passes locally (10/10 Solana gates)
- [ ] After merge, https://pay.sh/services/earnfi/agent-api shows 8 endpoints with dynamic x402 pricing