### PR TITLE
fix(google): populate empty OpenAPI specs for 5 providers

### DIFF
--- a/providers/solana-foundation/google/addressvalidation/openapi.json
+++ b/providers/solana-foundation/google/addressvalidation/openapi.json
@@ -1,788 +1,633 @@
 {
-  "openapi": "3.0.0",
-  "paths": {},
-  "basePath": "",
-  "baseUrl": "https://addressvalidation.google.gateway-402.com/",
-  "batchPath": "batch",
-  "canonicalName": "Address Validation",
-  "description": "The Address Validation API allows developers to verify the accuracy of addresses. Given an address, it returns information about the correctness of the components of the parsed address, a geocode, and a verdict on the deliverability of the parsed address.",
-  "discoveryVersion": "v1",
-  "documentationLink": "https://developers.google.com/maps/documentation/addressvalidation",
-  "fullyEncodeReservedExpansion": true,
-  "icons": {
-    "x16": "http://www.google.com/images/icons/product/search-16.gif",
-    "x32": "http://www.google.com/images/icons/product/search-32.gif"
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Address Validation API",
+    "description": "Validate, normalize, and geocode postal addresses worldwide. Returns deliverability verdicts, address component fixes, geocoded coordinates, USPS metadata, plus residential, commercial, and PO Box handling across 200+ countries.",
+    "version": "v1"
   },
-  "id": "addressvalidation:v1",
-  "kind": "discovery#restDescription",
-  "mtlsRootUrl": "https://addressvalidation.google.gateway-402.com/",
-  "name": "addressvalidation",
-  "ownerDomain": "google.com",
-  "ownerName": "Google",
-  "parameters": {
-    "$.xgafv": {
-      "description": "V1 error format.",
-      "enum": [
-        "1",
-        "2"
-      ],
-      "enumDescriptions": [
-        "v1 error format",
-        "v2 error format"
-      ],
-      "location": "query",
-      "type": "string"
-    },
-    "access_token": {
-      "description": "OAuth access token.",
-      "location": "query",
-      "type": "string"
-    },
-    "alt": {
-      "default": "json",
-      "description": "Data format for response.",
-      "enum": [
-        "json",
-        "media",
-        "proto"
-      ],
-      "enumDescriptions": [
-        "Responses with Content-Type of application/json",
-        "Media download with context-dependent Content-Type",
-        "Responses with Content-Type of application/x-protobuf"
-      ],
-      "location": "query",
-      "type": "string"
-    },
-    "callback": {
-      "description": "JSONP",
-      "location": "query",
-      "type": "string"
-    },
-    "fields": {
-      "description": "Selector specifying which fields to include in a partial response.",
-      "location": "query",
-      "type": "string"
-    },
-    "key": {
-      "description": "API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.",
-      "location": "query",
-      "type": "string"
-    },
-    "oauth_token": {
-      "description": "OAuth 2.0 token for the current user.",
-      "location": "query",
-      "type": "string"
-    },
-    "prettyPrint": {
-      "default": "true",
-      "description": "Returns response with indentations and line breaks.",
-      "location": "query",
-      "type": "boolean"
-    },
-    "quotaUser": {
-      "description": "Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.",
-      "location": "query",
-      "type": "string"
-    },
-    "uploadType": {
-      "description": "Legacy upload protocol for media (e.g. \"media\", \"multipart\").",
-      "location": "query",
-      "type": "string"
-    },
-    "upload_protocol": {
-      "description": "Upload protocol for media (e.g. \"raw\", \"multipart\").",
-      "location": "query",
-      "type": "string"
+  "servers": [
+    {
+      "url": "https://addressvalidation.google.gateway-402.com"
     }
-  },
-  "protocol": "rest",
-  "resources": {
-    "v1": {
-      "methods": {
-        "validateAddress": {
-          "description": "Validates an address. (v1:validateAddress)",
-          "flatPath": "v1:validateAddress",
-          "httpMethod": "POST",
-          "id": "addressvalidation.validateAddress",
-          "parameterOrder": [],
-          "parameters": {},
-          "path": "v1:validateAddress",
-          "request": {
-            "$ref": "GoogleMapsAddressvalidationV1ValidateAddressRequest"
-          },
-          "response": {
-            "$ref": "GoogleMapsAddressvalidationV1ValidateAddressResponse"
+  ],
+  "paths": {
+    "/v1:validateAddress": {
+      "post": {
+        "operationId": "addressvalidation.validateAddress",
+        "summary": "Validate a postal address and return normalized components.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GoogleMapsAddressvalidationV1ValidateAddressRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GoogleMapsAddressvalidationV1ValidateAddressResponse"
+                }
+              }
+            }
           }
         }
       }
     }
   },
-  "revision": "20260428",
-  "rootUrl": "https://addressvalidation.google.gateway-402.com/",
-  "schemas": {
-    "GoogleGeoTypeViewport": {
-      "description": "A latitude-longitude viewport, represented as two diagonally opposite `low` and `high` points. A viewport is considered a closed region, i.e. it includes its boundary. The latitude bounds must range between -90 to 90 degrees inclusive, and the longitude bounds must range between -180 to 180 degrees inclusive. Various cases include: - If `low` = `high`, the viewport consists of that single point. - If `low.longitude` > `high.longitude`, the longitude range is inverted (the viewport crosses the 180 degree longitude line). - If `low.longitude` = -180 degrees and `high.longitude` = 180 degrees, the viewport includes all longitudes. - If `low.longitude` = 180 degrees and `high.longitude` = -180 degrees, the longitude range is empty. - If `low.latitude` > `high.latitude`, the latitude range is empty. Both `low` and `high` must be populated, and the represented box cannot be empty (as specified by the definitions above). An empty viewport will result in an error. For example, this viewport fully encloses New York City: { \"low\": { \"latitude\": 40.477398, \"longitude\": -74.259087 }, \"high\": { \"latitude\": 40.91618, \"longitude\": -73.70018 } }",
-      "id": "GoogleGeoTypeViewport",
-      "properties": {
-        "high": {
-          "$ref": "GoogleTypeLatLng",
-          "description": "Required. The high point of the viewport."
-        },
-        "low": {
-          "$ref": "GoogleTypeLatLng",
-          "description": "Required. The low point of the viewport."
-        }
-      },
-      "type": "object"
-    },
-    "GoogleMapsAddressvalidationV1Address": {
-      "description": "Details of the post-processed address. Post-processing includes correcting misspelled parts of the address, replacing incorrect parts, and inferring missing parts.",
-      "id": "GoogleMapsAddressvalidationV1Address",
-      "properties": {
-        "addressComponents": {
-          "description": "Unordered list. The individual address components of the formatted and corrected address, along with validation information. This provides information on the validation status of the individual components. Address components are not ordered in a particular way. Do not make any assumptions on the ordering of the address components in the list.",
-          "items": {
-            "$ref": "GoogleMapsAddressvalidationV1AddressComponent"
+  "components": {
+    "schemas": {
+      "GoogleGeoTypeViewport": {
+        "type": "object",
+        "description": "A latitude-longitude viewport, represented as two diagonally opposite `low` and `high` points. A viewport is considered a closed region, i.e. it includes its boundary. The latitude bounds must range between -90 to 90 degrees inclusive, and the longitude bounds must range between -180 to 180 degrees inclusive. Various cases include: - If `low` = `high`, the viewport consists of that single point. - If `low.longitude` > `high.longitude`, the longitude range is inverted (the viewport crosses the 180 degree longitude line). - If `low.longitude` = -180 degrees and `high.longitude` = 180 degrees, the viewport includes all longitudes. - If `low.longitude` = 180 degrees and `high.longitude` = -180 degrees, the longitude range is empty. - If `low.latitude` > `high.latitude`, the latitude range is empty. Both `low` and `high` must be populated, and the represented box cannot be empty (as specified by the definitions above). An empty viewport will result in an error. For example, this viewport fully encloses New York City: { \"low\": { \"latitude\": 40.477398, \"longitude\": -74.259087 }, \"high\": { \"latitude\": 40.91618, \"longitude\": -73.70018 } }",
+        "properties": {
+          "low": {
+            "$ref": "#/components/schemas/GoogleTypeLatLng"
           },
-          "type": "array"
-        },
-        "formattedAddress": {
-          "description": "The post-processed address, formatted as a single-line address following the address formatting rules of the region where the address is located. Note: the format of this address may not match the format of the address in the `postal_address` field. For example, the `postal_address` always represents the country as a 2 letter `region_code`, such as \"US\" or \"NZ\". By contrast, this field uses a longer form of the country name, such as \"USA\" or \"New Zealand\".",
-          "type": "string"
-        },
-        "missingComponentTypes": {
-          "description": "The types of components that were expected to be present in a correctly formatted mailing address but were not found in the input AND could not be inferred. An example might be `['street_number', 'route']` for an input like \"Boulder, Colorado, 80301, USA\". The list of possible types can be found [here](https://developers.google.com/maps/documentation/geocoding/requests-geocoding#Types). **Note: you might see a missing component type when you think you've already supplied the missing component.** For example, this can happen when the input address contains the building name, but not the premise number. In the address \"渋谷区渋谷３丁目　Shibuya Stream\", the building name \"Shibuya Stream\" has the component type `premise`, but the premise number is missing, so `missing_component_types` will contain `premise`.",
-          "items": {
-            "type": "string"
+          "high": {
+            "$ref": "#/components/schemas/GoogleTypeLatLng"
+          }
+        }
+      },
+      "GoogleMapsAddressvalidationV1Address": {
+        "type": "object",
+        "description": "Details of the post-processed address. Post-processing includes correcting misspelled parts of the address, replacing incorrect parts, and inferring missing parts.",
+        "properties": {
+          "missingComponentTypes": {
+            "type": "array",
+            "description": "The types of components that were expected to be present in a correctly formatted mailing address but were not found in the input AND could not be inferred. An example might be `['street_number', 'route']` for an input like \"Boulder, Colorado, 80301, USA\". The list of possible types can be found [here](https://developers.google.com/maps/documentation/geocoding/requests-geocoding#Types). **Note: you might see a missing component type when you think you've already supplied the missing component.** For example, this can happen when the input address contains the building name, but not the premise number. In the address \"\u6e0b\u8c37\u533a\u6e0b\u8c37\uff13\u4e01\u76ee\u3000Shibuya Stream\", the building name \"Shibuya Stream\" has the component type `premise`, but the premise number is missing, so `missing_component_types` will contain `premise`.",
+            "items": {
+              "type": "string"
+            }
           },
-          "type": "array"
-        },
-        "postalAddress": {
-          "$ref": "GoogleTypePostalAddress",
-          "description": "The post-processed address represented as a postal address."
-        },
-        "unconfirmedComponentTypes": {
-          "description": "The types of the components that are present in the `address_components` but could not be confirmed to be correct. This field is provided for the sake of convenience: its contents are equivalent to iterating through the `address_components` to find the types of all the components where the confirmation_level is not CONFIRMED or the inferred flag is not set to `true`. The list of possible types can be found [here](https://developers.google.com/maps/documentation/geocoding/requests-geocoding#Types).",
-          "items": {
-            "type": "string"
+          "unconfirmedComponentTypes": {
+            "type": "array",
+            "description": "The types of the components that are present in the `address_components` but could not be confirmed to be correct. This field is provided for the sake of convenience: its contents are equivalent to iterating through the `address_components` to find the types of all the components where the confirmation_level is not CONFIRMED or the inferred flag is not set to `true`. The list of possible types can be found [here](https://developers.google.com/maps/documentation/geocoding/requests-geocoding#Types).",
+            "items": {
+              "type": "string"
+            }
           },
-          "type": "array"
-        },
-        "unresolvedTokens": {
-          "description": "Any tokens in the input that could not be resolved. This might be an input that was not recognized as a valid part of an address. For example, for an input such as \"Parcel 0000123123 & 0000456456 Str # Guthrie Center IA 50115 US\", the unresolved tokens might look like `[\"Parcel\", \"0000123123\", \"&\", \"0000456456\"]`.",
-          "items": {
-            "type": "string"
+          "formattedAddress": {
+            "type": "string",
+            "description": "The post-processed address, formatted as a single-line address following the address formatting rules of the region where the address is located. Note: the format of this address may not match the format of the address in the `postal_address` field. For example, the `postal_address` always represents the country as a 2 letter `region_code`, such as \"US\" or \"NZ\". By contrast, this field uses a longer form of the country name, such as \"USA\" or \"New Zealand\"."
           },
-          "type": "array"
-        }
-      },
-      "type": "object"
-    },
-    "GoogleMapsAddressvalidationV1AddressComponent": {
-      "description": "Represents an address component, such as a street, city, or state.",
-      "id": "GoogleMapsAddressvalidationV1AddressComponent",
-      "properties": {
-        "componentName": {
-          "$ref": "GoogleMapsAddressvalidationV1ComponentName",
-          "description": "The name for this component."
-        },
-        "componentType": {
-          "description": "The type of the address component. See [Table 2: Additional types returned by the Places service](https://developers.google.com/places/web-service/supported_types#table2) for a list of possible types.",
-          "type": "string"
-        },
-        "confirmationLevel": {
-          "description": "Indicates the level of certainty that we have that the component is correct.",
-          "enum": [
-            "CONFIRMATION_LEVEL_UNSPECIFIED",
-            "CONFIRMED",
-            "UNCONFIRMED_BUT_PLAUSIBLE",
-            "UNCONFIRMED_AND_SUSPICIOUS"
-          ],
-          "enumDescriptions": [
-            "Default value. This value is unused.",
-            "We were able to verify that this component exists and makes sense in the context of the rest of the address.",
-            "This component could not be confirmed, but it is plausible that it exists. For example, a street number within a known valid range of numbers on a street where specific house numbers are not known.",
-            "This component was not confirmed and is likely to be wrong. For example, a neighborhood that does not fit the rest of the address."
-          ],
-          "type": "string"
-        },
-        "inferred": {
-          "description": "Indicates that the component was not part of the input, but we inferred it for the address location and believe it should be provided for a complete address.",
-          "type": "boolean"
-        },
-        "replaced": {
-          "description": "Indicates the name of the component was replaced with a completely different one, for example a wrong postal code being replaced with one that is correct for the address. This is not a cosmetic change, the input component has been changed to a different one.",
-          "type": "boolean"
-        },
-        "spellCorrected": {
-          "description": "Indicates a correction to a misspelling in the component name. The API does not always flag changes from one spelling variant to another, such as when changing \"centre\" to \"center\". It also does not always flag common misspellings, such as when changing \"Amphitheater Pkwy\" to \"Amphitheatre Pkwy\".",
-          "type": "boolean"
-        },
-        "unexpected": {
-          "description": "Indicates an address component that is not expected to be present in a postal address for the given region. We have retained it only because it was part of the input.",
-          "type": "boolean"
-        }
-      },
-      "type": "object"
-    },
-    "GoogleMapsAddressvalidationV1AddressMetadata": {
-      "description": "The metadata for the post-processed address. `metadata` is not guaranteed to be fully populated for every address sent to the Address Validation API.",
-      "id": "GoogleMapsAddressvalidationV1AddressMetadata",
-      "properties": {
-        "business": {
-          "description": "Indicates that this is the address of a business. If unset, indicates that the value is unknown.",
-          "type": "boolean"
-        },
-        "poBox": {
-          "description": "Indicates that the address of a PO box. If unset, indicates that the value is unknown.",
-          "type": "boolean"
-        },
-        "residential": {
-          "description": "Indicates that this is the address of a residence. If unset, indicates that the value is unknown.",
-          "type": "boolean"
-        }
-      },
-      "type": "object"
-    },
-    "GoogleMapsAddressvalidationV1ComponentName": {
-      "description": "A wrapper for the name of the component.",
-      "id": "GoogleMapsAddressvalidationV1ComponentName",
-      "properties": {
-        "languageCode": {
-          "description": "The BCP-47 language code. This will not be present if the component name is not associated with a language, such as a street number.",
-          "type": "string"
-        },
-        "text": {
-          "description": "The name text. For example, \"5th Avenue\" for a street name or \"1253\" for a street number.",
-          "type": "string"
-        }
-      },
-      "type": "object"
-    },
-    "GoogleMapsAddressvalidationV1Geocode": {
-      "description": "Contains information about the place the input was geocoded to.",
-      "id": "GoogleMapsAddressvalidationV1Geocode",
-      "properties": {
-        "bounds": {
-          "$ref": "GoogleGeoTypeViewport",
-          "description": "The bounds of the geocoded place."
-        },
-        "featureSizeMeters": {
-          "description": "The size of the geocoded place, in meters. This is another measure of the coarseness of the geocoded location, but in physical size rather than in semantic meaning.",
-          "format": "float",
-          "type": "number"
-        },
-        "location": {
-          "$ref": "GoogleTypeLatLng",
-          "description": "The geocoded location of the input. Using place IDs is preferred over using addresses, latitude/longitude coordinates, or plus codes. Using coordinates when routing or calculating driving directions will always result in the point being snapped to the road nearest to those coordinates. This may not be a road that will quickly or safely lead to the destination and may not be near an access point to the property. Additionally, when a location is reverse geocoded, there is no guarantee that the returned address will match the original."
-        },
-        "placeId": {
-          "description": "The PlaceID of the place this input geocodes to. For more information about Place IDs see [here](https://developers.google.com/maps/documentation/places/web-service/place-id).",
-          "type": "string"
-        },
-        "placeTypes": {
-          "description": "The type(s) of place that the input geocoded to. For example, `['locality', 'political']`. The full list of types can be found [here](https://developers.google.com/maps/documentation/geocoding/requests-geocoding#Types).",
-          "items": {
-            "type": "string"
+          "addressComponents": {
+            "type": "array",
+            "description": "Unordered list. The individual address components of the formatted and corrected address, along with validation information. This provides information on the validation status of the individual components. Address components are not ordered in a particular way. Do not make any assumptions on the ordering of the address components in the list.",
+            "items": {
+              "$ref": "#/components/schemas/GoogleMapsAddressvalidationV1AddressComponent"
+            }
           },
-          "type": "array"
-        },
-        "plusCode": {
-          "$ref": "GoogleMapsAddressvalidationV1PlusCode",
-          "description": "The plus code corresponding to the `location`."
-        }
-      },
-      "type": "object"
-    },
-    "GoogleMapsAddressvalidationV1LanguageOptions": {
-      "description": "Preview: This feature is in Preview (pre-GA). Pre-GA products and features might have limited support, and changes to pre-GA products and features might not be compatible with other pre-GA versions. Pre-GA Offerings are covered by the [Google Maps Platform Service Specific Terms](https://cloud.google.com/maps-platform/terms/maps-service-terms). For more information, see the [launch stage descriptions](https://developers.google.com/maps/launch-stages). Enables the Address Validation API to include additional information in the response.",
-      "id": "GoogleMapsAddressvalidationV1LanguageOptions",
-      "properties": {
-        "returnEnglishLatinAddress": {
-          "description": "Preview: Return a [google.maps.addressvalidation.v1.Address] in English. See [google.maps.addressvalidation.v1.ValidationResult.english_latin_address] for details.",
-          "type": "boolean"
-        }
-      },
-      "type": "object"
-    },
-    "GoogleMapsAddressvalidationV1PlusCode": {
-      "description": "Plus code (http://plus.codes) is a location reference with two formats: global code defining a 14mx14m (1/8000th of a degree) or smaller rectangle, and compound code, replacing the prefix with a reference location.",
-      "id": "GoogleMapsAddressvalidationV1PlusCode",
-      "properties": {
-        "compoundCode": {
-          "description": "Place's compound code, such as \"33GV+HQ, Ramberg, Norway\", containing the suffix of the global code and replacing the prefix with a formatted name of a reference entity.",
-          "type": "string"
-        },
-        "globalCode": {
-          "description": "Place's global (full) code, such as \"9FWM33GV+HQ\", representing an 1/8000 by 1/8000 degree area (~14 by 14 meters).",
-          "type": "string"
-        }
-      },
-      "type": "object"
-    },
-    "GoogleMapsAddressvalidationV1UspsAddress": {
-      "description": "USPS representation of a US address.",
-      "id": "GoogleMapsAddressvalidationV1UspsAddress",
-      "properties": {
-        "city": {
-          "description": "City name.",
-          "type": "string"
-        },
-        "cityStateZipAddressLine": {
-          "description": "City + state + postal code.",
-          "type": "string"
-        },
-        "firm": {
-          "description": "Firm name.",
-          "type": "string"
-        },
-        "firstAddressLine": {
-          "description": "First address line.",
-          "type": "string"
-        },
-        "secondAddressLine": {
-          "description": "Second address line.",
-          "type": "string"
-        },
-        "state": {
-          "description": "2 letter state code.",
-          "type": "string"
-        },
-        "urbanization": {
-          "description": "Puerto Rican urbanization name.",
-          "type": "string"
-        },
-        "zipCode": {
-          "description": "Postal code e.g. 10009.",
-          "type": "string"
-        },
-        "zipCodeExtension": {
-          "description": "4-digit postal code extension e.g. 5023.",
-          "type": "string"
-        }
-      },
-      "type": "object"
-    },
-    "GoogleMapsAddressvalidationV1UspsData": {
-      "description": "The USPS data for the address. `uspsData` is not guaranteed to be fully populated for every US or PR address sent to the Address Validation API. It's recommended to integrate the backup address fields in the response if you utilize uspsData as the primary part of the response.",
-      "id": "GoogleMapsAddressvalidationV1UspsData",
-      "properties": {
-        "abbreviatedCity": {
-          "description": "Abbreviated city.",
-          "type": "string"
-        },
-        "addressRecordType": {
-          "description": "Type of the address record that matches the input address. * `F`: FIRM. This is a match to a Firm Record, which is the finest level of match available for an address. * `G`: GENERAL DELIVERY. This is a match to a General Delivery record. * `H`: BUILDING / APARTMENT. This is a match to a Building or Apartment record. * `P`: POST OFFICE BOX. This is a match to a Post Office Box. * `R`: RURAL ROUTE or HIGHWAY CONTRACT: This is a match to either a Rural Route or a Highway Contract record, both of which may have associated Box Number ranges. * `S`: STREET RECORD: This is a match to a Street record containing a valid primary number range.",
-          "type": "string"
-        },
-        "carrierRoute": {
-          "description": "The carrier route code. A four character code consisting of a one letter prefix and a three digit route designator. Prefixes: * `C`: Carrier route (or city route) * `R`: Rural route * `H`: Highway Contract Route * `B`: Post Office Box Section * `G`: General delivery unit",
-          "type": "string"
-        },
-        "carrierRouteIndicator": {
-          "description": "Carrier route rate sort indicator.",
-          "type": "string"
-        },
-        "cassProcessed": {
-          "description": "Indicator that the request has been CASS processed.",
-          "type": "boolean"
-        },
-        "county": {
-          "description": "County name.",
-          "type": "string"
-        },
-        "defaultAddress": {
-          "description": "Indicator that a default address was found, but more specific addresses exists.",
-          "type": "boolean"
-        },
-        "deliveryPointCheckDigit": {
-          "description": "The delivery point check digit. This number is added to the end of the delivery_point_barcode for mechanically scanned mail. Adding all the digits of the delivery_point_barcode, delivery_point_check_digit, postal code, and ZIP+4 together should yield a number divisible by 10.",
-          "type": "string"
-        },
-        "deliveryPointCode": {
-          "description": "2 digit delivery point code",
-          "type": "string"
-        },
-        "dpvCmra": {
-          "description": "Indicates if the address is a CMRA (Commercial Mail Receiving Agency)--a private business receiving mail for clients. Returns a single character. * `Y`: The address is a CMRA * `N`: The address is not a CMRA",
-          "type": "string"
-        },
-        "dpvConfirmation": {
-          "description": "The possible values for DPV confirmation. Returns a single character or returns no value. * `N`: Primary and any secondary number information failed to DPV confirm. * `D`: Address was DPV confirmed for the primary number only, and the secondary number information was missing. * `S`: Address was DPV confirmed for the primary number only, and the secondary number information was present but not confirmed. * `Y`: Address was DPV confirmed for primary and any secondary numbers. * Empty: If the response does not contain a `dpv_confirmation` value, the address was not submitted for DPV confirmation.",
-          "type": "string"
-        },
-        "dpvDoorNotAccessible": {
-          "description": "Flag indicates addresses where USPS cannot knock on a door to deliver mail. Returns a single character. * `Y`: The door is not accessible. * `N`: No indication the door is not accessible.",
-          "type": "string"
-        },
-        "dpvDrop": {
-          "description": "Flag indicates mail is delivered to a single receptable at a site. Returns a single character. * `Y`: The mail is delivered to a single receptable at a site. * `N`: The mail is not delivered to a single receptable at a site.",
-          "type": "string"
-        },
-        "dpvEnhancedDeliveryCode": {
-          "description": "Indicates that more than one DPV return code is valid for the address. Returns a single character. * `Y`: Address was DPV confirmed for primary and any secondary numbers. * `N`: Primary and any secondary number information failed to DPV confirm. * `S`: Address was DPV confirmed for the primary number only, and the secondary number information was present but not confirmed, or a single trailing alpha on a primary number was dropped to make a DPV match and secondary information required. * `D`: Address was DPV confirmed for the primary number only, and the secondary number information was missing. * `R`: Address confirmed but assigned to phantom route R777 and R779 and USPS delivery is not provided.",
-          "type": "string"
-        },
-        "dpvFootnote": {
-          "description": "The footnotes from delivery point validation. Multiple footnotes may be strung together in the same string. * `AA`: Input address matched to the ZIP+4 file * `A1`: Input address was not matched to the ZIP+4 file * `BB`: Matched to DPV (all components) * `CC`: Secondary number not matched and not required * `C1`: Secondary number not matched but required * `N1`: High-rise address missing secondary number * `M1`: Primary number missing * `M3`: Primary number invalid * `P1`: Input address PO, RR or HC box number missing * `P3`: Input address PO, RR, or HC Box number invalid * `F1`: Input address matched to a military address * `G1`: Input address matched to a general delivery address * `U1`: Input address matched to a unique ZIP code * `PB`: Input address matched to PBSA record * `RR`: DPV confirmed address with PMB information * `R1`: DPV confirmed address without PMB information * `R7`: Carrier Route R777 or R779 record * `IA`: Informed Address identified * `TA`: Primary number matched by dropping a trailing alpha",
-          "type": "string"
-        },
-        "dpvNoSecureLocation": {
-          "description": "Flag indicates door is accessible, but package will not be left due to security concerns. Returns a single character. * `Y`: The package will not be left due to security concerns. * `N`: No indication the package will not be left due to security concerns.",
-          "type": "string"
-        },
-        "dpvNoStat": {
-          "description": "Is this a no stat address or an active address? No stat addresses are ones which are not continuously occupied or addresses that the USPS does not service. Returns a single character. * `Y`: The address is not active * `N`: The address is active",
-          "type": "string"
-        },
-        "dpvNoStatReasonCode": {
-          "description": "Indicates the NoStat type. Returns a reason code as int. * `1`: IDA (Internal Drop Address) – Addresses that do not receive mail directly from the USPS but are delivered to a drop address that services them. * `2`: CDS - Addresses that have not yet become deliverable. For example, a new subdivision where lots and primary numbers have been determined, but no structure exists yet for occupancy. * `3`: Collision - Addresses that do not actually DPV confirm. * `4`: CMZ (College, Military and Other Types) - ZIP + 4 records USPS has incorporated into the data. * `5`: Regular - Indicates addresses not receiving delivery and the addresses are not counted as possible deliveries. * `6`: Secondary Required - The address requires secondary information.",
-          "format": "int32",
-          "type": "integer"
-        },
-        "dpvNonDeliveryDays": {
-          "description": "Flag indicates mail delivery is not performed every day of the week. Returns a single character. * `Y`: The mail delivery is not performed every day of the week. * `N`: No indication the mail delivery is not performed every day of the week.",
-          "type": "string"
-        },
-        "dpvNonDeliveryDaysValues": {
-          "description": "Integer identifying non-delivery days. It can be interrogated using bit flags: 0x40 – Sunday is a non-delivery day 0x20 – Monday is a non-delivery day 0x10 – Tuesday is a non-delivery day 0x08 – Wednesday is a non-delivery day 0x04 – Thursday is a non-delivery day 0x02 – Friday is a non-delivery day 0x01 – Saturday is a non-delivery day",
-          "format": "int32",
-          "type": "integer"
-        },
-        "dpvPbsa": {
-          "description": "Indicates the address was matched to PBSA record. Returns a single character. * `Y`: The address was matched to PBSA record. * `N`: The address was not matched to PBSA record.",
-          "type": "string"
-        },
-        "dpvThrowback": {
-          "description": "Indicates that mail is not delivered to the street address. Returns a single character. * `Y`: The mail is not delivered to the street address. * `N`: The mail is delivered to the street address.",
-          "type": "string"
-        },
-        "dpvVacant": {
-          "description": "Is this place vacant? Returns a single character. * `Y`: The address is vacant * `N`: The address is not vacant",
-          "type": "string"
-        },
-        "elotFlag": {
-          "description": "eLOT Ascending/Descending Flag (A/D).",
-          "type": "string"
-        },
-        "elotNumber": {
-          "description": "Enhanced Line of Travel (eLOT) number.",
-          "type": "string"
-        },
-        "errorMessage": {
-          "description": "Error message for USPS data retrieval. This is populated when USPS processing is suspended because of the detection of artificially created addresses. The USPS data fields might not be populated when this error is present.",
-          "type": "string"
-        },
-        "ewsNoMatch": {
-          "description": "The delivery address is matchable, but the EWS file indicates that an exact match will be available soon.",
-          "type": "boolean"
-        },
-        "fipsCountyCode": {
-          "description": "FIPS county code.",
-          "type": "string"
-        },
-        "lacsLinkIndicator": {
-          "description": "LACSLink indicator.",
-          "type": "string"
-        },
-        "lacsLinkReturnCode": {
-          "description": "LACSLink return code.",
-          "type": "string"
-        },
-        "pmbDesignator": {
-          "description": "PMB (Private Mail Box) unit designator.",
-          "type": "string"
-        },
-        "pmbNumber": {
-          "description": "PMB (Private Mail Box) number;",
-          "type": "string"
-        },
-        "poBoxOnlyPostalCode": {
-          "description": "PO Box only postal code.",
-          "type": "boolean"
-        },
-        "postOfficeCity": {
-          "description": "Main post office city.",
-          "type": "string"
-        },
-        "postOfficeState": {
-          "description": "Main post office state.",
-          "type": "string"
-        },
-        "standardizedAddress": {
-          "$ref": "GoogleMapsAddressvalidationV1UspsAddress",
-          "description": "USPS standardized address."
-        },
-        "suitelinkFootnote": {
-          "description": "Footnotes from matching a street or highrise record to suite information. If business name match is found, the secondary number is returned. * `A`: SuiteLink record match, business address improved. * `00`: No match, business address is not improved.",
-          "type": "string"
-        }
-      },
-      "type": "object"
-    },
-    "GoogleMapsAddressvalidationV1ValidateAddressRequest": {
-      "description": "The request for validating an address.",
-      "id": "GoogleMapsAddressvalidationV1ValidateAddressRequest",
-      "properties": {
-        "address": {
-          "$ref": "GoogleTypePostalAddress",
-          "description": "Required. The address being validated. Unformatted addresses should be submitted via `address_lines`. The total length of the fields in this input must not exceed 280 characters. Supported regions can be found [here](https://developers.google.com/maps/documentation/address-validation/coverage). The language_code value in the input address is reserved for future uses and is ignored today. The validated address result will be populated based on the preferred language for the given address, as identified by the system. The Address Validation API ignores the values in recipients and organization. Any values in those fields will be discarded and not returned. Please do not set them."
-        },
-        "enableUspsCass": {
-          "description": "Enables USPS CASS compatible mode. This affects _only_ the [google.maps.addressvalidation.v1.ValidationResult.usps_data] field of [google.maps.addressvalidation.v1.ValidationResult]. Note: for USPS CASS enabled requests for addresses in Puerto Rico, a [google.type.PostalAddress.region_code] of the `address` must be provided as \"PR\", or an [google.type.PostalAddress.administrative_area] of the `address` must be provided as \"Puerto Rico\" (case-insensitive) or \"PR\". It's recommended to use a componentized `address`, or alternatively specify at least two [google.type.PostalAddress.address_lines] where the first line contains the street number and name and the second line contains the city, state, and zip code.",
-          "type": "boolean"
-        },
-        "languageOptions": {
-          "$ref": "GoogleMapsAddressvalidationV1LanguageOptions",
-          "description": "Optional. Preview: This feature is in Preview (pre-GA). Pre-GA products and features might have limited support, and changes to pre-GA products and features might not be compatible with other pre-GA versions. Pre-GA Offerings are covered by the [Google Maps Platform Service Specific Terms](https://cloud.google.com/maps-platform/terms/maps-service-terms). For more information, see the [launch stage descriptions](https://developers.google.com/maps/launch-stages). Enables the Address Validation API to include additional information in the response."
-        },
-        "previousResponseId": {
-          "description": "This field must be empty for the first address validation request. If more requests are necessary to fully validate a single address (for example if the changes the user makes after the initial validation need to be re-validated), then each followup request must populate this field with the response_id from the very first response in the validation sequence.",
-          "type": "string"
-        },
-        "sessionToken": {
-          "description": "Optional. A string which identifies an Autocomplete session for billing purposes. Must be a URL and filename safe base64 string with at most 36 ASCII characters in length. Otherwise an INVALID_ARGUMENT error is returned. The session begins when the user makes an Autocomplete query, and concludes when they select a place and a call to Place Details or Address Validation is made. Each session can have multiple Autocomplete queries, followed by one Place Details or Address Validation request. The credentials used for each request within a session must belong to the same Google Cloud Console project. Once a session has concluded, the token is no longer valid; your app must generate a fresh token for each session. If the `sessionToken` parameter is omitted, or if you reuse a session token, the session is charged as if no session token was provided (each request is billed separately). Note: Address Validation can only be used in sessions with the Autocomplete (New) API, not the Autocomplete API. See https://developers.google.com/maps/documentation/places/web-service/session-pricing for more details.",
-          "type": "string"
-        }
-      },
-      "type": "object"
-    },
-    "GoogleMapsAddressvalidationV1ValidateAddressResponse": {
-      "description": "The response to an address validation request.",
-      "id": "GoogleMapsAddressvalidationV1ValidateAddressResponse",
-      "properties": {
-        "responseId": {
-          "description": "The UUID that identifies this response. If the address needs to be re-validated, this UUID *must* accompany the new request.",
-          "type": "string"
-        },
-        "result": {
-          "$ref": "GoogleMapsAddressvalidationV1ValidationResult",
-          "description": "The result of the address validation."
-        }
-      },
-      "type": "object"
-    },
-    "GoogleMapsAddressvalidationV1ValidationResult": {
-      "description": "The result of validating an address.",
-      "id": "GoogleMapsAddressvalidationV1ValidationResult",
-      "properties": {
-        "address": {
-          "$ref": "GoogleMapsAddressvalidationV1Address",
-          "description": "Information about the address itself as opposed to the geocode."
-        },
-        "englishLatinAddress": {
-          "$ref": "GoogleMapsAddressvalidationV1Address",
-          "description": "Preview: This feature is in Preview (pre-GA). Pre-GA products and features might have limited support, and changes to pre-GA products and features might not be compatible with other pre-GA versions. Pre-GA Offerings are covered by the [Google Maps Platform Service Specific Terms](https://cloud.google.com/maps-platform/terms/maps-service-terms). For more information, see the [launch stage descriptions](https://developers.google.com/maps/launch-stages). The address translated to English. Translated addresses are not reusable as API input. The service provides them so that the user can use their native language to confirm or deny the validation of the originally-provided address. If part of the address doesn't have an English translation, the service returns that part in an alternate language that uses a Latin script. See [here](https://developers.google.com/maps/documentation/address-validation/convert-addresses-english) for an explanation of how the alternate language is selected. If part of the address doesn't have any translations or transliterations in a language that uses a Latin script, the service returns that part in the local language associated with the address. Enable this output by using the [google.maps.addressvalidation.v1.LanguageOptions.return_english_latin_address] flag. Note: the [google.maps.addressvalidation.v1.Address.unconfirmed_component_types] field in the `english_latin_address` and the [google.maps.addressvalidation.v1.AddressComponent.confirmation_level] fields in `english_latin_address.address_components` are not populated."
-        },
-        "geocode": {
-          "$ref": "GoogleMapsAddressvalidationV1Geocode",
-          "description": "Information about the location and place that the address geocoded to."
-        },
-        "metadata": {
-          "$ref": "GoogleMapsAddressvalidationV1AddressMetadata",
-          "description": "Other information relevant to deliverability. `metadata` is not guaranteed to be fully populated for every address sent to the Address Validation API."
-        },
-        "uspsData": {
-          "$ref": "GoogleMapsAddressvalidationV1UspsData",
-          "description": "Extra deliverability flags provided by USPS. Only provided in region `US` and `PR`."
-        },
-        "verdict": {
-          "$ref": "GoogleMapsAddressvalidationV1Verdict",
-          "description": "Overall verdict flags"
-        }
-      },
-      "type": "object"
-    },
-    "GoogleMapsAddressvalidationV1Verdict": {
-      "description": "High level overview of the address validation result and geocode.",
-      "id": "GoogleMapsAddressvalidationV1Verdict",
-      "properties": {
-        "addressComplete": {
-          "description": "The post-processed address is considered complete if there are no unresolved tokens, no unexpected or missing address components. If unset, indicates that the value is `false`. See `missing_component_types`, `unresolved_tokens` or `unexpected` fields for more details.",
-          "type": "boolean"
-        },
-        "geocodeGranularity": {
-          "description": "Information about the granularity of the `geocode`. This can be understood as the semantic meaning of how coarse or fine the geocoded location is. This can differ from the `validation_granularity` above occasionally. For example, our database might record the existence of an apartment number but do not have a precise location for the apartment within a big apartment complex. In that case, the `validation_granularity` will be `SUB_PREMISE` but the `geocode_granularity` will be `PREMISE`.",
-          "enum": [
-            "GRANULARITY_UNSPECIFIED",
-            "SUB_PREMISE",
-            "PREMISE",
-            "PREMISE_PROXIMITY",
-            "BLOCK",
-            "ROUTE",
-            "OTHER"
-          ],
-          "enumDescriptions": [
-            "Default value. This value is unused.",
-            "Below-building level result, such as an apartment.",
-            "Building-level result.",
-            "A geocode that approximates the building-level location of the address.",
-            "The address or geocode indicates a block. Only used in regions which have block-level addressing, such as Japan.",
-            "The geocode or address is granular to route, such as a street, road, or highway.",
-            "All other granularities, which are bucketed together since they are not deliverable."
-          ],
-          "type": "string"
-        },
-        "hasInferredComponents": {
-          "description": "At least one address component was inferred (added) that wasn't in the input, see [google.maps.addressvalidation.v1.Address.address_components] for details.",
-          "type": "boolean"
-        },
-        "hasReplacedComponents": {
-          "description": "At least one address component was replaced, see [google.maps.addressvalidation.v1.Address.address_components] for details.",
-          "type": "boolean"
-        },
-        "hasSpellCorrectedComponents": {
-          "description": "At least one address component was spell-corrected, see [google.maps.addressvalidation.v1.Address.address_components] for details.",
-          "type": "boolean"
-        },
-        "hasUnconfirmedComponents": {
-          "description": "At least one address component cannot be categorized or validated, see [google.maps.addressvalidation.v1.Address.address_components] for details.",
-          "type": "boolean"
-        },
-        "inputGranularity": {
-          "description": "The granularity of the **input** address. This is the result of parsing the input address and does not give any validation signals. For validation signals, refer to `validation_granularity` below. For example, if the input address includes a specific apartment number, then the `input_granularity` here will be `SUB_PREMISE`. If the address validation service cannot match the apartment number in the databases or the apartment number is invalid, the `validation_granularity` will likely be `PREMISE` or more coarse.",
-          "enum": [
-            "GRANULARITY_UNSPECIFIED",
-            "SUB_PREMISE",
-            "PREMISE",
-            "PREMISE_PROXIMITY",
-            "BLOCK",
-            "ROUTE",
-            "OTHER"
-          ],
-          "enumDescriptions": [
-            "Default value. This value is unused.",
-            "Below-building level result, such as an apartment.",
-            "Building-level result.",
-            "A geocode that approximates the building-level location of the address.",
-            "The address or geocode indicates a block. Only used in regions which have block-level addressing, such as Japan.",
-            "The geocode or address is granular to route, such as a street, road, or highway.",
-            "All other granularities, which are bucketed together since they are not deliverable."
-          ],
-          "type": "string"
-        },
-        "possibleNextAction": {
-          "description": "Preview: This feature is in Preview (pre-GA). Pre-GA products and features might have limited support, and changes to pre-GA products and features might not be compatible with other pre-GA versions. Pre-GA Offerings are covered by the [Google Maps Platform Service Specific Terms](https://cloud.google.com/maps-platform/terms/maps-service-terms). For more information, see the [launch stage descriptions](https://developers.google.com/maps/launch-stages). Offers an interpretive summary of the API response, intended to assist in determining a potential subsequent action to take. This field is derived from other fields in the API response and should not be considered as a guarantee of address accuracy or deliverability. See [Build your validation logic](https://developers.google.com/maps/documentation/address-validation/build-validation-logic) for more details.",
-          "enum": [
-            "POSSIBLE_NEXT_ACTION_UNSPECIFIED",
-            "FIX",
-            "CONFIRM_ADD_SUBPREMISES",
-            "CONFIRM",
-            "ACCEPT"
-          ],
-          "enumDescriptions": [
-            "Default value. This value is unused.",
-            "One or more fields of the API response indicate a potential issue with the post-processed address, for example the `verdict.validation_granularity` is `OTHER`. Prompting your customer to edit the address could help improve the quality of the address.",
-            "The API response indicates the post-processed address might be missing a subpremises. Prompting your customer to review the address and consider adding a unit number could help improve the quality of the address. The post-processed address might also have other minor issues. Note: this enum value can only be returned for US addresses.",
-            "One or more fields of the API response indicate potential minor issues with the post-processed address, for example the `postal_code` address component was `replaced`. Prompting your customer to review the address could help improve the quality of the address.",
-            "The API response does not contain signals that warrant one of the other PossibleNextAction values. You might consider using the post-processed address without further prompting your customer, though this does not guarantee the address is valid, and the address might still contain corrections. It is your responsibility to determine if and how to prompt your customer, depending on your own risk assessment."
-          ],
-          "type": "string"
-        },
-        "validationGranularity": {
-          "description": "The level of granularity for the post-processed address that the API can fully validate. For example, a `validation_granularity` of `PREMISE` indicates all address components at the level of `PREMISE` or more coarse can be validated. Per address component validation result can be found in [google.maps.addressvalidation.v1.Address.address_components].",
-          "enum": [
-            "GRANULARITY_UNSPECIFIED",
-            "SUB_PREMISE",
-            "PREMISE",
-            "PREMISE_PROXIMITY",
-            "BLOCK",
-            "ROUTE",
-            "OTHER"
-          ],
-          "enumDescriptions": [
-            "Default value. This value is unused.",
-            "Below-building level result, such as an apartment.",
-            "Building-level result.",
-            "A geocode that approximates the building-level location of the address.",
-            "The address or geocode indicates a block. Only used in regions which have block-level addressing, such as Japan.",
-            "The geocode or address is granular to route, such as a street, road, or highway.",
-            "All other granularities, which are bucketed together since they are not deliverable."
-          ],
-          "type": "string"
-        }
-      },
-      "type": "object"
-    },
-    "GoogleTypeLatLng": {
-      "description": "An object that represents a latitude/longitude pair. This is expressed as a pair of doubles to represent degrees latitude and degrees longitude. Unless specified otherwise, this object must conform to the WGS84 standard. Values must be within normalized ranges.",
-      "id": "GoogleTypeLatLng",
-      "properties": {
-        "latitude": {
-          "description": "The latitude in degrees. It must be in the range [-90.0, +90.0].",
-          "format": "double",
-          "type": "number"
-        },
-        "longitude": {
-          "description": "The longitude in degrees. It must be in the range [-180.0, +180.0].",
-          "format": "double",
-          "type": "number"
-        }
-      },
-      "type": "object"
-    },
-    "GoogleTypePostalAddress": {
-      "description": "Represents a postal address, such as for postal delivery or payments addresses. With a postal address, a postal service can deliver items to a premise, P.O. box, or similar. A postal address is not intended to model geographical locations like roads, towns, or mountains. In typical usage, an address would be created by user input or from importing existing data, depending on the type of process. Advice on address input or editing: - Use an internationalization-ready address widget such as https://github.com/google/libaddressinput. - Users should not be presented with UI elements for input or editing of fields outside countries where that field is used. For more guidance on how to use this schema, see: https://support.google.com/business/answer/6397478.",
-      "id": "GoogleTypePostalAddress",
-      "properties": {
-        "addressLines": {
-          "description": "Unstructured address lines describing the lower levels of an address. Because values in `address_lines` do not have type information and may sometimes contain multiple values in a single field (for example, \"Austin, TX\"), it is important that the line order is clear. The order of address lines should be \"envelope order\" for the country or region of the address. In places where this can vary (for example, Japan), `address_language` is used to make it explicit (for example, \"ja\" for large-to-small ordering and \"ja-Latn\" or \"en\" for small-to-large). In this way, the most specific line of an address can be selected based on the language. The minimum permitted structural representation of an address consists of a `region_code` with all remaining information placed in the `address_lines`. It would be possible to format such an address very approximately without geocoding, but no semantic reasoning could be made about any of the address components until it was at least partially resolved. Creating an address only containing a `region_code` and `address_lines` and then geocoding is the recommended way to handle completely unstructured addresses (as opposed to guessing which parts of the address should be localities or administrative areas).",
-          "items": {
-            "type": "string"
+          "postalAddress": {
+            "$ref": "#/components/schemas/GoogleTypePostalAddress"
           },
-          "type": "array"
-        },
-        "administrativeArea": {
-          "description": "Optional. Highest administrative subdivision which is used for postal addresses of a country or region. For example, this can be a state, a province, an oblast, or a prefecture. For Spain, this is the province and not the autonomous community (for example, \"Barcelona\" and not \"Catalonia\"). Many countries don't use an administrative area in postal addresses. For example, in Switzerland, this should be left unpopulated.",
-          "type": "string"
-        },
-        "languageCode": {
-          "description": "Optional. BCP-47 language code of the contents of this address (if known). This is often the UI language of the input form or is expected to match one of the languages used in the address' country/region, or their transliterated equivalents. This can affect formatting in certain countries, but is not critical to the correctness of the data and will never affect any validation or other non-formatting related operations. If this value is not known, it should be omitted (rather than specifying a possibly incorrect default). Examples: \"zh-Hant\", \"ja\", \"ja-Latn\", \"en\".",
-          "type": "string"
-        },
-        "locality": {
-          "description": "Optional. Generally refers to the city or town portion of the address. Examples: US city, IT comune, UK post town. In regions of the world where localities are not well defined or do not fit into this structure well, leave `locality` empty and use `address_lines`.",
-          "type": "string"
-        },
-        "organization": {
-          "description": "Optional. The name of the organization at the address.",
-          "type": "string"
-        },
-        "postalCode": {
-          "description": "Optional. Postal code of the address. Not all countries use or require postal codes to be present, but where they are used, they may trigger additional validation with other parts of the address (for example, state or zip code validation in the United States).",
-          "type": "string"
-        },
-        "recipients": {
-          "description": "Optional. The recipient at the address. This field may, under certain circumstances, contain multiline information. For example, it might contain \"care of\" information.",
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
-        "regionCode": {
-          "description": "Required. CLDR region code of the country/region of the address. This is never inferred and it is up to the user to ensure the value is correct. See https://cldr.unicode.org/ and https://www.unicode.org/cldr/charts/30/supplemental/territory_information.html for details. Example: \"CH\" for Switzerland.",
-          "type": "string"
-        },
-        "revision": {
-          "description": "The schema revision of the `PostalAddress`. This must be set to 0, which is the latest revision. All new revisions **must** be backward compatible with old revisions.",
-          "format": "int32",
-          "type": "integer"
-        },
-        "sortingCode": {
-          "description": "Optional. Additional, country-specific, sorting code. This is not used in most regions. Where it is used, the value is either a string like \"CEDEX\", optionally followed by a number (for example, \"CEDEX 7\"), or just a number alone, representing the \"sector code\" (Jamaica), \"delivery area indicator\" (Malawi) or \"post office indicator\" (Côte d'Ivoire).",
-          "type": "string"
-        },
-        "sublocality": {
-          "description": "Optional. Sublocality of the address. For example, this can be a neighborhood, borough, or district.",
-          "type": "string"
+          "unresolvedTokens": {
+            "type": "array",
+            "description": "Any tokens in the input that could not be resolved. This might be an input that was not recognized as a valid part of an address. For example, for an input such as \"Parcel 0000123123 & 0000456456 Str # Guthrie Center IA 50115 US\", the unresolved tokens might look like `[\"Parcel\", \"0000123123\", \"&\", \"0000456456\"]`.",
+            "items": {
+              "type": "string"
+            }
+          }
         }
       },
-      "type": "object"
+      "GoogleMapsAddressvalidationV1AddressComponent": {
+        "type": "object",
+        "description": "Represents an address component, such as a street, city, or state.",
+        "properties": {
+          "componentType": {
+            "type": "string",
+            "description": "The type of the address component. See [Table 2: Additional types returned by the Places service](https://developers.google.com/places/web-service/supported_types#table2) for a list of possible types."
+          },
+          "componentName": {
+            "$ref": "#/components/schemas/GoogleMapsAddressvalidationV1ComponentName"
+          },
+          "inferred": {
+            "type": "boolean",
+            "description": "Indicates that the component was not part of the input, but we inferred it for the address location and believe it should be provided for a complete address."
+          },
+          "replaced": {
+            "type": "boolean",
+            "description": "Indicates the name of the component was replaced with a completely different one, for example a wrong postal code being replaced with one that is correct for the address. This is not a cosmetic change, the input component has been changed to a different one."
+          },
+          "confirmationLevel": {
+            "type": "string",
+            "description": "Indicates the level of certainty that we have that the component is correct.",
+            "enum": [
+              "CONFIRMATION_LEVEL_UNSPECIFIED",
+              "CONFIRMED",
+              "UNCONFIRMED_BUT_PLAUSIBLE",
+              "UNCONFIRMED_AND_SUSPICIOUS"
+            ]
+          },
+          "spellCorrected": {
+            "type": "boolean",
+            "description": "Indicates a correction to a misspelling in the component name. The API does not always flag changes from one spelling variant to another, such as when changing \"centre\" to \"center\". It also does not always flag common misspellings, such as when changing \"Amphitheater Pkwy\" to \"Amphitheatre Pkwy\"."
+          },
+          "unexpected": {
+            "type": "boolean",
+            "description": "Indicates an address component that is not expected to be present in a postal address for the given region. We have retained it only because it was part of the input."
+          }
+        }
+      },
+      "GoogleMapsAddressvalidationV1AddressMetadata": {
+        "type": "object",
+        "description": "The metadata for the post-processed address. `metadata` is not guaranteed to be fully populated for every address sent to the Address Validation API.",
+        "properties": {
+          "poBox": {
+            "type": "boolean",
+            "description": "Indicates that the address of a PO box. If unset, indicates that the value is unknown."
+          },
+          "residential": {
+            "type": "boolean",
+            "description": "Indicates that this is the address of a residence. If unset, indicates that the value is unknown."
+          },
+          "business": {
+            "type": "boolean",
+            "description": "Indicates that this is the address of a business. If unset, indicates that the value is unknown."
+          }
+        }
+      },
+      "GoogleMapsAddressvalidationV1ComponentName": {
+        "type": "object",
+        "description": "A wrapper for the name of the component.",
+        "properties": {
+          "languageCode": {
+            "type": "string",
+            "description": "The BCP-47 language code. This will not be present if the component name is not associated with a language, such as a street number."
+          },
+          "text": {
+            "type": "string",
+            "description": "The name text. For example, \"5th Avenue\" for a street name or \"1253\" for a street number."
+          }
+        }
+      },
+      "GoogleMapsAddressvalidationV1Geocode": {
+        "type": "object",
+        "description": "Contains information about the place the input was geocoded to.",
+        "properties": {
+          "location": {
+            "$ref": "#/components/schemas/GoogleTypeLatLng"
+          },
+          "featureSizeMeters": {
+            "type": "number",
+            "format": "float",
+            "description": "The size of the geocoded place, in meters. This is another measure of the coarseness of the geocoded location, but in physical size rather than in semantic meaning."
+          },
+          "placeTypes": {
+            "type": "array",
+            "description": "The type(s) of place that the input geocoded to. For example, `['locality', 'political']`. The full list of types can be found [here](https://developers.google.com/maps/documentation/geocoding/requests-geocoding#Types).",
+            "items": {
+              "type": "string"
+            }
+          },
+          "bounds": {
+            "$ref": "#/components/schemas/GoogleGeoTypeViewport"
+          },
+          "plusCode": {
+            "$ref": "#/components/schemas/GoogleMapsAddressvalidationV1PlusCode"
+          },
+          "placeId": {
+            "type": "string",
+            "description": "The PlaceID of the place this input geocodes to. For more information about Place IDs see [here](https://developers.google.com/maps/documentation/places/web-service/place-id)."
+          }
+        }
+      },
+      "GoogleMapsAddressvalidationV1LanguageOptions": {
+        "type": "object",
+        "description": "Preview: This feature is in Preview (pre-GA). Pre-GA products and features might have limited support, and changes to pre-GA products and features might not be compatible with other pre-GA versions. Pre-GA Offerings are covered by the [Google Maps Platform Service Specific Terms](https://cloud.google.com/maps-platform/terms/maps-service-terms). For more information, see the [launch stage descriptions](https://developers.google.com/maps/launch-stages). Enables the Address Validation API to include additional information in the response.",
+        "properties": {
+          "returnEnglishLatinAddress": {
+            "type": "boolean",
+            "description": "Preview: Return a [google.maps.addressvalidation.v1.Address] in English. See [google.maps.addressvalidation.v1.ValidationResult.english_latin_address] for details."
+          }
+        }
+      },
+      "GoogleMapsAddressvalidationV1PlusCode": {
+        "type": "object",
+        "description": "Plus code (http://plus.codes) is a location reference with two formats: global code defining a 14mx14m (1/8000th of a degree) or smaller rectangle, and compound code, replacing the prefix with a reference location.",
+        "properties": {
+          "globalCode": {
+            "type": "string",
+            "description": "Place's global (full) code, such as \"9FWM33GV+HQ\", representing an 1/8000 by 1/8000 degree area (~14 by 14 meters)."
+          },
+          "compoundCode": {
+            "type": "string",
+            "description": "Place's compound code, such as \"33GV+HQ, Ramberg, Norway\", containing the suffix of the global code and replacing the prefix with a formatted name of a reference entity."
+          }
+        }
+      },
+      "GoogleMapsAddressvalidationV1UspsAddress": {
+        "type": "object",
+        "description": "USPS representation of a US address.",
+        "properties": {
+          "firm": {
+            "type": "string",
+            "description": "Firm name."
+          },
+          "cityStateZipAddressLine": {
+            "type": "string",
+            "description": "City + state + postal code."
+          },
+          "zipCodeExtension": {
+            "type": "string",
+            "description": "4-digit postal code extension e.g. 5023."
+          },
+          "state": {
+            "type": "string",
+            "description": "2 letter state code."
+          },
+          "zipCode": {
+            "type": "string",
+            "description": "Postal code e.g. 10009."
+          },
+          "firstAddressLine": {
+            "type": "string",
+            "description": "First address line."
+          },
+          "urbanization": {
+            "type": "string",
+            "description": "Puerto Rican urbanization name."
+          },
+          "secondAddressLine": {
+            "type": "string",
+            "description": "Second address line."
+          },
+          "city": {
+            "type": "string",
+            "description": "City name."
+          }
+        }
+      },
+      "GoogleMapsAddressvalidationV1UspsData": {
+        "type": "object",
+        "description": "The USPS data for the address. `uspsData` is not guaranteed to be fully populated for every US or PR address sent to the Address Validation API. It's recommended to integrate the backup address fields in the response if you utilize uspsData as the primary part of the response.",
+        "properties": {
+          "addressRecordType": {
+            "type": "string",
+            "description": "Type of the address record that matches the input address. * `F`: FIRM. This is a match to a Firm Record, which is the finest level of match available for an address. * `G`: GENERAL DELIVERY. This is a match to a General Delivery record. * `H`: BUILDING / APARTMENT. This is a match to a Building or Apartment record. * `P`: POST OFFICE BOX. This is a match to a Post Office Box. * `R`: RURAL ROUTE or HIGHWAY CONTRACT: This is a match to either a Rural Route or a Highway Contract record, both of which may have associated Box Number ranges. * `S`: STREET RECORD: This is a match to a Street record containing a valid primary number range."
+          },
+          "deliveryPointCheckDigit": {
+            "type": "string",
+            "description": "The delivery point check digit. This number is added to the end of the delivery_point_barcode for mechanically scanned mail. Adding all the digits of the delivery_point_barcode, delivery_point_check_digit, postal code, and ZIP+4 together should yield a number divisible by 10."
+          },
+          "dpvDoorNotAccessible": {
+            "type": "string",
+            "description": "Flag indicates addresses where USPS cannot knock on a door to deliver mail. Returns a single character. * `Y`: The door is not accessible. * `N`: No indication the door is not accessible."
+          },
+          "poBoxOnlyPostalCode": {
+            "type": "boolean",
+            "description": "PO Box only postal code."
+          },
+          "elotNumber": {
+            "type": "string",
+            "description": "Enhanced Line of Travel (eLOT) number."
+          },
+          "carrierRouteIndicator": {
+            "type": "string",
+            "description": "Carrier route rate sort indicator."
+          },
+          "suitelinkFootnote": {
+            "type": "string",
+            "description": "Footnotes from matching a street or highrise record to suite information. If business name match is found, the secondary number is returned. * `A`: SuiteLink record match, business address improved. * `00`: No match, business address is not improved."
+          },
+          "carrierRoute": {
+            "type": "string",
+            "description": "The carrier route code. A four character code consisting of a one letter prefix and a three digit route designator. Prefixes: * `C`: Carrier route (or city route) * `R`: Rural route * `H`: Highway Contract Route * `B`: Post Office Box Section * `G`: General delivery unit"
+          },
+          "county": {
+            "type": "string",
+            "description": "County name."
+          },
+          "cassProcessed": {
+            "type": "boolean",
+            "description": "Indicator that the request has been CASS processed."
+          },
+          "pmbNumber": {
+            "type": "string",
+            "description": "PMB (Private Mail Box) number;"
+          },
+          "dpvFootnote": {
+            "type": "string",
+            "description": "The footnotes from delivery point validation. Multiple footnotes may be strung together in the same string. * `AA`: Input address matched to the ZIP+4 file * `A1`: Input address was not matched to the ZIP+4 file * `BB`: Matched to DPV (all components) * `CC`: Secondary number not matched and not required * `C1`: Secondary number not matched but required * `N1`: High-rise address missing secondary number * `M1`: Primary number missing * `M3`: Primary number invalid * `P1`: Input address PO, RR or HC box number missing * `P3`: Input address PO, RR, or HC Box number invalid * `F1`: Input address matched to a military address * `G1`: Input address matched to a general delivery address * `U1`: Input address matched to a unique ZIP code * `PB`: Input address matched to PBSA record * `RR`: DPV confirmed address with PMB information * `R1`: DPV confirmed address without PMB information * `R7`: Carrier Route R777 or R779 record * `IA`: Informed Address identified * `TA`: Primary number matched by dropping a trailing alpha"
+          },
+          "abbreviatedCity": {
+            "type": "string",
+            "description": "Abbreviated city."
+          },
+          "elotFlag": {
+            "type": "string",
+            "description": "eLOT Ascending/Descending Flag (A/D)."
+          },
+          "dpvVacant": {
+            "type": "string",
+            "description": "Is this place vacant? Returns a single character. * `Y`: The address is vacant * `N`: The address is not vacant"
+          },
+          "dpvThrowback": {
+            "type": "string",
+            "description": "Indicates that mail is not delivered to the street address. Returns a single character. * `Y`: The mail is not delivered to the street address. * `N`: The mail is delivered to the street address."
+          },
+          "pmbDesignator": {
+            "type": "string",
+            "description": "PMB (Private Mail Box) unit designator."
+          },
+          "lacsLinkIndicator": {
+            "type": "string",
+            "description": "LACSLink indicator."
+          },
+          "dpvNonDeliveryDays": {
+            "type": "string",
+            "description": "Flag indicates mail delivery is not performed every day of the week. Returns a single character. * `Y`: The mail delivery is not performed every day of the week. * `N`: No indication the mail delivery is not performed every day of the week."
+          },
+          "dpvNoSecureLocation": {
+            "type": "string",
+            "description": "Flag indicates door is accessible, but package will not be left due to security concerns. Returns a single character. * `Y`: The package will not be left due to security concerns. * `N`: No indication the package will not be left due to security concerns."
+          },
+          "dpvDrop": {
+            "type": "string",
+            "description": "Flag indicates mail is delivered to a single receptable at a site. Returns a single character. * `Y`: The mail is delivered to a single receptable at a site. * `N`: The mail is not delivered to a single receptable at a site."
+          },
+          "fipsCountyCode": {
+            "type": "string",
+            "description": "FIPS county code."
+          },
+          "deliveryPointCode": {
+            "type": "string",
+            "description": "2 digit delivery point code"
+          },
+          "standardizedAddress": {
+            "$ref": "#/components/schemas/GoogleMapsAddressvalidationV1UspsAddress"
+          },
+          "dpvCmra": {
+            "type": "string",
+            "description": "Indicates if the address is a CMRA (Commercial Mail Receiving Agency)--a private business receiving mail for clients. Returns a single character. * `Y`: The address is a CMRA * `N`: The address is not a CMRA"
+          },
+          "dpvNonDeliveryDaysValues": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Integer identifying non-delivery days. It can be interrogated using bit flags: 0x40 \u2013 Sunday is a non-delivery day 0x20 \u2013 Monday is a non-delivery day 0x10 \u2013 Tuesday is a non-delivery day 0x08 \u2013 Wednesday is a non-delivery day 0x04 \u2013 Thursday is a non-delivery day 0x02 \u2013 Friday is a non-delivery day 0x01 \u2013 Saturday is a non-delivery day"
+          },
+          "defaultAddress": {
+            "type": "boolean",
+            "description": "Indicator that a default address was found, but more specific addresses exists."
+          },
+          "dpvNoStat": {
+            "type": "string",
+            "description": "Is this a no stat address or an active address? No stat addresses are ones which are not continuously occupied or addresses that the USPS does not service. Returns a single character. * `Y`: The address is not active * `N`: The address is active"
+          },
+          "dpvPbsa": {
+            "type": "string",
+            "description": "Indicates the address was matched to PBSA record. Returns a single character. * `Y`: The address was matched to PBSA record. * `N`: The address was not matched to PBSA record."
+          },
+          "postOfficeCity": {
+            "type": "string",
+            "description": "Main post office city."
+          },
+          "ewsNoMatch": {
+            "type": "boolean",
+            "description": "The delivery address is matchable, but the EWS file indicates that an exact match will be available soon."
+          },
+          "dpvConfirmation": {
+            "type": "string",
+            "description": "The possible values for DPV confirmation. Returns a single character or returns no value. * `N`: Primary and any secondary number information failed to DPV confirm. * `D`: Address was DPV confirmed for the primary number only, and the secondary number information was missing. * `S`: Address was DPV confirmed for the primary number only, and the secondary number information was present but not confirmed. * `Y`: Address was DPV confirmed for primary and any secondary numbers. * Empty: If the response does not contain a `dpv_confirmation` value, the address was not submitted for DPV confirmation."
+          },
+          "dpvNoStatReasonCode": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Indicates the NoStat type. Returns a reason code as int. * `1`: IDA (Internal Drop Address) \u2013 Addresses that do not receive mail directly from the USPS but are delivered to a drop address that services them. * `2`: CDS - Addresses that have not yet become deliverable. For example, a new subdivision where lots and primary numbers have been determined, but no structure exists yet for occupancy. * `3`: Collision - Addresses that do not actually DPV confirm. * `4`: CMZ (College, Military and Other Types) - ZIP + 4 records USPS has incorporated into the data. * `5`: Regular - Indicates addresses not receiving delivery and the addresses are not counted as possible deliveries. * `6`: Secondary Required - The address requires secondary information."
+          },
+          "postOfficeState": {
+            "type": "string",
+            "description": "Main post office state."
+          },
+          "errorMessage": {
+            "type": "string",
+            "description": "Error message for USPS data retrieval. This is populated when USPS processing is suspended because of the detection of artificially created addresses. The USPS data fields might not be populated when this error is present."
+          },
+          "dpvEnhancedDeliveryCode": {
+            "type": "string",
+            "description": "Indicates that more than one DPV return code is valid for the address. Returns a single character. * `Y`: Address was DPV confirmed for primary and any secondary numbers. * `N`: Primary and any secondary number information failed to DPV confirm. * `S`: Address was DPV confirmed for the primary number only, and the secondary number information was present but not confirmed, or a single trailing alpha on a primary number was dropped to make a DPV match and secondary information required. * `D`: Address was DPV confirmed for the primary number only, and the secondary number information was missing. * `R`: Address confirmed but assigned to phantom route R777 and R779 and USPS delivery is not provided."
+          },
+          "lacsLinkReturnCode": {
+            "type": "string",
+            "description": "LACSLink return code."
+          }
+        }
+      },
+      "GoogleMapsAddressvalidationV1ValidateAddressRequest": {
+        "type": "object",
+        "description": "The request for validating an address.",
+        "properties": {
+          "previousResponseId": {
+            "type": "string",
+            "description": "This field must be empty for the first address validation request. If more requests are necessary to fully validate a single address (for example if the changes the user makes after the initial validation need to be re-validated), then each followup request must populate this field with the response_id from the very first response in the validation sequence."
+          },
+          "languageOptions": {
+            "$ref": "#/components/schemas/GoogleMapsAddressvalidationV1LanguageOptions"
+          },
+          "sessionToken": {
+            "type": "string",
+            "description": "Optional. A string which identifies an Autocomplete session for billing purposes. Must be a URL and filename safe base64 string with at most 36 ASCII characters in length. Otherwise an INVALID_ARGUMENT error is returned. The session begins when the user makes an Autocomplete query, and concludes when they select a place and a call to Place Details or Address Validation is made. Each session can have multiple Autocomplete queries, followed by one Place Details or Address Validation request. The credentials used for each request within a session must belong to the same Google Cloud Console project. Once a session has concluded, the token is no longer valid; your app must generate a fresh token for each session. If the `sessionToken` parameter is omitted, or if you reuse a session token, the session is charged as if no session token was provided (each request is billed separately). Note: Address Validation can only be used in sessions with the Autocomplete (New) API, not the Autocomplete API. See https://developers.google.com/maps/documentation/places/web-service/session-pricing for more details."
+          },
+          "enableUspsCass": {
+            "type": "boolean",
+            "description": "Enables USPS CASS compatible mode. This affects _only_ the [google.maps.addressvalidation.v1.ValidationResult.usps_data] field of [google.maps.addressvalidation.v1.ValidationResult]. Note: for USPS CASS enabled requests for addresses in Puerto Rico, a [google.type.PostalAddress.region_code] of the `address` must be provided as \"PR\", or an [google.type.PostalAddress.administrative_area] of the `address` must be provided as \"Puerto Rico\" (case-insensitive) or \"PR\". It's recommended to use a componentized `address`, or alternatively specify at least two [google.type.PostalAddress.address_lines] where the first line contains the street number and name and the second line contains the city, state, and zip code."
+          },
+          "address": {
+            "$ref": "#/components/schemas/GoogleTypePostalAddress"
+          }
+        }
+      },
+      "GoogleMapsAddressvalidationV1ValidateAddressResponse": {
+        "type": "object",
+        "description": "The response to an address validation request.",
+        "properties": {
+          "result": {
+            "$ref": "#/components/schemas/GoogleMapsAddressvalidationV1ValidationResult"
+          },
+          "responseId": {
+            "type": "string",
+            "description": "The UUID that identifies this response. If the address needs to be re-validated, this UUID *must* accompany the new request."
+          }
+        }
+      },
+      "GoogleMapsAddressvalidationV1ValidationResult": {
+        "type": "object",
+        "description": "The result of validating an address.",
+        "properties": {
+          "geocode": {
+            "$ref": "#/components/schemas/GoogleMapsAddressvalidationV1Geocode"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/GoogleMapsAddressvalidationV1AddressMetadata"
+          },
+          "englishLatinAddress": {
+            "$ref": "#/components/schemas/GoogleMapsAddressvalidationV1Address"
+          },
+          "address": {
+            "$ref": "#/components/schemas/GoogleMapsAddressvalidationV1Address"
+          },
+          "uspsData": {
+            "$ref": "#/components/schemas/GoogleMapsAddressvalidationV1UspsData"
+          },
+          "verdict": {
+            "$ref": "#/components/schemas/GoogleMapsAddressvalidationV1Verdict"
+          }
+        }
+      },
+      "GoogleMapsAddressvalidationV1Verdict": {
+        "type": "object",
+        "description": "High level overview of the address validation result and geocode.",
+        "properties": {
+          "addressComplete": {
+            "type": "boolean",
+            "description": "The post-processed address is considered complete if there are no unresolved tokens, no unexpected or missing address components. If unset, indicates that the value is `false`. See `missing_component_types`, `unresolved_tokens` or `unexpected` fields for more details."
+          },
+          "geocodeGranularity": {
+            "type": "string",
+            "description": "Information about the granularity of the `geocode`. This can be understood as the semantic meaning of how coarse or fine the geocoded location is. This can differ from the `validation_granularity` above occasionally. For example, our database might record the existence of an apartment number but do not have a precise location for the apartment within a big apartment complex. In that case, the `validation_granularity` will be `SUB_PREMISE` but the `geocode_granularity` will be `PREMISE`.",
+            "enum": [
+              "GRANULARITY_UNSPECIFIED",
+              "SUB_PREMISE",
+              "PREMISE",
+              "PREMISE_PROXIMITY",
+              "BLOCK",
+              "ROUTE",
+              "OTHER"
+            ]
+          },
+          "hasUnconfirmedComponents": {
+            "type": "boolean",
+            "description": "At least one address component cannot be categorized or validated, see [google.maps.addressvalidation.v1.Address.address_components] for details."
+          },
+          "hasInferredComponents": {
+            "type": "boolean",
+            "description": "At least one address component was inferred (added) that wasn't in the input, see [google.maps.addressvalidation.v1.Address.address_components] for details."
+          },
+          "hasReplacedComponents": {
+            "type": "boolean",
+            "description": "At least one address component was replaced, see [google.maps.addressvalidation.v1.Address.address_components] for details."
+          },
+          "hasSpellCorrectedComponents": {
+            "type": "boolean",
+            "description": "At least one address component was spell-corrected, see [google.maps.addressvalidation.v1.Address.address_components] for details."
+          },
+          "validationGranularity": {
+            "type": "string",
+            "description": "The level of granularity for the post-processed address that the API can fully validate. For example, a `validation_granularity` of `PREMISE` indicates all address components at the level of `PREMISE` or more coarse can be validated. Per address component validation result can be found in [google.maps.addressvalidation.v1.Address.address_components].",
+            "enum": [
+              "GRANULARITY_UNSPECIFIED",
+              "SUB_PREMISE",
+              "PREMISE",
+              "PREMISE_PROXIMITY",
+              "BLOCK",
+              "ROUTE",
+              "OTHER"
+            ]
+          },
+          "possibleNextAction": {
+            "type": "string",
+            "description": "Preview: This feature is in Preview (pre-GA). Pre-GA products and features might have limited support, and changes to pre-GA products and features might not be compatible with other pre-GA versions. Pre-GA Offerings are covered by the [Google Maps Platform Service Specific Terms](https://cloud.google.com/maps-platform/terms/maps-service-terms). For more information, see the [launch stage descriptions](https://developers.google.com/maps/launch-stages). Offers an interpretive summary of the API response, intended to assist in determining a potential subsequent action to take. This field is derived from other fields in the API response and should not be considered as a guarantee of address accuracy or deliverability. See [Build your validation logic](https://developers.google.com/maps/documentation/address-validation/build-validation-logic) for more details.",
+            "enum": [
+              "POSSIBLE_NEXT_ACTION_UNSPECIFIED",
+              "FIX",
+              "CONFIRM_ADD_SUBPREMISES",
+              "CONFIRM",
+              "ACCEPT"
+            ]
+          },
+          "inputGranularity": {
+            "type": "string",
+            "description": "The granularity of the **input** address. This is the result of parsing the input address and does not give any validation signals. For validation signals, refer to `validation_granularity` below. For example, if the input address includes a specific apartment number, then the `input_granularity` here will be `SUB_PREMISE`. If the address validation service cannot match the apartment number in the databases or the apartment number is invalid, the `validation_granularity` will likely be `PREMISE` or more coarse.",
+            "enum": [
+              "GRANULARITY_UNSPECIFIED",
+              "SUB_PREMISE",
+              "PREMISE",
+              "PREMISE_PROXIMITY",
+              "BLOCK",
+              "ROUTE",
+              "OTHER"
+            ]
+          }
+        }
+      },
+      "GoogleTypeLatLng": {
+        "type": "object",
+        "description": "An object that represents a latitude/longitude pair. This is expressed as a pair of doubles to represent degrees latitude and degrees longitude. Unless specified otherwise, this object must conform to the WGS84 standard. Values must be within normalized ranges.",
+        "properties": {
+          "latitude": {
+            "type": "number",
+            "format": "double",
+            "description": "The latitude in degrees. It must be in the range [-90.0, +90.0]."
+          },
+          "longitude": {
+            "type": "number",
+            "format": "double",
+            "description": "The longitude in degrees. It must be in the range [-180.0, +180.0]."
+          }
+        }
+      },
+      "GoogleTypePostalAddress": {
+        "type": "object",
+        "description": "Represents a postal address, such as for postal delivery or payments addresses. With a postal address, a postal service can deliver items to a premise, P.O. box, or similar. A postal address is not intended to model geographical locations like roads, towns, or mountains. In typical usage, an address would be created by user input or from importing existing data, depending on the type of process. Advice on address input or editing: - Use an internationalization-ready address widget such as https://github.com/google/libaddressinput. - Users should not be presented with UI elements for input or editing of fields outside countries where that field is used. For more guidance on how to use this schema, see: https://support.google.com/business/answer/6397478.",
+        "properties": {
+          "addressLines": {
+            "type": "array",
+            "description": "Unstructured address lines describing the lower levels of an address. Because values in `address_lines` do not have type information and may sometimes contain multiple values in a single field (for example, \"Austin, TX\"), it is important that the line order is clear. The order of address lines should be \"envelope order\" for the country or region of the address. In places where this can vary (for example, Japan), `address_language` is used to make it explicit (for example, \"ja\" for large-to-small ordering and \"ja-Latn\" or \"en\" for small-to-large). In this way, the most specific line of an address can be selected based on the language. The minimum permitted structural representation of an address consists of a `region_code` with all remaining information placed in the `address_lines`. It would be possible to format such an address very approximately without geocoding, but no semantic reasoning could be made about any of the address components until it was at least partially resolved. Creating an address only containing a `region_code` and `address_lines` and then geocoding is the recommended way to handle completely unstructured addresses (as opposed to guessing which parts of the address should be localities or administrative areas).",
+            "items": {
+              "type": "string"
+            }
+          },
+          "languageCode": {
+            "type": "string",
+            "description": "Optional. BCP-47 language code of the contents of this address (if known). This is often the UI language of the input form or is expected to match one of the languages used in the address' country/region, or their transliterated equivalents. This can affect formatting in certain countries, but is not critical to the correctness of the data and will never affect any validation or other non-formatting related operations. If this value is not known, it should be omitted (rather than specifying a possibly incorrect default). Examples: \"zh-Hant\", \"ja\", \"ja-Latn\", \"en\"."
+          },
+          "sortingCode": {
+            "type": "string",
+            "description": "Optional. Additional, country-specific, sorting code. This is not used in most regions. Where it is used, the value is either a string like \"CEDEX\", optionally followed by a number (for example, \"CEDEX 7\"), or just a number alone, representing the \"sector code\" (Jamaica), \"delivery area indicator\" (Malawi) or \"post office indicator\" (C\u00f4te d'Ivoire)."
+          },
+          "regionCode": {
+            "type": "string",
+            "description": "Required. CLDR region code of the country/region of the address. This is never inferred and it is up to the user to ensure the value is correct. See https://cldr.unicode.org/ and https://www.unicode.org/cldr/charts/30/supplemental/territory_information.html for details. Example: \"CH\" for Switzerland."
+          },
+          "administrativeArea": {
+            "type": "string",
+            "description": "Optional. Highest administrative subdivision which is used for postal addresses of a country or region. For example, this can be a state, a province, an oblast, or a prefecture. For Spain, this is the province and not the autonomous community (for example, \"Barcelona\" and not \"Catalonia\"). Many countries don't use an administrative area in postal addresses. For example, in Switzerland, this should be left unpopulated."
+          },
+          "postalCode": {
+            "type": "string",
+            "description": "Optional. Postal code of the address. Not all countries use or require postal codes to be present, but where they are used, they may trigger additional validation with other parts of the address (for example, state or zip code validation in the United States)."
+          },
+          "organization": {
+            "type": "string",
+            "description": "Optional. The name of the organization at the address."
+          },
+          "recipients": {
+            "type": "array",
+            "description": "Optional. The recipient at the address. This field may, under certain circumstances, contain multiline information. For example, it might contain \"care of\" information.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "revision": {
+            "type": "integer",
+            "format": "int32",
+            "description": "The schema revision of the `PostalAddress`. This must be set to 0, which is the latest revision. All new revisions **must** be backward compatible with old revisions."
+          },
+          "locality": {
+            "type": "string",
+            "description": "Optional. Generally refers to the city or town portion of the address. Examples: US city, IT comune, UK post town. In regions of the world where localities are not well defined or do not fit into this structure well, leave `locality` empty and use `address_lines`."
+          },
+          "sublocality": {
+            "type": "string",
+            "description": "Optional. Sublocality of the address. For example, this can be a neighborhood, borough, or district."
+          }
+        }
+      }
     }
-  },
-  "servicePath": "",
-  "title": "Address Validation API",
-  "version": "v1",
-  "version_module": true
+  }
 }

--- a/providers/solana-foundation/google/airquality/openapi.json
+++ b/providers/solana-foundation/google/airquality/openapi.json
@@ -1,229 +1,164 @@
 {
-  "openapi": "3.0.0",
-  "paths": {},
-  "basePath": "",
-  "baseUrl": "https://airquality.google.gateway-402.com/",
-  "batchPath": "batch",
-  "canonicalName": "Air Quality",
-  "description": "The Air Quality API.",
-  "discoveryVersion": "v1",
-  "documentationLink": "https://developers.google.com/maps/documentation/air-quality",
-  "fullyEncodeReservedExpansion": true,
-  "icons": {
-    "x16": "http://www.google.com/images/icons/product/search-16.gif",
-    "x32": "http://www.google.com/images/icons/product/search-32.gif"
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Air Quality API",
+    "description": "Look up current, historical, and forecast air quality for global coordinates. Returns AQI, pollutant concentrations (PM2.5, PM10, O3, NO2, SO2, CO), health recommendations, local indexes, and heatmap tiles for maps.",
+    "version": "v1"
   },
-  "id": "airquality:v1",
-  "kind": "discovery#restDescription",
-  "mtlsRootUrl": "https://airquality.google.gateway-402.com/",
-  "name": "airquality",
-  "ownerDomain": "google.com",
-  "ownerName": "Google",
-  "parameters": {
-    "$.xgafv": {
-      "description": "V1 error format.",
-      "enum": [
-        "1",
-        "2"
-      ],
-      "enumDescriptions": [
-        "v1 error format",
-        "v2 error format"
-      ],
-      "location": "query",
-      "type": "string"
-    },
-    "access_token": {
-      "description": "OAuth access token.",
-      "location": "query",
-      "type": "string"
-    },
-    "alt": {
-      "default": "json",
-      "description": "Data format for response.",
-      "enum": [
-        "json",
-        "media",
-        "proto"
-      ],
-      "enumDescriptions": [
-        "Responses with Content-Type of application/json",
-        "Media download with context-dependent Content-Type",
-        "Responses with Content-Type of application/x-protobuf"
-      ],
-      "location": "query",
-      "type": "string"
-    },
-    "callback": {
-      "description": "JSONP",
-      "location": "query",
-      "type": "string"
-    },
-    "fields": {
-      "description": "Selector specifying which fields to include in a partial response.",
-      "location": "query",
-      "type": "string"
-    },
-    "key": {
-      "description": "API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.",
-      "location": "query",
-      "type": "string"
-    },
-    "oauth_token": {
-      "description": "OAuth 2.0 token for the current user.",
-      "location": "query",
-      "type": "string"
-    },
-    "prettyPrint": {
-      "default": "true",
-      "description": "Returns response with indentations and line breaks.",
-      "location": "query",
-      "type": "boolean"
-    },
-    "quotaUser": {
-      "description": "Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.",
-      "location": "query",
-      "type": "string"
-    },
-    "uploadType": {
-      "description": "Legacy upload protocol for media (e.g. \"media\", \"multipart\").",
-      "location": "query",
-      "type": "string"
-    },
-    "upload_protocol": {
-      "description": "Upload protocol for media (e.g. \"raw\", \"multipart\").",
-      "location": "query",
-      "type": "string"
+  "servers": [
+    {
+      "url": "https://airquality.google.gateway-402.com"
     }
-  },
-  "protocol": "rest",
-  "resources": {
-    "currentConditions": {
-      "methods": {
-        "lookup": {
-          "description": "The Current Conditions endpoint provides hourly air quality",
-          "flatPath": "v1/currentConditions:lookup",
-          "httpMethod": "POST",
-          "id": "airquality.currentConditions.lookup",
-          "parameterOrder": [],
-          "parameters": {},
-          "path": "v1/currentConditions:lookup",
-          "request": {
-            "$ref": "LookupCurrentConditionsRequest"
-          },
-          "response": {
-            "$ref": "LookupCurrentConditionsResponse"
+  ],
+  "paths": {
+    "/v1/currentConditions:lookup": {
+      "post": {
+        "operationId": "airquality.currentConditions.lookup",
+        "summary": "The Current Conditions endpoint provides hourly air quality",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LookupCurrentConditionsRequest"
+              }
+            }
           }
-        }
-      }
-    },
-    "forecast": {
-      "methods": {
-        "lookup": {
-          "description": "Returns air quality forecast for a specific location for a",
-          "flatPath": "v1/forecast:lookup",
-          "httpMethod": "POST",
-          "id": "airquality.forecast.lookup",
-          "parameterOrder": [],
-          "parameters": {},
-          "path": "v1/forecast:lookup",
-          "request": {
-            "$ref": "LookupForecastRequest"
-          },
-          "response": {
-            "$ref": "LookupForecastResponse"
-          }
-        }
-      }
-    },
-    "history": {
-      "methods": {
-        "lookup": {
-          "description": "Returns air quality history for a specific location for a",
-          "flatPath": "v1/history:lookup",
-          "httpMethod": "POST",
-          "id": "airquality.history.lookup",
-          "parameterOrder": [],
-          "parameters": {},
-          "path": "v1/history:lookup",
-          "request": {
-            "$ref": "LookupHistoryRequest"
-          },
-          "response": {
-            "$ref": "LookupHistoryResponse"
-          }
-        }
-      }
-    },
-    "mapTypes": {
-      "resources": {
-        "heatmapTiles": {
-          "methods": {
-            "lookupHeatmapTile": {
-              "description": "Returns a bytes array containing the data of the tile PNG image",
-              "flatPath": "v1/mapTypes/{mapType}/heatmapTiles/{zoom}/{x}/{y}",
-              "httpMethod": "GET",
-              "id": "airquality.mapTypes.heatmapTiles.lookupHeatmapTile",
-              "parameterOrder": [
-                "mapType",
-                "zoom",
-                "x",
-                "y"
-              ],
-              "parameters": {
-                "mapType": {
-                  "description": "Required. The type of the air quality heatmap. Defines the pollutant that the map will graphically represent. Allowed values: - UAQI_RED_GREEN (UAQI, red-green palette) - UAQI_INDIGO_PERSIAN (UAQI, indigo-persian palette) - PM25_INDIGO_PERSIAN - GBR_DEFRA - DEU_UBA - CAN_EC - FRA_ATMO - US_AQI",
-                  "enum": [
-                    "MAP_TYPE_UNSPECIFIED",
-                    "UAQI_RED_GREEN",
-                    "UAQI_INDIGO_PERSIAN",
-                    "PM25_INDIGO_PERSIAN",
-                    "GBR_DEFRA",
-                    "DEU_UBA",
-                    "CAN_EC",
-                    "FRA_ATMO",
-                    "US_AQI"
-                  ],
-                  "enumDescriptions": [
-                    "The default value. The server ignores it if it is passed as a parameter.",
-                    "Universal Air Quality Index red-green palette.",
-                    "Universal Air Quality Index indigo-persian palette.",
-                    "PM2.5 index indigo-persian palette.",
-                    "Daily Air Quality Index (UK) color palette.",
-                    "German Local Air Quality Index color palette.",
-                    "Canadian Air Quality Health Index color palette.",
-                    "France Air Quality Index color palette.",
-                    "US Air Quality Index color palette."
-                  ],
-                  "location": "path",
-                  "required": true,
-                  "type": "string"
-                },
-                "x": {
-                  "description": "Required. Defines the east-west point in the requested tile.",
-                  "format": "int32",
-                  "location": "path",
-                  "required": true,
-                  "type": "integer"
-                },
-                "y": {
-                  "description": "Required. Defines the north-south point in the requested tile.",
-                  "format": "int32",
-                  "location": "path",
-                  "required": true,
-                  "type": "integer"
-                },
-                "zoom": {
-                  "description": "Required. The map's zoom level. Defines how large or small the contents of a map appear in a map view. Zoom level 0 is the entire world in a single tile. Zoom level 1 is the entire world in 4 tiles. Zoom level 2 is the entire world in 16 tiles. Zoom level 16 is the entire world in 65,536 tiles. Allowed values: 0-16",
-                  "format": "int32",
-                  "location": "path",
-                  "required": true,
-                  "type": "integer"
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LookupCurrentConditionsResponse"
                 }
-              },
-              "path": "v1/mapTypes/{mapType}/heatmapTiles/{zoom}/{x}/{y}",
-              "response": {
-                "$ref": "HttpBody"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/forecast:lookup": {
+      "post": {
+        "operationId": "airquality.forecast.lookup",
+        "summary": "Returns air quality forecast for a specific location for a",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LookupForecastRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LookupForecastResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/history:lookup": {
+      "post": {
+        "operationId": "airquality.history.lookup",
+        "summary": "Returns air quality history for a specific location for a",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LookupHistoryRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LookupHistoryResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/mapTypes/{mapType}/heatmapTiles/{zoom}/{x}/{y}": {
+      "get": {
+        "operationId": "airquality.mapTypes.heatmapTiles.lookupHeatmapTile",
+        "summary": "Returns a bytes array containing the data of the tile PNG",
+        "parameters": [
+          {
+            "name": "mapType",
+            "in": "path",
+            "required": true,
+            "description": "Required. The type of the air quality heatmap. Defines the pollutant that the map will graphically represent. Allowed values: - UAQI_RED_GREEN (UAQI, red-green palette) - UAQI_INDIGO_PERSIAN (UAQI, indigo-persian palette) - PM25_INDIGO_PERSIAN - GBR_DEFRA - DEU_UBA - CAN_EC - FRA_ATMO - US_AQI",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "MAP_TYPE_UNSPECIFIED",
+                "UAQI_RED_GREEN",
+                "UAQI_INDIGO_PERSIAN",
+                "PM25_INDIGO_PERSIAN",
+                "GBR_DEFRA",
+                "DEU_UBA",
+                "CAN_EC",
+                "FRA_ATMO",
+                "US_AQI"
+              ]
+            }
+          },
+          {
+            "name": "zoom",
+            "in": "path",
+            "required": true,
+            "description": "Required. The map's zoom level. Defines how large or small the contents of a map appear in a map view. Zoom level 0 is the entire world in a single tile. Zoom level 1 is the entire world in 4 tiles. Zoom level 2 is the entire world in 16 tiles. Zoom level 16 is the entire world in 65,536 tiles. Allowed values: 0-16",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "x",
+            "in": "path",
+            "required": true,
+            "description": "Required. Defines the east-west point in the requested tile.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "y",
+            "in": "path",
+            "required": true,
+            "description": "Required. Defines the north-south point in the requested tile.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpBody"
+                }
               }
             }
           }
@@ -231,626 +166,545 @@
       }
     }
   },
-  "revision": "20260427",
-  "rootUrl": "https://airquality.google.gateway-402.com/",
-  "schemas": {
-    "AdditionalInfo": {
-      "description": "The emission sources and health effects of a given pollutant.",
-      "id": "AdditionalInfo",
-      "properties": {
-        "effects": {
-          "description": "Text representing the pollutant's main health effects.",
-          "type": "string"
-        },
-        "sources": {
-          "description": "Text representing the pollutant's main emission sources.",
-          "type": "string"
-        }
-      },
-      "type": "object"
-    },
-    "AirQualityIndex": {
-      "description": "The basic object for representing different air quality metrics. When brought together, these metrics provide a snapshot about the current air quality conditions. There are multiple indexes in the world serving different purposes and groups interested in measuring different aspects of air quality.",
-      "id": "AirQualityIndex",
-      "properties": {
-        "aqi": {
-          "description": " The index's numeric score. Examples: 10, 100. The value is not normalized and should only be interpreted in the context of its related air-quality index. For non-numeric indexes, this field will not be returned. Note: This field should be used for calculations, graph display, etc. For displaying the index score, you should use the AQI display field.",
-          "format": "int32",
-          "type": "integer"
-        },
-        "aqiDisplay": {
-          "description": "Textual representation of the index numeric score, that may include prefix or suffix symbols, which usually represents the worst index score. Example: >100 or 10+. Note: This field should be used when you want to display the index score. For non-numeric indexes, this field is empty.",
-          "type": "string"
-        },
-        "category": {
-          "description": "Textual classification of the index numeric score interpretation. For example: \"Excellent air quality\".",
-          "type": "string"
-        },
-        "code": {
-          "description": "The index's code. This field represents the index for programming purposes by using snake case instead of spaces. Examples: \"uaqi\", \"fra_atmo\".",
-          "type": "string"
-        },
-        "color": {
-          "$ref": "Color",
-          "description": "The color used to represent the AQI numeric score."
-        },
-        "displayName": {
-          "description": "A human readable representation of the index name. Example: \"AQI (US)\"",
-          "type": "string"
-        },
-        "dominantPollutant": {
-          "description": "The chemical symbol of the dominant pollutant. For example: \"CO\".",
-          "type": "string"
-        }
-      },
-      "type": "object"
-    },
-    "Color": {
-      "description": "Represents a color in the RGBA color space. This representation is designed for simplicity of conversion to and from color representations in various languages over compactness. For example, the fields of this representation can be trivially provided to the constructor of `java.awt.Color` in Java; it can also be trivially provided to UIColor's `+colorWithRed:green:blue:alpha` method in iOS; and, with just a little work, it can be easily formatted into a CSS `rgba()` string in JavaScript. This reference page doesn't have information about the absolute color space that should be used to interpret the RGB value—for example, sRGB, Adobe RGB, DCI-P3, and BT.2020. By default, applications should assume the sRGB color space. When color equality needs to be decided, implementations, unless documented otherwise, treat two colors as equal if all their red, green, blue, and alpha values each differ by at most `1e-5`. Example (Java): import com.google.type.Color; // ... public static java.awt.Color fromProto(Color protocolor) { float alpha = protocolor.hasAlpha() ? protocolor.getAlpha().getValue() : 1.0; return new java.awt.Color( protocolor.getRed(), protocolor.getGreen(), protocolor.getBlue(), alpha); } public static Color toProto(java.awt.Color color) { float red = (float) color.getRed(); float green = (float) color.getGreen(); float blue = (float) color.getBlue(); float denominator = 255.0; Color.Builder resultBuilder = Color .newBuilder() .setRed(red / denominator) .setGreen(green / denominator) .setBlue(blue / denominator); int alpha = color.getAlpha(); if (alpha != 255) { result.setAlpha( FloatValue .newBuilder() .setValue(((float) alpha) / denominator) .build()); } return resultBuilder.build(); } // ... Example (iOS / Obj-C): // ... static UIColor* fromProto(Color* protocolor) { float red = [protocolor red]; float green = [protocolor green]; float blue = [protocolor blue]; FloatValue* alpha_wrapper = [protocolor alpha]; float alpha = 1.0; if (alpha_wrapper != nil) { alpha = [alpha_wrapper value]; } return [UIColor colorWithRed:red green:green blue:blue alpha:alpha]; } static Color* toProto(UIColor* color) { CGFloat red, green, blue, alpha; if (![color getRed:&red green:&green blue:&blue alpha:&alpha]) { return nil; } Color* result = [[Color alloc] init]; [result setRed:red]; [result setGreen:green]; [result setBlue:blue]; if (alpha <= 0.9999) { [result setAlpha:floatWrapperWithValue(alpha)]; } [result autorelease]; return result; } // ... Example (JavaScript): // ... var protoToCssColor = function(rgb_color) { var redFrac = rgb_color.red || 0.0; var greenFrac = rgb_color.green || 0.0; var blueFrac = rgb_color.blue || 0.0; var red = Math.floor(redFrac * 255); var green = Math.floor(greenFrac * 255); var blue = Math.floor(blueFrac * 255); if (!('alpha' in rgb_color)) { return rgbToCssColor(red, green, blue); } var alphaFrac = rgb_color.alpha.value || 0.0; var rgbParams = [red, green, blue].join(','); return ['rgba(', rgbParams, ',', alphaFrac, ')'].join(''); }; var rgbToCssColor = function(red, green, blue) { var rgbNumber = new Number((red << 16) | (green << 8) | blue); var hexString = rgbNumber.toString(16); var missingZeros = 6 - hexString.length; var resultBuilder = ['#']; for (var i = 0; i < missingZeros; i++) { resultBuilder.push('0'); } resultBuilder.push(hexString); return resultBuilder.join(''); }; // ...",
-      "id": "Color",
-      "properties": {
-        "alpha": {
-          "description": "The fraction of this color that should be applied to the pixel. That is, the final pixel color is defined by the equation: `pixel color = alpha * (this color) + (1.0 - alpha) * (background color)` This means that a value of 1.0 corresponds to a solid color, whereas a value of 0.0 corresponds to a completely transparent color. This uses a wrapper message rather than a simple float scalar so that it is possible to distinguish between a default value and the value being unset. If omitted, this color object is rendered as a solid color (as if the alpha value had been explicitly given a value of 1.0).",
-          "format": "float",
-          "type": "number"
-        },
-        "blue": {
-          "description": "The amount of blue in the color as a value in the interval [0, 1].",
-          "format": "float",
-          "type": "number"
-        },
-        "green": {
-          "description": "The amount of green in the color as a value in the interval [0, 1].",
-          "format": "float",
-          "type": "number"
-        },
-        "red": {
-          "description": "The amount of red in the color as a value in the interval [0, 1].",
-          "format": "float",
-          "type": "number"
-        }
-      },
-      "type": "object"
-    },
-    "Concentration": {
-      "description": "The concentration of a given pollutant in the air.",
-      "id": "Concentration",
-      "properties": {
-        "units": {
-          "description": "Units for measuring this pollutant concentration.",
-          "enum": [
-            "UNIT_UNSPECIFIED",
-            "PARTS_PER_BILLION",
-            "MICROGRAMS_PER_CUBIC_METER"
-          ],
-          "enumDescriptions": [
-            "Unspecified concentration unit.",
-            "The ppb (parts per billion) concentration unit.",
-            "The \"µg/m^3\" (micrograms per cubic meter) concentration unit."
-          ],
-          "type": "string"
-        },
-        "value": {
-          "description": "Value of the pollutant concentration.",
-          "format": "float",
-          "type": "number"
-        }
-      },
-      "type": "object"
-    },
-    "CustomLocalAqi": {
-      "description": "Expresses a 'country/region to AQI' relationship. Pairs a country/region with a desired AQI so that air quality data that is required for that country/region will be displayed according to the chosen AQI.",
-      "id": "CustomLocalAqi",
-      "properties": {
-        "aqi": {
-          "description": "The AQI to associate the country/region with. Value should be a [valid index](/maps/documentation/air-quality/laqis) code.",
-          "type": "string"
-        },
-        "regionCode": {
-          "description": "The country/region requiring the custom AQI. Value should be provided using [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) code.",
-          "type": "string"
-        }
-      },
-      "type": "object"
-    },
-    "HealthRecommendations": {
-      "description": "Health recommendations for different population groups in a free text format. The recommendations are derived from their associated air quality conditions.",
-      "id": "HealthRecommendations",
-      "properties": {
-        "athletes": {
-          "description": "Sports and other strenuous outdoor activities.",
-          "type": "string"
-        },
-        "children": {
-          "description": "Younger populations including children, toddlers, and babies.",
-          "type": "string"
-        },
-        "elderly": {
-          "description": "Retirees and people older than the general population.",
-          "type": "string"
-        },
-        "generalPopulation": {
-          "description": "No specific sensitivities.",
-          "type": "string"
-        },
-        "heartDiseasePopulation": {
-          "description": "Heart and circulatory system diseases.",
-          "type": "string"
-        },
-        "lungDiseasePopulation": {
-          "description": "Respiratory related problems and asthma suffers.",
-          "type": "string"
-        },
-        "pregnantWomen": {
-          "description": "Women at all stages of pregnancy.",
-          "type": "string"
-        }
-      },
-      "type": "object"
-    },
-    "HourInfo": {
-      "description": "Contains the air quality information for each hour in the requested range. For example, if the request is for 48 hours of history there will be 48 elements of hourly info.",
-      "id": "HourInfo",
-      "properties": {
-        "dateTime": {
-          "description": "A rounded down timestamp indicating the time the data refers to in RFC3339 UTC \"Zulu\" format, with nanosecond resolution and up to nine fractional digits. For example: \"2014-10-02T15:00:00Z\".",
-          "format": "google-datetime",
-          "type": "string"
-        },
-        "healthRecommendations": {
-          "$ref": "HealthRecommendations",
-          "description": "Health advice and recommended actions related to the reported air quality conditions. Recommendations are tailored differently for populations at risk, groups with greater sensitivities to pollutants, and the general population."
-        },
-        "indexes": {
-          "description": "Based on the request parameters, this list will include (up to) two air quality indexes: - Universal AQI. Will be returned if the universalAqi boolean is set to true. - Local AQI. Will be returned if the LOCAL_AQI extra computation is specified.",
-          "items": {
-            "$ref": "AirQualityIndex"
+  "components": {
+    "schemas": {
+      "AdditionalInfo": {
+        "type": "object",
+        "description": "The emission sources and health effects of a given pollutant.",
+        "properties": {
+          "sources": {
+            "type": "string",
+            "description": "Text representing the pollutant's main emission sources."
           },
-          "type": "array"
-        },
-        "pollutants": {
-          "description": "A list of pollutants affecting the location specified in the request. Note: This field will be returned only for requests that specified one or more of the following extra computations: POLLUTANT_ADDITIONAL_INFO, DOMINANT_POLLUTANT_CONCENTRATION, POLLUTANT_CONCENTRATION.",
-          "items": {
-            "$ref": "Pollutant"
-          },
-          "type": "array"
+          "effects": {
+            "type": "string",
+            "description": "Text representing the pollutant's main health effects."
+          }
         }
       },
-      "type": "object"
-    },
-    "HourlyForecast": {
-      "description": "Contains the air quality information for each hour in the requested range. For example, if the request is for 48 hours of forecast there will be 48 elements of hourly forecasts.",
-      "id": "HourlyForecast",
-      "properties": {
-        "dateTime": {
-          "description": "A rounded down timestamp indicating the time (hour) the data refers to in RFC3339 UTC \"Zulu\" format. For example: \"2014-10-02T15:00:00Z\".",
-          "format": "google-datetime",
-          "type": "string"
-        },
-        "healthRecommendations": {
-          "$ref": "HealthRecommendations",
-          "description": "Health advice and recommended actions related to the reported air quality conditions. Recommendations are tailored differently for populations at risk, groups with greater sensitivities to pollutants, and the general population."
-        },
-        "indexes": {
-          "description": "Based on the request parameters, this list will include (up to) two air quality indexes: - Universal AQI. Will be returned if the `universal_aqi` boolean is set to true. - Local AQI. Will be returned if the LOCAL_AQI extra computation is specified.",
-          "items": {
-            "$ref": "AirQualityIndex"
+      "AirQualityIndex": {
+        "type": "object",
+        "description": "The basic object for representing different air quality metrics. When brought together, these metrics provide a snapshot about the current air quality conditions. There are multiple indexes in the world serving different purposes and groups interested in measuring different aspects of air quality.",
+        "properties": {
+          "dominantPollutant": {
+            "type": "string",
+            "description": "The chemical symbol of the dominant pollutant. For example: \"CO\"."
           },
-          "type": "array"
-        },
-        "pollutants": {
-          "description": "A list of pollutants affecting the location specified in the request. Note: This field will be returned only for requests that specified one or more of the following extra computations: POLLUTANT_ADDITIONAL_INFO, DOMINANT_POLLUTANT_CONCENTRATION, POLLUTANT_CONCENTRATION.",
-          "items": {
-            "$ref": "Pollutant"
+          "color": {
+            "$ref": "#/components/schemas/Color"
           },
-          "type": "array"
+          "code": {
+            "type": "string",
+            "description": "The index's code. This field represents the index for programming purposes by using snake case instead of spaces. Examples: \"uaqi\", \"fra_atmo\"."
+          },
+          "aqiDisplay": {
+            "type": "string",
+            "description": "Textual representation of the index numeric score, that may include prefix or suffix symbols, which usually represents the worst index score. Example: >100 or 10+. Note: This field should be used when you want to display the index score. For non-numeric indexes, this field is empty."
+          },
+          "displayName": {
+            "type": "string",
+            "description": "A human readable representation of the index name. Example: \"AQI (US)\""
+          },
+          "aqi": {
+            "type": "integer",
+            "format": "int32",
+            "description": " The index's numeric score. Examples: 10, 100. The value is not normalized and should only be interpreted in the context of its related air-quality index. For non-numeric indexes, this field will not be returned. Note: This field should be used for calculations, graph display, etc. For displaying the index score, you should use the AQI display field."
+          },
+          "category": {
+            "type": "string",
+            "description": "Textual classification of the index numeric score interpretation. For example: \"Excellent air quality\"."
+          }
         }
       },
-      "type": "object"
-    },
-    "HttpBody": {
-      "description": "Message that represents an arbitrary HTTP body. It should only be used for payload formats that can't be represented as JSON, such as raw binary or an HTML page. This message can be used both in streaming and non-streaming API methods in the request as well as the response. It can be used as a top-level request field, which is convenient if one wants to extract parameters from either the URL or HTTP template into the request fields and also want access to the raw HTTP body. Example: message GetResourceRequest { // A unique request id. string request_id = 1; // The raw HTTP body is bound to this field. google.api.HttpBody http_body = 2; } service ResourceService { rpc GetResource(GetResourceRequest) returns (google.api.HttpBody); rpc UpdateResource(google.api.HttpBody) returns (google.protobuf.Empty); } Example with streaming methods: service CaldavService { rpc GetCalendar(stream google.api.HttpBody) returns (stream google.api.HttpBody); rpc UpdateCalendar(stream google.api.HttpBody) returns (stream google.api.HttpBody); } Use of this type only changes how the request and response bodies are handled, all other features will continue to work unchanged.",
-      "id": "HttpBody",
-      "properties": {
-        "contentType": {
-          "description": "The HTTP Content-Type header value specifying the content type of the body.",
-          "type": "string"
-        },
-        "data": {
-          "description": "The HTTP request/response body as raw binary.",
-          "format": "byte",
-          "type": "string"
-        },
-        "extensions": {
-          "description": "Application specific response metadata. Must be set in the first response for streaming APIs.",
-          "items": {
-            "additionalProperties": {
-              "description": "Properties of the object. Contains field @type with type URL.",
-              "type": "any"
-            },
-            "type": "object"
+      "Color": {
+        "type": "object",
+        "description": "Represents a color in the RGBA color space. This representation is designed for simplicity of conversion to and from color representations in various languages over compactness. For example, the fields of this representation can be trivially provided to the constructor of `java.awt.Color` in Java; it can also be trivially provided to UIColor's `+colorWithRed:green:blue:alpha` method in iOS; and, with just a little work, it can be easily formatted into a CSS `rgba()` string in JavaScript. This reference page doesn't have information about the absolute color space that should be used to interpret the RGB value\u2014for example, sRGB, Adobe RGB, DCI-P3, and BT.2020. By default, applications should assume the sRGB color space. When color equality needs to be decided, implementations, unless documented otherwise, treat two colors as equal if all their red, green, blue, and alpha values each differ by at most `1e-5`. Example (Java): import com.google.type.Color; // ... public static java.awt.Color fromProto(Color protocolor) { float alpha = protocolor.hasAlpha() ? protocolor.getAlpha().getValue() : 1.0; return new java.awt.Color( protocolor.getRed(), protocolor.getGreen(), protocolor.getBlue(), alpha); } public static Color toProto(java.awt.Color color) { float red = (float) color.getRed(); float green = (float) color.getGreen(); float blue = (float) color.getBlue(); float denominator = 255.0; Color.Builder resultBuilder = Color .newBuilder() .setRed(red / denominator) .setGreen(green / denominator) .setBlue(blue / denominator); int alpha = color.getAlpha(); if (alpha != 255) { result.setAlpha( FloatValue .newBuilder() .setValue(((float) alpha) / denominator) .build()); } return resultBuilder.build(); } // ... Example (iOS / Obj-C): // ... static UIColor* fromProto(Color* protocolor) { float red = [protocolor red]; float green = [protocolor green]; float blue = [protocolor blue]; FloatValue* alpha_wrapper = [protocolor alpha]; float alpha = 1.0; if (alpha_wrapper != nil) { alpha = [alpha_wrapper value]; } return [UIColor colorWithRed:red green:green blue:blue alpha:alpha]; } static Color* toProto(UIColor* color) { CGFloat red, green, blue, alpha; if (![color getRed:&red green:&green blue:&blue alpha:&alpha]) { return nil; } Color* result = [[Color alloc] init]; [result setRed:red]; [result setGreen:green]; [result setBlue:blue]; if (alpha <= 0.9999) { [result setAlpha:floatWrapperWithValue(alpha)]; } [result autorelease]; return result; } // ... Example (JavaScript): // ... var protoToCssColor = function(rgb_color) { var redFrac = rgb_color.red || 0.0; var greenFrac = rgb_color.green || 0.0; var blueFrac = rgb_color.blue || 0.0; var red = Math.floor(redFrac * 255); var green = Math.floor(greenFrac * 255); var blue = Math.floor(blueFrac * 255); if (!('alpha' in rgb_color)) { return rgbToCssColor(red, green, blue); } var alphaFrac = rgb_color.alpha.value || 0.0; var rgbParams = [red, green, blue].join(','); return ['rgba(', rgbParams, ',', alphaFrac, ')'].join(''); }; var rgbToCssColor = function(red, green, blue) { var rgbNumber = new Number((red << 16) | (green << 8) | blue); var hexString = rgbNumber.toString(16); var missingZeros = 6 - hexString.length; var resultBuilder = ['#']; for (var i = 0; i < missingZeros; i++) { resultBuilder.push('0'); } resultBuilder.push(hexString); return resultBuilder.join(''); }; // ...",
+        "properties": {
+          "alpha": {
+            "type": "number",
+            "format": "float",
+            "description": "The fraction of this color that should be applied to the pixel. That is, the final pixel color is defined by the equation: `pixel color = alpha * (this color) + (1.0 - alpha) * (background color)` This means that a value of 1.0 corresponds to a solid color, whereas a value of 0.0 corresponds to a completely transparent color. This uses a wrapper message rather than a simple float scalar so that it is possible to distinguish between a default value and the value being unset. If omitted, this color object is rendered as a solid color (as if the alpha value had been explicitly given a value of 1.0)."
           },
-          "type": "array"
-        }
-      },
-      "type": "object"
-    },
-    "Interval": {
-      "description": "Represents a time interval, encoded as a Timestamp start (inclusive) and a Timestamp end (exclusive). The start must be less than or equal to the end. When the start equals the end, the interval is empty (matches no time). When both start and end are unspecified, the interval matches any time.",
-      "id": "Interval",
-      "properties": {
-        "endTime": {
-          "description": "Optional. Exclusive end of the interval. If specified, a Timestamp matching this interval will have to be before the end.",
-          "format": "google-datetime",
-          "type": "string"
-        },
-        "startTime": {
-          "description": "Optional. Inclusive start of the interval. If specified, a Timestamp matching this interval will have to be the same or after the start.",
-          "format": "google-datetime",
-          "type": "string"
-        }
-      },
-      "type": "object"
-    },
-    "LatLng": {
-      "description": "An object that represents a latitude/longitude pair. This is expressed as a pair of doubles to represent degrees latitude and degrees longitude. Unless specified otherwise, this object must conform to the WGS84 standard. Values must be within normalized ranges.",
-      "id": "LatLng",
-      "properties": {
-        "latitude": {
-          "description": "The latitude in degrees. It must be in the range [-90.0, +90.0].",
-          "format": "double",
-          "type": "number"
-        },
-        "longitude": {
-          "description": "The longitude in degrees. It must be in the range [-180.0, +180.0].",
-          "format": "double",
-          "type": "number"
-        }
-      },
-      "type": "object"
-    },
-    "LookupCurrentConditionsRequest": {
-      "description": "The request definition of the air quality current conditions.",
-      "id": "LookupCurrentConditionsRequest",
-      "properties": {
-        "customLocalAqis": {
-          "description": "Optional. Expresses a 'country/region to AQI' relationship. Pairs a country/region with a desired AQI so that air quality data that is required for that country/region will be displayed according to the chosen AQI. This parameter can be used to specify a non-default AQI for a given country, for example, to get the US EPA index for Canada rather than the default index for Canada.",
-          "items": {
-            "$ref": "CustomLocalAqi"
+          "red": {
+            "type": "number",
+            "format": "float",
+            "description": "The amount of red in the color as a value in the interval [0, 1]."
           },
-          "type": "array"
-        },
-        "extraComputations": {
-          "description": "Optional. Additional features that can be optionally enabled. Specifying extra computations will result in the relevant elements and fields to be returned in the response.",
-          "items": {
+          "green": {
+            "type": "number",
+            "format": "float",
+            "description": "The amount of green in the color as a value in the interval [0, 1]."
+          },
+          "blue": {
+            "type": "number",
+            "format": "float",
+            "description": "The amount of blue in the color as a value in the interval [0, 1]."
+          }
+        }
+      },
+      "Concentration": {
+        "type": "object",
+        "description": "The concentration of a given pollutant in the air.",
+        "properties": {
+          "value": {
+            "type": "number",
+            "format": "float",
+            "description": "Value of the pollutant concentration."
+          },
+          "units": {
+            "type": "string",
+            "description": "Units for measuring this pollutant concentration.",
             "enum": [
-              "EXTRA_COMPUTATION_UNSPECIFIED",
-              "LOCAL_AQI",
-              "HEALTH_RECOMMENDATIONS",
-              "POLLUTANT_ADDITIONAL_INFO",
-              "DOMINANT_POLLUTANT_CONCENTRATION",
-              "POLLUTANT_CONCENTRATION"
-            ],
-            "enumDescriptions": [
-              "The default value. The server ignores it if it is passed as a parameter.",
-              "Determines whether to include the local (national) AQI of the requested location (country) in the response. If specified, the response will contain an 'air_quality_index' data structure with all the relevant data on the location's local AQI.",
-              "Determines whether the response will include the health advice and recommended actions for the current AQI conditions. The recommendations are tailored for the general population and six populations at risk groups with greater sensitivities to pollutants than the general population. If specified, the `health_recommendations` field will be populated in the response when the relevant data is available.",
-              "Determines whether to include in the response the additional information of each pollutant. If specified, each air quality index object contained in the 'indexes' field response will include an `additional_info` field when the data is available.",
-              "Determines whether the response would include the concentrations of the dominant pollutants measured according to global and/or local indexes. If the request specified both the global AQI and the local AQI, there may be up to two pollutant codes returned. If specified, the dominant pollutant object contained in the 'pollutants' list will include a `concentration` field when the data is available.",
-              "Determines whether the response would include the concentrations of all pollutants with available measurements according to global and/or local indexes. If specified, each pollutant object contained in the 'pollutants' field in the response will include a `concentration` field when the data is available."
-            ],
-            "type": "string"
-          },
-          "type": "array"
-        },
-        "languageCode": {
-          "description": "Optional. Allows the client to choose the language for the response. If data cannot be provided for that language the API uses the closest match. Allowed values rely on the IETF standard. Default value is en.",
-          "type": "string"
-        },
-        "location": {
-          "$ref": "LatLng",
-          "description": "Required. The longitude and latitude from which the API looks for air quality current conditions data."
-        },
-        "uaqiColorPalette": {
-          "description": "Optional. Determines the color palette used for data provided by the 'Universal Air Quality Index' (UAQI). This color palette is relevant just for UAQI, other AQIs have a predetermined color palette that can't be controlled.",
-          "enum": [
-            "COLOR_PALETTE_UNSPECIFIED",
-            "RED_GREEN",
-            "INDIGO_PERSIAN_DARK",
-            "INDIGO_PERSIAN_LIGHT"
-          ],
-          "enumDescriptions": [
-            "The default value. Ignored if passed as a parameter.",
-            "Determines whether to use a red/green palette.",
-            "Determines whether to use a indigo/persian palette (dark theme).",
-            "Determines whether to use a indigo/persian palette (light theme)."
-          ],
-          "type": "string"
-        },
-        "universalAqi": {
-          "description": "Optional. If set to true, the Universal AQI will be included in the 'indexes' field of the response. Default value is true.",
-          "type": "boolean"
+              "UNIT_UNSPECIFIED",
+              "PARTS_PER_BILLION",
+              "MICROGRAMS_PER_CUBIC_METER"
+            ]
+          }
         }
       },
-      "type": "object"
-    },
-    "LookupCurrentConditionsResponse": {
-      "id": "LookupCurrentConditionsResponse",
-      "properties": {
-        "dateTime": {
-          "description": "A rounded down timestamp in RFC3339 UTC \"Zulu\" format, with nanosecond resolution and up to nine fractional digits. For example: \"2014-10-02T15:00:00Z\".",
-          "format": "google-datetime",
-          "type": "string"
-        },
-        "healthRecommendations": {
-          "$ref": "HealthRecommendations",
-          "description": "Health advice and recommended actions related to the reported air quality conditions. Recommendations are tailored differently for populations at risk, groups with greater sensitivities to pollutants, and the general population."
-        },
-        "indexes": {
-          "description": "Based on the request parameters, this list will include (up to) two air quality indexes: - Universal AQI. Will be returned if the universalAqi boolean is set to true. - Local AQI. Will be returned if the LOCAL_AQI extra computation is specified.",
-          "items": {
-            "$ref": "AirQualityIndex"
+      "CustomLocalAqi": {
+        "type": "object",
+        "description": "Expresses a 'country/region to AQI' relationship. Pairs a country/region with a desired AQI so that air quality data that is required for that country/region will be displayed according to the chosen AQI.",
+        "properties": {
+          "aqi": {
+            "type": "string",
+            "description": "The AQI to associate the country/region with. Value should be a [valid index](/maps/documentation/air-quality/laqis) code."
           },
-          "type": "array"
-        },
-        "pollutants": {
-          "description": "A list of pollutants affecting the location specified in the request. Note: This field will be returned only for requests that specified one or more of the following extra computations: POLLUTANT_ADDITIONAL_INFO, DOMINANT_POLLUTANT_CONCENTRATION, POLLUTANT_CONCENTRATION.",
-          "items": {
-            "$ref": "Pollutant"
-          },
-          "type": "array"
-        },
-        "regionCode": {
-          "description": "The ISO_3166-1 alpha-2 code of the country/region corresponding to the location provided in the request. This field might be omitted from the response if the location provided in the request resides in a disputed territory.",
-          "type": "string"
+          "regionCode": {
+            "type": "string",
+            "description": "The country/region requiring the custom AQI. Value should be provided using [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) code."
+          }
         }
       },
-      "type": "object"
-    },
-    "LookupForecastRequest": {
-      "description": "The request object of the air quality forecast API.",
-      "id": "LookupForecastRequest",
-      "properties": {
-        "customLocalAqis": {
-          "description": "Optional. Expresses a 'country/region to AQI' relationship. Pairs a country/region with a desired AQI so that air quality data that is required for that country/region will be displayed according to the chosen AQI. This parameter can be used to specify a non-default AQI for a given country, for example, to get the US EPA index for Canada rather than the default index for Canada.",
-          "items": {
-            "$ref": "CustomLocalAqi"
+      "HealthRecommendations": {
+        "type": "object",
+        "description": "Health recommendations for different population groups in a free text format. The recommendations are derived from their associated air quality conditions.",
+        "properties": {
+          "lungDiseasePopulation": {
+            "type": "string",
+            "description": "Respiratory related problems and asthma suffers."
           },
-          "type": "array"
-        },
-        "dateTime": {
-          "description": "A timestamp for which to return the data for a specific point in time. The timestamp is rounded to the previous exact hour. Note: this will return hourly data for the requested timestamp only (i.e. a single hourly info element). For example, a request sent where the date_time parameter is set to 2023-01-03T11:05:49Z will be rounded down to 2023-01-03T11:00:00Z.",
-          "format": "google-datetime",
-          "type": "string"
-        },
-        "extraComputations": {
-          "description": "Optional. Additional features that can be optionally enabled. Specifying extra computations will result in the relevant elements and fields to be returned in the response.",
-          "items": {
+          "elderly": {
+            "type": "string",
+            "description": "Retirees and people older than the general population."
+          },
+          "athletes": {
+            "type": "string",
+            "description": "Sports and other strenuous outdoor activities."
+          },
+          "generalPopulation": {
+            "type": "string",
+            "description": "No specific sensitivities."
+          },
+          "heartDiseasePopulation": {
+            "type": "string",
+            "description": "Heart and circulatory system diseases."
+          },
+          "pregnantWomen": {
+            "type": "string",
+            "description": "Women at all stages of pregnancy."
+          },
+          "children": {
+            "type": "string",
+            "description": "Younger populations including children, toddlers, and babies."
+          }
+        }
+      },
+      "HourInfo": {
+        "type": "object",
+        "description": "Contains the air quality information for each hour in the requested range. For example, if the request is for 48 hours of history there will be 48 elements of hourly info.",
+        "properties": {
+          "dateTime": {
+            "type": "string",
+            "format": "google-datetime",
+            "description": "A rounded down timestamp indicating the time the data refers to in RFC3339 UTC \"Zulu\" format, with nanosecond resolution and up to nine fractional digits. For example: \"2014-10-02T15:00:00Z\"."
+          },
+          "pollutants": {
+            "type": "array",
+            "description": "A list of pollutants affecting the location specified in the request. Note: This field will be returned only for requests that specified one or more of the following extra computations: POLLUTANT_ADDITIONAL_INFO, DOMINANT_POLLUTANT_CONCENTRATION, POLLUTANT_CONCENTRATION.",
+            "items": {
+              "$ref": "#/components/schemas/Pollutant"
+            }
+          },
+          "healthRecommendations": {
+            "$ref": "#/components/schemas/HealthRecommendations"
+          },
+          "indexes": {
+            "type": "array",
+            "description": "Based on the request parameters, this list will include (up to) two air quality indexes: - Universal AQI. Will be returned if the universalAqi boolean is set to true. - Local AQI. Will be returned if the LOCAL_AQI extra computation is specified.",
+            "items": {
+              "$ref": "#/components/schemas/AirQualityIndex"
+            }
+          }
+        }
+      },
+      "HourlyForecast": {
+        "type": "object",
+        "description": "Contains the air quality information for each hour in the requested range. For example, if the request is for 48 hours of forecast there will be 48 elements of hourly forecasts.",
+        "properties": {
+          "dateTime": {
+            "type": "string",
+            "format": "google-datetime",
+            "description": "A rounded down timestamp indicating the time (hour) the data refers to in RFC3339 UTC \"Zulu\" format. For example: \"2014-10-02T15:00:00Z\"."
+          },
+          "pollutants": {
+            "type": "array",
+            "description": "A list of pollutants affecting the location specified in the request. Note: This field will be returned only for requests that specified one or more of the following extra computations: POLLUTANT_ADDITIONAL_INFO, DOMINANT_POLLUTANT_CONCENTRATION, POLLUTANT_CONCENTRATION.",
+            "items": {
+              "$ref": "#/components/schemas/Pollutant"
+            }
+          },
+          "healthRecommendations": {
+            "$ref": "#/components/schemas/HealthRecommendations"
+          },
+          "indexes": {
+            "type": "array",
+            "description": "Based on the request parameters, this list will include (up to) two air quality indexes: - Universal AQI. Will be returned if the `universal_aqi` boolean is set to true. - Local AQI. Will be returned if the LOCAL_AQI extra computation is specified.",
+            "items": {
+              "$ref": "#/components/schemas/AirQualityIndex"
+            }
+          }
+        }
+      },
+      "HttpBody": {
+        "type": "object",
+        "description": "Message that represents an arbitrary HTTP body. It should only be used for payload formats that can't be represented as JSON, such as raw binary or an HTML page. This message can be used both in streaming and non-streaming API methods in the request as well as the response. It can be used as a top-level request field, which is convenient if one wants to extract parameters from either the URL or HTTP template into the request fields and also want access to the raw HTTP body. Example: message GetResourceRequest { // A unique request id. string request_id = 1; // The raw HTTP body is bound to this field. google.api.HttpBody http_body = 2; } service ResourceService { rpc GetResource(GetResourceRequest) returns (google.api.HttpBody); rpc UpdateResource(google.api.HttpBody) returns (google.protobuf.Empty); } Example with streaming methods: service CaldavService { rpc GetCalendar(stream google.api.HttpBody) returns (stream google.api.HttpBody); rpc UpdateCalendar(stream google.api.HttpBody) returns (stream google.api.HttpBody); } Use of this type only changes how the request and response bodies are handled, all other features will continue to work unchanged.",
+        "properties": {
+          "data": {
+            "type": "string",
+            "format": "byte",
+            "description": "The HTTP request/response body as raw binary."
+          },
+          "contentType": {
+            "type": "string",
+            "description": "The HTTP Content-Type header value specifying the content type of the body."
+          },
+          "extensions": {
+            "type": "array",
+            "description": "Application specific response metadata. Must be set in the first response for streaming APIs.",
+            "items": {
+              "type": "object",
+              "additionalProperties": {
+                "description": "Properties of the object. Contains field @type with type URL."
+              }
+            }
+          }
+        }
+      },
+      "Interval": {
+        "type": "object",
+        "description": "Represents a time interval, encoded as a Timestamp start (inclusive) and a Timestamp end (exclusive). The start must be less than or equal to the end. When the start equals the end, the interval is empty (matches no time). When both start and end are unspecified, the interval matches any time.",
+        "properties": {
+          "startTime": {
+            "type": "string",
+            "format": "google-datetime",
+            "description": "Optional. Inclusive start of the interval. If specified, a Timestamp matching this interval will have to be the same or after the start."
+          },
+          "endTime": {
+            "type": "string",
+            "format": "google-datetime",
+            "description": "Optional. Exclusive end of the interval. If specified, a Timestamp matching this interval will have to be before the end."
+          }
+        }
+      },
+      "LatLng": {
+        "type": "object",
+        "description": "An object that represents a latitude/longitude pair. This is expressed as a pair of doubles to represent degrees latitude and degrees longitude. Unless specified otherwise, this object must conform to the WGS84 standard. Values must be within normalized ranges.",
+        "properties": {
+          "longitude": {
+            "type": "number",
+            "format": "double",
+            "description": "The longitude in degrees. It must be in the range [-180.0, +180.0]."
+          },
+          "latitude": {
+            "type": "number",
+            "format": "double",
+            "description": "The latitude in degrees. It must be in the range [-90.0, +90.0]."
+          }
+        }
+      },
+      "LookupCurrentConditionsRequest": {
+        "type": "object",
+        "description": "The request definition of the air quality current conditions.",
+        "properties": {
+          "extraComputations": {
+            "type": "array",
+            "description": "Optional. Additional features that can be optionally enabled. Specifying extra computations will result in the relevant elements and fields to be returned in the response.",
+            "items": {
+              "type": "string",
+              "enum": [
+                "EXTRA_COMPUTATION_UNSPECIFIED",
+                "LOCAL_AQI",
+                "HEALTH_RECOMMENDATIONS",
+                "POLLUTANT_ADDITIONAL_INFO",
+                "DOMINANT_POLLUTANT_CONCENTRATION",
+                "POLLUTANT_CONCENTRATION"
+              ]
+            }
+          },
+          "languageCode": {
+            "type": "string",
+            "description": "Optional. Allows the client to choose the language for the response. If data cannot be provided for that language the API uses the closest match. Allowed values rely on the IETF standard. Default value is en."
+          },
+          "customLocalAqis": {
+            "type": "array",
+            "description": "Optional. Expresses a 'country/region to AQI' relationship. Pairs a country/region with a desired AQI so that air quality data that is required for that country/region will be displayed according to the chosen AQI. This parameter can be used to specify a non-default AQI for a given country, for example, to get the US EPA index for Canada rather than the default index for Canada.",
+            "items": {
+              "$ref": "#/components/schemas/CustomLocalAqi"
+            }
+          },
+          "location": {
+            "$ref": "#/components/schemas/LatLng"
+          },
+          "uaqiColorPalette": {
+            "type": "string",
+            "description": "Optional. Determines the color palette used for data provided by the 'Universal Air Quality Index' (UAQI). This color palette is relevant just for UAQI, other AQIs have a predetermined color palette that can't be controlled.",
             "enum": [
-              "EXTRA_COMPUTATION_UNSPECIFIED",
-              "LOCAL_AQI",
-              "HEALTH_RECOMMENDATIONS",
-              "POLLUTANT_ADDITIONAL_INFO",
-              "DOMINANT_POLLUTANT_CONCENTRATION",
-              "POLLUTANT_CONCENTRATION"
-            ],
-            "enumDescriptions": [
-              "The default value. The server ignores it if it is passed as a parameter.",
-              "Determines whether to include the local (national) AQI of the requested location (country) in the response. If specified, the response will contain an 'air_quality_index' data structure with all the relevant data on the location's local AQI.",
-              "Determines whether the response will include the health advice and recommended actions for the current AQI conditions. The recommendations are tailored for the general population and six populations at risk groups with greater sensitivities to pollutants than the general population. If specified, the `health_recommendations` field will be populated in the response when the relevant data is available.",
-              "Determines whether to include in the response the additional information of each pollutant. If specified, each air quality index object contained in the 'indexes' field response will include an `additional_info` field when the data is available.",
-              "Determines whether the response would include the concentrations of the dominant pollutants measured according to global and/or local indexes. If the request specified both the global AQI and the local AQI, there may be up to two pollutant codes returned. If specified, the dominant pollutant object contained in the 'pollutants' list will include a `concentration` field when the data is available.",
-              "Determines whether the response would include the concentrations of all pollutants with available measurements according to global and/or local indexes. If specified, each pollutant object contained in the 'pollutants' field in the response will include a `concentration` field when the data is available."
-            ],
-            "type": "string"
+              "COLOR_PALETTE_UNSPECIFIED",
+              "RED_GREEN",
+              "INDIGO_PERSIAN_DARK",
+              "INDIGO_PERSIAN_LIGHT"
+            ]
           },
-          "type": "array"
-        },
-        "languageCode": {
-          "description": "Optional. Allows the client to choose the language for the response. If data cannot be provided for that language the API uses the closest match. Allowed values rely on the IETF standard (default = 'en').",
-          "type": "string"
-        },
-        "location": {
-          "$ref": "LatLng",
-          "description": "Required. The latitude and longitude for which the API looks for air quality data."
-        },
-        "pageSize": {
-          "description": "Optional. The maximum number of hourly info records to return per page (default = 24).",
-          "format": "int32",
-          "type": "integer"
-        },
-        "pageToken": {
-          "description": "Optional. A page token received from a previous forecast call. It is used to retrieve the subsequent page.",
-          "type": "string"
-        },
-        "period": {
-          "$ref": "Interval",
-          "description": "Indicates the start and end period for which to get the forecast data. The timestamp is rounded to the previous exact hour."
-        },
-        "uaqiColorPalette": {
-          "description": "Optional. Determines the color palette used for data provided by the 'Universal Air Quality Index' (UAQI). This color palette is relevant just for UAQI, other AQIs have a predetermined color palette that can't be controlled.",
-          "enum": [
-            "COLOR_PALETTE_UNSPECIFIED",
-            "RED_GREEN",
-            "INDIGO_PERSIAN_DARK",
-            "INDIGO_PERSIAN_LIGHT"
-          ],
-          "enumDescriptions": [
-            "The default value. Ignored if passed as a parameter.",
-            "Determines whether to use a red/green palette.",
-            "Determines whether to use a indigo/persian palette (dark theme).",
-            "Determines whether to use a indigo/persian palette (light theme)."
-          ],
-          "type": "string"
-        },
-        "universalAqi": {
-          "description": "Optional. If set to true, the Universal AQI will be included in the 'indexes' field of the response (default = true).",
-          "type": "boolean"
+          "universalAqi": {
+            "type": "boolean",
+            "description": "Optional. If set to true, the Universal AQI will be included in the 'indexes' field of the response. Default value is true."
+          }
         }
       },
-      "type": "object"
-    },
-    "LookupForecastResponse": {
-      "description": "The response object of the air quality forecast API.",
-      "id": "LookupForecastResponse",
-      "properties": {
-        "hourlyForecasts": {
-          "description": "Optional. Contains the air quality information for each hour in the requested range. For example, if the request is for 48 hours of forecast there will be 48 elements of hourly forecasts.",
-          "items": {
-            "$ref": "HourlyForecast"
+      "LookupCurrentConditionsResponse": {
+        "type": "object",
+        "properties": {
+          "pollutants": {
+            "type": "array",
+            "description": "A list of pollutants affecting the location specified in the request. Note: This field will be returned only for requests that specified one or more of the following extra computations: POLLUTANT_ADDITIONAL_INFO, DOMINANT_POLLUTANT_CONCENTRATION, POLLUTANT_CONCENTRATION.",
+            "items": {
+              "$ref": "#/components/schemas/Pollutant"
+            }
           },
-          "type": "array"
-        },
-        "nextPageToken": {
-          "description": "Optional. The token to retrieve the next page.",
-          "type": "string"
-        },
-        "regionCode": {
-          "description": "Optional. The ISO_3166-1 alpha-2 code of the country/region corresponding to the location provided in the request. This field might be omitted from the response if the location provided in the request resides in a disputed territory.",
-          "type": "string"
+          "healthRecommendations": {
+            "$ref": "#/components/schemas/HealthRecommendations"
+          },
+          "regionCode": {
+            "type": "string",
+            "description": "The ISO_3166-1 alpha-2 code of the country/region corresponding to the location provided in the request. This field might be omitted from the response if the location provided in the request resides in a disputed territory."
+          },
+          "dateTime": {
+            "type": "string",
+            "format": "google-datetime",
+            "description": "A rounded down timestamp in RFC3339 UTC \"Zulu\" format, with nanosecond resolution and up to nine fractional digits. For example: \"2014-10-02T15:00:00Z\"."
+          },
+          "indexes": {
+            "type": "array",
+            "description": "Based on the request parameters, this list will include (up to) two air quality indexes: - Universal AQI. Will be returned if the universalAqi boolean is set to true. - Local AQI. Will be returned if the LOCAL_AQI extra computation is specified.",
+            "items": {
+              "$ref": "#/components/schemas/AirQualityIndex"
+            }
+          }
         }
       },
-      "type": "object"
-    },
-    "LookupHistoryRequest": {
-      "description": "The request object of the air quality history API.",
-      "id": "LookupHistoryRequest",
-      "properties": {
-        "customLocalAqis": {
-          "description": "Optional. Expresses a 'country/region to AQI' relationship. Pairs a country/region with a desired AQI so that air quality data that is required for that country/region will be displayed according to the chosen AQI. This parameter can be used to specify a non-default AQI for a given country, for example, to get the US EPA index for Canada rather than the default index for Canada.",
-          "items": {
-            "$ref": "CustomLocalAqi"
+      "LookupForecastRequest": {
+        "type": "object",
+        "description": "The request object of the air quality forecast API.",
+        "properties": {
+          "dateTime": {
+            "type": "string",
+            "format": "google-datetime",
+            "description": "A timestamp for which to return the data for a specific point in time. The timestamp is rounded to the previous exact hour. Note: this will return hourly data for the requested timestamp only (i.e. a single hourly info element). For example, a request sent where the date_time parameter is set to 2023-01-03T11:05:49Z will be rounded down to 2023-01-03T11:00:00Z."
           },
-          "type": "array"
-        },
-        "dateTime": {
-          "description": "A timestamp for which to return historical data. The timestamp is rounded to the previous exact hour. Note: this will return hourly data for the requested timestamp only (i.e. a single hourly info element). For example, a request sent where the dateTime parameter is set to 2023-01-03T11:05:49Z will be rounded down to 2023-01-03T11:00:00Z. A timestamp in RFC3339 UTC \"Zulu\" format, with nanosecond resolution and up to nine fractional digits. Examples: \"2014-10-02T15:01:23Z\" and \"2014-10-02T15:01:23.045123456Z\".",
-          "format": "google-datetime",
-          "type": "string"
-        },
-        "extraComputations": {
-          "description": "Optional. Additional features that can be optionally enabled. Specifying extra computations will result in the relevant elements and fields to be returned in the response.",
-          "items": {
+          "languageCode": {
+            "type": "string",
+            "description": "Optional. Allows the client to choose the language for the response. If data cannot be provided for that language the API uses the closest match. Allowed values rely on the IETF standard (default = 'en')."
+          },
+          "pageSize": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Optional. The maximum number of hourly info records to return per page (default = 24)."
+          },
+          "universalAqi": {
+            "type": "boolean",
+            "description": "Optional. If set to true, the Universal AQI will be included in the 'indexes' field of the response (default = true)."
+          },
+          "pageToken": {
+            "type": "string",
+            "description": "Optional. A page token received from a previous forecast call. It is used to retrieve the subsequent page."
+          },
+          "location": {
+            "$ref": "#/components/schemas/LatLng"
+          },
+          "period": {
+            "$ref": "#/components/schemas/Interval"
+          },
+          "extraComputations": {
+            "type": "array",
+            "description": "Optional. Additional features that can be optionally enabled. Specifying extra computations will result in the relevant elements and fields to be returned in the response.",
+            "items": {
+              "type": "string",
+              "enum": [
+                "EXTRA_COMPUTATION_UNSPECIFIED",
+                "LOCAL_AQI",
+                "HEALTH_RECOMMENDATIONS",
+                "POLLUTANT_ADDITIONAL_INFO",
+                "DOMINANT_POLLUTANT_CONCENTRATION",
+                "POLLUTANT_CONCENTRATION"
+              ]
+            }
+          },
+          "customLocalAqis": {
+            "type": "array",
+            "description": "Optional. Expresses a 'country/region to AQI' relationship. Pairs a country/region with a desired AQI so that air quality data that is required for that country/region will be displayed according to the chosen AQI. This parameter can be used to specify a non-default AQI for a given country, for example, to get the US EPA index for Canada rather than the default index for Canada.",
+            "items": {
+              "$ref": "#/components/schemas/CustomLocalAqi"
+            }
+          },
+          "uaqiColorPalette": {
+            "type": "string",
+            "description": "Optional. Determines the color palette used for data provided by the 'Universal Air Quality Index' (UAQI). This color palette is relevant just for UAQI, other AQIs have a predetermined color palette that can't be controlled.",
             "enum": [
-              "EXTRA_COMPUTATION_UNSPECIFIED",
-              "LOCAL_AQI",
-              "HEALTH_RECOMMENDATIONS",
-              "POLLUTANT_ADDITIONAL_INFO",
-              "DOMINANT_POLLUTANT_CONCENTRATION",
-              "POLLUTANT_CONCENTRATION"
-            ],
-            "enumDescriptions": [
-              "The default value. The server ignores it if it is passed as a parameter.",
-              "Determines whether to include the local (national) AQI of the requested location (country) in the response. If specified, the response will contain an 'air_quality_index' data structure with all the relevant data on the location's local AQI.",
-              "Determines whether the response will include the health advice and recommended actions for the current AQI conditions. The recommendations are tailored for the general population and six populations at risk groups with greater sensitivities to pollutants than the general population. If specified, the `health_recommendations` field will be populated in the response when the relevant data is available.",
-              "Determines whether to include in the response the additional information of each pollutant. If specified, each air quality index object contained in the 'indexes' field response will include an `additional_info` field when the data is available.",
-              "Determines whether the response would include the concentrations of the dominant pollutants measured according to global and/or local indexes. If the request specified both the global AQI and the local AQI, there may be up to two pollutant codes returned. If specified, the dominant pollutant object contained in the 'pollutants' list will include a `concentration` field when the data is available.",
-              "Determines whether the response would include the concentrations of all pollutants with available measurements according to global and/or local indexes. If specified, each pollutant object contained in the 'pollutants' field in the response will include a `concentration` field when the data is available."
-            ],
-            "type": "string"
+              "COLOR_PALETTE_UNSPECIFIED",
+              "RED_GREEN",
+              "INDIGO_PERSIAN_DARK",
+              "INDIGO_PERSIAN_LIGHT"
+            ]
+          }
+        }
+      },
+      "LookupForecastResponse": {
+        "type": "object",
+        "description": "The response object of the air quality forecast API.",
+        "properties": {
+          "nextPageToken": {
+            "type": "string",
+            "description": "Optional. The token to retrieve the next page."
           },
-          "type": "array"
-        },
-        "hours": {
-          "description": "Number from 1 to 720 that indicates the hours range for the request. For example: A value of 48 will yield data from the last 48 hours.",
-          "format": "int32",
-          "type": "integer"
-        },
-        "languageCode": {
-          "description": "Optional. Allows the client to choose the language for the response. If data cannot be provided for that language the API uses the closest match. Allowed values rely on the IETF standard. Default value is en.",
-          "type": "string"
-        },
-        "location": {
-          "$ref": "LatLng",
-          "description": "Required. The latitude and longitude for which the API looks for air quality history data."
-        },
-        "pageSize": {
-          "description": "Optional. The maximum number of hourly info records to return per page. The default is 72 and the max value is 168 (7 days of data).",
-          "format": "int32",
-          "type": "integer"
-        },
-        "pageToken": {
-          "description": "Optional. A page token received from a previous history call. It is used to retrieve the subsequent page. Note that when providing a value for this parameter all other parameters provided must match the call that provided the page token (the previous call).",
-          "type": "string"
-        },
-        "period": {
-          "$ref": "Interval",
-          "description": "Indicates the start and end period for which to get the historical data. The timestamp is rounded to the previous exact hour."
-        },
-        "uaqiColorPalette": {
-          "description": "Optional. Determines the color palette used for data provided by the 'Universal Air Quality Index' (UAQI). This color palette is relevant just for UAQI, other AQIs have a predetermined color palette that can't be controlled.",
-          "enum": [
-            "COLOR_PALETTE_UNSPECIFIED",
-            "RED_GREEN",
-            "INDIGO_PERSIAN_DARK",
-            "INDIGO_PERSIAN_LIGHT"
-          ],
-          "enumDescriptions": [
-            "The default value. Ignored if passed as a parameter.",
-            "Determines whether to use a red/green palette.",
-            "Determines whether to use a indigo/persian palette (dark theme).",
-            "Determines whether to use a indigo/persian palette (light theme)."
-          ],
-          "type": "string"
-        },
-        "universalAqi": {
-          "description": "Optional. If set to true, the Universal AQI will be included in the 'indexes' field of the response. Default value is true.",
-          "type": "boolean"
-        }
-      },
-      "type": "object"
-    },
-    "LookupHistoryResponse": {
-      "id": "LookupHistoryResponse",
-      "properties": {
-        "hoursInfo": {
-          "description": "Optional. Contains the air quality information for each hour in the requested range. For example, if the request is for 48 hours of history there will be 48 elements of hourly info.",
-          "items": {
-            "$ref": "HourInfo"
+          "hourlyForecasts": {
+            "type": "array",
+            "description": "Optional. Contains the air quality information for each hour in the requested range. For example, if the request is for 48 hours of forecast there will be 48 elements of hourly forecasts.",
+            "items": {
+              "$ref": "#/components/schemas/HourlyForecast"
+            }
           },
-          "type": "array"
-        },
-        "nextPageToken": {
-          "description": "Optional. The token to retrieve the next page.",
-          "type": "string"
-        },
-        "regionCode": {
-          "description": "Optional. The ISO_3166-1 alpha-2 code of the country/region corresponding to the location provided in the request. This field might be omitted from the response if the location provided in the request resides in a disputed territory.",
-          "type": "string"
+          "regionCode": {
+            "type": "string",
+            "description": "Optional. The ISO_3166-1 alpha-2 code of the country/region corresponding to the location provided in the request. This field might be omitted from the response if the location provided in the request resides in a disputed territory."
+          }
         }
       },
-      "type": "object"
-    },
-    "Pollutant": {
-      "description": "Data regarding an air quality pollutant.",
-      "id": "Pollutant",
-      "properties": {
-        "additionalInfo": {
-          "$ref": "AdditionalInfo",
-          "description": "Additional information about the pollutant."
-        },
-        "code": {
-          "description": "The pollutant's code name (for example, \"so2\"). For a list of supported pollutant codes, see [Reported pollutants](/maps/documentation/air-quality/pollutants#reported_pollutants).",
-          "type": "string"
-        },
-        "concentration": {
-          "$ref": "Concentration",
-          "description": "The pollutant's concentration level measured by one of the standard air pollutation measure units."
-        },
-        "displayName": {
-          "description": "The pollutant's display name. For example: \"NOx\".",
-          "type": "string"
-        },
-        "fullName": {
-          "description": "The pollutant's full name. For chemical compounds, this is the IUPAC name. Example: \"Sulfur Dioxide\". For more information about the IUPAC names table, see https://iupac.org/what-we-do/periodic-table-of-elements/.",
-          "type": "string"
+      "LookupHistoryRequest": {
+        "type": "object",
+        "description": "The request object of the air quality history API.",
+        "properties": {
+          "pageSize": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Optional. The maximum number of hourly info records to return per page. The default is 72 and the max value is 168 (7 days of data)."
+          },
+          "languageCode": {
+            "type": "string",
+            "description": "Optional. Allows the client to choose the language for the response. If data cannot be provided for that language the API uses the closest match. Allowed values rely on the IETF standard. Default value is en."
+          },
+          "dateTime": {
+            "type": "string",
+            "format": "google-datetime",
+            "description": "A timestamp for which to return historical data. The timestamp is rounded to the previous exact hour. Note: this will return hourly data for the requested timestamp only (i.e. a single hourly info element). For example, a request sent where the dateTime parameter is set to 2023-01-03T11:05:49Z will be rounded down to 2023-01-03T11:00:00Z. A timestamp in RFC3339 UTC \"Zulu\" format, with nanosecond resolution and up to nine fractional digits. Examples: \"2014-10-02T15:01:23Z\" and \"2014-10-02T15:01:23.045123456Z\"."
+          },
+          "hours": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Number from 1 to 720 that indicates the hours range for the request. For example: A value of 48 will yield data from the last 48 hours."
+          },
+          "location": {
+            "$ref": "#/components/schemas/LatLng"
+          },
+          "pageToken": {
+            "type": "string",
+            "description": "Optional. A page token received from a previous history call. It is used to retrieve the subsequent page. Note that when providing a value for this parameter all other parameters provided must match the call that provided the page token (the previous call)."
+          },
+          "universalAqi": {
+            "type": "boolean",
+            "description": "Optional. If set to true, the Universal AQI will be included in the 'indexes' field of the response. Default value is true."
+          },
+          "customLocalAqis": {
+            "type": "array",
+            "description": "Optional. Expresses a 'country/region to AQI' relationship. Pairs a country/region with a desired AQI so that air quality data that is required for that country/region will be displayed according to the chosen AQI. This parameter can be used to specify a non-default AQI for a given country, for example, to get the US EPA index for Canada rather than the default index for Canada.",
+            "items": {
+              "$ref": "#/components/schemas/CustomLocalAqi"
+            }
+          },
+          "extraComputations": {
+            "type": "array",
+            "description": "Optional. Additional features that can be optionally enabled. Specifying extra computations will result in the relevant elements and fields to be returned in the response.",
+            "items": {
+              "type": "string",
+              "enum": [
+                "EXTRA_COMPUTATION_UNSPECIFIED",
+                "LOCAL_AQI",
+                "HEALTH_RECOMMENDATIONS",
+                "POLLUTANT_ADDITIONAL_INFO",
+                "DOMINANT_POLLUTANT_CONCENTRATION",
+                "POLLUTANT_CONCENTRATION"
+              ]
+            }
+          },
+          "period": {
+            "$ref": "#/components/schemas/Interval"
+          },
+          "uaqiColorPalette": {
+            "type": "string",
+            "description": "Optional. Determines the color palette used for data provided by the 'Universal Air Quality Index' (UAQI). This color palette is relevant just for UAQI, other AQIs have a predetermined color palette that can't be controlled.",
+            "enum": [
+              "COLOR_PALETTE_UNSPECIFIED",
+              "RED_GREEN",
+              "INDIGO_PERSIAN_DARK",
+              "INDIGO_PERSIAN_LIGHT"
+            ]
+          }
         }
       },
-      "type": "object"
+      "LookupHistoryResponse": {
+        "type": "object",
+        "properties": {
+          "hoursInfo": {
+            "type": "array",
+            "description": "Optional. Contains the air quality information for each hour in the requested range. For example, if the request is for 48 hours of history there will be 48 elements of hourly info.",
+            "items": {
+              "$ref": "#/components/schemas/HourInfo"
+            }
+          },
+          "regionCode": {
+            "type": "string",
+            "description": "Optional. The ISO_3166-1 alpha-2 code of the country/region corresponding to the location provided in the request. This field might be omitted from the response if the location provided in the request resides in a disputed territory."
+          },
+          "nextPageToken": {
+            "type": "string",
+            "description": "Optional. The token to retrieve the next page."
+          }
+        }
+      },
+      "Pollutant": {
+        "type": "object",
+        "description": "Data regarding an air quality pollutant.",
+        "properties": {
+          "code": {
+            "type": "string",
+            "description": "The pollutant's code name (for example, \"so2\"). For a list of supported pollutant codes, see [Reported pollutants](/maps/documentation/air-quality/pollutants#reported_pollutants)."
+          },
+          "fullName": {
+            "type": "string",
+            "description": "The pollutant's full name. For chemical compounds, this is the IUPAC name. Example: \"Sulfur Dioxide\". For more information about the IUPAC names table, see https://iupac.org/what-we-do/periodic-table-of-elements/."
+          },
+          "additionalInfo": {
+            "$ref": "#/components/schemas/AdditionalInfo"
+          },
+          "displayName": {
+            "type": "string",
+            "description": "The pollutant's display name. For example: \"NOx\"."
+          },
+          "concentration": {
+            "$ref": "#/components/schemas/Concentration"
+          }
+        }
+      }
     }
-  },
-  "servicePath": "",
-  "title": "Air Quality API",
-  "version": "v1",
-  "version_module": true
+  }
 }

--- a/providers/solana-foundation/google/documentai/openapi.json
+++ b/providers/solana-foundation/google/documentai/openapi.json
@@ -1,52 +1,2800 @@
 {
-  "externalDocs": {
-    "url": "https://cloud.google.com/document-ai/docs/"
-  },
+  "openapi": "3.0.3",
   "info": {
-    "contact": {
-      "name": "Google",
-      "url": "https://google.com",
-      "x-twitter": "youtube"
-    },
-    "description": "Service to parse structured information from unstructured or semi-structured documents using state-of-the-art Google AI such as natural language, computer vision, translation, and AutoML.",
-    "license": {
-      "name": "Creative Commons Attribution 3.0",
-      "url": "http://creativecommons.org/licenses/by/3.0/"
-    },
-    "termsOfService": "https://developers.google.com/terms/",
     "title": "Cloud Document AI API",
-    "version": "v1",
-    "x-apisguru-categories": [
-      "analytics",
-      "media"
-    ],
-    "x-logo": {
-      "url": "https://upload.wikimedia.org/wikipedia/commons/e/e1/YouTube_play_buttom_icon_%282013-2017%29.svg"
-    },
-    "x-origin": [
-      {
-        "format": "google",
-        "url": "https://documentai.googleapis.com/$discovery/rest?version=v1",
-        "version": "v1"
-      }
-    ],
-    "x-preferred": false,
-    "x-providerName": "googleapis.com",
-    "x-serviceName": "documentai"
+    "description": "Extract structured data from PDFs, scans, and document images using OCR and ML. Handles invoices, receipts, forms, contracts, tax documents, IDs, and custom schemas, returning text, tables, entities, fields, and confidence signals.",
+    "version": "v1"
   },
-  "openapi": "3.0.0",
-  "paths": {},
   "servers": [
     {
       "url": "https://documentai.google.gateway-402.com"
     }
   ],
-  "tags": [
-    {
-      "name": "operations"
+  "paths": {
+    "/v1/projects/{projectsId}/locations/{locationsId}/processorTypes": {
+      "get": {
+        "operationId": "documentai.projects.locations.processorTypes.list",
+        "summary": "Lists the processor types that exist.",
+        "parameters": [
+          {
+            "name": "projectsId",
+            "in": "path",
+            "required": true,
+            "description": "Identifier for the `project` segment of the resource path.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "locationsId",
+            "in": "path",
+            "required": true,
+            "description": "Identifier for the `location` segment of the resource path.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "description": "The maximum number of processor types to return. If unspecified, at most `100` processor types will be returned. The maximum value is `500`. Values above `500` will be coerced to `500`.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "pageToken",
+            "in": "query",
+            "required": false,
+            "description": "Used to retrieve the next page of results, empty if at the end of the list.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GoogleCloudDocumentaiV1ListProcessorTypesResponse"
+                }
+              }
+            }
+          }
+        }
+      }
     },
-    {
-      "name": "projects"
+    "/v1/projects/{projectsId}/locations/{locationsId}/processorTypes/{processorTypesId}": {
+      "get": {
+        "operationId": "documentai.projects.locations.processorTypes.get",
+        "summary": "Gets a processor type detail.",
+        "parameters": [
+          {
+            "name": "projectsId",
+            "in": "path",
+            "required": true,
+            "description": "Identifier for the `project` segment of the resource path.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "locationsId",
+            "in": "path",
+            "required": true,
+            "description": "Identifier for the `location` segment of the resource path.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "processorTypesId",
+            "in": "path",
+            "required": true,
+            "description": "Identifier for the `processorType` segment of the resource path.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GoogleCloudDocumentaiV1ProcessorType"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/projects/{projectsId}/locations/{locationsId}/processors/{processorsId}/processorVersions/{processorVersionsId}:batchProcess": {
+      "post": {
+        "operationId": "documentai.projects.locations.processors.processorVersions.batchProcess",
+        "summary": "LRO endpoint to batch process many documents. The output is",
+        "parameters": [
+          {
+            "name": "projectsId",
+            "in": "path",
+            "required": true,
+            "description": "Identifier for the `project` segment of the resource path.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "locationsId",
+            "in": "path",
+            "required": true,
+            "description": "Identifier for the `location` segment of the resource path.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "processorsId",
+            "in": "path",
+            "required": true,
+            "description": "Identifier for the `processor` segment of the resource path.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "processorVersionsId",
+            "in": "path",
+            "required": true,
+            "description": "Identifier for the `processorVersion` segment of the resource path.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GoogleCloudDocumentaiV1BatchProcessRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GoogleLongrunningOperation"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/projects/{projectsId}/locations/{locationsId}/processors/{processorsId}/processorVersions/{processorVersionsId}:process": {
+      "post": {
+        "operationId": "documentai.projects.locations.processors.processorVersions.process",
+        "summary": "Processes a single document.",
+        "parameters": [
+          {
+            "name": "projectsId",
+            "in": "path",
+            "required": true,
+            "description": "Identifier for the `project` segment of the resource path.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "locationsId",
+            "in": "path",
+            "required": true,
+            "description": "Identifier for the `location` segment of the resource path.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "processorsId",
+            "in": "path",
+            "required": true,
+            "description": "Identifier for the `processor` segment of the resource path.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "processorVersionsId",
+            "in": "path",
+            "required": true,
+            "description": "Identifier for the `processorVersion` segment of the resource path.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GoogleCloudDocumentaiV1ProcessRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GoogleCloudDocumentaiV1ProcessResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/projects/{projectsId}/locations/{locationsId}/processors/{processorsId}:batchProcess": {
+      "post": {
+        "operationId": "documentai.projects.locations.processors.batchProcess",
+        "summary": "LRO endpoint to batch process many documents. The output is",
+        "parameters": [
+          {
+            "name": "projectsId",
+            "in": "path",
+            "required": true,
+            "description": "Identifier for the `project` segment of the resource path.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "locationsId",
+            "in": "path",
+            "required": true,
+            "description": "Identifier for the `location` segment of the resource path.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "processorsId",
+            "in": "path",
+            "required": true,
+            "description": "Identifier for the `processor` segment of the resource path.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GoogleCloudDocumentaiV1BatchProcessRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GoogleLongrunningOperation"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/projects/{projectsId}/locations/{locationsId}/processors/{processorsId}:process": {
+      "post": {
+        "operationId": "documentai.projects.locations.processors.process",
+        "summary": "Processes a single document.",
+        "parameters": [
+          {
+            "name": "projectsId",
+            "in": "path",
+            "required": true,
+            "description": "Identifier for the `project` segment of the resource path.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "locationsId",
+            "in": "path",
+            "required": true,
+            "description": "Identifier for the `location` segment of the resource path.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "processorsId",
+            "in": "path",
+            "required": true,
+            "description": "Identifier for the `processor` segment of the resource path.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GoogleCloudDocumentaiV1ProcessRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GoogleCloudDocumentaiV1ProcessResponse"
+                }
+              }
+            }
+          }
+        }
+      }
     }
-  ]
+  },
+  "components": {
+    "schemas": {
+      "GoogleCloudDocumentaiV1Barcode": {
+        "type": "object",
+        "description": "Encodes the detailed information of a barcode.",
+        "properties": {
+          "format": {
+            "type": "string",
+            "description": "Format of a barcode. The supported formats are: - `CODE_128`: Code 128 type. - `CODE_39`: Code 39 type. - `CODE_93`: Code 93 type. - `CODABAR`: Codabar type. - `DATA_MATRIX`: 2D Data Matrix type. - `ITF`: ITF type. - `EAN_13`: EAN-13 type. - `EAN_8`: EAN-8 type. - `QR_CODE`: 2D QR code type. - `UPC_A`: UPC-A type. - `UPC_E`: UPC-E type. - `PDF417`: PDF417 type. - `AZTEC`: 2D Aztec code type. - `DATABAR`: GS1 DataBar code type."
+          },
+          "valueFormat": {
+            "type": "string",
+            "description": "Value format describes the format of the value that a barcode encodes. The supported formats are: - `CONTACT_INFO`: Contact information. - `EMAIL`: Email address. - `ISBN`: ISBN identifier. - `PHONE`: Phone number. - `PRODUCT`: Product. - `SMS`: SMS message. - `TEXT`: Text string. - `URL`: URL address. - `WIFI`: Wifi information. - `GEO`: Geo-localization. - `CALENDAR_EVENT`: Calendar event. - `DRIVER_LICENSE`: Driver's license."
+          },
+          "rawValue": {
+            "type": "string",
+            "description": "Raw value encoded in the barcode. For example: `'MEBKM:TITLE:Google;URL:https://www.google.com;;'`."
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1BatchDocumentsInputConfig": {
+        "type": "object",
+        "description": "The common config to specify a set of documents used as input.",
+        "properties": {
+          "gcsPrefix": {
+            "$ref": "#/components/schemas/GoogleCloudDocumentaiV1GcsPrefix"
+          },
+          "gcsDocuments": {
+            "$ref": "#/components/schemas/GoogleCloudDocumentaiV1GcsDocuments"
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1BatchProcessRequest": {
+        "type": "object",
+        "description": "Request message for BatchProcessDocuments.",
+        "properties": {
+          "inputDocuments": {
+            "$ref": "#/components/schemas/GoogleCloudDocumentaiV1BatchDocumentsInputConfig"
+          },
+          "documentOutputConfig": {
+            "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentOutputConfig"
+          },
+          "skipHumanReview": {
+            "type": "boolean",
+            "description": "Whether human review should be skipped for this request. Default to `false`.",
+            "deprecated": true
+          },
+          "processOptions": {
+            "$ref": "#/components/schemas/GoogleCloudDocumentaiV1ProcessOptions"
+          },
+          "labels": {
+            "type": "object",
+            "description": "Optional. The labels with user-defined metadata for the request. Label keys and values can be no longer than 63 characters (Unicode codepoints) and can only contain lowercase letters, numeric characters, underscores, and dashes. International characters are allowed. Label values are optional. Label keys must start with a letter.",
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1BoundingPoly": {
+        "type": "object",
+        "description": "A bounding polygon for the detected image annotation.",
+        "properties": {
+          "vertices": {
+            "type": "array",
+            "description": "The bounding polygon vertices.",
+            "items": {
+              "$ref": "#/components/schemas/GoogleCloudDocumentaiV1Vertex"
+            }
+          },
+          "normalizedVertices": {
+            "type": "array",
+            "description": "The bounding polygon normalized vertices.",
+            "items": {
+              "$ref": "#/components/schemas/GoogleCloudDocumentaiV1NormalizedVertex"
+            }
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1Document": {
+        "type": "object",
+        "description": "Document represents the canonical document resource in Document AI. It is an interchange format that provides insights into documents and allows for collaboration between users and Document AI to iterate and optimize for quality.",
+        "properties": {
+          "uri": {
+            "type": "string",
+            "description": "Optional. Currently supports Google Cloud Storage URI of the form `gs://bucket_name/object_name`. Object versioning is not supported. For more information, refer to [Google Cloud Storage Request URIs](https://cloud.google.com/storage/docs/reference-uris)."
+          },
+          "content": {
+            "type": "string",
+            "format": "byte",
+            "description": "Optional. Inline document content, represented as a stream of bytes. Note: As with all `bytes` fields, protobuffers use a pure binary representation, whereas JSON representations use base64."
+          },
+          "docid": {
+            "type": "string",
+            "description": "Optional. An internal identifier for document. Should be loggable (no PII)."
+          },
+          "mimeType": {
+            "type": "string",
+            "description": "An IANA published [media type (MIME type)](https://www.iana.org/assignments/media-types/media-types.xhtml)."
+          },
+          "text": {
+            "type": "string",
+            "description": "Optional. UTF-8 encoded text in reading order from the document."
+          },
+          "textStyles": {
+            "type": "array",
+            "description": "Styles for the Document.text.",
+            "deprecated": true,
+            "items": {
+              "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentStyle"
+            }
+          },
+          "pages": {
+            "type": "array",
+            "description": "Visual page layout for the Document.",
+            "items": {
+              "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentPage"
+            }
+          },
+          "entities": {
+            "type": "array",
+            "description": "A list of entities detected on Document.text. For document shards, entities in this list may cross shard boundaries.",
+            "items": {
+              "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentEntity"
+            }
+          },
+          "entityRelations": {
+            "type": "array",
+            "description": "Placeholder. Relationship among Document.entities.",
+            "items": {
+              "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentEntityRelation"
+            }
+          },
+          "textChanges": {
+            "type": "array",
+            "description": "Placeholder. A list of text corrections made to Document.text. This is usually used for annotating corrections to OCR mistakes. Text changes for a given revision may not overlap with each other.",
+            "items": {
+              "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentTextChange"
+            }
+          },
+          "shardInfo": {
+            "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentShardInfo"
+          },
+          "error": {
+            "$ref": "#/components/schemas/GoogleRpcStatus"
+          },
+          "revisions": {
+            "type": "array",
+            "description": "Placeholder. Revision history of this document.",
+            "items": {
+              "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentRevision"
+            }
+          },
+          "documentLayout": {
+            "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentDocumentLayout"
+          },
+          "chunkedDocument": {
+            "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentChunkedDocument"
+          },
+          "blobAssets": {
+            "type": "array",
+            "description": "Optional. The blob assets in this document. This is used to store the content of the inline blobs in this document, for example, image bytes, such that it can be referenced by other fields in the document via asset id.",
+            "items": {
+              "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentBlobAsset"
+            }
+          },
+          "entityValidationOutput": {
+            "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentEntityValidationOutput"
+          },
+          "entitiesRevisions": {
+            "type": "array",
+            "description": "A list of entity revisions. The entity revisions are appended to the document in the processing order. This field can be used for comparing the entity extraction results at different stages of the processing.",
+            "items": {
+              "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentEntitiesRevision"
+            }
+          },
+          "entitiesRevisionId": {
+            "type": "string",
+            "description": "The entity revision ID that `document.entities` field is based on. If this field is set and `entities_revisions` is not empty, the entities in `document.entities` field are the entities in the entity revision with this id and `document.entity_validation_output` field is the `entity_validation_output` field in this entity revision."
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1DocumentAnnotations": {
+        "type": "object",
+        "description": "Represents the annotation of a block or a chunk.",
+        "properties": {
+          "description": {
+            "type": "string",
+            "description": "The description of the content with this annotation."
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1DocumentBlobAsset": {
+        "type": "object",
+        "description": "Represents a blob asset. It's used to store the content of the inline blob in this document, for example, image bytes, such that it can be referenced by other fields in the document via asset ID.",
+        "properties": {
+          "assetId": {
+            "type": "string",
+            "description": "Optional. The id of the blob asset."
+          },
+          "content": {
+            "type": "string",
+            "format": "byte",
+            "description": "Optional. The content of the blob asset, for example, image bytes."
+          },
+          "mimeType": {
+            "type": "string",
+            "description": "The mime type of the blob asset. An IANA published [media type (MIME type)](https://www.iana.org/assignments/media-types/media-types.xhtml)."
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1DocumentChunkedDocument": {
+        "type": "object",
+        "description": "Represents the chunks that the document is divided into.",
+        "properties": {
+          "chunks": {
+            "type": "array",
+            "description": "List of chunks.",
+            "items": {
+              "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentChunkedDocumentChunk"
+            }
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1DocumentChunkedDocumentChunk": {
+        "type": "object",
+        "description": "Represents a chunk.",
+        "properties": {
+          "chunkId": {
+            "type": "string",
+            "description": "ID of the chunk."
+          },
+          "sourceBlockIds": {
+            "type": "array",
+            "description": "Unused.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "content": {
+            "type": "string",
+            "description": "Text content of the chunk."
+          },
+          "pageSpan": {
+            "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentChunkedDocumentChunkChunkPageSpan"
+          },
+          "pageHeaders": {
+            "type": "array",
+            "description": "Page headers associated with the chunk.",
+            "items": {
+              "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentChunkedDocumentChunkChunkPageHeader"
+            }
+          },
+          "pageFooters": {
+            "type": "array",
+            "description": "Page footers associated with the chunk.",
+            "items": {
+              "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentChunkedDocumentChunkChunkPageFooter"
+            }
+          },
+          "chunkFields": {
+            "type": "array",
+            "description": "Chunk fields inside this chunk.",
+            "items": {
+              "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentChunkedDocumentChunkChunkField"
+            }
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1DocumentChunkedDocumentChunkChunkField": {
+        "type": "object",
+        "description": "The chunk field in the chunk. A chunk field could be one of the various types (for example, image, table) supported.",
+        "properties": {
+          "imageChunkField": {
+            "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentChunkedDocumentChunkImageChunkField"
+          },
+          "tableChunkField": {
+            "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentChunkedDocumentChunkTableChunkField"
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1DocumentChunkedDocumentChunkChunkPageFooter": {
+        "type": "object",
+        "description": "Represents the page footer associated with the chunk.",
+        "properties": {
+          "text": {
+            "type": "string",
+            "description": "Footer in text format."
+          },
+          "pageSpan": {
+            "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentChunkedDocumentChunkChunkPageSpan"
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1DocumentChunkedDocumentChunkChunkPageHeader": {
+        "type": "object",
+        "description": "Represents the page header associated with the chunk.",
+        "properties": {
+          "text": {
+            "type": "string",
+            "description": "Header in text format."
+          },
+          "pageSpan": {
+            "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentChunkedDocumentChunkChunkPageSpan"
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1DocumentChunkedDocumentChunkChunkPageSpan": {
+        "type": "object",
+        "description": "Represents where the chunk starts and ends in the document.",
+        "properties": {
+          "pageStart": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Page where chunk starts in the document."
+          },
+          "pageEnd": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Page where chunk ends in the document."
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1DocumentChunkedDocumentChunkImageChunkField": {
+        "type": "object",
+        "description": "The image chunk field in the chunk.",
+        "properties": {
+          "blobAssetId": {
+            "type": "string",
+            "description": "Optional. Asset id of the inline image. If set, find the image content in the blob_assets field."
+          },
+          "gcsUri": {
+            "type": "string",
+            "description": "Optional. Google Cloud Storage uri of the image."
+          },
+          "dataUri": {
+            "type": "string",
+            "description": "Optional. Data uri of the image. It is composed of four parts: a prefix (data:), a MIME type indicating the type of data, an optional base64 token if non-textual, and the data itself: data:,"
+          },
+          "annotations": {
+            "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentAnnotations"
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1DocumentChunkedDocumentChunkTableChunkField": {
+        "type": "object",
+        "description": "The table chunk field in the chunk.",
+        "properties": {
+          "annotations": {
+            "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentAnnotations"
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1DocumentDocumentLayout": {
+        "type": "object",
+        "description": "Represents the parsed layout of a document as a collection of blocks that the document is divided into.",
+        "properties": {
+          "blocks": {
+            "type": "array",
+            "description": "List of blocks in the document.",
+            "items": {
+              "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentDocumentLayoutDocumentLayoutBlock"
+            }
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1DocumentDocumentLayoutDocumentLayoutBlock": {
+        "type": "object",
+        "description": "Represents a block. A block could be one of the various types (text, table, list) supported.",
+        "properties": {
+          "textBlock": {
+            "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentDocumentLayoutDocumentLayoutBlockLayoutTextBlock"
+          },
+          "tableBlock": {
+            "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentDocumentLayoutDocumentLayoutBlockLayoutTableBlock"
+          },
+          "listBlock": {
+            "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentDocumentLayoutDocumentLayoutBlockLayoutListBlock"
+          },
+          "imageBlock": {
+            "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentDocumentLayoutDocumentLayoutBlockLayoutImageBlock"
+          },
+          "blockId": {
+            "type": "string",
+            "description": "ID of the block."
+          },
+          "pageSpan": {
+            "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentDocumentLayoutDocumentLayoutBlockLayoutPageSpan"
+          },
+          "boundingBox": {
+            "$ref": "#/components/schemas/GoogleCloudDocumentaiV1BoundingPoly"
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1DocumentDocumentLayoutDocumentLayoutBlockLayoutImageBlock": {
+        "type": "object",
+        "description": "Represents an image type block.",
+        "properties": {
+          "blobAssetId": {
+            "type": "string",
+            "description": "Optional. Asset id of the inline image. If set, find the image content in the blob_assets field."
+          },
+          "gcsUri": {
+            "type": "string",
+            "description": "Optional. Google Cloud Storage uri of the image."
+          },
+          "dataUri": {
+            "type": "string",
+            "description": "Optional. Data uri of the image. It is composed of four parts: a prefix (data:), a MIME type indicating the type of data, an optional base64 token if non-textual, and the data itself: data:,"
+          },
+          "mimeType": {
+            "type": "string",
+            "description": "Mime type of the image. An IANA published [media type (MIME type)] (https://www.iana.org/assignments/media-types/media-types.xhtml)."
+          },
+          "imageText": {
+            "type": "string",
+            "description": "Text extracted from the image using OCR or alt text describing the image."
+          },
+          "annotations": {
+            "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentAnnotations"
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1DocumentDocumentLayoutDocumentLayoutBlockLayoutListBlock": {
+        "type": "object",
+        "description": "Represents a list type block.",
+        "properties": {
+          "listEntries": {
+            "type": "array",
+            "description": "List entries that constitute a list block.",
+            "items": {
+              "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentDocumentLayoutDocumentLayoutBlockLayoutListEntry"
+            }
+          },
+          "type": {
+            "type": "string",
+            "description": "Type of the list_entries (if exist). Available options are `ordered` and `unordered`."
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1DocumentDocumentLayoutDocumentLayoutBlockLayoutListEntry": {
+        "type": "object",
+        "description": "Represents an entry in the list.",
+        "properties": {
+          "blocks": {
+            "type": "array",
+            "description": "A list entry is a list of blocks. Repeated blocks support further hierarchies and nested blocks.",
+            "items": {
+              "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentDocumentLayoutDocumentLayoutBlock"
+            }
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1DocumentDocumentLayoutDocumentLayoutBlockLayoutPageSpan": {
+        "type": "object",
+        "description": "Represents where the block starts and ends in the document.",
+        "properties": {
+          "pageStart": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Page where block starts in the document."
+          },
+          "pageEnd": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Page where block ends in the document."
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1DocumentDocumentLayoutDocumentLayoutBlockLayoutTableBlock": {
+        "type": "object",
+        "description": "Represents a table type block.",
+        "properties": {
+          "headerRows": {
+            "type": "array",
+            "description": "Header rows at the top of the table.",
+            "items": {
+              "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentDocumentLayoutDocumentLayoutBlockLayoutTableRow"
+            }
+          },
+          "bodyRows": {
+            "type": "array",
+            "description": "Body rows containing main table content.",
+            "items": {
+              "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentDocumentLayoutDocumentLayoutBlockLayoutTableRow"
+            }
+          },
+          "caption": {
+            "type": "string",
+            "description": "Table caption/title."
+          },
+          "annotations": {
+            "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentAnnotations"
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1DocumentDocumentLayoutDocumentLayoutBlockLayoutTableCell": {
+        "type": "object",
+        "description": "Represents a cell in a table row.",
+        "properties": {
+          "blocks": {
+            "type": "array",
+            "description": "A table cell is a list of blocks. Repeated blocks support further hierarchies and nested blocks.",
+            "items": {
+              "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentDocumentLayoutDocumentLayoutBlock"
+            }
+          },
+          "rowSpan": {
+            "type": "integer",
+            "format": "int32",
+            "description": "How many rows this cell spans."
+          },
+          "colSpan": {
+            "type": "integer",
+            "format": "int32",
+            "description": "How many columns this cell spans."
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1DocumentDocumentLayoutDocumentLayoutBlockLayoutTableRow": {
+        "type": "object",
+        "description": "Represents a row in a table.",
+        "properties": {
+          "cells": {
+            "type": "array",
+            "description": "A table row is a list of table cells.",
+            "items": {
+              "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentDocumentLayoutDocumentLayoutBlockLayoutTableCell"
+            }
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1DocumentDocumentLayoutDocumentLayoutBlockLayoutTextBlock": {
+        "type": "object",
+        "description": "Represents a text type block.",
+        "properties": {
+          "text": {
+            "type": "string",
+            "description": "Text content stored in the block."
+          },
+          "type": {
+            "type": "string",
+            "description": "Type of the text in the block. Available options are: `paragraph`, `subtitle`, `heading-1`, `heading-2`, `heading-3`, `heading-4`, `heading-5`, `header`, `footer`."
+          },
+          "blocks": {
+            "type": "array",
+            "description": "A text block could further have child blocks. Repeated blocks support further hierarchies and nested blocks.",
+            "items": {
+              "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentDocumentLayoutDocumentLayoutBlock"
+            }
+          },
+          "annotations": {
+            "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentAnnotations"
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1DocumentEntitiesRevision": {
+        "type": "object",
+        "description": "Entity revision.",
+        "properties": {
+          "revisionId": {
+            "type": "string",
+            "description": "The revision id."
+          },
+          "entities": {
+            "type": "array",
+            "description": "The entities in this revision.",
+            "items": {
+              "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentEntity"
+            }
+          },
+          "entityValidationOutput": {
+            "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentEntityValidationOutput"
+          },
+          "provenance": {
+            "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentProvenance"
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1DocumentEntity": {
+        "type": "object",
+        "description": "An entity that could be a phrase in the text or a property that belongs to the document. It is a known entity type, such as a person, an organization, or location.",
+        "properties": {
+          "textAnchor": {
+            "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentTextAnchor"
+          },
+          "type": {
+            "type": "string",
+            "description": "Required. Entity type from a schema, for example, `Address`."
+          },
+          "mentionText": {
+            "type": "string",
+            "description": "Optional. Text value of the entity, for example, `1600 Amphitheatre Pkwy`."
+          },
+          "mentionId": {
+            "type": "string",
+            "description": "Optional. Deprecated. Use `id` field instead."
+          },
+          "confidence": {
+            "type": "number",
+            "format": "float",
+            "description": "Optional. Confidence of detected Schema entity. Range `[0, 1]`."
+          },
+          "pageAnchor": {
+            "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentPageAnchor"
+          },
+          "id": {
+            "type": "string",
+            "description": "Optional. Canonical id. This will be a unique value in the entity list for this document."
+          },
+          "normalizedValue": {
+            "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentEntityNormalizedValue"
+          },
+          "properties": {
+            "type": "array",
+            "description": "Optional. Entities can be nested to form a hierarchical data structure representing the content in the document.",
+            "items": {
+              "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentEntity"
+            }
+          },
+          "provenance": {
+            "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentProvenance"
+          },
+          "redacted": {
+            "type": "boolean",
+            "description": "Optional. Whether the entity will be redacted for de-identification purposes."
+          },
+          "method": {
+            "type": "string",
+            "description": "Optional. Specifies how the entity's value is obtained.",
+            "enum": [
+              "METHOD_UNSPECIFIED",
+              "EXTRACT",
+              "DERIVE"
+            ]
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1DocumentEntityNormalizedValue": {
+        "type": "object",
+        "description": "Parsed and normalized entity value.",
+        "properties": {
+          "moneyValue": {
+            "$ref": "#/components/schemas/GoogleTypeMoney"
+          },
+          "dateValue": {
+            "$ref": "#/components/schemas/GoogleTypeDate"
+          },
+          "datetimeValue": {
+            "$ref": "#/components/schemas/GoogleTypeDateTime"
+          },
+          "addressValue": {
+            "$ref": "#/components/schemas/GoogleTypePostalAddress"
+          },
+          "booleanValue": {
+            "type": "boolean",
+            "description": "Boolean value. Can be used for entities with binary values, or for checkboxes."
+          },
+          "integerValue": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Integer value."
+          },
+          "floatValue": {
+            "type": "number",
+            "format": "float",
+            "description": "Float value."
+          },
+          "signatureValue": {
+            "type": "boolean",
+            "description": "A signature - a graphical representation of a person's name, often used to sign a document."
+          },
+          "text": {
+            "type": "string",
+            "description": "Optional. An optional field to store a normalized string. For some entity types, one of respective `structured_value` fields may also be populated. Also not all the types of `structured_value` will be normalized. For example, some processors may not generate `float` or `integer` normalized text by default. Below are sample formats mapped to structured values. - Money/Currency type (`money_value`) is in the ISO 4217 text format. - Date type (`date_value`) is in the ISO 8601 text format. - Datetime type (`datetime_value`) is in the ISO 8601 text format."
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1DocumentEntityRelation": {
+        "type": "object",
+        "description": "Relationship between Entities.",
+        "properties": {
+          "subjectId": {
+            "type": "string",
+            "description": "Subject entity id."
+          },
+          "objectId": {
+            "type": "string",
+            "description": "Object entity id."
+          },
+          "relation": {
+            "type": "string",
+            "description": "Relationship description."
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1DocumentEntityValidationOutput": {
+        "type": "object",
+        "description": "The output of the validation given the document and the validation rules.",
+        "properties": {
+          "validationResults": {
+            "type": "array",
+            "description": "The result of each validation rule.",
+            "items": {
+              "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentEntityValidationOutputValidationResult"
+            }
+          },
+          "passAllRules": {
+            "type": "boolean",
+            "description": "The overall result of the validation, true if all applicable rules are valid."
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1DocumentEntityValidationOutputValidationResult": {
+        "type": "object",
+        "description": "Validation result for a single validation rule.",
+        "properties": {
+          "rule": {
+            "type": "string",
+            "description": "Optional. The name of the rule resource that is used for validation. Format: `projects/{project}/locations/{location}/rules/{rule}`"
+          },
+          "ruleName": {
+            "type": "string",
+            "description": "The display name of the validation rule."
+          },
+          "ruleDescription": {
+            "type": "string",
+            "description": "The description of the validation rule."
+          },
+          "validationResultType": {
+            "type": "string",
+            "description": "The result of the validation rule.",
+            "enum": [
+              "VALIDATION_RESULT_TYPE_UNSPECIFIED",
+              "VALIDATION_RESULT_TYPE_VALID",
+              "VALIDATION_RESULT_TYPE_INVALID",
+              "VALIDATION_RESULT_TYPE_SKIPPED",
+              "VALIDATION_RESULT_TYPE_NOT_APPLICABLE"
+            ]
+          },
+          "validationDetails": {
+            "type": "string",
+            "description": "The detailed information of the running the validation process using the entity from the document based on the validation rule."
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1DocumentOutputConfig": {
+        "type": "object",
+        "description": "Config that controls the output of documents. All documents will be written as a JSON file.",
+        "properties": {
+          "gcsOutputConfig": {
+            "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentOutputConfigGcsOutputConfig"
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1DocumentOutputConfigGcsOutputConfig": {
+        "type": "object",
+        "description": "The configuration used when outputting documents.",
+        "properties": {
+          "gcsUri": {
+            "type": "string",
+            "description": "The Cloud Storage uri (a directory) of the output."
+          },
+          "fieldMask": {
+            "type": "string",
+            "format": "google-fieldmask",
+            "description": "Specifies which fields to include in the output documents. Only supports top level document and pages field so it must be in the form of `{document_field_name}` or `pages.{page_field_name}`."
+          },
+          "shardingConfig": {
+            "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentOutputConfigGcsOutputConfigShardingConfig"
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1DocumentOutputConfigGcsOutputConfigShardingConfig": {
+        "type": "object",
+        "description": "The sharding config for the output document.",
+        "properties": {
+          "pagesPerShard": {
+            "type": "integer",
+            "format": "int32",
+            "description": "The number of pages per shard."
+          },
+          "pagesOverlap": {
+            "type": "integer",
+            "format": "int32",
+            "description": "The number of overlapping pages between consecutive shards."
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1DocumentPage": {
+        "type": "object",
+        "description": "A page in a Document.",
+        "properties": {
+          "pageNumber": {
+            "type": "integer",
+            "format": "int32",
+            "description": "1-based index for current Page in a parent Document. Useful when a page is taken out of a Document for individual processing."
+          },
+          "image": {
+            "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentPageImage"
+          },
+          "transforms": {
+            "type": "array",
+            "description": "Transformation matrices that were applied to the original document image to produce Page.image.",
+            "items": {
+              "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentPageMatrix"
+            }
+          },
+          "dimension": {
+            "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentPageDimension"
+          },
+          "layout": {
+            "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentPageLayout"
+          },
+          "detectedLanguages": {
+            "type": "array",
+            "description": "A list of detected languages together with confidence.",
+            "items": {
+              "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentPageDetectedLanguage"
+            }
+          },
+          "blocks": {
+            "type": "array",
+            "description": "A list of visually detected text blocks on the page. A block has a set of lines (collected into paragraphs) that have a common line-spacing and orientation.",
+            "items": {
+              "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentPageBlock"
+            }
+          },
+          "paragraphs": {
+            "type": "array",
+            "description": "A list of visually detected text paragraphs on the page. A collection of lines that a human would perceive as a paragraph.",
+            "items": {
+              "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentPageParagraph"
+            }
+          },
+          "lines": {
+            "type": "array",
+            "description": "A list of visually detected text lines on the page. A collection of tokens that a human would perceive as a line.",
+            "items": {
+              "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentPageLine"
+            }
+          },
+          "tokens": {
+            "type": "array",
+            "description": "A list of visually detected tokens on the page.",
+            "items": {
+              "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentPageToken"
+            }
+          },
+          "visualElements": {
+            "type": "array",
+            "description": "A list of detected non-text visual elements, for example, checkbox, signature etc. on the page.",
+            "items": {
+              "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentPageVisualElement"
+            }
+          },
+          "tables": {
+            "type": "array",
+            "description": "A list of visually detected tables on the page.",
+            "items": {
+              "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentPageTable"
+            }
+          },
+          "formFields": {
+            "type": "array",
+            "description": "A list of visually detected form fields on the page.",
+            "items": {
+              "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentPageFormField"
+            }
+          },
+          "symbols": {
+            "type": "array",
+            "description": "A list of visually detected symbols on the page.",
+            "items": {
+              "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentPageSymbol"
+            }
+          },
+          "detectedBarcodes": {
+            "type": "array",
+            "description": "A list of detected barcodes.",
+            "items": {
+              "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentPageDetectedBarcode"
+            }
+          },
+          "imageQualityScores": {
+            "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentPageImageQualityScores"
+          },
+          "provenance": {
+            "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentProvenance"
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1DocumentPageAnchor": {
+        "type": "object",
+        "description": "Referencing the visual context of the entity in the Document.pages. Page anchors can be cross-page, consist of multiple bounding polygons and optionally reference specific layout element types.",
+        "properties": {
+          "pageRefs": {
+            "type": "array",
+            "description": "One or more references to visual page elements",
+            "items": {
+              "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentPageAnchorPageRef"
+            }
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1DocumentPageAnchorPageRef": {
+        "type": "object",
+        "description": "Represents a weak reference to a page element within a document.",
+        "properties": {
+          "page": {
+            "type": "string",
+            "format": "int64",
+            "description": "Required. Index into the Document.pages element, for example using `Document.pages` to locate the related page element. This field is skipped when its value is the default `0`. See https://developers.google.com/protocol-buffers/docs/proto3#json."
+          },
+          "layoutType": {
+            "type": "string",
+            "description": "Optional. The type of the layout element that is being referenced if any.",
+            "enum": [
+              "LAYOUT_TYPE_UNSPECIFIED",
+              "BLOCK",
+              "PARAGRAPH",
+              "LINE",
+              "TOKEN",
+              "VISUAL_ELEMENT",
+              "TABLE",
+              "FORM_FIELD"
+            ]
+          },
+          "layoutId": {
+            "type": "string",
+            "description": "Optional. Deprecated. Use PageRef.bounding_poly instead.",
+            "deprecated": true
+          },
+          "boundingPoly": {
+            "$ref": "#/components/schemas/GoogleCloudDocumentaiV1BoundingPoly"
+          },
+          "confidence": {
+            "type": "number",
+            "format": "float",
+            "description": "Optional. Confidence of detected page element, if applicable. Range `[0, 1]`."
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1DocumentPageBlock": {
+        "type": "object",
+        "description": "A block has a set of lines (collected into paragraphs) that have a common line-spacing and orientation.",
+        "properties": {
+          "layout": {
+            "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentPageLayout"
+          },
+          "detectedLanguages": {
+            "type": "array",
+            "description": "A list of detected languages together with confidence.",
+            "items": {
+              "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentPageDetectedLanguage"
+            }
+          },
+          "provenance": {
+            "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentProvenance"
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1DocumentPageDetectedBarcode": {
+        "type": "object",
+        "description": "A detected barcode.",
+        "properties": {
+          "layout": {
+            "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentPageLayout"
+          },
+          "barcode": {
+            "$ref": "#/components/schemas/GoogleCloudDocumentaiV1Barcode"
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1DocumentPageDetectedLanguage": {
+        "type": "object",
+        "description": "Detected language for a structural component.",
+        "properties": {
+          "languageCode": {
+            "type": "string",
+            "description": "The [BCP-47 language code](https://www.unicode.org/reports/tr35/#Unicode_locale_identifier), such as `en-US` or `sr-Latn`."
+          },
+          "confidence": {
+            "type": "number",
+            "format": "float",
+            "description": "Confidence of detected language. Range `[0, 1]`."
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1DocumentPageDimension": {
+        "type": "object",
+        "description": "Dimension for the page.",
+        "properties": {
+          "width": {
+            "type": "number",
+            "format": "float",
+            "description": "Page width."
+          },
+          "height": {
+            "type": "number",
+            "format": "float",
+            "description": "Page height."
+          },
+          "unit": {
+            "type": "string",
+            "description": "Dimension unit."
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1DocumentPageFormField": {
+        "type": "object",
+        "description": "A form field detected on the page.",
+        "properties": {
+          "fieldName": {
+            "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentPageLayout"
+          },
+          "fieldValue": {
+            "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentPageLayout"
+          },
+          "nameDetectedLanguages": {
+            "type": "array",
+            "description": "A list of detected languages for name together with confidence.",
+            "items": {
+              "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentPageDetectedLanguage"
+            }
+          },
+          "valueDetectedLanguages": {
+            "type": "array",
+            "description": "A list of detected languages for value together with confidence.",
+            "items": {
+              "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentPageDetectedLanguage"
+            }
+          },
+          "valueType": {
+            "type": "string",
+            "description": "If the value is non-textual, this field represents the type. Current valid values are: - blank (this indicates the `field_value` is normal text) - `unfilled_checkbox` - `filled_checkbox`"
+          },
+          "correctedKeyText": {
+            "type": "string",
+            "description": "Created for Labeling UI to export key text. If corrections were made to the text identified by the `field_name.text_anchor`, this field will contain the correction."
+          },
+          "correctedValueText": {
+            "type": "string",
+            "description": "Created for Labeling UI to export value text. If corrections were made to the text identified by the `field_value.text_anchor`, this field will contain the correction."
+          },
+          "provenance": {
+            "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentProvenance"
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1DocumentPageImage": {
+        "type": "object",
+        "description": "Rendered image contents for this page.",
+        "properties": {
+          "content": {
+            "type": "string",
+            "format": "byte",
+            "description": "Raw byte content of the image."
+          },
+          "mimeType": {
+            "type": "string",
+            "description": "Encoding [media type (MIME type)](https://www.iana.org/assignments/media-types/media-types.xhtml) for the image."
+          },
+          "width": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Width of the image in pixels."
+          },
+          "height": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Height of the image in pixels."
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1DocumentPageImageQualityScores": {
+        "type": "object",
+        "description": "Image quality scores for the page image.",
+        "properties": {
+          "qualityScore": {
+            "type": "number",
+            "format": "float",
+            "description": "The overall quality score. Range `[0, 1]` where `1` is perfect quality."
+          },
+          "detectedDefects": {
+            "type": "array",
+            "description": "A list of detected defects.",
+            "items": {
+              "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentPageImageQualityScoresDetectedDefect"
+            }
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1DocumentPageImageQualityScoresDetectedDefect": {
+        "type": "object",
+        "description": "Image Quality Defects",
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "Name of the defect type. Supported values are: - `quality/defect_blurry` - `quality/defect_noisy` - `quality/defect_dark` - `quality/defect_faint` - `quality/defect_text_too_small` - `quality/defect_document_cutoff` - `quality/defect_text_cutoff` - `quality/defect_glare`"
+          },
+          "confidence": {
+            "type": "number",
+            "format": "float",
+            "description": "Confidence of detected defect. Range `[0, 1]` where `1` indicates strong confidence that the defect exists."
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1DocumentPageLayout": {
+        "type": "object",
+        "description": "Visual element describing a layout unit on a page.",
+        "properties": {
+          "textAnchor": {
+            "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentTextAnchor"
+          },
+          "confidence": {
+            "type": "number",
+            "format": "float",
+            "description": "Confidence of the current Layout within context of the object this layout is for. For example, confidence can be for a single token, a table, a visual element, etc. depending on context. Range `[0, 1]`."
+          },
+          "boundingPoly": {
+            "$ref": "#/components/schemas/GoogleCloudDocumentaiV1BoundingPoly"
+          },
+          "orientation": {
+            "type": "string",
+            "description": "Detected orientation for the Layout.",
+            "enum": [
+              "ORIENTATION_UNSPECIFIED",
+              "PAGE_UP",
+              "PAGE_RIGHT",
+              "PAGE_DOWN",
+              "PAGE_LEFT"
+            ]
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1DocumentPageLine": {
+        "type": "object",
+        "description": "A collection of tokens that a human would perceive as a line. Does not cross column boundaries, can be horizontal, vertical, etc.",
+        "properties": {
+          "layout": {
+            "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentPageLayout"
+          },
+          "detectedLanguages": {
+            "type": "array",
+            "description": "A list of detected languages together with confidence.",
+            "items": {
+              "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentPageDetectedLanguage"
+            }
+          },
+          "provenance": {
+            "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentProvenance"
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1DocumentPageMatrix": {
+        "type": "object",
+        "description": "Representation for transformation matrix, intended to be compatible and used with OpenCV format for image manipulation.",
+        "properties": {
+          "rows": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Number of rows in the matrix."
+          },
+          "cols": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Number of columns in the matrix."
+          },
+          "type": {
+            "type": "integer",
+            "format": "int32",
+            "description": "This encodes information about what data type the matrix uses. For example, 0 (CV_8U) is an unsigned 8-bit image. For the full list of OpenCV primitive data types, please refer to https://docs.opencv.org/4.3.0/d1/d1b/group__core__hal__interface.html"
+          },
+          "data": {
+            "type": "string",
+            "format": "byte",
+            "description": "The matrix data."
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1DocumentPageParagraph": {
+        "type": "object",
+        "description": "A collection of lines that a human would perceive as a paragraph.",
+        "properties": {
+          "layout": {
+            "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentPageLayout"
+          },
+          "detectedLanguages": {
+            "type": "array",
+            "description": "A list of detected languages together with confidence.",
+            "items": {
+              "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentPageDetectedLanguage"
+            }
+          },
+          "provenance": {
+            "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentProvenance"
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1DocumentPageSymbol": {
+        "type": "object",
+        "description": "A detected symbol.",
+        "properties": {
+          "layout": {
+            "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentPageLayout"
+          },
+          "detectedLanguages": {
+            "type": "array",
+            "description": "A list of detected languages together with confidence.",
+            "items": {
+              "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentPageDetectedLanguage"
+            }
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1DocumentPageTable": {
+        "type": "object",
+        "description": "A table representation similar to HTML table structure.",
+        "properties": {
+          "layout": {
+            "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentPageLayout"
+          },
+          "headerRows": {
+            "type": "array",
+            "description": "Header rows of the table.",
+            "items": {
+              "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentPageTableTableRow"
+            }
+          },
+          "bodyRows": {
+            "type": "array",
+            "description": "Body rows of the table.",
+            "items": {
+              "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentPageTableTableRow"
+            }
+          },
+          "detectedLanguages": {
+            "type": "array",
+            "description": "A list of detected languages together with confidence.",
+            "items": {
+              "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentPageDetectedLanguage"
+            }
+          },
+          "provenance": {
+            "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentProvenance"
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1DocumentPageTableTableCell": {
+        "type": "object",
+        "description": "A cell representation inside the table.",
+        "properties": {
+          "layout": {
+            "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentPageLayout"
+          },
+          "rowSpan": {
+            "type": "integer",
+            "format": "int32",
+            "description": "How many rows this cell spans."
+          },
+          "colSpan": {
+            "type": "integer",
+            "format": "int32",
+            "description": "How many columns this cell spans."
+          },
+          "detectedLanguages": {
+            "type": "array",
+            "description": "A list of detected languages together with confidence.",
+            "items": {
+              "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentPageDetectedLanguage"
+            }
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1DocumentPageTableTableRow": {
+        "type": "object",
+        "description": "A row of table cells.",
+        "properties": {
+          "cells": {
+            "type": "array",
+            "description": "Cells that make up this row.",
+            "items": {
+              "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentPageTableTableCell"
+            }
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1DocumentPageToken": {
+        "type": "object",
+        "description": "A detected token.",
+        "properties": {
+          "layout": {
+            "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentPageLayout"
+          },
+          "detectedBreak": {
+            "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentPageTokenDetectedBreak"
+          },
+          "detectedLanguages": {
+            "type": "array",
+            "description": "A list of detected languages together with confidence.",
+            "items": {
+              "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentPageDetectedLanguage"
+            }
+          },
+          "provenance": {
+            "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentProvenance"
+          },
+          "styleInfo": {
+            "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentPageTokenStyleInfo"
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1DocumentPageTokenDetectedBreak": {
+        "type": "object",
+        "description": "Detected break at the end of a Token.",
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "Detected break type.",
+            "enum": [
+              "TYPE_UNSPECIFIED",
+              "SPACE",
+              "WIDE_SPACE",
+              "HYPHEN"
+            ]
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1DocumentPageTokenStyleInfo": {
+        "type": "object",
+        "description": "Font and other text style attributes.",
+        "properties": {
+          "fontSize": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Font size in points (`1` point is `\u00b9\u2044\u2087\u2082` inches)."
+          },
+          "pixelFontSize": {
+            "type": "number",
+            "format": "double",
+            "description": "Font size in pixels, equal to _unrounded font_size_ * _resolution_ \u00f7 `72.0`."
+          },
+          "letterSpacing": {
+            "type": "number",
+            "format": "double",
+            "description": "Letter spacing in points."
+          },
+          "fontType": {
+            "type": "string",
+            "description": "Name or style of the font."
+          },
+          "bold": {
+            "type": "boolean",
+            "description": "Whether the text is bold (equivalent to font_weight is at least `700`)."
+          },
+          "italic": {
+            "type": "boolean",
+            "description": "Whether the text is italic."
+          },
+          "underlined": {
+            "type": "boolean",
+            "description": "Whether the text is underlined."
+          },
+          "strikeout": {
+            "type": "boolean",
+            "description": "Whether the text is strikethrough. This feature is not supported yet."
+          },
+          "subscript": {
+            "type": "boolean",
+            "description": "Whether the text is a subscript. This feature is not supported yet."
+          },
+          "superscript": {
+            "type": "boolean",
+            "description": "Whether the text is a superscript. This feature is not supported yet."
+          },
+          "smallcaps": {
+            "type": "boolean",
+            "description": "Whether the text is in small caps. This feature is not supported yet."
+          },
+          "fontWeight": {
+            "type": "integer",
+            "format": "int32",
+            "description": "TrueType weight on a scale `100` (thin) to `1000` (ultra-heavy). Normal is `400`, bold is `700`."
+          },
+          "handwritten": {
+            "type": "boolean",
+            "description": "Whether the text is handwritten."
+          },
+          "textColor": {
+            "$ref": "#/components/schemas/GoogleTypeColor"
+          },
+          "backgroundColor": {
+            "$ref": "#/components/schemas/GoogleTypeColor"
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1DocumentPageVisualElement": {
+        "type": "object",
+        "description": "Detected non-text visual elements, for example, checkbox, signature etc. on the page.",
+        "properties": {
+          "layout": {
+            "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentPageLayout"
+          },
+          "type": {
+            "type": "string",
+            "description": "Type of the VisualElement."
+          },
+          "detectedLanguages": {
+            "type": "array",
+            "description": "A list of detected languages together with confidence.",
+            "items": {
+              "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentPageDetectedLanguage"
+            }
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1DocumentProvenance": {
+        "type": "object",
+        "description": "Structure to identify provenance relationships between annotations in different revisions.",
+        "properties": {
+          "revision": {
+            "type": "integer",
+            "format": "int32",
+            "description": "The index of the revision that produced this element.",
+            "deprecated": true
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32",
+            "description": "The Id of this operation. Needs to be unique within the scope of the revision.",
+            "deprecated": true
+          },
+          "parents": {
+            "type": "array",
+            "description": "References to the original elements that are replaced.",
+            "items": {
+              "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentProvenanceParent"
+            }
+          },
+          "type": {
+            "type": "string",
+            "description": "The type of provenance operation.",
+            "enum": [
+              "OPERATION_TYPE_UNSPECIFIED",
+              "ADD",
+              "REMOVE",
+              "UPDATE",
+              "REPLACE",
+              "EVAL_REQUESTED",
+              "EVAL_APPROVED",
+              "EVAL_SKIPPED"
+            ]
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1DocumentProvenanceParent": {
+        "type": "object",
+        "description": "The parent element the current element is based on. Used for referencing/aligning, removal and replacement operations.",
+        "properties": {
+          "revision": {
+            "type": "integer",
+            "format": "int32",
+            "description": "The index of the index into current revision's parent_ids list."
+          },
+          "index": {
+            "type": "integer",
+            "format": "int32",
+            "description": "The index of the parent item in the corresponding item list (eg. list of entities, properties within entities, etc.) in the parent revision."
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32",
+            "description": "The id of the parent provenance.",
+            "deprecated": true
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1DocumentRevision": {
+        "type": "object",
+        "description": "Contains past or forward revisions of this document.",
+        "properties": {
+          "agent": {
+            "type": "string",
+            "description": "If the change was made by a person specify the name or id of that person."
+          },
+          "processor": {
+            "type": "string",
+            "description": "If the annotation was made by processor identify the processor by its resource name."
+          },
+          "id": {
+            "type": "string",
+            "description": "Id of the revision, internally generated by doc proto storage. Unique within the context of the document."
+          },
+          "parent": {
+            "type": "array",
+            "description": "The revisions that this revision is based on. This can include one or more parent (when documents are merged.) This field represents the index into the `revisions` field.",
+            "deprecated": true,
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          "parentIds": {
+            "type": "array",
+            "description": "The revisions that this revision is based on. Must include all the ids that have anything to do with this revision - eg. there are `provenance.parent.revision` fields that index into this field.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "createTime": {
+            "type": "string",
+            "format": "google-datetime",
+            "description": "The time that the revision was created, internally generated by doc proto storage at the time of create."
+          },
+          "humanReview": {
+            "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentRevisionHumanReview"
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1DocumentRevisionHumanReview": {
+        "type": "object",
+        "description": "Human Review information of the document.",
+        "properties": {
+          "state": {
+            "type": "string",
+            "description": "Human review state. For example, `requested`, `succeeded`, `rejected`."
+          },
+          "stateMessage": {
+            "type": "string",
+            "description": "A message providing more details about the current state of processing. For example, the rejection reason when the state is `rejected`."
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1DocumentSchema": {
+        "type": "object",
+        "description": "The schema defines the output of the processed document by a processor.",
+        "properties": {
+          "displayName": {
+            "type": "string",
+            "description": "Display name to show users."
+          },
+          "description": {
+            "type": "string",
+            "description": "Description of the schema."
+          },
+          "entityTypes": {
+            "type": "array",
+            "description": "Entity types of the schema.",
+            "items": {
+              "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentSchemaEntityType"
+            }
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentSchemaMetadata"
+          },
+          "documentPrompt": {
+            "type": "string",
+            "description": "Optional. Document level prompt provided by the user. This custom text is injected into the AI model's prompt to provide extra, document-wide guidance for processing."
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1DocumentSchemaEntityType": {
+        "type": "object",
+        "description": "EntityType is the wrapper of a label of the corresponding model with detailed attributes and limitations for entity-based processors. Multiple types can also compose a dependency tree to represent nested types.",
+        "properties": {
+          "enumValues": {
+            "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentSchemaEntityTypeEnumValues"
+          },
+          "displayName": {
+            "type": "string",
+            "description": "User defined name for the type."
+          },
+          "name": {
+            "type": "string",
+            "description": "Name of the type. It must be unique within the schema file and cannot be a \"Common Type\". The following naming conventions are used: - Use `snake_casing`. - Name matching is case-sensitive. - Maximum 64 characters. - Must start with a letter. - Allowed characters: ASCII letters `[a-z0-9_-]`. (For backward compatibility, internal infrastructure and tooling can handle any ASCII character.) - The `/` is sometimes used to denote a property of a type. For example `line_item/amount`. This convention is deprecated, but will still be honored for backward compatibility."
+          },
+          "baseTypes": {
+            "type": "array",
+            "description": "The entity type that this type is derived from. For now, one and only one should be set.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "properties": {
+            "type": "array",
+            "description": "Description the nested structure, or composition of an entity.",
+            "items": {
+              "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentSchemaEntityTypeProperty"
+            }
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1DocumentSchemaEntityTypeEnumValues": {
+        "type": "object",
+        "description": "Defines the a list of enum values.",
+        "properties": {
+          "values": {
+            "type": "array",
+            "description": "The individual values that this enum values type can include.",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1DocumentSchemaEntityTypeProperty": {
+        "type": "object",
+        "description": "Defines properties that can be part of the entity type.",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The name of the property. Follows the same guidelines as the EntityType name."
+          },
+          "displayName": {
+            "type": "string",
+            "description": "User defined name for the property."
+          },
+          "valueType": {
+            "type": "string",
+            "description": "A reference to the value type of the property. This type is subject to the same conventions as the `Entity.base_types` field."
+          },
+          "occurrenceType": {
+            "type": "string",
+            "description": "Occurrence type limits the number of instances an entity type appears in the document.",
+            "enum": [
+              "OCCURRENCE_TYPE_UNSPECIFIED",
+              "OPTIONAL_ONCE",
+              "OPTIONAL_MULTIPLE",
+              "REQUIRED_ONCE",
+              "REQUIRED_MULTIPLE"
+            ]
+          },
+          "method": {
+            "type": "string",
+            "description": "Specifies how the entity's value is obtained.",
+            "enum": [
+              "METHOD_UNSPECIFIED",
+              "EXTRACT",
+              "DERIVE",
+              "RELAXED_EXTRACT"
+            ]
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1DocumentSchemaMetadata": {
+        "type": "object",
+        "description": "Metadata for global schema behavior.",
+        "properties": {
+          "documentSplitter": {
+            "type": "boolean",
+            "description": "If true, a `document` entity type can be applied to subdocument (splitting). Otherwise, it can only be applied to the entire document (classification)."
+          },
+          "documentAllowMultipleLabels": {
+            "type": "boolean",
+            "description": "If true, on a given page, there can be multiple `document` annotations covering it."
+          },
+          "prefixedNamingOnProperties": {
+            "type": "boolean",
+            "description": "If set, all the nested entities must be prefixed with the parents."
+          },
+          "skipNamingValidation": {
+            "type": "boolean",
+            "description": "If set, this will skip the naming format validation in the schema. So the string values in `DocumentSchema.EntityType.name` and `DocumentSchema.EntityType.Property.name` will not be checked."
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1DocumentShardInfo": {
+        "type": "object",
+        "description": "For a large document, sharding may be performed to produce several document shards. Each document shard contains this field to detail which shard it is.",
+        "properties": {
+          "shardIndex": {
+            "type": "string",
+            "format": "int64",
+            "description": "The 0-based index of this shard."
+          },
+          "shardCount": {
+            "type": "string",
+            "format": "int64",
+            "description": "Total number of shards."
+          },
+          "textOffset": {
+            "type": "string",
+            "format": "int64",
+            "description": "The index of the first character in Document.text in the overall document global text."
+          },
+          "pageOffset": {
+            "type": "integer",
+            "format": "int32",
+            "description": "The index of the first page in Document.pages in the overall document global pages. Available for document shards created by the document splitter."
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1DocumentStyle": {
+        "type": "object",
+        "description": "Annotation for common text style attributes. This adheres to CSS conventions as much as possible.",
+        "properties": {
+          "textAnchor": {
+            "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentTextAnchor"
+          },
+          "color": {
+            "$ref": "#/components/schemas/GoogleTypeColor"
+          },
+          "backgroundColor": {
+            "$ref": "#/components/schemas/GoogleTypeColor"
+          },
+          "fontWeight": {
+            "type": "string",
+            "description": "[Font weight](https://www.w3schools.com/cssref/pr_font_weight.asp). Possible values are `normal`, `bold`, `bolder`, and `lighter`."
+          },
+          "textStyle": {
+            "type": "string",
+            "description": "[Text style](https://www.w3schools.com/cssref/pr_font_font-style.asp). Possible values are `normal`, `italic`, and `oblique`."
+          },
+          "textDecoration": {
+            "type": "string",
+            "description": "[Text decoration](https://www.w3schools.com/cssref/pr_text_text-decoration.asp). Follows CSS standard. "
+          },
+          "fontSize": {
+            "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentStyleFontSize"
+          },
+          "fontFamily": {
+            "type": "string",
+            "description": "Font family such as `Arial`, `Times New Roman`. https://www.w3schools.com/cssref/pr_font_font-family.asp"
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1DocumentStyleFontSize": {
+        "type": "object",
+        "description": "Font size with unit.",
+        "properties": {
+          "size": {
+            "type": "number",
+            "format": "float",
+            "description": "Font size for the text."
+          },
+          "unit": {
+            "type": "string",
+            "description": "Unit for the font size. Follows CSS naming (such as `in`, `px`, and `pt`)."
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1DocumentTextAnchor": {
+        "type": "object",
+        "description": "Text reference indexing into the Document.text.",
+        "properties": {
+          "textSegments": {
+            "type": "array",
+            "description": "The text segments from the Document.text.",
+            "items": {
+              "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentTextAnchorTextSegment"
+            }
+          },
+          "content": {
+            "type": "string",
+            "description": "Contains the content of the text span so that users do not have to look it up in the text_segments. It is always populated for formFields."
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1DocumentTextAnchorTextSegment": {
+        "type": "object",
+        "description": "A text segment in the Document.text. The indices may be out of bounds which indicate that the text extends into another document shard for large sharded documents. See ShardInfo.text_offset",
+        "properties": {
+          "startIndex": {
+            "type": "string",
+            "format": "int64",
+            "description": "TextSegment start UTF-8 char index in the Document.text."
+          },
+          "endIndex": {
+            "type": "string",
+            "format": "int64",
+            "description": "TextSegment half open end UTF-8 char index in the Document.text."
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1DocumentTextChange": {
+        "type": "object",
+        "description": "This message is used for text changes aka. OCR corrections.",
+        "properties": {
+          "textAnchor": {
+            "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentTextAnchor"
+          },
+          "changedText": {
+            "type": "string",
+            "description": "The text that replaces the text identified in the `text_anchor`."
+          },
+          "provenance": {
+            "type": "array",
+            "description": "The history of this annotation.",
+            "deprecated": true,
+            "items": {
+              "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentProvenance"
+            }
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1GcsDocument": {
+        "type": "object",
+        "description": "Specifies a document stored on Cloud Storage.",
+        "properties": {
+          "gcsUri": {
+            "type": "string",
+            "description": "The Cloud Storage object uri."
+          },
+          "mimeType": {
+            "type": "string",
+            "description": "An IANA MIME type (RFC6838) of the content."
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1GcsDocuments": {
+        "type": "object",
+        "description": "Specifies a set of documents on Cloud Storage.",
+        "properties": {
+          "documents": {
+            "type": "array",
+            "description": "The list of documents.",
+            "items": {
+              "$ref": "#/components/schemas/GoogleCloudDocumentaiV1GcsDocument"
+            }
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1GcsPrefix": {
+        "type": "object",
+        "description": "Specifies all documents on Cloud Storage with a common prefix.",
+        "properties": {
+          "gcsUriPrefix": {
+            "type": "string",
+            "description": "The URI prefix."
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1HumanReviewStatus": {
+        "type": "object",
+        "description": "The status of human review on a processed document.",
+        "properties": {
+          "state": {
+            "type": "string",
+            "description": "The state of human review on the processing request.",
+            "enum": [
+              "STATE_UNSPECIFIED",
+              "SKIPPED",
+              "VALIDATION_PASSED",
+              "IN_PROGRESS",
+              "ERROR"
+            ]
+          },
+          "stateMessage": {
+            "type": "string",
+            "description": "A message providing more details about the human review state."
+          },
+          "humanReviewOperation": {
+            "type": "string",
+            "description": "The name of the operation triggered by the processed document. This field is populated only when the state is `HUMAN_REVIEW_IN_PROGRESS`. It has the same response type and metadata as the long-running operation returned by ReviewDocument."
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1ListProcessorTypesResponse": {
+        "type": "object",
+        "description": "Response message for the ListProcessorTypes method.",
+        "properties": {
+          "processorTypes": {
+            "type": "array",
+            "description": "The processor types.",
+            "items": {
+              "$ref": "#/components/schemas/GoogleCloudDocumentaiV1ProcessorType"
+            }
+          },
+          "nextPageToken": {
+            "type": "string",
+            "description": "Points to the next page, otherwise empty."
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1NormalizedVertex": {
+        "type": "object",
+        "description": "A vertex represents a 2D point in the image. NOTE: the normalized vertex coordinates are relative to the original image and range from 0 to 1.",
+        "properties": {
+          "x": {
+            "type": "number",
+            "format": "float",
+            "description": "X coordinate."
+          },
+          "y": {
+            "type": "number",
+            "format": "float",
+            "description": "Y coordinate (starts from the top of the image)."
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1OcrConfig": {
+        "type": "object",
+        "description": "Config for Document OCR.",
+        "properties": {
+          "hints": {
+            "$ref": "#/components/schemas/GoogleCloudDocumentaiV1OcrConfigHints"
+          },
+          "enableNativePdfParsing": {
+            "type": "boolean",
+            "description": "Enables special handling for PDFs with existing text information. Results in better text extraction quality in such PDF inputs."
+          },
+          "enableImageQualityScores": {
+            "type": "boolean",
+            "description": "Enables intelligent document quality scores after OCR. Can help with diagnosing why OCR responses are of poor quality for a given input. Adds additional latency comparable to regular OCR to the process call."
+          },
+          "advancedOcrOptions": {
+            "type": "array",
+            "description": "A list of advanced OCR options to further fine-tune OCR behavior. Current valid values are: - `legacy_layout`: a heuristics layout detection algorithm, which serves as an alternative to the current ML-based layout detection algorithm. Customers can choose the best suitable layout algorithm based on their situation.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "enableSymbol": {
+            "type": "boolean",
+            "description": "Includes symbol level OCR information if set to true."
+          },
+          "computeStyleInfo": {
+            "type": "boolean",
+            "description": "Turn on font identification model and return font style information. Deprecated, use PremiumFeatures.compute_style_info instead.",
+            "deprecated": true
+          },
+          "disableCharacterBoxesDetection": {
+            "type": "boolean",
+            "description": "Turn off character box detector in OCR engine. Character box detection is enabled by default in OCR 2.0 (and later) processors."
+          },
+          "premiumFeatures": {
+            "$ref": "#/components/schemas/GoogleCloudDocumentaiV1OcrConfigPremiumFeatures"
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1OcrConfigHints": {
+        "type": "object",
+        "description": "Hints for OCR Engine",
+        "properties": {
+          "languageHints": {
+            "type": "array",
+            "description": "List of BCP-47 language codes to use for OCR. In most cases, not specifying it yields the best results since it enables automatic language detection. For languages based on the Latin alphabet, setting hints is not needed. In rare cases, when the language of the text in the image is known, setting a hint will help get better results (although it will be a significant hindrance if the hint is wrong).",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1OcrConfigPremiumFeatures": {
+        "type": "object",
+        "description": "Configurations for premium OCR features.",
+        "properties": {
+          "enableSelectionMarkDetection": {
+            "type": "boolean",
+            "description": "Turn on selection mark detector in OCR engine. Only available in OCR 2.0 (and later) processors."
+          },
+          "computeStyleInfo": {
+            "type": "boolean",
+            "description": "Turn on font identification model and return font style information."
+          },
+          "enableMathOcr": {
+            "type": "boolean",
+            "description": "Turn on the model that can extract LaTeX math formulas."
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1ProcessOptions": {
+        "type": "object",
+        "description": "Options for Process API",
+        "properties": {
+          "individualPageSelector": {
+            "$ref": "#/components/schemas/GoogleCloudDocumentaiV1ProcessOptionsIndividualPageSelector"
+          },
+          "fromStart": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Only process certain pages from the start. Process all if the document has fewer pages."
+          },
+          "fromEnd": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Only process certain pages from the end, same as above."
+          },
+          "ocrConfig": {
+            "$ref": "#/components/schemas/GoogleCloudDocumentaiV1OcrConfig"
+          },
+          "layoutConfig": {
+            "$ref": "#/components/schemas/GoogleCloudDocumentaiV1ProcessOptionsLayoutConfig"
+          },
+          "schemaOverride": {
+            "$ref": "#/components/schemas/GoogleCloudDocumentaiV1DocumentSchema"
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1ProcessOptionsIndividualPageSelector": {
+        "type": "object",
+        "description": "A list of individual page numbers.",
+        "properties": {
+          "pages": {
+            "type": "array",
+            "description": "Optional. Indices of the pages (starting from 1).",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1ProcessOptionsLayoutConfig": {
+        "type": "object",
+        "description": "Serving config for layout parser processor.",
+        "properties": {
+          "chunkingConfig": {
+            "$ref": "#/components/schemas/GoogleCloudDocumentaiV1ProcessOptionsLayoutConfigChunkingConfig"
+          },
+          "returnImages": {
+            "type": "boolean",
+            "description": "Optional. Whether to include images in layout parser processor response."
+          },
+          "returnBoundingBoxes": {
+            "type": "boolean",
+            "description": "Optional. Whether to include bounding boxes in layout parser processor response."
+          },
+          "enableImageAnnotation": {
+            "type": "boolean",
+            "description": "Optional. Whether to include image annotations in layout parser response."
+          },
+          "enableTableAnnotation": {
+            "type": "boolean",
+            "description": "Optional. Whether to include table annotations in layout parser response."
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1ProcessOptionsLayoutConfigChunkingConfig": {
+        "type": "object",
+        "description": "Serving config for chunking.",
+        "properties": {
+          "chunkSize": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Optional. The chunk sizes to use when splitting documents, in order of level."
+          },
+          "includeAncestorHeadings": {
+            "type": "boolean",
+            "description": "Optional. Whether or not to include ancestor headings when splitting."
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1ProcessRequest": {
+        "type": "object",
+        "description": "Request message for the ProcessDocument method.",
+        "properties": {
+          "inlineDocument": {
+            "$ref": "#/components/schemas/GoogleCloudDocumentaiV1Document"
+          },
+          "rawDocument": {
+            "$ref": "#/components/schemas/GoogleCloudDocumentaiV1RawDocument"
+          },
+          "gcsDocument": {
+            "$ref": "#/components/schemas/GoogleCloudDocumentaiV1GcsDocument"
+          },
+          "skipHumanReview": {
+            "type": "boolean",
+            "description": "Whether human review should be skipped for this request. Default to `false`.",
+            "deprecated": true
+          },
+          "fieldMask": {
+            "type": "string",
+            "format": "google-fieldmask",
+            "description": "Specifies which fields to include in the ProcessResponse.document output. Only supports top-level document and pages field, so it must be in the form of `{document_field_name}` or `pages.{page_field_name}`."
+          },
+          "processOptions": {
+            "$ref": "#/components/schemas/GoogleCloudDocumentaiV1ProcessOptions"
+          },
+          "labels": {
+            "type": "object",
+            "description": "Optional. The labels with user-defined metadata for the request. Label keys and values can be no longer than 63 characters (Unicode codepoints) and can only contain lowercase letters, numeric characters, underscores, and dashes. International characters are allowed. Label values are optional. Label keys must start with a letter.",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "imagelessMode": {
+            "type": "boolean",
+            "description": "Optional. Option to remove images from the document."
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1ProcessResponse": {
+        "type": "object",
+        "description": "Response message for the ProcessDocument method.",
+        "properties": {
+          "document": {
+            "$ref": "#/components/schemas/GoogleCloudDocumentaiV1Document"
+          },
+          "humanReviewStatus": {
+            "$ref": "#/components/schemas/GoogleCloudDocumentaiV1HumanReviewStatus"
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1ProcessorType": {
+        "type": "object",
+        "description": "A processor type is responsible for performing a certain document understanding task on a certain type of document.",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The resource name of the processor type. Format: `projects/{project}/processorTypes/{processor_type}`"
+          },
+          "type": {
+            "type": "string",
+            "description": "The processor type, such as: `OCR_PROCESSOR`, `INVOICE_PROCESSOR`."
+          },
+          "category": {
+            "type": "string",
+            "description": "The processor category, used by UI to group processor types."
+          },
+          "availableLocations": {
+            "type": "array",
+            "description": "The locations in which this processor is available.",
+            "items": {
+              "$ref": "#/components/schemas/GoogleCloudDocumentaiV1ProcessorTypeLocationInfo"
+            }
+          },
+          "allowCreation": {
+            "type": "boolean",
+            "description": "Whether the processor type allows creation. If true, users can create a processor of this processor type. Otherwise, users need to request access."
+          },
+          "launchStage": {
+            "type": "string",
+            "description": "Launch stage of the processor type",
+            "enum": [
+              "LAUNCH_STAGE_UNSPECIFIED",
+              "UNIMPLEMENTED",
+              "PRELAUNCH",
+              "EARLY_ACCESS",
+              "ALPHA",
+              "BETA",
+              "GA",
+              "DEPRECATED"
+            ]
+          },
+          "sampleDocumentUris": {
+            "type": "array",
+            "description": "A set of Cloud Storage URIs of sample documents for this processor.",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1ProcessorTypeLocationInfo": {
+        "type": "object",
+        "description": "The location information about where the processor is available.",
+        "properties": {
+          "locationId": {
+            "type": "string",
+            "description": "The location ID. For supported locations, refer to [regional and multi-regional support](/document-ai/docs/regions)."
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1RawDocument": {
+        "type": "object",
+        "description": "Payload message of raw document content (bytes).",
+        "properties": {
+          "content": {
+            "type": "string",
+            "format": "byte",
+            "description": "Inline document content."
+          },
+          "mimeType": {
+            "type": "string",
+            "description": "An IANA MIME type (RFC6838) indicating the nature and format of the content."
+          },
+          "displayName": {
+            "type": "string",
+            "description": "The display name of the document, it supports all Unicode characters except the following: `*`, `?`, `[`, `]`, `%`, `{`, `}`,`'`, `\\\"`, `,` `~`, `=` and `:` are reserved. If not specified, a default ID is generated."
+          }
+        }
+      },
+      "GoogleCloudDocumentaiV1Vertex": {
+        "type": "object",
+        "description": "A vertex represents a 2D point in the image. NOTE: the vertex coordinates are in the same scale as the original image.",
+        "properties": {
+          "x": {
+            "type": "integer",
+            "format": "int32",
+            "description": "X coordinate."
+          },
+          "y": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Y coordinate (starts from the top of the image)."
+          }
+        }
+      },
+      "GoogleLongrunningOperation": {
+        "type": "object",
+        "description": "This resource represents a long-running operation that is the result of a network API call.",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The server-assigned name, which is only unique within the same service that originally returns it. If you use the default HTTP mapping, the `name` should be a resource name ending with `operations/{unique_id}`."
+          },
+          "metadata": {
+            "type": "object",
+            "description": "Service-specific metadata associated with the operation. It typically contains progress information and common metadata such as create time. Some services might not provide such metadata. Any method that returns a long-running operation should document the metadata type, if any.",
+            "additionalProperties": {
+              "description": "Properties of the object. Contains field @type with type URL."
+            }
+          },
+          "done": {
+            "type": "boolean",
+            "description": "If the value is `false`, it means the operation is still in progress. If `true`, the operation is completed, and either `error` or `response` is available."
+          },
+          "error": {
+            "$ref": "#/components/schemas/GoogleRpcStatus"
+          },
+          "response": {
+            "type": "object",
+            "description": "The normal, successful response of the operation. If the original method returns no data on success, such as `Delete`, the response is `google.protobuf.Empty`. If the original method is standard `Get`/`Create`/`Update`, the response should be the resource. For other methods, the response should have the type `XxxResponse`, where `Xxx` is the original method name. For example, if the original method name is `TakeSnapshot()`, the inferred response type is `TakeSnapshotResponse`.",
+            "additionalProperties": {
+              "description": "Properties of the object. Contains field @type with type URL."
+            }
+          }
+        }
+      },
+      "GoogleRpcStatus": {
+        "type": "object",
+        "description": "The `Status` type defines a logical error model that is suitable for different programming environments, including REST APIs and RPC APIs. It is used by [gRPC](https://github.com/grpc). Each `Status` message contains three pieces of data: error code, error message, and error details. You can find out more about this error model and how to work with it in the [API Design Guide](https://cloud.google.com/apis/design/errors).",
+        "properties": {
+          "code": {
+            "type": "integer",
+            "format": "int32",
+            "description": "The status code, which should be an enum value of google.rpc.Code."
+          },
+          "message": {
+            "type": "string",
+            "description": "A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the google.rpc.Status.details field, or localized by the client."
+          },
+          "details": {
+            "type": "array",
+            "description": "A list of messages that carry the error details. There is a common set of message types for APIs to use.",
+            "items": {
+              "type": "object",
+              "additionalProperties": {
+                "description": "Properties of the object. Contains field @type with type URL."
+              }
+            }
+          }
+        }
+      },
+      "GoogleTypeColor": {
+        "type": "object",
+        "description": "Represents a color in the RGBA color space. This representation is designed for simplicity of conversion to and from color representations in various languages over compactness. For example, the fields of this representation can be trivially provided to the constructor of `java.awt.Color` in Java; it can also be trivially provided to UIColor's `+colorWithRed:green:blue:alpha` method in iOS; and, with just a little work, it can be easily formatted into a CSS `rgba()` string in JavaScript. This reference page doesn't have information about the absolute color space that should be used to interpret the RGB value\u2014for example, sRGB, Adobe RGB, DCI-P3, and BT.2020. By default, applications should assume the sRGB color space. When color equality needs to be decided, implementations, unless documented otherwise, treat two colors as equal if all their red, green, blue, and alpha values each differ by at most `1e-5`. Example (Java): import com.google.type.Color; // ... public static java.awt.Color fromProto(Color protocolor) { float alpha = protocolor.hasAlpha() ? protocolor.getAlpha().getValue() : 1.0; return new java.awt.Color( protocolor.getRed(), protocolor.getGreen(), protocolor.getBlue(), alpha); } public static Color toProto(java.awt.Color color) { float red = (float) color.getRed(); float green = (float) color.getGreen(); float blue = (float) color.getBlue(); float denominator = 255.0; Color.Builder resultBuilder = Color .newBuilder() .setRed(red / denominator) .setGreen(green / denominator) .setBlue(blue / denominator); int alpha = color.getAlpha(); if (alpha != 255) { result.setAlpha( FloatValue .newBuilder() .setValue(((float) alpha) / denominator) .build()); } return resultBuilder.build(); } // ... Example (iOS / Obj-C): // ... static UIColor* fromProto(Color* protocolor) { float red = [protocolor red]; float green = [protocolor green]; float blue = [protocolor blue]; FloatValue* alpha_wrapper = [protocolor alpha]; float alpha = 1.0; if (alpha_wrapper != nil) { alpha = [alpha_wrapper value]; } return [UIColor colorWithRed:red green:green blue:blue alpha:alpha]; } static Color* toProto(UIColor* color) { CGFloat red, green, blue, alpha; if (![color getRed:&red green:&green blue:&blue alpha:&alpha]) { return nil; } Color* result = [[Color alloc] init]; [result setRed:red]; [result setGreen:green]; [result setBlue:blue]; if (alpha <= 0.9999) { [result setAlpha:floatWrapperWithValue(alpha)]; } [result autorelease]; return result; } // ... Example (JavaScript): // ... var protoToCssColor = function(rgb_color) { var redFrac = rgb_color.red || 0.0; var greenFrac = rgb_color.green || 0.0; var blueFrac = rgb_color.blue || 0.0; var red = Math.floor(redFrac * 255); var green = Math.floor(greenFrac * 255); var blue = Math.floor(blueFrac * 255); if (!('alpha' in rgb_color)) { return rgbToCssColor(red, green, blue); } var alphaFrac = rgb_color.alpha.value || 0.0; var rgbParams = [red, green, blue].join(','); return ['rgba(', rgbParams, ',', alphaFrac, ')'].join(''); }; var rgbToCssColor = function(red, green, blue) { var rgbNumber = new Number((red << 16) | (green << 8) | blue); var hexString = rgbNumber.toString(16); var missingZeros = 6 - hexString.length; var resultBuilder = ['#']; for (var i = 0; i < missingZeros; i++) { resultBuilder.push('0'); } resultBuilder.push(hexString); return resultBuilder.join(''); }; // ...",
+        "properties": {
+          "red": {
+            "type": "number",
+            "format": "float",
+            "description": "The amount of red in the color as a value in the interval [0, 1]."
+          },
+          "green": {
+            "type": "number",
+            "format": "float",
+            "description": "The amount of green in the color as a value in the interval [0, 1]."
+          },
+          "blue": {
+            "type": "number",
+            "format": "float",
+            "description": "The amount of blue in the color as a value in the interval [0, 1]."
+          },
+          "alpha": {
+            "type": "number",
+            "format": "float",
+            "description": "The fraction of this color that should be applied to the pixel. That is, the final pixel color is defined by the equation: `pixel color = alpha * (this color) + (1.0 - alpha) * (background color)` This means that a value of 1.0 corresponds to a solid color, whereas a value of 0.0 corresponds to a completely transparent color. This uses a wrapper message rather than a simple float scalar so that it is possible to distinguish between a default value and the value being unset. If omitted, this color object is rendered as a solid color (as if the alpha value had been explicitly given a value of 1.0)."
+          }
+        }
+      },
+      "GoogleTypeDate": {
+        "type": "object",
+        "description": "Represents a whole or partial calendar date, such as a birthday. The time of day and time zone are either specified elsewhere or are insignificant. The date is relative to the Gregorian Calendar. This can represent one of the following: * A full date, with non-zero year, month, and day values. * A month and day, with a zero year (for example, an anniversary). * A year on its own, with a zero month and a zero day. * A year and month, with a zero day (for example, a credit card expiration date). Related types: * google.type.TimeOfDay * google.type.DateTime * google.protobuf.Timestamp",
+        "properties": {
+          "year": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Year of the date. Must be from 1 to 9999, or 0 to specify a date without a year."
+          },
+          "month": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Month of a year. Must be from 1 to 12, or 0 to specify a year without a month and day."
+          },
+          "day": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Day of a month. Must be from 1 to 31 and valid for the year and month, or 0 to specify a year by itself or a year and month where the day isn't significant."
+          }
+        }
+      },
+      "GoogleTypeDateTime": {
+        "type": "object",
+        "description": "Represents civil time (or occasionally physical time). This type can represent a civil time in one of a few possible ways: * When utc_offset is set and time_zone is unset: a civil time on a calendar day with a particular offset from UTC. * When time_zone is set and utc_offset is unset: a civil time on a calendar day in a particular time zone. * When neither time_zone nor utc_offset is set: a civil time on a calendar day in local time. The date is relative to the Proleptic Gregorian Calendar. If year, month, or day are 0, the DateTime is considered not to have a specific year, month, or day respectively. This type may also be used to represent a physical time if all the date and time fields are set and either case of the `time_offset` oneof is set. Consider using `Timestamp` message for physical time instead. If your use case also would like to store the user's timezone, that can be done in another field. This type is more flexible than some applications may want. Make sure to document and validate your application's limitations.",
+        "properties": {
+          "year": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Optional. Year of date. Must be from 1 to 9999, or 0 if specifying a datetime without a year."
+          },
+          "month": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Optional. Month of year. Must be from 1 to 12, or 0 if specifying a datetime without a month."
+          },
+          "day": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Optional. Day of month. Must be from 1 to 31 and valid for the year and month, or 0 if specifying a datetime without a day."
+          },
+          "hours": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Optional. Hours of day in 24 hour format. Should be from 0 to 23, defaults to 0 (midnight). An API may choose to allow the value \"24:00:00\" for scenarios like business closing time."
+          },
+          "minutes": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Optional. Minutes of hour of day. Must be from 0 to 59, defaults to 0."
+          },
+          "seconds": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Optional. Seconds of minutes of the time. Must normally be from 0 to 59, defaults to 0. An API may allow the value 60 if it allows leap-seconds."
+          },
+          "nanos": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Optional. Fractions of seconds in nanoseconds. Must be from 0 to 999,999,999, defaults to 0."
+          },
+          "utcOffset": {
+            "type": "string",
+            "format": "google-duration",
+            "description": "UTC offset. Must be whole seconds, between -18 hours and +18 hours. For example, a UTC offset of -4:00 would be represented as { seconds: -14400 }."
+          },
+          "timeZone": {
+            "$ref": "#/components/schemas/GoogleTypeTimeZone"
+          }
+        }
+      },
+      "GoogleTypeMoney": {
+        "type": "object",
+        "description": "Represents an amount of money with its currency type.",
+        "properties": {
+          "currencyCode": {
+            "type": "string",
+            "description": "The three-letter currency code defined in ISO 4217."
+          },
+          "units": {
+            "type": "string",
+            "format": "int64",
+            "description": "The whole units of the amount. For example if `currencyCode` is `\"USD\"`, then 1 unit is one US dollar."
+          },
+          "nanos": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Number of nano (10^-9) units of the amount. The value must be between -999,999,999 and +999,999,999 inclusive. If `units` is positive, `nanos` must be positive or zero. If `units` is zero, `nanos` can be positive, zero, or negative. If `units` is negative, `nanos` must be negative or zero. For example $-1.75 is represented as `units`=-1 and `nanos`=-750,000,000."
+          }
+        }
+      },
+      "GoogleTypePostalAddress": {
+        "type": "object",
+        "description": "Represents a postal address, such as for postal delivery or payments addresses. With a postal address, a postal service can deliver items to a premise, P.O. box, or similar. A postal address is not intended to model geographical locations like roads, towns, or mountains. In typical usage, an address would be created by user input or from importing existing data, depending on the type of process. Advice on address input or editing: - Use an internationalization-ready address widget such as https://github.com/google/libaddressinput. - Users should not be presented with UI elements for input or editing of fields outside countries where that field is used. For more guidance on how to use this schema, see: https://support.google.com/business/answer/6397478.",
+        "properties": {
+          "revision": {
+            "type": "integer",
+            "format": "int32",
+            "description": "The schema revision of the `PostalAddress`. This must be set to 0, which is the latest revision. All new revisions **must** be backward compatible with old revisions."
+          },
+          "regionCode": {
+            "type": "string",
+            "description": "Required. CLDR region code of the country/region of the address. This is never inferred and it is up to the user to ensure the value is correct. See https://cldr.unicode.org/ and https://www.unicode.org/cldr/charts/30/supplemental/territory_information.html for details. Example: \"CH\" for Switzerland."
+          },
+          "languageCode": {
+            "type": "string",
+            "description": "Optional. BCP-47 language code of the contents of this address (if known). This is often the UI language of the input form or is expected to match one of the languages used in the address' country/region, or their transliterated equivalents. This can affect formatting in certain countries, but is not critical to the correctness of the data and will never affect any validation or other non-formatting related operations. If this value is not known, it should be omitted (rather than specifying a possibly incorrect default). Examples: \"zh-Hant\", \"ja\", \"ja-Latn\", \"en\"."
+          },
+          "postalCode": {
+            "type": "string",
+            "description": "Optional. Postal code of the address. Not all countries use or require postal codes to be present, but where they are used, they may trigger additional validation with other parts of the address (for example, state or zip code validation in the United States)."
+          },
+          "sortingCode": {
+            "type": "string",
+            "description": "Optional. Additional, country-specific, sorting code. This is not used in most regions. Where it is used, the value is either a string like \"CEDEX\", optionally followed by a number (for example, \"CEDEX 7\"), or just a number alone, representing the \"sector code\" (Jamaica), \"delivery area indicator\" (Malawi) or \"post office indicator\" (C\u00f4te d'Ivoire)."
+          },
+          "administrativeArea": {
+            "type": "string",
+            "description": "Optional. Highest administrative subdivision which is used for postal addresses of a country or region. For example, this can be a state, a province, an oblast, or a prefecture. For Spain, this is the province and not the autonomous community (for example, \"Barcelona\" and not \"Catalonia\"). Many countries don't use an administrative area in postal addresses. For example, in Switzerland, this should be left unpopulated."
+          },
+          "locality": {
+            "type": "string",
+            "description": "Optional. Generally refers to the city or town portion of the address. Examples: US city, IT comune, UK post town. In regions of the world where localities are not well defined or do not fit into this structure well, leave `locality` empty and use `address_lines`."
+          },
+          "sublocality": {
+            "type": "string",
+            "description": "Optional. Sublocality of the address. For example, this can be a neighborhood, borough, or district."
+          },
+          "addressLines": {
+            "type": "array",
+            "description": "Unstructured address lines describing the lower levels of an address. Because values in `address_lines` do not have type information and may sometimes contain multiple values in a single field (for example, \"Austin, TX\"), it is important that the line order is clear. The order of address lines should be \"envelope order\" for the country or region of the address. In places where this can vary (for example, Japan), `address_language` is used to make it explicit (for example, \"ja\" for large-to-small ordering and \"ja-Latn\" or \"en\" for small-to-large). In this way, the most specific line of an address can be selected based on the language. The minimum permitted structural representation of an address consists of a `region_code` with all remaining information placed in the `address_lines`. It would be possible to format such an address very approximately without geocoding, but no semantic reasoning could be made about any of the address components until it was at least partially resolved. Creating an address only containing a `region_code` and `address_lines` and then geocoding is the recommended way to handle completely unstructured addresses (as opposed to guessing which parts of the address should be localities or administrative areas).",
+            "items": {
+              "type": "string"
+            }
+          },
+          "recipients": {
+            "type": "array",
+            "description": "Optional. The recipient at the address. This field may, under certain circumstances, contain multiline information. For example, it might contain \"care of\" information.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "organization": {
+            "type": "string",
+            "description": "Optional. The name of the organization at the address."
+          }
+        }
+      },
+      "GoogleTypeTimeZone": {
+        "type": "object",
+        "description": "Represents a time zone from the [IANA Time Zone Database](https://www.iana.org/time-zones).",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "IANA Time Zone Database time zone. For example \"America/New_York\"."
+          },
+          "version": {
+            "type": "string",
+            "description": "Optional. IANA Time Zone Database version number. For example \"2019a\"."
+          }
+        }
+      }
+    }
+  }
 }

--- a/providers/solana-foundation/google/generativelanguage/openapi.json
+++ b/providers/solana-foundation/google/generativelanguage/openapi.json
@@ -1,224 +1,4123 @@
 {
-  "openapi": "3.0.0",
-  "paths": {},
-  "basePath": "",
-  "baseUrl": "https://generativelanguage.google.gateway-402.com/",
-  "batchPath": "batch",
-  "canonicalName": "Generative Language",
-  "description": "The Gemini API allows developers to build generative AI applications using Gemini models. Gemini is our most capable model, built from the ground up to be multimodal. It can generalize and seamlessly understand, operate across, and combine different types of information including language, images, audio, video, and code. You can use the Gemini API for use cases like reasoning across text and images, content generation, dialogue agents, summarization and classification systems, and more.",
-  "discoveryVersion": "v1",
-  "documentationLink": "https://developers.generativeai.google/api",
-  "fullyEncodeReservedExpansion": true,
-  "icons": {
-    "x16": "http://www.google.com/images/icons/product/search-16.gif",
-    "x32": "http://www.google.com/images/icons/product/search-32.gif"
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Generative Language API (Gemini)",
+    "description": "Use Google Gemini models for text generation, multimodal image/audio/video understanding, chat, embeddings, code generation, JSON output, function calling, cached context, file search, grounding with Google Search, and fine-tuned models.",
+    "version": "v1beta"
   },
-  "id": "generativelanguage:v1beta",
-  "kind": "discovery#restDescription",
-  "mtlsRootUrl": "https://generativelanguage.google.gateway-402.com/",
-  "name": "generativelanguage",
-  "ownerDomain": "google.com",
-  "ownerName": "Google",
-  "parameters": {
-    "$.xgafv": {
-      "description": "V1 error format.",
-      "enum": [
-        "1",
-        "2"
-      ],
-      "enumDescriptions": [
-        "v1 error format",
-        "v2 error format"
-      ],
-      "location": "query",
-      "type": "string"
-    },
-    "access_token": {
-      "description": "OAuth access token.",
-      "location": "query",
-      "type": "string"
-    },
-    "alt": {
-      "default": "json",
-      "description": "Data format for response.",
-      "enum": [
-        "json",
-        "media",
-        "proto"
-      ],
-      "enumDescriptions": [
-        "Responses with Content-Type of application/json",
-        "Media download with context-dependent Content-Type",
-        "Responses with Content-Type of application/x-protobuf"
-      ],
-      "location": "query",
-      "type": "string"
-    },
-    "callback": {
-      "description": "JSONP",
-      "location": "query",
-      "type": "string"
-    },
-    "fields": {
-      "description": "Selector specifying which fields to include in a partial response.",
-      "location": "query",
-      "type": "string"
-    },
-    "key": {
-      "description": "API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.",
-      "location": "query",
-      "type": "string"
-    },
-    "oauth_token": {
-      "description": "OAuth 2.0 token for the current user.",
-      "location": "query",
-      "type": "string"
-    },
-    "prettyPrint": {
-      "default": "true",
-      "description": "Returns response with indentations and line breaks.",
-      "location": "query",
-      "type": "boolean"
-    },
-    "quotaUser": {
-      "description": "Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.",
-      "location": "query",
-      "type": "string"
-    },
-    "uploadType": {
-      "description": "Legacy upload protocol for media (e.g. \"media\", \"multipart\").",
-      "location": "query",
-      "type": "string"
-    },
-    "upload_protocol": {
-      "description": "Upload protocol for media (e.g. \"raw\", \"multipart\").",
-      "location": "query",
-      "type": "string"
+  "servers": [
+    {
+      "url": "https://generativelanguage.google.gateway-402.com"
     }
-  },
-  "protocol": "rest",
-  "resources": {
-    "models": {
-      "methods": {
-        "list": {
-          "description": "Lists the Models available through the Gemini API",
-          "flatPath": "v1beta/models",
-          "httpMethod": "GET",
-          "id": "generativelanguage.models.list",
-          "parameterOrder": [],
-          "parameters": {
-            "pageSize": {
-              "description": "The maximum number of `Models` to return (per page). If unspecified, 50 models will be returned per page. This method returns at most 1000 models per page, even if you pass a larger page_size.",
-              "format": "int32",
-              "location": "query",
-              "type": "integer"
-            },
-            "pageToken": {
-              "description": "A page token, received from a previous `ListModels` call. Provide the `page_token` returned by one request as an argument to the next request to retrieve the next page. When paginating, all other parameters provided to `ListModels` must match the call that provided the page token.",
-              "location": "query",
+  ],
+  "paths": {
+    "/v1beta/dynamic/{dynamicId}:generateContent": {
+      "post": {
+        "operationId": "generativelanguage.dynamic.generateContent",
+        "summary": "Generates a model response given an input",
+        "parameters": [
+          {
+            "name": "dynamicId",
+            "in": "path",
+            "required": true,
+            "description": "Identifier for the `dynamic` segment of the resource path.",
+            "schema": {
               "type": "string"
             }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GenerateContentRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GenerateContentResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1beta/dynamic/{dynamicId}:streamGenerateContent": {
+      "post": {
+        "operationId": "generativelanguage.dynamic.streamGenerateContent",
+        "summary": "Stream a generated response from a tuned dynamic model.",
+        "parameters": [
+          {
+            "name": "dynamicId",
+            "in": "path",
+            "required": true,
+            "description": "Identifier for the `dynamic` segment of the resource path.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GenerateContentRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GenerateContentResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1beta/models": {
+      "get": {
+        "operationId": "generativelanguage.models.list",
+        "summary": "List available Gemini models and their metadata.",
+        "parameters": [
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "description": "The maximum number of `Models` to return (per page). If unspecified, 50 models will be returned per page. This method returns at most 1000 models per page, even if you pass a larger page_size.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
           },
-          "path": "v1beta/models",
-          "response": {
-            "$ref": "ListModelsResponse"
+          {
+            "name": "pageToken",
+            "in": "query",
+            "required": false,
+            "description": "A page token, received from a previous `ListModels` call. Provide the `page_token` returned by one request as an argument to the next request to retrieve the next page. When paginating, all other parameters provided to `ListModels` must match the call that provided the page token.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListModelsResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1beta/models/{modelsId}": {
+      "get": {
+        "operationId": "generativelanguage.models.get",
+        "summary": "Gets information about a specific `Model` such as its version",
+        "parameters": [
+          {
+            "name": "modelsId",
+            "in": "path",
+            "required": true,
+            "description": "Identifier for the `model` segment of the resource path.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Model"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1beta/models/{modelsId}:asyncBatchEmbedContent": {
+      "post": {
+        "operationId": "generativelanguage.models.asyncBatchEmbedContent",
+        "summary": "Enqueues a batch of `EmbedContent` requests for batch",
+        "parameters": [
+          {
+            "name": "modelsId",
+            "in": "path",
+            "required": true,
+            "description": "Identifier for the `model` segment of the resource path.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AsyncBatchEmbedContentRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Operation"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1beta/models/{modelsId}:batchEmbedContents": {
+      "post": {
+        "operationId": "generativelanguage.models.batchEmbedContents",
+        "summary": "Generates multiple embedding vectors from the input `Content`",
+        "parameters": [
+          {
+            "name": "modelsId",
+            "in": "path",
+            "required": true,
+            "description": "Identifier for the `model` segment of the resource path.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BatchEmbedContentsRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BatchEmbedContentsResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1beta/models/{modelsId}:batchEmbedText": {
+      "post": {
+        "operationId": "generativelanguage.models.batchEmbedText",
+        "summary": "Generates multiple embeddings from the model given input text",
+        "parameters": [
+          {
+            "name": "modelsId",
+            "in": "path",
+            "required": true,
+            "description": "Identifier for the `model` segment of the resource path.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BatchEmbedTextRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BatchEmbedTextResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1beta/models/{modelsId}:batchGenerateContent": {
+      "post": {
+        "operationId": "generativelanguage.models.batchGenerateContent",
+        "summary": "Enqueues a batch of `GenerateContent` requests for batch",
+        "parameters": [
+          {
+            "name": "modelsId",
+            "in": "path",
+            "required": true,
+            "description": "Identifier for the `model` segment of the resource path.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BatchGenerateContentRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Operation"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1beta/models/{modelsId}:countMessageTokens": {
+      "post": {
+        "operationId": "generativelanguage.models.countMessageTokens",
+        "summary": "Runs a model's tokenizer on a string and returns the token",
+        "parameters": [
+          {
+            "name": "modelsId",
+            "in": "path",
+            "required": true,
+            "description": "Identifier for the `model` segment of the resource path.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CountMessageTokensRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CountMessageTokensResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1beta/models/{modelsId}:countTextTokens": {
+      "post": {
+        "operationId": "generativelanguage.models.countTextTokens",
+        "summary": "Runs a model's tokenizer on a text and returns the token count.",
+        "parameters": [
+          {
+            "name": "modelsId",
+            "in": "path",
+            "required": true,
+            "description": "Identifier for the `model` segment of the resource path.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CountTextTokensRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CountTextTokensResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1beta/models/{modelsId}:countTokens": {
+      "post": {
+        "operationId": "generativelanguage.models.countTokens",
+        "summary": "Runs a model's tokenizer on input `Content` and returns the",
+        "parameters": [
+          {
+            "name": "modelsId",
+            "in": "path",
+            "required": true,
+            "description": "Identifier for the `model` segment of the resource path.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CountTokensRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CountTokensResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1beta/models/{modelsId}:embedContent": {
+      "post": {
+        "operationId": "generativelanguage.models.embedContent",
+        "summary": "Generates a text embedding vector from the input `Content`",
+        "parameters": [
+          {
+            "name": "modelsId",
+            "in": "path",
+            "required": true,
+            "description": "Identifier for the `model` segment of the resource path.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EmbedContentRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EmbedContentResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1beta/models/{modelsId}:embedText": {
+      "post": {
+        "operationId": "generativelanguage.models.embedText",
+        "summary": "Generates an embedding from the model given an input message.",
+        "parameters": [
+          {
+            "name": "modelsId",
+            "in": "path",
+            "required": true,
+            "description": "Identifier for the `model` segment of the resource path.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EmbedTextRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EmbedTextResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1beta/models/{modelsId}:generateAnswer": {
+      "post": {
+        "operationId": "generativelanguage.models.generateAnswer",
+        "summary": "Generates a grounded answer from the model given an input",
+        "parameters": [
+          {
+            "name": "modelsId",
+            "in": "path",
+            "required": true,
+            "description": "Identifier for the `model` segment of the resource path.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GenerateAnswerRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GenerateAnswerResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1beta/models/{modelsId}:generateContent": {
+      "post": {
+        "operationId": "generativelanguage.models.generateContent",
+        "summary": "Generates a model response given an input",
+        "parameters": [
+          {
+            "name": "modelsId",
+            "in": "path",
+            "required": true,
+            "description": "Identifier for the `model` segment of the resource path.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GenerateContentRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GenerateContentResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1beta/models/{modelsId}:generateMessage": {
+      "post": {
+        "operationId": "generativelanguage.models.generateMessage",
+        "summary": "Generates a response from the model given an input",
+        "parameters": [
+          {
+            "name": "modelsId",
+            "in": "path",
+            "required": true,
+            "description": "Identifier for the `model` segment of the resource path.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GenerateMessageRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GenerateMessageResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1beta/models/{modelsId}:generateText": {
+      "post": {
+        "operationId": "generativelanguage.models.generateText",
+        "summary": "Generates a response from the model given an input message.",
+        "parameters": [
+          {
+            "name": "modelsId",
+            "in": "path",
+            "required": true,
+            "description": "Identifier for the `model` segment of the resource path.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GenerateTextRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GenerateTextResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1beta/models/{modelsId}:predict": {
+      "post": {
+        "operationId": "generativelanguage.models.predict",
+        "summary": "Performs a prediction request.",
+        "parameters": [
+          {
+            "name": "modelsId",
+            "in": "path",
+            "required": true,
+            "description": "Identifier for the `model` segment of the resource path.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PredictRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PredictResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1beta/models/{modelsId}:predictLongRunning": {
+      "post": {
+        "operationId": "generativelanguage.models.predictLongRunning",
+        "summary": "Same as Predict but returns an LRO.",
+        "parameters": [
+          {
+            "name": "modelsId",
+            "in": "path",
+            "required": true,
+            "description": "Identifier for the `model` segment of the resource path.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PredictLongRunningRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Operation"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1beta/models/{modelsId}:streamGenerateContent": {
+      "post": {
+        "operationId": "generativelanguage.models.streamGenerateContent",
+        "summary": "Stream a generated model response as server-sent chunks.",
+        "parameters": [
+          {
+            "name": "modelsId",
+            "in": "path",
+            "required": true,
+            "description": "Identifier for the `model` segment of the resource path.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GenerateContentRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GenerateContentResponse"
+                }
+              }
+            }
           }
         }
       }
     }
   },
-  "revision": "20260428",
-  "rootUrl": "https://generativelanguage.google.gateway-402.com/",
-  "schemas": {
-    "ListModelsResponse": {
-      "description": "Response from `ListModel` containing a paginated list of Models.",
-      "id": "ListModelsResponse",
-      "properties": {
-        "models": {
-          "description": "The returned Models.",
-          "items": {
-            "$ref": "Model"
-          },
-          "type": "array"
-        },
-        "nextPageToken": {
-          "description": "A token, which can be sent as `page_token` to retrieve the next page. If this field is omitted, there are no more pages.",
-          "type": "string"
+  "components": {
+    "schemas": {
+      "AsyncBatchEmbedContentRequest": {
+        "type": "object",
+        "description": "Request for an `AsyncBatchEmbedContent` operation.",
+        "properties": {
+          "batch": {
+            "$ref": "#/components/schemas/EmbedContentBatch"
+          }
         }
       },
-      "type": "object"
-    },
-    "Model": {
-      "description": "Information about a Generative Language Model.",
-      "id": "Model",
-      "properties": {
-        "baseModelId": {
-          "description": "Required. The name of the base model, pass this to the generation request. Examples: * `gemini-1.5-flash`",
-          "type": "string"
-        },
-        "description": {
-          "description": "A short description of the model.",
-          "type": "string"
-        },
-        "displayName": {
-          "description": "The human-readable name of the model. E.g. \"Gemini 1.5 Flash\". The name can be up to 128 characters long and can consist of any UTF-8 characters.",
-          "type": "string"
-        },
-        "inputTokenLimit": {
-          "description": "Maximum number of input tokens allowed for this model.",
-          "format": "int32",
-          "type": "integer"
-        },
-        "maxTemperature": {
-          "description": "The maximum temperature this model can use.",
-          "format": "float",
-          "type": "number"
-        },
-        "name": {
-          "description": "Required. The resource name of the `Model`. Refer to [Model variants](https://ai.google.dev/gemini-api/docs/models/gemini#model-variations) for all allowed values. Format: `models/{model}` with a `{model}` naming convention of: * \"{base_model_id}-{version}\" Examples: * `models/gemini-1.5-flash-001`",
-          "type": "string"
-        },
-        "outputTokenLimit": {
-          "description": "Maximum number of output tokens available for this model.",
-          "format": "int32",
-          "type": "integer"
-        },
-        "supportedGenerationMethods": {
-          "description": "The model's supported generation methods. The corresponding API method names are defined as Pascal case strings, such as `generateMessage` and `generateContent`.",
-          "items": {
-            "type": "string"
+      "AttributionSourceId": {
+        "type": "object",
+        "description": "Identifier for the source contributing to this attribution.",
+        "properties": {
+          "groundingPassage": {
+            "$ref": "#/components/schemas/GroundingPassageId"
           },
-          "type": "array"
-        },
-        "temperature": {
-          "description": "Controls the randomness of the output. Values can range over `[0.0,max_temperature]`, inclusive. A higher value will produce responses that are more varied, while a value closer to `0.0` will typically result in less surprising responses from the model. This value specifies default to be used by the backend while making the call to the model.",
-          "format": "float",
-          "type": "number"
-        },
-        "thinking": {
-          "description": "Whether the model supports thinking.",
-          "type": "boolean"
-        },
-        "topK": {
-          "description": "For Top-k sampling. Top-k sampling considers the set of `top_k` most probable tokens. This value specifies default to be used by the backend while making the call to the model. If empty, indicates the model doesn't use top-k sampling, and `top_k` isn't allowed as a generation parameter.",
-          "format": "int32",
-          "type": "integer"
-        },
-        "topP": {
-          "description": "For [Nucleus sampling](https://ai.google.dev/gemini-api/docs/prompting-strategies#top-p). Nucleus sampling considers the smallest set of tokens whose probability sum is at least `top_p`. This value specifies default to be used by the backend while making the call to the model.",
-          "format": "float",
-          "type": "number"
-        },
-        "version": {
-          "description": "Required. The version number of the model. This represents the major version (`1.0` or `1.5`)",
-          "type": "string"
+          "semanticRetrieverChunk": {
+            "$ref": "#/components/schemas/SemanticRetrieverChunk"
+          }
         }
       },
-      "type": "object"
+      "AudioResponseFormat": {
+        "type": "object",
+        "description": "Configuration for audio output format.",
+        "properties": {
+          "sampleRate": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Optional. Sample rate in Hz."
+          },
+          "bitRate": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Optional. Bit rate in bits per second (bps). Only applicable for compressed formats (MP3, Opus)."
+          },
+          "mimeType": {
+            "type": "string",
+            "description": "Optional. The MIME type of the audio output.",
+            "enum": [
+              "MIME_TYPE_UNSPECIFIED",
+              "AUDIO_MP3",
+              "AUDIO_OGG_OPUS",
+              "AUDIO_L16",
+              "AUDIO_WAV",
+              "AUDIO_ALAW",
+              "AUDIO_MULAW"
+            ]
+          },
+          "delivery": {
+            "type": "string",
+            "description": "Optional. The delivery mode for the audio output.",
+            "enum": [
+              "DELIVERY_UNSPECIFIED",
+              "INLINE",
+              "URI"
+            ]
+          }
+        }
+      },
+      "BatchEmbedContentsRequest": {
+        "type": "object",
+        "description": "Batch request to get embeddings from the model for a list of prompts.",
+        "properties": {
+          "requests": {
+            "type": "array",
+            "description": "Required. Embed requests for the batch. The model in each of these requests must match the model specified `BatchEmbedContentsRequest.model`.",
+            "items": {
+              "$ref": "#/components/schemas/EmbedContentRequest"
+            }
+          }
+        }
+      },
+      "BatchEmbedContentsResponse": {
+        "type": "object",
+        "description": "The response to a `BatchEmbedContentsRequest`.",
+        "properties": {
+          "usageMetadata": {
+            "$ref": "#/components/schemas/EmbeddingUsageMetadata"
+          },
+          "embeddings": {
+            "type": "array",
+            "description": "Output only. The embeddings for each request, in the same order as provided in the batch request.",
+            "items": {
+              "$ref": "#/components/schemas/ContentEmbedding"
+            }
+          }
+        }
+      },
+      "BatchEmbedTextRequest": {
+        "type": "object",
+        "description": "Batch request to get a text embedding from the model.",
+        "properties": {
+          "texts": {
+            "type": "array",
+            "description": "Optional. The free-form input texts that the model will turn into an embedding. The current limit is 100 texts, over which an error will be thrown.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "requests": {
+            "type": "array",
+            "description": "Optional. Embed requests for the batch. Only one of `texts` or `requests` can be set.",
+            "items": {
+              "$ref": "#/components/schemas/EmbedTextRequest"
+            }
+          }
+        }
+      },
+      "BatchEmbedTextResponse": {
+        "type": "object",
+        "description": "The response to a EmbedTextRequest.",
+        "properties": {
+          "embeddings": {
+            "type": "array",
+            "description": "Output only. The embeddings generated from the input text.",
+            "items": {
+              "$ref": "#/components/schemas/Embedding"
+            }
+          }
+        }
+      },
+      "BatchGenerateContentRequest": {
+        "type": "object",
+        "description": "Request for a `BatchGenerateContent` operation.",
+        "properties": {
+          "batch": {
+            "$ref": "#/components/schemas/GenerateContentBatch"
+          }
+        }
+      },
+      "BatchStats": {
+        "type": "object",
+        "description": "Stats about the batch.",
+        "properties": {
+          "failedRequestCount": {
+            "type": "string",
+            "format": "int64",
+            "description": "Output only. The number of requests that failed to be processed."
+          },
+          "pendingRequestCount": {
+            "type": "string",
+            "format": "int64",
+            "description": "Output only. The number of requests that are still pending processing."
+          },
+          "requestCount": {
+            "type": "string",
+            "format": "int64",
+            "description": "Output only. The number of requests in the batch."
+          },
+          "successfulRequestCount": {
+            "type": "string",
+            "format": "int64",
+            "description": "Output only. The number of requests that were successfully processed."
+          }
+        }
+      },
+      "Blob": {
+        "type": "object",
+        "description": "Raw media bytes. Text should not be sent as raw bytes, use the 'text' field.",
+        "properties": {
+          "data": {
+            "type": "string",
+            "format": "byte",
+            "description": "Raw bytes for media formats."
+          },
+          "mimeType": {
+            "type": "string",
+            "description": "The IANA standard MIME type of the source data. Examples of supported types: - Images: image/png, image/jpeg, image/jpg, image/webp, image/heic, image/heif, image/gif, image/avif - Audio: audio/*, video/audio/s16le, video/audio/wav - Video: video/* - Text: text/plain, text/html, text/css, text/javascript, text/x-typescript, text/csv, text/markdown, text/x-python, text/xml, text/rtf, video/text/timestamp - Applications: application/x-javascript, application/x-typescript, application/x-python-code, application/json, application/x-ipynb+json, application/rtf, application/pdf For additional context, see [Supported file formats](https://ai.google.dev/gemini-api/docs/file-input-methods#supported-content-types). //"
+          }
+        }
+      },
+      "Candidate": {
+        "type": "object",
+        "description": "A response candidate generated from the model.",
+        "properties": {
+          "safetyRatings": {
+            "type": "array",
+            "description": "List of ratings for the safety of a response candidate. There is at most one rating per category.",
+            "items": {
+              "$ref": "#/components/schemas/SafetyRating"
+            }
+          },
+          "content": {
+            "$ref": "#/components/schemas/Content"
+          },
+          "finishReason": {
+            "type": "string",
+            "description": "Optional. Output only. The reason why the model stopped generating tokens. If empty, the model has not stopped generating tokens.",
+            "enum": [
+              "FINISH_REASON_UNSPECIFIED",
+              "STOP",
+              "MAX_TOKENS",
+              "SAFETY",
+              "RECITATION",
+              "LANGUAGE",
+              "OTHER",
+              "BLOCKLIST",
+              "PROHIBITED_CONTENT",
+              "SPII",
+              "MALFORMED_FUNCTION_CALL",
+              "IMAGE_SAFETY",
+              "IMAGE_PROHIBITED_CONTENT",
+              "IMAGE_OTHER",
+              "NO_IMAGE",
+              "IMAGE_RECITATION",
+              "UNEXPECTED_TOOL_CALL",
+              "TOO_MANY_TOOL_CALLS",
+              "MISSING_THOUGHT_SIGNATURE",
+              "MALFORMED_RESPONSE",
+              "ESCALATION"
+            ]
+          },
+          "finishMessage": {
+            "type": "string",
+            "description": "Optional. Output only. Details the reason why the model stopped generating tokens. This is populated only when `finish_reason` is set."
+          },
+          "avgLogprobs": {
+            "type": "number",
+            "format": "double",
+            "description": "Output only. Average log probability score of the candidate."
+          },
+          "urlContextMetadata": {
+            "$ref": "#/components/schemas/UrlContextMetadata"
+          },
+          "citationMetadata": {
+            "$ref": "#/components/schemas/CitationMetadata"
+          },
+          "groundingMetadata": {
+            "$ref": "#/components/schemas/GroundingMetadata"
+          },
+          "logprobsResult": {
+            "$ref": "#/components/schemas/LogprobsResult"
+          },
+          "groundingAttributions": {
+            "type": "array",
+            "description": "Output only. Attribution information for sources that contributed to a grounded answer. This field is populated for `GenerateAnswer` calls.",
+            "items": {
+              "$ref": "#/components/schemas/GroundingAttribution"
+            }
+          },
+          "index": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Output only. Index of the candidate in the list of response candidates."
+          },
+          "tokenCount": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Output only. Token count for this candidate."
+          }
+        }
+      },
+      "CitationMetadata": {
+        "type": "object",
+        "description": "A collection of source attributions for a piece of content.",
+        "properties": {
+          "citationSources": {
+            "type": "array",
+            "description": "Citations to sources for a specific response.",
+            "items": {
+              "$ref": "#/components/schemas/CitationSource"
+            }
+          }
+        }
+      },
+      "CitationSource": {
+        "type": "object",
+        "description": "A citation to a source for a portion of a specific response.",
+        "properties": {
+          "endIndex": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Optional. End of the attributed segment, exclusive."
+          },
+          "uri": {
+            "type": "string",
+            "description": "Optional. URI that is attributed as a source for a portion of the text."
+          },
+          "startIndex": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Optional. Start of segment of the response that is attributed to this source. Index indicates the start of the segment, measured in bytes."
+          },
+          "license": {
+            "type": "string",
+            "description": "Optional. License for the GitHub project that is attributed as a source for segment. License info is required for code citations."
+          }
+        }
+      },
+      "CodeExecution": {
+        "type": "object",
+        "description": "Tool that executes code generated by the model, and automatically returns the result to the model. See also `ExecutableCode` and `CodeExecutionResult` which are only generated when using this tool.",
+        "properties": {}
+      },
+      "CodeExecutionResult": {
+        "type": "object",
+        "description": "Result of executing the `ExecutableCode`. Generated only when the `CodeExecution` tool is used.",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Optional. The identifier of the `ExecutableCode` part this result is for. Only populated if the corresponding `ExecutableCode` has an id."
+          },
+          "outcome": {
+            "type": "string",
+            "description": "Required. Outcome of the code execution.",
+            "enum": [
+              "OUTCOME_UNSPECIFIED",
+              "OUTCOME_OK",
+              "OUTCOME_FAILED",
+              "OUTCOME_DEADLINE_EXCEEDED"
+            ]
+          },
+          "output": {
+            "type": "string",
+            "description": "Optional. Contains stdout when code execution is successful, stderr or other description otherwise."
+          }
+        }
+      },
+      "ComputerUse": {
+        "type": "object",
+        "description": "Computer Use tool type.",
+        "properties": {
+          "environment": {
+            "type": "string",
+            "description": "Required. The environment being operated.",
+            "enum": [
+              "ENVIRONMENT_UNSPECIFIED",
+              "ENVIRONMENT_BROWSER",
+              "ENVIRONMENT_MOBILE",
+              "ENVIRONMENT_DESKTOP"
+            ]
+          },
+          "disabledSafetyPolicies": {
+            "type": "array",
+            "description": "Optional. Disabled safety policies for computer use.",
+            "items": {
+              "type": "string",
+              "enum": [
+                "SAFETY_POLICY_UNSPECIFIED",
+                "FINANCIAL_TRANSACTIONS",
+                "SENSITIVE_DATA_MODIFICATION",
+                "COMMUNICATION_TOOL",
+                "ACCOUNT_CREATION",
+                "DATA_MODIFICATION",
+                "USER_CONSENT_MANAGEMENT",
+                "LEGAL_TERMS_AND_AGREEMENTS"
+              ]
+            }
+          },
+          "excludedPredefinedFunctions": {
+            "type": "array",
+            "description": "Optional. By default, predefined functions are included in the final model call. Some of them can be explicitly excluded from being automatically included. This can serve two purposes: 1. Using a more restricted / different action space. 2. Improving the definitions / instructions of predefined functions.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "enablePromptInjectionDetection": {
+            "type": "boolean",
+            "description": "Optional. Whether enable the prompt injection detection check on computer-use request."
+          }
+        }
+      },
+      "Condition": {
+        "type": "object",
+        "description": "Filter condition applicable to a single key.",
+        "properties": {
+          "stringValue": {
+            "type": "string",
+            "description": "The string value to filter the metadata on."
+          },
+          "numericValue": {
+            "type": "number",
+            "format": "float",
+            "description": "The numeric value to filter the metadata on."
+          },
+          "operation": {
+            "type": "string",
+            "description": "Required. Operator applied to the given key-value pair to trigger the condition.",
+            "enum": [
+              "OPERATOR_UNSPECIFIED",
+              "LESS",
+              "LESS_EQUAL",
+              "EQUAL",
+              "GREATER_EQUAL",
+              "GREATER",
+              "NOT_EQUAL",
+              "INCLUDES",
+              "EXCLUDES"
+            ]
+          }
+        }
+      },
+      "Content": {
+        "type": "object",
+        "description": "The base structured datatype containing multi-part content of a message. A `Content` includes a `role` field designating the producer of the `Content` and a `parts` field containing multi-part data that contains the content of the message turn.",
+        "properties": {
+          "parts": {
+            "type": "array",
+            "description": "Ordered `Parts` that constitute a single message. Parts may have different MIME types.",
+            "items": {
+              "$ref": "#/components/schemas/Part"
+            }
+          },
+          "role": {
+            "type": "string",
+            "description": "Optional. The producer of the content. Must be either 'user' or 'model'. Useful to set for multi-turn conversations, otherwise can be left blank or unset."
+          }
+        }
+      },
+      "ContentEmbedding": {
+        "type": "object",
+        "description": "A list of floats representing an embedding.",
+        "properties": {
+          "values": {
+            "type": "array",
+            "description": "The embedding values. This is for 3P users only and will not be populated for 1P calls.",
+            "items": {
+              "type": "number",
+              "format": "float"
+            }
+          },
+          "shape": {
+            "type": "array",
+            "description": "This field stores the soft tokens tensor frame shape (e.g. [1, 1, 256, 2048]).",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        }
+      },
+      "ContentFilter": {
+        "type": "object",
+        "description": "Content filtering metadata associated with processing a single request. ContentFilter contains a reason and an optional supporting string. The reason may be unspecified.",
+        "properties": {
+          "reason": {
+            "type": "string",
+            "description": "The reason content was blocked during request processing.",
+            "enum": [
+              "BLOCKED_REASON_UNSPECIFIED",
+              "SAFETY",
+              "OTHER"
+            ]
+          },
+          "message": {
+            "type": "string",
+            "description": "A string that describes the filtering behavior in more detail."
+          }
+        }
+      },
+      "CountMessageTokensRequest": {
+        "type": "object",
+        "description": "Counts the number of tokens in the `prompt` sent to a model. Models may tokenize text differently, so each model may return a different `token_count`.",
+        "properties": {
+          "prompt": {
+            "$ref": "#/components/schemas/MessagePrompt"
+          }
+        }
+      },
+      "CountMessageTokensResponse": {
+        "type": "object",
+        "description": "A response from `CountMessageTokens`. It returns the model's `token_count` for the `prompt`.",
+        "properties": {
+          "tokenCount": {
+            "type": "integer",
+            "format": "int32",
+            "description": "The number of tokens that the `model` tokenizes the `prompt` into. Always non-negative."
+          }
+        }
+      },
+      "CountTextTokensRequest": {
+        "type": "object",
+        "description": "Counts the number of tokens in the `prompt` sent to a model. Models may tokenize text differently, so each model may return a different `token_count`.",
+        "properties": {
+          "prompt": {
+            "$ref": "#/components/schemas/TextPrompt"
+          }
+        }
+      },
+      "CountTextTokensResponse": {
+        "type": "object",
+        "description": "A response from `CountTextTokens`. It returns the model's `token_count` for the `prompt`.",
+        "properties": {
+          "tokenCount": {
+            "type": "integer",
+            "format": "int32",
+            "description": "The number of tokens that the `model` tokenizes the `prompt` into. Always non-negative."
+          }
+        }
+      },
+      "CountTokensRequest": {
+        "type": "object",
+        "description": "Counts the number of tokens in the `prompt` sent to a model. Models may tokenize text differently, so each model may return a different `token_count`.",
+        "properties": {
+          "contents": {
+            "type": "array",
+            "description": "Optional. The input given to the model as a prompt. This field is ignored when `generate_content_request` is set.",
+            "items": {
+              "$ref": "#/components/schemas/Content"
+            }
+          },
+          "generateContentRequest": {
+            "$ref": "#/components/schemas/GenerateContentRequest"
+          }
+        }
+      },
+      "CountTokensResponse": {
+        "type": "object",
+        "description": "A response from `CountTokens`. It returns the model's `token_count` for the `prompt`.",
+        "properties": {
+          "cacheTokensDetails": {
+            "type": "array",
+            "description": "Output only. List of modalities that were processed in the cached content.",
+            "items": {
+              "$ref": "#/components/schemas/ModalityTokenCount"
+            }
+          },
+          "totalTokens": {
+            "type": "integer",
+            "format": "int32",
+            "description": "The number of tokens that the `Model` tokenizes the `prompt` into. Always non-negative."
+          },
+          "cachedContentTokenCount": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Number of tokens in the cached part of the prompt (the cached content)."
+          },
+          "promptTokensDetails": {
+            "type": "array",
+            "description": "Output only. List of modalities that were processed in the request input.",
+            "items": {
+              "$ref": "#/components/schemas/ModalityTokenCount"
+            }
+          }
+        }
+      },
+      "DynamicRetrievalConfig": {
+        "type": "object",
+        "description": "Describes the options to customize dynamic retrieval.",
+        "properties": {
+          "mode": {
+            "type": "string",
+            "description": "The mode of the predictor to be used in dynamic retrieval.",
+            "enum": [
+              "MODE_UNSPECIFIED",
+              "MODE_DYNAMIC"
+            ]
+          },
+          "dynamicThreshold": {
+            "type": "number",
+            "format": "float",
+            "description": "The threshold to be used in dynamic retrieval. If not set, a system default value is used."
+          }
+        }
+      },
+      "EmbedContentBatch": {
+        "type": "object",
+        "description": "A resource representing a batch of `EmbedContent` requests.",
+        "properties": {
+          "endTime": {
+            "type": "string",
+            "format": "google-datetime",
+            "description": "Output only. The time at which the batch processing completed."
+          },
+          "output": {
+            "$ref": "#/components/schemas/EmbedContentBatchOutput"
+          },
+          "model": {
+            "type": "string",
+            "description": "Required. The name of the `Model` to use for generating the completion. Format: `models/{model}`."
+          },
+          "createTime": {
+            "type": "string",
+            "format": "google-datetime",
+            "description": "Output only. The time at which the batch was created."
+          },
+          "name": {
+            "type": "string",
+            "description": "Output only. Identifier. Resource name of the batch. Format: `batches/{batch_id}`."
+          },
+          "updateTime": {
+            "type": "string",
+            "format": "google-datetime",
+            "description": "Output only. The time at which the batch was last updated."
+          },
+          "inputConfig": {
+            "$ref": "#/components/schemas/InputEmbedContentConfig"
+          },
+          "batchStats": {
+            "$ref": "#/components/schemas/EmbedContentBatchStats"
+          },
+          "state": {
+            "type": "string",
+            "description": "Output only. The state of the batch.",
+            "enum": [
+              "BATCH_STATE_UNSPECIFIED",
+              "BATCH_STATE_PENDING",
+              "BATCH_STATE_RUNNING",
+              "BATCH_STATE_SUCCEEDED",
+              "BATCH_STATE_FAILED",
+              "BATCH_STATE_CANCELLED",
+              "BATCH_STATE_EXPIRED"
+            ]
+          },
+          "priority": {
+            "type": "string",
+            "format": "int64",
+            "description": "Optional. The priority of the batch. Batches with a higher priority value will be processed before batches with a lower priority value. Negative values are allowed. Default is 0."
+          },
+          "displayName": {
+            "type": "string",
+            "description": "Required. The user-defined name of this batch."
+          }
+        }
+      },
+      "EmbedContentBatchOutput": {
+        "type": "object",
+        "description": "The output of a batch request. This is returned in the `AsyncBatchEmbedContentResponse` or the `EmbedContentBatch.output` field.",
+        "properties": {
+          "inlinedResponses": {
+            "$ref": "#/components/schemas/InlinedEmbedContentResponses"
+          },
+          "responsesFile": {
+            "type": "string",
+            "description": "Output only. The file ID of the file containing the responses. The file will be a JSONL file with a single response per line. The responses will be `EmbedContentResponse` messages formatted as JSON. The responses will be written in the same order as the input requests."
+          }
+        }
+      },
+      "EmbedContentBatchStats": {
+        "type": "object",
+        "description": "Stats about the batch.",
+        "properties": {
+          "successfulRequestCount": {
+            "type": "string",
+            "format": "int64",
+            "description": "Output only. The number of requests that were successfully processed."
+          },
+          "requestCount": {
+            "type": "string",
+            "format": "int64",
+            "description": "Output only. The number of requests in the batch."
+          },
+          "pendingRequestCount": {
+            "type": "string",
+            "format": "int64",
+            "description": "Output only. The number of requests that are still pending processing."
+          },
+          "failedRequestCount": {
+            "type": "string",
+            "format": "int64",
+            "description": "Output only. The number of requests that failed to be processed."
+          }
+        }
+      },
+      "EmbedContentConfig": {
+        "type": "object",
+        "description": "Configurations for the EmbedContent request.",
+        "properties": {
+          "title": {
+            "type": "string",
+            "description": "Optional. The title for the text."
+          },
+          "taskType": {
+            "type": "string",
+            "description": "Optional. The task type of the embedding.",
+            "enum": [
+              "TASK_TYPE_UNSPECIFIED",
+              "RETRIEVAL_QUERY",
+              "RETRIEVAL_DOCUMENT",
+              "SEMANTIC_SIMILARITY",
+              "CLASSIFICATION",
+              "CLUSTERING",
+              "QUESTION_ANSWERING",
+              "FACT_VERIFICATION",
+              "CODE_RETRIEVAL_QUERY"
+            ]
+          },
+          "documentOcr": {
+            "type": "boolean",
+            "description": "Optional. Whether to enable OCR for document content."
+          },
+          "outputDimensionality": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Optional. Reduced dimension for the output embedding. If set, excessive values in the output embedding are truncated from the end."
+          },
+          "autoTruncate": {
+            "type": "boolean",
+            "description": "Optional. Whether to silently truncate the input content if it's longer than the maximum sequence length."
+          },
+          "audioTrackExtraction": {
+            "type": "boolean",
+            "description": "Optional. Whether to extract audio from video content."
+          }
+        }
+      },
+      "EmbedContentRequest": {
+        "type": "object",
+        "description": "Request containing the `Content` for the model to embed.",
+        "properties": {
+          "taskType": {
+            "type": "string",
+            "description": "Optional. Deprecated: Please use EmbedContentConfig.task_type instead. Optional task type for which the embeddings will be used. Not supported on earlier models (`models/embedding-001`).",
+            "deprecated": true,
+            "enum": [
+              "TASK_TYPE_UNSPECIFIED",
+              "RETRIEVAL_QUERY",
+              "RETRIEVAL_DOCUMENT",
+              "SEMANTIC_SIMILARITY",
+              "CLASSIFICATION",
+              "CLUSTERING",
+              "QUESTION_ANSWERING",
+              "FACT_VERIFICATION",
+              "CODE_RETRIEVAL_QUERY"
+            ]
+          },
+          "embedContentConfig": {
+            "$ref": "#/components/schemas/EmbedContentConfig"
+          },
+          "title": {
+            "type": "string",
+            "description": "Optional. Deprecated: Please use EmbedContentConfig.title instead. An optional title for the text. Only applicable when TaskType is `RETRIEVAL_DOCUMENT`. Note: Specifying a `title` for `RETRIEVAL_DOCUMENT` provides better quality embeddings for retrieval.",
+            "deprecated": true
+          },
+          "model": {
+            "type": "string",
+            "description": "Required. The model's resource name. This serves as an ID for the Model to use. This name should match a model name returned by the `ListModels` method. Format: `models/{model}`"
+          },
+          "content": {
+            "$ref": "#/components/schemas/Content"
+          },
+          "outputDimensionality": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Optional. Deprecated: Please use EmbedContentConfig.output_dimensionality instead. Optional reduced dimension for the output embedding. If set, excessive values in the output embedding are truncated from the end. Supported by newer models since 2024 only. You cannot set this value if using the earlier model (`models/embedding-001`).",
+            "deprecated": true
+          }
+        }
+      },
+      "EmbedContentResponse": {
+        "type": "object",
+        "description": "The response to an `EmbedContentRequest`.",
+        "properties": {
+          "usageMetadata": {
+            "$ref": "#/components/schemas/EmbeddingUsageMetadata"
+          },
+          "embedding": {
+            "$ref": "#/components/schemas/ContentEmbedding"
+          }
+        }
+      },
+      "EmbedTextRequest": {
+        "type": "object",
+        "description": "Request to get a text embedding from the model.",
+        "properties": {
+          "text": {
+            "type": "string",
+            "description": "Optional. The free-form input text that the model will turn into an embedding."
+          },
+          "model": {
+            "type": "string",
+            "description": "Required. The model name to use with the format model=models/{model}."
+          }
+        }
+      },
+      "EmbedTextResponse": {
+        "type": "object",
+        "description": "The response to a EmbedTextRequest.",
+        "properties": {
+          "embedding": {
+            "$ref": "#/components/schemas/Embedding"
+          }
+        }
+      },
+      "Embedding": {
+        "type": "object",
+        "description": "A list of floats representing the embedding.",
+        "properties": {
+          "value": {
+            "type": "array",
+            "description": "The embedding values.",
+            "items": {
+              "type": "number",
+              "format": "float"
+            }
+          }
+        }
+      },
+      "EmbeddingUsageMetadata": {
+        "type": "object",
+        "description": "Metadata on the usage of the embedding request.",
+        "properties": {
+          "promptTokenDetails": {
+            "type": "array",
+            "description": "Output only. List of modalities that were processed in the request input.",
+            "items": {
+              "$ref": "#/components/schemas/ModalityTokenCount"
+            }
+          },
+          "promptTokenCount": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Output only. Number of tokens in the prompt."
+          }
+        }
+      },
+      "Example": {
+        "type": "object",
+        "description": "An input/output example used to instruct the Model. It demonstrates how the model should respond or format its response.",
+        "properties": {
+          "input": {
+            "$ref": "#/components/schemas/Message"
+          },
+          "output": {
+            "$ref": "#/components/schemas/Message"
+          }
+        }
+      },
+      "ExecutableCode": {
+        "type": "object",
+        "description": "Code generated by the model that is meant to be executed, and the result returned to the model. Only generated when using the `CodeExecution` tool, in which the code will be automatically executed, and a corresponding `CodeExecutionResult` will also be generated.",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Optional. Unique identifier of the `ExecutableCode` part. The server returns the `CodeExecutionResult` with the matching `id`."
+          },
+          "language": {
+            "type": "string",
+            "description": "Required. Programming language of the `code`.",
+            "enum": [
+              "LANGUAGE_UNSPECIFIED",
+              "PYTHON"
+            ]
+          },
+          "code": {
+            "type": "string",
+            "description": "Required. The code to be executed."
+          }
+        }
+      },
+      "FileData": {
+        "type": "object",
+        "description": "URI based data.",
+        "properties": {
+          "fileUri": {
+            "type": "string",
+            "description": "Required. URI."
+          },
+          "mimeType": {
+            "type": "string",
+            "description": "Optional. The IANA standard MIME type of the source data."
+          }
+        }
+      },
+      "FileSearch": {
+        "type": "object",
+        "description": "The FileSearch tool that retrieves knowledge from Semantic Retrieval corpora. Files are imported to Semantic Retrieval corpora using the ImportFile API.",
+        "properties": {
+          "topK": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Optional. The number of semantic retrieval chunks to retrieve."
+          },
+          "metadataFilter": {
+            "type": "string",
+            "description": "Optional. Metadata filter to apply to the semantic retrieval documents and chunks."
+          },
+          "fileSearchStoreNames": {
+            "type": "array",
+            "description": "Required. The names of the file_search_stores to retrieve from. Example: `fileSearchStores/my-file-search-store-123`",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "FunctionCall": {
+        "type": "object",
+        "description": "A predicted `FunctionCall` returned from the model that contains a string representing the `FunctionDeclaration.name` with the arguments and their values.",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Required. The name of the function to call. Must be a-z, A-Z, 0-9, or contain underscores and dashes, with a maximum length of 128."
+          },
+          "id": {
+            "type": "string",
+            "description": "Optional. Unique identifier of the function call. If populated, the client to execute the `function_call` and return the response with the matching `id`."
+          },
+          "args": {
+            "type": "object",
+            "description": "Optional. The function parameters and values in JSON object format.",
+            "additionalProperties": {
+              "description": "Properties of the object."
+            }
+          }
+        }
+      },
+      "FunctionCallingConfig": {
+        "type": "object",
+        "description": "Configuration for specifying function calling behavior.",
+        "properties": {
+          "mode": {
+            "type": "string",
+            "description": "Optional. Specifies the mode in which function calling should execute. If unspecified, the default value will be set to AUTO.",
+            "enum": [
+              "MODE_UNSPECIFIED",
+              "AUTO",
+              "ANY",
+              "NONE",
+              "VALIDATED"
+            ]
+          },
+          "allowedFunctionNames": {
+            "type": "array",
+            "description": "Optional. A set of function names that, when provided, limits the functions the model will call. This should only be set when the Mode is ANY or VALIDATED. Function names should match [FunctionDeclaration.name]. When set, model will predict a function call from only allowed function names.",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "FunctionDeclaration": {
+        "type": "object",
+        "description": "Structured representation of a function declaration as defined by the [OpenAPI 3.03 specification](https://spec.openapis.org/oas/v3.0.3). Included in this declaration are the function name and parameters. This FunctionDeclaration is a representation of a block of code that can be used as a `Tool` by the model and executed by the client.",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Required. The name of the function. Must be a-z, A-Z, 0-9, or contain underscores, colons, dots, and dashes, with a maximum length of 128."
+          },
+          "behavior": {
+            "type": "string",
+            "description": "Optional. Specifies the function Behavior. Currently only supported by the BidiGenerateContent method.",
+            "enum": [
+              "UNSPECIFIED",
+              "BLOCKING",
+              "NON_BLOCKING"
+            ]
+          },
+          "parameters": {
+            "$ref": "#/components/schemas/Schema"
+          },
+          "parametersJsonSchema": {
+            "description": "Optional. Describes the parameters to the function in JSON Schema format. The schema must describe an object where the properties are the parameters to the function. For example: ``` { \"type\": \"object\", \"properties\": { \"name\": { \"type\": \"string\" }, \"age\": { \"type\": \"integer\" } }, \"additionalProperties\": false, \"required\": [\"name\", \"age\"], \"propertyOrdering\": [\"name\", \"age\"] } ``` This field is mutually exclusive with `parameters`."
+          },
+          "description": {
+            "type": "string",
+            "description": "Required. A brief description of the function."
+          },
+          "response": {
+            "$ref": "#/components/schemas/Schema"
+          },
+          "responseJsonSchema": {
+            "description": "Optional. Describes the output from this function in JSON Schema format. The value specified by the schema is the response value of the function. This field is mutually exclusive with `response`."
+          }
+        }
+      },
+      "FunctionResponse": {
+        "type": "object",
+        "description": "The result output from a `FunctionCall` that contains a string representing the `FunctionDeclaration.name` and a structured JSON object containing any output from the function is used as context to the model. This should contain the result of a`FunctionCall` made based on model prediction.",
+        "properties": {
+          "willContinue": {
+            "type": "boolean",
+            "description": "Optional. Signals that function call continues, and more responses will be returned, turning the function call into a generator. Is only applicable to NON_BLOCKING function calls, is ignored otherwise. If set to false, future responses will not be considered. It is allowed to return empty `response` with `will_continue=False` to signal that the function call is finished. This may still trigger the model generation. To avoid triggering the generation and finish the function call, additionally set `scheduling` to `SILENT`."
+          },
+          "response": {
+            "type": "object",
+            "description": "Required. The function response in JSON object format. Callers can use any keys of their choice that fit the function's syntax to return the function output, e.g. \"output\", \"result\", etc. In particular, if the function call failed to execute, the response can have an \"error\" key to return error details to the model. Multimedia can be included by using a subobject containing a single \"$ref\" key whose value is the `inline_data.display_name` of a `FunctionResponsePart` holding the multimedia. See https://ai.google.dev/gemini-api/docs/function-calling#multimodal.",
+            "additionalProperties": {
+              "description": "Properties of the object."
+            }
+          },
+          "name": {
+            "type": "string",
+            "description": "Required. The name of the function to call. Must be a-z, A-Z, 0-9, or contain underscores and dashes, with a maximum length of 128."
+          },
+          "parts": {
+            "type": "array",
+            "description": "Optional. Ordered `Parts` that constitute a function response. Parts may have different IANA MIME types.",
+            "items": {
+              "$ref": "#/components/schemas/FunctionResponsePart"
+            }
+          },
+          "id": {
+            "type": "string",
+            "description": "Optional. The identifier of the function call this response is for. Populated by the client to match the corresponding function call `id`."
+          },
+          "scheduling": {
+            "type": "string",
+            "description": "Optional. Specifies how the response should be scheduled in the conversation. Only applicable to NON_BLOCKING function calls, is ignored otherwise. Defaults to WHEN_IDLE.",
+            "enum": [
+              "SCHEDULING_UNSPECIFIED",
+              "SILENT",
+              "WHEN_IDLE",
+              "INTERRUPT"
+            ]
+          }
+        }
+      },
+      "FunctionResponseBlob": {
+        "type": "object",
+        "description": "Raw media bytes for function response. Text should not be sent as raw bytes, use the 'FunctionResponse.response' field.",
+        "properties": {
+          "mimeType": {
+            "type": "string",
+            "description": "The IANA standard MIME type of the source data. Examples: - image/png - image/jpeg If an unsupported MIME type is provided, an error will be returned. For a complete list of supported types, see [Supported file formats](https://ai.google.dev/gemini-api/docs/prompting_with_media#supported_file_formats)."
+          },
+          "data": {
+            "type": "string",
+            "format": "byte",
+            "description": "Raw bytes for media formats."
+          }
+        }
+      },
+      "FunctionResponsePart": {
+        "type": "object",
+        "description": "A datatype containing media that is part of a `FunctionResponse` message. A `FunctionResponsePart` consists of data which has an associated datatype. A `FunctionResponsePart` can only contain one of the accepted types in `FunctionResponsePart.data`. A `FunctionResponsePart` must have a fixed IANA MIME type identifying the type and subtype of the media if the `inline_data` field is filled with raw bytes.",
+        "properties": {
+          "inlineData": {
+            "$ref": "#/components/schemas/FunctionResponseBlob"
+          }
+        }
+      },
+      "GenerateAnswerRequest": {
+        "type": "object",
+        "description": "Request to generate a grounded answer from the `Model`.",
+        "properties": {
+          "temperature": {
+            "type": "number",
+            "format": "float",
+            "description": "Optional. Controls the randomness of the output. Values can range from [0.0,1.0], inclusive. A value closer to 1.0 will produce responses that are more varied and creative, while a value closer to 0.0 will typically result in more straightforward responses from the model. A low temperature (~0.2) is usually recommended for Attributed-Question-Answering use cases."
+          },
+          "answerStyle": {
+            "type": "string",
+            "description": "Required. Style in which answers should be returned.",
+            "enum": [
+              "ANSWER_STYLE_UNSPECIFIED",
+              "ABSTRACTIVE",
+              "EXTRACTIVE",
+              "VERBOSE"
+            ]
+          },
+          "inlinePassages": {
+            "$ref": "#/components/schemas/GroundingPassages"
+          },
+          "contents": {
+            "type": "array",
+            "description": "Required. The content of the current conversation with the `Model`. For single-turn queries, this is a single question to answer. For multi-turn queries, this is a repeated field that contains conversation history and the last `Content` in the list containing the question. Note: `GenerateAnswer` only supports queries in English.",
+            "items": {
+              "$ref": "#/components/schemas/Content"
+            }
+          },
+          "safetySettings": {
+            "type": "array",
+            "description": "Optional. A list of unique `SafetySetting` instances for blocking unsafe content. This will be enforced on the `GenerateAnswerRequest.contents` and `GenerateAnswerResponse.candidate`. There should not be more than one setting for each `SafetyCategory` type. The API will block any contents and responses that fail to meet the thresholds set by these settings. This list overrides the default settings for each `SafetyCategory` specified in the safety_settings. If there is no `SafetySetting` for a given `SafetyCategory` provided in the list, the API will use the default safety setting for that category. Harm categories HARM_CATEGORY_HATE_SPEECH, HARM_CATEGORY_SEXUALLY_EXPLICIT, HARM_CATEGORY_DANGEROUS_CONTENT, HARM_CATEGORY_HARASSMENT are supported. Refer to the [guide](https://ai.google.dev/gemini-api/docs/safety-settings) for detailed information on available safety settings. Also refer to the [Safety guidance](https://ai.google.dev/gemini-api/docs/safety-guidance) to learn how to incorporate safety considerations in your AI applications.",
+            "items": {
+              "$ref": "#/components/schemas/SafetySetting"
+            }
+          },
+          "semanticRetriever": {
+            "$ref": "#/components/schemas/SemanticRetrieverConfig"
+          }
+        }
+      },
+      "GenerateAnswerResponse": {
+        "type": "object",
+        "description": "Response from the model for a grounded answer.",
+        "properties": {
+          "answerableProbability": {
+            "type": "number",
+            "format": "float",
+            "description": "Output only. The model's estimate of the probability that its answer is correct and grounded in the input passages. A low `answerable_probability` indicates that the answer might not be grounded in the sources. When `answerable_probability` is low, you may want to: * Display a message to the effect of \"We couldn\u2019t answer that question\" to the user. * Fall back to a general-purpose LLM that answers the question from world knowledge. The threshold and nature of such fallbacks will depend on individual use cases. `0.5` is a good starting threshold."
+          },
+          "answer": {
+            "$ref": "#/components/schemas/Candidate"
+          },
+          "inputFeedback": {
+            "$ref": "#/components/schemas/InputFeedback"
+          }
+        }
+      },
+      "GenerateContentBatch": {
+        "type": "object",
+        "description": "A resource representing a batch of `GenerateContent` requests.",
+        "properties": {
+          "output": {
+            "$ref": "#/components/schemas/GenerateContentBatchOutput"
+          },
+          "endTime": {
+            "type": "string",
+            "format": "google-datetime",
+            "description": "Output only. The time at which the batch processing completed."
+          },
+          "displayName": {
+            "type": "string",
+            "description": "Required. The user-defined name of this batch."
+          },
+          "batchStats": {
+            "$ref": "#/components/schemas/BatchStats"
+          },
+          "state": {
+            "type": "string",
+            "description": "Output only. The state of the batch.",
+            "enum": [
+              "BATCH_STATE_UNSPECIFIED",
+              "BATCH_STATE_PENDING",
+              "BATCH_STATE_RUNNING",
+              "BATCH_STATE_SUCCEEDED",
+              "BATCH_STATE_FAILED",
+              "BATCH_STATE_CANCELLED",
+              "BATCH_STATE_EXPIRED"
+            ]
+          },
+          "priority": {
+            "type": "string",
+            "format": "int64",
+            "description": "Optional. The priority of the batch. Batches with a higher priority value will be processed before batches with a lower priority value. Negative values are allowed. Default is 0."
+          },
+          "inputConfig": {
+            "$ref": "#/components/schemas/InputConfig"
+          },
+          "name": {
+            "type": "string",
+            "description": "Output only. Identifier. Resource name of the batch. Format: `batches/{batch_id}`."
+          },
+          "updateTime": {
+            "type": "string",
+            "format": "google-datetime",
+            "description": "Output only. The time at which the batch was last updated."
+          },
+          "createTime": {
+            "type": "string",
+            "format": "google-datetime",
+            "description": "Output only. The time at which the batch was created."
+          },
+          "model": {
+            "type": "string",
+            "description": "Required. The name of the `Model` to use for generating the completion. Format: `models/{model}`."
+          }
+        }
+      },
+      "GenerateContentBatchOutput": {
+        "type": "object",
+        "description": "The output of a batch request. This is returned in the `BatchGenerateContentResponse` or the `GenerateContentBatch.output` field.",
+        "properties": {
+          "responsesFile": {
+            "type": "string",
+            "description": "Output only. The file ID of the file containing the responses. The file will be a JSONL file with a single response per line. The responses will be `GenerateContentResponse` messages formatted as JSON. The responses will be written in the same order as the input requests."
+          },
+          "inlinedResponses": {
+            "$ref": "#/components/schemas/InlinedResponses"
+          }
+        }
+      },
+      "GenerateContentRequest": {
+        "type": "object",
+        "description": "Request to generate a completion from the model.",
+        "properties": {
+          "store": {
+            "type": "boolean",
+            "description": "Optional. Configures the logging behavior for a given request. If set, it takes precedence over the project-level logging config."
+          },
+          "cachedContent": {
+            "type": "string",
+            "description": "Optional. The name of the content [cached](https://ai.google.dev/gemini-api/docs/caching) to use as context to serve the prediction. Format: `cachedContents/{cachedContent}`"
+          },
+          "contents": {
+            "type": "array",
+            "description": "Required. The content of the current conversation with the model. For single-turn queries, this is a single instance. For multi-turn queries like [chat](https://ai.google.dev/gemini-api/docs/text-generation#chat), this is a repeated field that contains the conversation history and the latest request.",
+            "items": {
+              "$ref": "#/components/schemas/Content"
+            }
+          },
+          "safetySettings": {
+            "type": "array",
+            "description": "Optional. A list of unique `SafetySetting` instances for blocking unsafe content. This will be enforced on the `GenerateContentRequest.contents` and `GenerateContentResponse.candidates`. There should not be more than one setting for each `SafetyCategory` type. The API will block any contents and responses that fail to meet the thresholds set by these settings. This list overrides the default settings for each `SafetyCategory` specified in the safety_settings. If there is no `SafetySetting` for a given `SafetyCategory` provided in the list, the API will use the default safety setting for that category. Harm categories HARM_CATEGORY_HATE_SPEECH, HARM_CATEGORY_SEXUALLY_EXPLICIT, HARM_CATEGORY_DANGEROUS_CONTENT, HARM_CATEGORY_HARASSMENT, HARM_CATEGORY_CIVIC_INTEGRITY are supported. Refer to the [guide](https://ai.google.dev/gemini-api/docs/safety-settings) for detailed information on available safety settings. Also refer to the [Safety guidance](https://ai.google.dev/gemini-api/docs/safety-guidance) to learn how to incorporate safety considerations in your AI applications.",
+            "items": {
+              "$ref": "#/components/schemas/SafetySetting"
+            }
+          },
+          "tools": {
+            "type": "array",
+            "description": "Optional. A list of `Tools` the `Model` may use to generate the next response. A `Tool` is a piece of code that enables the system to interact with external systems to perform an action, or set of actions, outside of knowledge and scope of the `Model`. Supported `Tool`s are `Function` and `code_execution`. Refer to the [Function calling](https://ai.google.dev/gemini-api/docs/function-calling) and the [Code execution](https://ai.google.dev/gemini-api/docs/code-execution) guides to learn more.",
+            "items": {
+              "$ref": "#/components/schemas/Tool"
+            }
+          },
+          "systemInstruction": {
+            "$ref": "#/components/schemas/Content"
+          },
+          "serviceTier": {
+            "type": "string",
+            "description": "Optional. The service tier of the request.",
+            "enum": [
+              "unspecified",
+              "standard",
+              "flex",
+              "priority"
+            ]
+          },
+          "generationConfig": {
+            "$ref": "#/components/schemas/GenerationConfig"
+          },
+          "model": {
+            "type": "string",
+            "description": "Required. The name of the `Model` to use for generating the completion. Format: `models/{model}`."
+          },
+          "toolConfig": {
+            "$ref": "#/components/schemas/ToolConfig"
+          }
+        }
+      },
+      "GenerateContentResponse": {
+        "type": "object",
+        "description": "Response from the model supporting multiple candidate responses. Safety ratings and content filtering are reported for both prompt in `GenerateContentResponse.prompt_feedback` and for each candidate in `finish_reason` and in `safety_ratings`. The API: - Returns either all requested candidates or none of them - Returns no candidates at all only if there was something wrong with the prompt (check `prompt_feedback`) - Reports feedback on each candidate in `finish_reason` and `safety_ratings`.",
+        "properties": {
+          "modelVersion": {
+            "type": "string",
+            "description": "Output only. The model version used to generate the response."
+          },
+          "candidates": {
+            "type": "array",
+            "description": "Candidate responses from the model.",
+            "items": {
+              "$ref": "#/components/schemas/Candidate"
+            }
+          },
+          "usageMetadata": {
+            "$ref": "#/components/schemas/UsageMetadata"
+          },
+          "promptFeedback": {
+            "$ref": "#/components/schemas/PromptFeedback"
+          },
+          "modelStatus": {
+            "$ref": "#/components/schemas/ModelStatus"
+          },
+          "responseId": {
+            "type": "string",
+            "description": "Output only. response_id is used to identify each response."
+          }
+        }
+      },
+      "GenerateMessageRequest": {
+        "type": "object",
+        "description": "Request to generate a message response from the model.",
+        "properties": {
+          "candidateCount": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Optional. The number of generated response messages to return. This value must be between `[1, 8]`, inclusive. If unset, this will default to `1`."
+          },
+          "prompt": {
+            "$ref": "#/components/schemas/MessagePrompt"
+          },
+          "temperature": {
+            "type": "number",
+            "format": "float",
+            "description": "Optional. Controls the randomness of the output. Values can range over `[0.0,1.0]`, inclusive. A value closer to `1.0` will produce responses that are more varied, while a value closer to `0.0` will typically result in less surprising responses from the model."
+          },
+          "topP": {
+            "type": "number",
+            "format": "float",
+            "description": "Optional. The maximum cumulative probability of tokens to consider when sampling. The model uses combined Top-k and nucleus sampling. Nucleus sampling considers the smallest set of tokens whose probability sum is at least `top_p`."
+          },
+          "topK": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Optional. The maximum number of tokens to consider when sampling. The model uses combined Top-k and nucleus sampling. Top-k sampling considers the set of `top_k` most probable tokens."
+          }
+        }
+      },
+      "GenerateMessageResponse": {
+        "type": "object",
+        "description": "The response from the model. This includes candidate messages and conversation history in the form of chronologically-ordered messages.",
+        "properties": {
+          "messages": {
+            "type": "array",
+            "description": "The conversation history used by the model.",
+            "items": {
+              "$ref": "#/components/schemas/Message"
+            }
+          },
+          "filters": {
+            "type": "array",
+            "description": "A set of content filtering metadata for the prompt and response text. This indicates which `SafetyCategory`(s) blocked a candidate from this response, the lowest `HarmProbability` that triggered a block, and the HarmThreshold setting for that category.",
+            "items": {
+              "$ref": "#/components/schemas/ContentFilter"
+            }
+          },
+          "candidates": {
+            "type": "array",
+            "description": "Candidate response messages from the model.",
+            "items": {
+              "$ref": "#/components/schemas/Message"
+            }
+          }
+        }
+      },
+      "GenerateTextRequest": {
+        "type": "object",
+        "description": "Request to generate a text completion response from the model.",
+        "properties": {
+          "safetySettings": {
+            "type": "array",
+            "description": "Optional. A list of unique `SafetySetting` instances for blocking unsafe content. that will be enforced on the `GenerateTextRequest.prompt` and `GenerateTextResponse.candidates`. There should not be more than one setting for each `SafetyCategory` type. The API will block any prompts and responses that fail to meet the thresholds set by these settings. This list overrides the default settings for each `SafetyCategory` specified in the safety_settings. If there is no `SafetySetting` for a given `SafetyCategory` provided in the list, the API will use the default safety setting for that category. Harm categories HARM_CATEGORY_DEROGATORY, HARM_CATEGORY_TOXICITY, HARM_CATEGORY_VIOLENCE, HARM_CATEGORY_SEXUAL, HARM_CATEGORY_MEDICAL, HARM_CATEGORY_DANGEROUS are supported in text service.",
+            "items": {
+              "$ref": "#/components/schemas/SafetySetting"
+            }
+          },
+          "topP": {
+            "type": "number",
+            "format": "float",
+            "description": "Optional. The maximum cumulative probability of tokens to consider when sampling. The model uses combined Top-k and nucleus sampling. Tokens are sorted based on their assigned probabilities so that only the most likely tokens are considered. Top-k sampling directly limits the maximum number of tokens to consider, while Nucleus sampling limits number of tokens based on the cumulative probability. Note: The default value varies by model, see the `Model.top_p` attribute of the `Model` returned the `getModel` function."
+          },
+          "topK": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Optional. The maximum number of tokens to consider when sampling. The model uses combined Top-k and nucleus sampling. Top-k sampling considers the set of `top_k` most probable tokens. Defaults to 40. Note: The default value varies by model, see the `Model.top_k` attribute of the `Model` returned the `getModel` function."
+          },
+          "stopSequences": {
+            "type": "array",
+            "description": "The set of character sequences (up to 5) that will stop output generation. If specified, the API will stop at the first appearance of a stop sequence. The stop sequence will not be included as part of the response.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "candidateCount": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Optional. Number of generated responses to return. This value must be between [1, 8], inclusive. If unset, this will default to 1."
+          },
+          "temperature": {
+            "type": "number",
+            "format": "float",
+            "description": "Optional. Controls the randomness of the output. Note: The default value varies by model, see the `Model.temperature` attribute of the `Model` returned the `getModel` function. Values can range from [0.0,1.0], inclusive. A value closer to 1.0 will produce responses that are more varied and creative, while a value closer to 0.0 will typically result in more straightforward responses from the model."
+          },
+          "maxOutputTokens": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Optional. The maximum number of tokens to include in a candidate. If unset, this will default to output_token_limit specified in the `Model` specification."
+          },
+          "prompt": {
+            "$ref": "#/components/schemas/TextPrompt"
+          }
+        }
+      },
+      "GenerateTextResponse": {
+        "type": "object",
+        "description": "The response from the model, including candidate completions.",
+        "properties": {
+          "candidates": {
+            "type": "array",
+            "description": "Candidate responses from the model.",
+            "items": {
+              "$ref": "#/components/schemas/TextCompletion"
+            }
+          },
+          "filters": {
+            "type": "array",
+            "description": "A set of content filtering metadata for the prompt and response text. This indicates which `SafetyCategory`(s) blocked a candidate from this response, the lowest `HarmProbability` that triggered a block, and the HarmThreshold setting for that category. This indicates the smallest change to the `SafetySettings` that would be necessary to unblock at least 1 response. The blocking is configured by the `SafetySettings` in the request (or the default `SafetySettings` of the API).",
+            "items": {
+              "$ref": "#/components/schemas/ContentFilter"
+            }
+          },
+          "safetyFeedback": {
+            "type": "array",
+            "description": "Returns any safety feedback related to content filtering.",
+            "items": {
+              "$ref": "#/components/schemas/SafetyFeedback"
+            }
+          }
+        }
+      },
+      "GenerationConfig": {
+        "type": "object",
+        "description": "Configuration options for model generation and outputs. Not all parameters are configurable for every model.",
+        "properties": {
+          "responseModalities": {
+            "type": "array",
+            "description": "Optional. The requested modalities of the response. Represents the set of modalities that the model can return, and should be expected in the response. This is an exact match to the modalities of the response. A model may have multiple combinations of supported modalities. If the requested modalities do not match any of the supported combinations, an error will be returned. An empty list is equivalent to requesting only text.",
+            "items": {
+              "type": "string",
+              "enum": [
+                "MODALITY_UNSPECIFIED",
+                "TEXT",
+                "IMAGE",
+                "AUDIO"
+              ]
+            }
+          },
+          "candidateCount": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Optional. Number of generated responses to return. If unset, this will default to 1. Please note that this doesn't work for previous generation models (Gemini 1.0 family)"
+          },
+          "translationConfig": {
+            "$ref": "#/components/schemas/TranslationConfig"
+          },
+          "topK": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Optional. The maximum number of tokens to consider when sampling. Gemini models use Top-p (nucleus) sampling or a combination of Top-k and nucleus sampling. Top-k sampling considers the set of `top_k` most probable tokens. Models running with nucleus sampling don't allow top_k setting. Note: The default value varies by `Model` and is specified by the`Model.top_p` attribute returned from the `getModel` function. An empty `top_k` attribute indicates that the model doesn't apply top-k sampling and doesn't allow setting `top_k` on requests."
+          },
+          "seed": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Optional. Seed used in decoding. If not set, the request uses a randomly generated seed."
+          },
+          "imageConfig": {
+            "$ref": "#/components/schemas/ImageConfig"
+          },
+          "_responseJsonSchema": {
+            "description": "Optional. Output schema of the generated response. This is an alternative to `response_schema` that accepts [JSON Schema](https://json-schema.org/). If set, `response_schema` must be omitted, but `response_mime_type` is required. While the full JSON Schema may be sent, not all features are supported. Specifically, only the following properties are supported: - `$id` - `$defs` - `$ref` - `$anchor` - `type` - `format` - `title` - `description` - `enum` (for strings and numbers) - `items` - `prefixItems` - `minItems` - `maxItems` - `minimum` - `maximum` - `anyOf` - `oneOf` (interpreted the same as `anyOf`) - `properties` - `additionalProperties` - `required` The non-standard `propertyOrdering` property may also be set. Cyclic references are unrolled to a limited degree and, as such, may only be used within non-required properties. (Nullable properties are not sufficient.) If `$ref` is set on a sub-schema, no other properties, except for than those starting as a `$`, may be set."
+          },
+          "enableEnhancedCivicAnswers": {
+            "type": "boolean",
+            "description": "Optional. Enables enhanced civic answers. It may not be available for all models."
+          },
+          "thinkingConfig": {
+            "$ref": "#/components/schemas/ThinkingConfig"
+          },
+          "stopSequences": {
+            "type": "array",
+            "description": "Optional. The set of character sequences (up to 5) that will stop output generation. If specified, the API will stop at the first appearance of a `stop_sequence`. The stop sequence will not be included as part of the response.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "responseSchema": {
+            "$ref": "#/components/schemas/Schema"
+          },
+          "speechConfig": {
+            "$ref": "#/components/schemas/SpeechConfig"
+          },
+          "responseJsonSchema": {
+            "description": "Optional. An internal detail. Use `responseJsonSchema` rather than this field."
+          },
+          "responseMimeType": {
+            "type": "string",
+            "description": "Optional. MIME type of the generated candidate text. Supported MIME types are: `text/plain`: (default) Text output. `application/json`: JSON response in the response candidates. `text/x.enum`: ENUM as a string response in the response candidates. Refer to the [docs](https://ai.google.dev/gemini-api/docs/prompting_with_media#plain_text_formats) for a list of all supported text MIME types."
+          },
+          "logprobs": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Optional. Only valid if response_logprobs=True. This sets the number of top logprobs, including the chosen candidate, to return at each decoding step in the Candidate.logprobs_result. The number must be in the range of [0, 20]."
+          },
+          "mediaResolution": {
+            "type": "string",
+            "description": "Optional. If specified, the media resolution specified will be used.",
+            "enum": [
+              "MEDIA_RESOLUTION_UNSPECIFIED",
+              "MEDIA_RESOLUTION_LOW",
+              "MEDIA_RESOLUTION_MEDIUM",
+              "MEDIA_RESOLUTION_HIGH"
+            ]
+          },
+          "maxOutputTokens": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Optional. The maximum number of tokens to include in a response candidate. Note: The default value varies by model, see the `Model.output_token_limit` attribute of the `Model` returned from the `getModel` function."
+          },
+          "temperature": {
+            "type": "number",
+            "format": "float",
+            "description": "Optional. Controls the randomness of the output. Note: The default value varies by model, see the `Model.temperature` attribute of the `Model` returned from the `getModel` function. Values can range from [0.0, 2.0]."
+          },
+          "responseLogprobs": {
+            "type": "boolean",
+            "description": "Optional. If true, export the logprobs results in response."
+          },
+          "topP": {
+            "type": "number",
+            "format": "float",
+            "description": "Optional. The maximum cumulative probability of tokens to consider when sampling. The model uses combined Top-k and Top-p (nucleus) sampling. Tokens are sorted based on their assigned probabilities so that only the most likely tokens are considered. Top-k sampling directly limits the maximum number of tokens to consider, while Nucleus sampling limits the number of tokens based on the cumulative probability. Note: The default value varies by `Model` and is specified by the`Model.top_p` attribute returned from the `getModel` function. An empty `top_k` attribute indicates that the model doesn't apply top-k sampling and doesn't allow setting `top_k` on requests."
+          },
+          "frequencyPenalty": {
+            "type": "number",
+            "format": "float",
+            "description": "Optional. Frequency penalty applied to the next token's logprobs, multiplied by the number of times each token has been seen in the respponse so far. A positive penalty will discourage the use of tokens that have already been used, proportional to the number of times the token has been used: The more a token is used, the more difficult it is for the model to use that token again increasing the vocabulary of responses. Caution: A _negative_ penalty will encourage the model to reuse tokens proportional to the number of times the token has been used. Small negative values will reduce the vocabulary of a response. Larger negative values will cause the model to start repeating a common token until it hits the max_output_tokens limit."
+          },
+          "presencePenalty": {
+            "type": "number",
+            "format": "float",
+            "description": "Optional. Presence penalty applied to the next token's logprobs if the token has already been seen in the response. This penalty is binary on/off and not dependant on the number of times the token is used (after the first). Use frequency_penalty for a penalty that increases with each use. A positive penalty will discourage the use of tokens that have already been used in the response, increasing the vocabulary. A negative penalty will encourage the use of tokens that have already been used in the response, decreasing the vocabulary."
+          },
+          "responseFormat": {
+            "$ref": "#/components/schemas/ResponseFormatConfig"
+          }
+        }
+      },
+      "GoogleAiGenerativelanguageV1betaGroundingSupport": {
+        "type": "object",
+        "description": "Grounding support.",
+        "properties": {
+          "groundingChunkIndices": {
+            "type": "array",
+            "description": "Optional. A list of indices (into 'grounding_chunk' in `response.candidate.grounding_metadata`) specifying the citations associated with the claim. For instance [1,3,4] means that grounding_chunk[1], grounding_chunk[3], grounding_chunk[4] are the retrieved content attributed to the claim. If the response is streaming, the grounding_chunk_indices refer to the indices across all responses. It is the client's responsibility to accumulate the grounding chunks from all responses (while maintaining the same order).",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          "renderedParts": {
+            "type": "array",
+            "description": "Output only. Indices into the `parts` field of the candidate's content. These indices specify which rendered parts are associated with this support source.",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          "confidenceScores": {
+            "type": "array",
+            "description": "Optional. Confidence score of the support references. Ranges from 0 to 1. 1 is the most confident. This list must have the same size as the grounding_chunk_indices.",
+            "items": {
+              "type": "number",
+              "format": "float"
+            }
+          },
+          "segment": {
+            "$ref": "#/components/schemas/GoogleAiGenerativelanguageV1betaSegment"
+          }
+        }
+      },
+      "GoogleAiGenerativelanguageV1betaSegment": {
+        "type": "object",
+        "description": "Segment of the content.",
+        "properties": {
+          "startIndex": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Start index in the given Part, measured in bytes. Offset from the start of the Part, inclusive, starting at zero."
+          },
+          "endIndex": {
+            "type": "integer",
+            "format": "int32",
+            "description": "End index in the given Part, measured in bytes. Offset from the start of the Part, exclusive, starting at zero."
+          },
+          "text": {
+            "type": "string",
+            "description": "The text corresponding to the segment from the response."
+          },
+          "partIndex": {
+            "type": "integer",
+            "format": "int32",
+            "description": "The index of a Part object within its parent Content object."
+          }
+        }
+      },
+      "GoogleMaps": {
+        "type": "object",
+        "description": "The GoogleMaps Tool that provides geospatial context for the user's query.",
+        "properties": {
+          "enableWidget": {
+            "type": "boolean",
+            "description": "Optional. Whether to return a widget context token in the GroundingMetadata of the response. Developers can use the widget context token to render a Google Maps widget with geospatial context related to the places that the model references in the response."
+          }
+        }
+      },
+      "GoogleSearch": {
+        "type": "object",
+        "description": "GoogleSearch tool type. Tool to support Google Search in Model. Powered by Google.",
+        "properties": {
+          "timeRangeFilter": {
+            "$ref": "#/components/schemas/Interval"
+          },
+          "searchTypes": {
+            "$ref": "#/components/schemas/SearchTypes"
+          }
+        }
+      },
+      "GoogleSearchRetrieval": {
+        "type": "object",
+        "description": "Tool to retrieve public web data for grounding, powered by Google.",
+        "properties": {
+          "dynamicRetrievalConfig": {
+            "$ref": "#/components/schemas/DynamicRetrievalConfig"
+          }
+        }
+      },
+      "GroundingAttribution": {
+        "type": "object",
+        "description": "Attribution for a source that contributed to an answer.",
+        "properties": {
+          "sourceId": {
+            "$ref": "#/components/schemas/AttributionSourceId"
+          },
+          "content": {
+            "$ref": "#/components/schemas/Content"
+          }
+        }
+      },
+      "GroundingChunk": {
+        "type": "object",
+        "description": "A `GroundingChunk` represents a segment of supporting evidence that grounds the model's response. It can be a chunk from the web, a retrieved context from a file, or information from Google Maps.",
+        "properties": {
+          "retrievedContext": {
+            "$ref": "#/components/schemas/RetrievedContext"
+          },
+          "image": {
+            "$ref": "#/components/schemas/Image"
+          },
+          "web": {
+            "$ref": "#/components/schemas/Web"
+          },
+          "maps": {
+            "$ref": "#/components/schemas/Maps"
+          }
+        }
+      },
+      "GroundingChunkCustomMetadata": {
+        "type": "object",
+        "description": "User provided metadata about the GroundingFact.",
+        "properties": {
+          "stringListValue": {
+            "$ref": "#/components/schemas/GroundingChunkStringList"
+          },
+          "stringValue": {
+            "type": "string",
+            "description": "Optional. The string value of the metadata."
+          },
+          "numericValue": {
+            "type": "number",
+            "format": "float",
+            "description": "Optional. The numeric value of the metadata. The expected range for this value depends on the specific `key` used."
+          },
+          "key": {
+            "type": "string",
+            "description": "The key of the metadata."
+          }
+        }
+      },
+      "GroundingChunkStringList": {
+        "type": "object",
+        "description": "A list of string values.",
+        "properties": {
+          "values": {
+            "type": "array",
+            "description": "The string values of the list.",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "GroundingMetadata": {
+        "type": "object",
+        "description": "Metadata returned to client when grounding is enabled.",
+        "properties": {
+          "retrievalMetadata": {
+            "$ref": "#/components/schemas/RetrievalMetadata"
+          },
+          "groundingChunks": {
+            "type": "array",
+            "description": "List of supporting references retrieved from specified grounding source. When streaming, this only contains the grounding chunks that have not been included in the grounding metadata of previous responses.",
+            "items": {
+              "$ref": "#/components/schemas/GroundingChunk"
+            }
+          },
+          "googleMapsWidgetContextToken": {
+            "type": "string",
+            "description": "Optional. Resource name of the Google Maps widget context token that can be used with the PlacesContextElement widget in order to render contextual data. Only populated in the case that grounding with Google Maps is enabled."
+          },
+          "imageSearchQueries": {
+            "type": "array",
+            "description": "Image search queries used for grounding.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "searchEntryPoint": {
+            "$ref": "#/components/schemas/SearchEntryPoint"
+          },
+          "groundingSupports": {
+            "type": "array",
+            "description": "List of grounding support.",
+            "items": {
+              "$ref": "#/components/schemas/GoogleAiGenerativelanguageV1betaGroundingSupport"
+            }
+          },
+          "webSearchQueries": {
+            "type": "array",
+            "description": "Web search queries for the following-up web search.",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "GroundingPassage": {
+        "type": "object",
+        "description": "Passage included inline with a grounding configuration.",
+        "properties": {
+          "content": {
+            "$ref": "#/components/schemas/Content"
+          },
+          "id": {
+            "type": "string",
+            "description": "Identifier for the passage for attributing this passage in grounded answers."
+          }
+        }
+      },
+      "GroundingPassageId": {
+        "type": "object",
+        "description": "Identifier for a part within a `GroundingPassage`.",
+        "properties": {
+          "passageId": {
+            "type": "string",
+            "description": "Output only. ID of the passage matching the `GenerateAnswerRequest`'s `GroundingPassage.id`."
+          },
+          "partIndex": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Output only. Index of the part within the `GenerateAnswerRequest`'s `GroundingPassage.content`."
+          }
+        }
+      },
+      "GroundingPassages": {
+        "type": "object",
+        "description": "A repeated list of passages.",
+        "properties": {
+          "passages": {
+            "type": "array",
+            "description": "List of passages.",
+            "items": {
+              "$ref": "#/components/schemas/GroundingPassage"
+            }
+          }
+        }
+      },
+      "Image": {
+        "type": "object",
+        "description": "Chunk from image search.",
+        "properties": {
+          "title": {
+            "type": "string",
+            "description": "The title of the web page that the image is from."
+          },
+          "domain": {
+            "type": "string",
+            "description": "The root domain of the web page that the image is from, e.g. \"example.com\"."
+          },
+          "sourceUri": {
+            "type": "string",
+            "description": "The web page URI for attribution."
+          },
+          "imageUri": {
+            "type": "string",
+            "description": "The image asset URL."
+          }
+        }
+      },
+      "ImageConfig": {
+        "type": "object",
+        "description": "Config for image generation features.",
+        "properties": {
+          "aspectRatio": {
+            "type": "string",
+            "description": "Optional. The aspect ratio of the image to generate. Supported aspect ratios: `1:1`, `1:4`, `4:1`, `1:8`, `8:1`, `2:3`, `3:2`, `3:4`, `4:3`, `4:5`, `5:4`, `9:16`, `16:9`, or `21:9`. If not specified, the model will choose a default aspect ratio based on any reference images provided."
+          },
+          "imageSize": {
+            "type": "string",
+            "description": "Optional. Specifies the size of generated images. Supported values are `512`, `1K`, `2K`, `4K`. If not specified, the model will use default value `1K`."
+          }
+        }
+      },
+      "ImageResponseFormat": {
+        "type": "object",
+        "description": "Configuration for image output format.",
+        "properties": {
+          "aspectRatio": {
+            "type": "string",
+            "description": "Optional. The aspect ratio for the image output.",
+            "enum": [
+              "ASPECT_RATIO_UNSPECIFIED",
+              "ASPECT_RATIO_ONE_BY_ONE",
+              "ASPECT_RATIO_TWO_BY_THREE",
+              "ASPECT_RATIO_THREE_BY_TWO",
+              "ASPECT_RATIO_THREE_BY_FOUR",
+              "ASPECT_RATIO_FOUR_BY_THREE",
+              "ASPECT_RATIO_FOUR_BY_FIVE",
+              "ASPECT_RATIO_FIVE_BY_FOUR",
+              "ASPECT_RATIO_NINE_BY_SIXTEEN",
+              "ASPECT_RATIO_SIXTEEN_BY_NINE",
+              "ASPECT_RATIO_TWENTY_ONE_BY_NINE",
+              "ASPECT_RATIO_ONE_BY_EIGHT",
+              "ASPECT_RATIO_EIGHT_BY_ONE",
+              "ASPECT_RATIO_ONE_BY_FOUR",
+              "ASPECT_RATIO_FOUR_BY_ONE"
+            ]
+          },
+          "mimeType": {
+            "type": "string",
+            "description": "Optional. The MIME type of the image output.",
+            "enum": [
+              "MIME_TYPE_UNSPECIFIED",
+              "IMAGE_JPEG"
+            ]
+          },
+          "delivery": {
+            "type": "string",
+            "description": "Optional. The delivery mode for the image output.",
+            "enum": [
+              "DELIVERY_UNSPECIFIED",
+              "INLINE",
+              "URI"
+            ]
+          },
+          "imageSize": {
+            "type": "string",
+            "description": "Optional. The size of the image output.",
+            "enum": [
+              "IMAGE_SIZE_UNSPECIFIED",
+              "IMAGE_SIZE_FIVE_TWELVE",
+              "IMAGE_SIZE_ONE_K",
+              "IMAGE_SIZE_TWO_K",
+              "IMAGE_SIZE_FOUR_K"
+            ]
+          }
+        }
+      },
+      "ImageSearch": {
+        "type": "object",
+        "description": "Image search for grounding and related configurations.",
+        "properties": {}
+      },
+      "InlinedEmbedContentRequest": {
+        "type": "object",
+        "description": "The request to be processed in the batch.",
+        "properties": {
+          "metadata": {
+            "type": "object",
+            "description": "Optional. The metadata to be associated with the request.",
+            "additionalProperties": {
+              "description": "Properties of the object."
+            }
+          },
+          "request": {
+            "$ref": "#/components/schemas/EmbedContentRequest"
+          }
+        }
+      },
+      "InlinedEmbedContentRequests": {
+        "type": "object",
+        "description": "The requests to be processed in the batch if provided as part of the batch creation request.",
+        "properties": {
+          "requests": {
+            "type": "array",
+            "description": "Required. The requests to be processed in the batch.",
+            "items": {
+              "$ref": "#/components/schemas/InlinedEmbedContentRequest"
+            }
+          }
+        }
+      },
+      "InlinedEmbedContentResponse": {
+        "type": "object",
+        "description": "The response to a single request in the batch.",
+        "properties": {
+          "response": {
+            "$ref": "#/components/schemas/EmbedContentResponse"
+          },
+          "error": {
+            "$ref": "#/components/schemas/Status"
+          },
+          "metadata": {
+            "type": "object",
+            "description": "Output only. The metadata associated with the request.",
+            "additionalProperties": {
+              "description": "Properties of the object."
+            }
+          }
+        }
+      },
+      "InlinedEmbedContentResponses": {
+        "type": "object",
+        "description": "The responses to the requests in the batch.",
+        "properties": {
+          "inlinedResponses": {
+            "type": "array",
+            "description": "Output only. The responses to the requests in the batch.",
+            "items": {
+              "$ref": "#/components/schemas/InlinedEmbedContentResponse"
+            }
+          }
+        }
+      },
+      "InlinedRequest": {
+        "type": "object",
+        "description": "The request to be processed in the batch.",
+        "properties": {
+          "metadata": {
+            "type": "object",
+            "description": "Optional. The metadata to be associated with the request.",
+            "additionalProperties": {
+              "description": "Properties of the object."
+            }
+          },
+          "request": {
+            "$ref": "#/components/schemas/GenerateContentRequest"
+          }
+        }
+      },
+      "InlinedRequests": {
+        "type": "object",
+        "description": "The requests to be processed in the batch if provided as part of the batch creation request.",
+        "properties": {
+          "requests": {
+            "type": "array",
+            "description": "Required. The requests to be processed in the batch.",
+            "items": {
+              "$ref": "#/components/schemas/InlinedRequest"
+            }
+          }
+        }
+      },
+      "InlinedResponse": {
+        "type": "object",
+        "description": "The response to a single request in the batch.",
+        "properties": {
+          "error": {
+            "$ref": "#/components/schemas/Status"
+          },
+          "response": {
+            "$ref": "#/components/schemas/GenerateContentResponse"
+          },
+          "metadata": {
+            "type": "object",
+            "description": "Output only. The metadata associated with the request.",
+            "additionalProperties": {
+              "description": "Properties of the object."
+            }
+          }
+        }
+      },
+      "InlinedResponses": {
+        "type": "object",
+        "description": "The responses to the requests in the batch.",
+        "properties": {
+          "inlinedResponses": {
+            "type": "array",
+            "description": "Output only. The responses to the requests in the batch.",
+            "items": {
+              "$ref": "#/components/schemas/InlinedResponse"
+            }
+          }
+        }
+      },
+      "InputConfig": {
+        "type": "object",
+        "description": "Configures the input to the batch request.",
+        "properties": {
+          "fileName": {
+            "type": "string",
+            "description": "The name of the `File` containing the input requests."
+          },
+          "requests": {
+            "$ref": "#/components/schemas/InlinedRequests"
+          }
+        }
+      },
+      "InputEmbedContentConfig": {
+        "type": "object",
+        "description": "Configures the input to the batch request.",
+        "properties": {
+          "fileName": {
+            "type": "string",
+            "description": "The name of the `File` containing the input requests."
+          },
+          "requests": {
+            "$ref": "#/components/schemas/InlinedEmbedContentRequests"
+          }
+        }
+      },
+      "InputFeedback": {
+        "type": "object",
+        "description": "Feedback related to the input data used to answer the question, as opposed to the model-generated response to the question.",
+        "properties": {
+          "blockReason": {
+            "type": "string",
+            "description": "Optional. If set, the input was blocked and no candidates are returned. Rephrase the input.",
+            "enum": [
+              "BLOCK_REASON_UNSPECIFIED",
+              "SAFETY",
+              "OTHER"
+            ]
+          },
+          "safetyRatings": {
+            "type": "array",
+            "description": "Ratings for safety of the input. There is at most one rating per category.",
+            "items": {
+              "$ref": "#/components/schemas/SafetyRating"
+            }
+          }
+        }
+      },
+      "Interval": {
+        "type": "object",
+        "description": "Represents a time interval, encoded as a Timestamp start (inclusive) and a Timestamp end (exclusive). The start must be less than or equal to the end. When the start equals the end, the interval is empty (matches no time). When both start and end are unspecified, the interval matches any time.",
+        "properties": {
+          "endTime": {
+            "type": "string",
+            "format": "google-datetime",
+            "description": "Optional. Exclusive end of the interval. If specified, a Timestamp matching this interval will have to be before the end."
+          },
+          "startTime": {
+            "type": "string",
+            "format": "google-datetime",
+            "description": "Optional. Inclusive start of the interval. If specified, a Timestamp matching this interval will have to be the same or after the start."
+          }
+        }
+      },
+      "LatLng": {
+        "type": "object",
+        "description": "An object that represents a latitude/longitude pair. This is expressed as a pair of doubles to represent degrees latitude and degrees longitude. Unless specified otherwise, this object must conform to the WGS84 standard. Values must be within normalized ranges.",
+        "properties": {
+          "longitude": {
+            "type": "number",
+            "format": "double",
+            "description": "The longitude in degrees. It must be in the range [-180.0, +180.0]."
+          },
+          "latitude": {
+            "type": "number",
+            "format": "double",
+            "description": "The latitude in degrees. It must be in the range [-90.0, +90.0]."
+          }
+        }
+      },
+      "ListModelsResponse": {
+        "type": "object",
+        "description": "Response from `ListModel` containing a paginated list of Models.",
+        "properties": {
+          "models": {
+            "type": "array",
+            "description": "The returned Models.",
+            "items": {
+              "$ref": "#/components/schemas/Model"
+            }
+          },
+          "nextPageToken": {
+            "type": "string",
+            "description": "A token, which can be sent as `page_token` to retrieve the next page. If this field is omitted, there are no more pages."
+          }
+        }
+      },
+      "LogprobsResult": {
+        "type": "object",
+        "description": "Logprobs Result",
+        "properties": {
+          "logProbabilitySum": {
+            "type": "number",
+            "format": "float",
+            "description": "Sum of log probabilities for all tokens."
+          },
+          "topCandidates": {
+            "type": "array",
+            "description": "Length = total number of decoding steps.",
+            "items": {
+              "$ref": "#/components/schemas/TopCandidates"
+            }
+          },
+          "chosenCandidates": {
+            "type": "array",
+            "description": "Length = total number of decoding steps. The chosen candidates may or may not be in top_candidates.",
+            "items": {
+              "$ref": "#/components/schemas/LogprobsResultCandidate"
+            }
+          }
+        }
+      },
+      "LogprobsResultCandidate": {
+        "type": "object",
+        "description": "Candidate for the logprobs token and score.",
+        "properties": {
+          "token": {
+            "type": "string",
+            "description": "The candidate\u2019s token string value."
+          },
+          "logProbability": {
+            "type": "number",
+            "format": "float",
+            "description": "The candidate's log probability."
+          },
+          "tokenId": {
+            "type": "integer",
+            "format": "int32",
+            "description": "The candidate\u2019s token id value."
+          }
+        }
+      },
+      "Maps": {
+        "type": "object",
+        "description": "A grounding chunk from Google Maps. A Maps chunk corresponds to a single place.",
+        "properties": {
+          "title": {
+            "type": "string",
+            "description": "Title of the place."
+          },
+          "text": {
+            "type": "string",
+            "description": "Text description of the place answer."
+          },
+          "uri": {
+            "type": "string",
+            "description": "URI reference of the place."
+          },
+          "placeId": {
+            "type": "string",
+            "description": "The ID of the place, in `places/{place_id}` format. A user can use this ID to look up that place."
+          },
+          "placeAnswerSources": {
+            "$ref": "#/components/schemas/PlaceAnswerSources"
+          }
+        }
+      },
+      "McpServer": {
+        "type": "object",
+        "description": "A MCPServer is a server that can be called by the model to perform actions. It is a server that implements the MCP protocol. Next ID: 6",
+        "properties": {
+          "streamableHttpTransport": {
+            "$ref": "#/components/schemas/StreamableHttpTransport"
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the MCPServer."
+          }
+        }
+      },
+      "MediaResolution": {
+        "description": "Opaque value; type `MediaResolution` is referenced but not defined in the upstream Google discovery document."
+      },
+      "Message": {
+        "type": "object",
+        "description": "The base unit of structured text. A `Message` includes an `author` and the `content` of the `Message`. The `author` is used to tag messages when they are fed to the model as text.",
+        "properties": {
+          "content": {
+            "type": "string",
+            "description": "Required. The text content of the structured `Message`."
+          },
+          "author": {
+            "type": "string",
+            "description": "Optional. The author of this Message. This serves as a key for tagging the content of this Message when it is fed to the model as text. The author can be any alphanumeric string."
+          },
+          "citationMetadata": {
+            "$ref": "#/components/schemas/CitationMetadata"
+          }
+        }
+      },
+      "MessagePrompt": {
+        "type": "object",
+        "description": "All of the structured input text passed to the model as a prompt. A `MessagePrompt` contains a structured set of fields that provide context for the conversation, examples of user input/model output message pairs that prime the model to respond in different ways, and the conversation history or list of messages representing the alternating turns of the conversation between the user and the model.",
+        "properties": {
+          "context": {
+            "type": "string",
+            "description": "Optional. Text that should be provided to the model first to ground the response. If not empty, this `context` will be given to the model first before the `examples` and `messages`. When using a `context` be sure to provide it with every request to maintain continuity. This field can be a description of your prompt to the model to help provide context and guide the responses. Examples: \"Translate the phrase from English to French.\" or \"Given a statement, classify the sentiment as happy, sad or neutral.\" Anything included in this field will take precedence over message history if the total input size exceeds the model's `input_token_limit` and the input request is truncated."
+          },
+          "messages": {
+            "type": "array",
+            "description": "Required. A snapshot of the recent conversation history sorted chronologically. Turns alternate between two authors. If the total input size exceeds the model's `input_token_limit` the input will be truncated: The oldest items will be dropped from `messages`.",
+            "items": {
+              "$ref": "#/components/schemas/Message"
+            }
+          },
+          "examples": {
+            "type": "array",
+            "description": "Optional. Examples of what the model should generate. This includes both user input and the response that the model should emulate. These `examples` are treated identically to conversation messages except that they take precedence over the history in `messages`: If the total input size exceeds the model's `input_token_limit` the input will be truncated. Items will be dropped from `messages` before `examples`.",
+            "items": {
+              "$ref": "#/components/schemas/Example"
+            }
+          }
+        }
+      },
+      "MetadataFilter": {
+        "type": "object",
+        "description": "User provided filter to limit retrieval based on `Chunk` or `Document` level metadata values. Example (genre = drama OR genre = action): key = \"document.custom_metadata.genre\" conditions = [{string_value = \"drama\", operation = EQUAL}, {string_value = \"action\", operation = EQUAL}]",
+        "properties": {
+          "key": {
+            "type": "string",
+            "description": "Required. The key of the metadata to filter on."
+          },
+          "conditions": {
+            "type": "array",
+            "description": "Required. The `Condition`s for the given key that will trigger this filter. Multiple `Condition`s are joined by logical ORs.",
+            "items": {
+              "$ref": "#/components/schemas/Condition"
+            }
+          }
+        }
+      },
+      "ModalityTokenCount": {
+        "type": "object",
+        "description": "Represents token counting info for a single modality.",
+        "properties": {
+          "tokenCount": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Number of tokens."
+          },
+          "modality": {
+            "type": "string",
+            "description": "The modality associated with this token count.",
+            "enum": [
+              "MODALITY_UNSPECIFIED",
+              "TEXT",
+              "IMAGE",
+              "VIDEO",
+              "AUDIO",
+              "DOCUMENT"
+            ]
+          }
+        }
+      },
+      "Model": {
+        "type": "object",
+        "description": "Information about a Generative Language Model.",
+        "properties": {
+          "temperature": {
+            "type": "number",
+            "format": "float",
+            "description": "Controls the randomness of the output. Values can range over `[0.0,max_temperature]`, inclusive. A higher value will produce responses that are more varied, while a value closer to `0.0` will typically result in less surprising responses from the model. This value specifies default to be used by the backend while making the call to the model."
+          },
+          "baseModelId": {
+            "type": "string",
+            "description": "Required. The name of the base model, pass this to the generation request. Examples: * `gemini-1.5-flash`"
+          },
+          "inputTokenLimit": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Maximum number of input tokens allowed for this model."
+          },
+          "topP": {
+            "type": "number",
+            "format": "float",
+            "description": "For [Nucleus sampling](https://ai.google.dev/gemini-api/docs/prompting-strategies#top-p). Nucleus sampling considers the smallest set of tokens whose probability sum is at least `top_p`. This value specifies default to be used by the backend while making the call to the model."
+          },
+          "version": {
+            "type": "string",
+            "description": "Required. The version number of the model. This represents the major version (`1.0` or `1.5`)"
+          },
+          "displayName": {
+            "type": "string",
+            "description": "The human-readable name of the model. E.g. \"Gemini 1.5 Flash\". The name can be up to 128 characters long and can consist of any UTF-8 characters."
+          },
+          "description": {
+            "type": "string",
+            "description": "A short description of the model."
+          },
+          "outputTokenLimit": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Maximum number of output tokens available for this model."
+          },
+          "name": {
+            "type": "string",
+            "description": "Required. The resource name of the `Model`. Refer to [Model variants](https://ai.google.dev/gemini-api/docs/models/gemini#model-variations) for all allowed values. Format: `models/{model}` with a `{model}` naming convention of: * \"{base_model_id}-{version}\" Examples: * `models/gemini-1.5-flash-001`"
+          },
+          "thinking": {
+            "type": "boolean",
+            "description": "Whether the model supports thinking."
+          },
+          "supportedGenerationMethods": {
+            "type": "array",
+            "description": "The model's supported generation methods. The corresponding API method names are defined as Pascal case strings, such as `generateMessage` and `generateContent`.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "maxTemperature": {
+            "type": "number",
+            "format": "float",
+            "description": "The maximum temperature this model can use."
+          },
+          "topK": {
+            "type": "integer",
+            "format": "int32",
+            "description": "For Top-k sampling. Top-k sampling considers the set of `top_k` most probable tokens. This value specifies default to be used by the backend while making the call to the model. If empty, indicates the model doesn't use top-k sampling, and `top_k` isn't allowed as a generation parameter."
+          }
+        }
+      },
+      "ModelStatus": {
+        "type": "object",
+        "description": "The status of the underlying model. This is used to indicate the stage of the underlying model and the retirement time if applicable.",
+        "properties": {
+          "retirementTime": {
+            "type": "string",
+            "format": "google-datetime",
+            "description": "The time at which the model will be retired."
+          },
+          "message": {
+            "type": "string",
+            "description": "A message explaining the model status."
+          },
+          "modelStage": {
+            "type": "string",
+            "description": "The stage of the underlying model.",
+            "enum": [
+              "MODEL_STAGE_UNSPECIFIED",
+              "UNSTABLE_EXPERIMENTAL",
+              "EXPERIMENTAL",
+              "PREVIEW",
+              "STABLE",
+              "LEGACY",
+              "DEPRECATED",
+              "RETIRED"
+            ]
+          }
+        }
+      },
+      "MultiSpeakerVoiceConfig": {
+        "type": "object",
+        "description": "The configuration for the multi-speaker setup.",
+        "properties": {
+          "speakerVoiceConfigs": {
+            "type": "array",
+            "description": "Required. All the enabled speaker voices.",
+            "items": {
+              "$ref": "#/components/schemas/SpeakerVoiceConfig"
+            }
+          }
+        }
+      },
+      "Operation": {
+        "type": "object",
+        "description": "This resource represents a long-running operation that is the result of a network API call.",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The server-assigned name, which is only unique within the same service that originally returns it. If you use the default HTTP mapping, the `name` should be a resource name ending with `operations/{unique_id}`."
+          },
+          "metadata": {
+            "type": "object",
+            "description": "Service-specific metadata associated with the operation. It typically contains progress information and common metadata such as create time. Some services might not provide such metadata. Any method that returns a long-running operation should document the metadata type, if any.",
+            "additionalProperties": {
+              "description": "Properties of the object. Contains field @type with type URL."
+            }
+          },
+          "done": {
+            "type": "boolean",
+            "description": "If the value is `false`, it means the operation is still in progress. If `true`, the operation is completed, and either `error` or `response` is available."
+          },
+          "response": {
+            "type": "object",
+            "description": "The normal, successful response of the operation. If the original method returns no data on success, such as `Delete`, the response is `google.protobuf.Empty`. If the original method is standard `Get`/`Create`/`Update`, the response should be the resource. For other methods, the response should have the type `XxxResponse`, where `Xxx` is the original method name. For example, if the original method name is `TakeSnapshot()`, the inferred response type is `TakeSnapshotResponse`.",
+            "additionalProperties": {
+              "description": "Properties of the object. Contains field @type with type URL."
+            }
+          },
+          "error": {
+            "$ref": "#/components/schemas/Status"
+          }
+        }
+      },
+      "Part": {
+        "type": "object",
+        "description": "A datatype containing media that is part of a multi-part `Content` message. A `Part` consists of data which has an associated datatype. A `Part` can only contain one of the accepted types in `Part.data`. A `Part` must have a fixed IANA MIME type identifying the type and subtype of the media if the `inline_data` field is filled with raw bytes.",
+        "properties": {
+          "codeExecutionResult": {
+            "$ref": "#/components/schemas/CodeExecutionResult"
+          },
+          "thought": {
+            "type": "boolean",
+            "description": "Optional. Indicates if the part is thought from the model."
+          },
+          "toolCall": {
+            "$ref": "#/components/schemas/ToolCall"
+          },
+          "inlineData": {
+            "$ref": "#/components/schemas/Blob"
+          },
+          "mediaResolution": {
+            "$ref": "#/components/schemas/MediaResolution"
+          },
+          "executableCode": {
+            "$ref": "#/components/schemas/ExecutableCode"
+          },
+          "thoughtSignature": {
+            "type": "string",
+            "format": "byte",
+            "description": "Optional. An opaque signature for the thought so it can be reused in subsequent requests."
+          },
+          "functionCall": {
+            "$ref": "#/components/schemas/FunctionCall"
+          },
+          "toolResponse": {
+            "$ref": "#/components/schemas/ToolResponse"
+          },
+          "partMetadata": {
+            "type": "object",
+            "description": "Custom metadata associated with the Part. Agents using genai.Part as content representation may need to keep track of the additional information. For example it can be name of a file/source from which the Part originates or a way to multiplex multiple Part streams.",
+            "additionalProperties": {
+              "description": "Properties of the object."
+            }
+          },
+          "fileData": {
+            "$ref": "#/components/schemas/FileData"
+          },
+          "text": {
+            "type": "string",
+            "description": "Inline text."
+          },
+          "functionResponse": {
+            "$ref": "#/components/schemas/FunctionResponse"
+          },
+          "videoMetadata": {
+            "$ref": "#/components/schemas/VideoMetadata"
+          }
+        }
+      },
+      "PlaceAnswerSources": {
+        "type": "object",
+        "description": "Collection of sources that provide answers about the features of a given place in Google Maps. Each PlaceAnswerSources message corresponds to a specific place in Google Maps. The Google Maps tool used these sources in order to answer questions about features of the place (e.g: \"does Bar Foo have Wifi\" or \"is Foo Bar wheelchair accessible?\"). Currently we only support review snippets as sources.",
+        "properties": {
+          "reviewSnippets": {
+            "type": "array",
+            "description": "Snippets of reviews that are used to generate answers about the features of a given place in Google Maps.",
+            "items": {
+              "$ref": "#/components/schemas/ReviewSnippet"
+            }
+          }
+        }
+      },
+      "PrebuiltVoiceConfig": {
+        "type": "object",
+        "description": "The configuration for the prebuilt speaker to use.",
+        "properties": {
+          "voiceName": {
+            "type": "string",
+            "description": "The name of the preset voice to use."
+          }
+        }
+      },
+      "PredictLongRunningRequest": {
+        "type": "object",
+        "description": "Request message for [PredictionService.PredictLongRunning].",
+        "properties": {
+          "parameters": {
+            "description": "Optional. The parameters that govern the prediction call."
+          },
+          "instances": {
+            "type": "array",
+            "description": "Required. The instances that are the input to the prediction call.",
+            "items": {}
+          }
+        }
+      },
+      "PredictRequest": {
+        "type": "object",
+        "description": "Request message for PredictionService.Predict.",
+        "properties": {
+          "instances": {
+            "type": "array",
+            "description": "Required. The instances that are the input to the prediction call.",
+            "items": {}
+          },
+          "parameters": {
+            "description": "Optional. The parameters that govern the prediction call."
+          }
+        }
+      },
+      "PredictResponse": {
+        "type": "object",
+        "description": "Response message for [PredictionService.Predict].",
+        "properties": {
+          "predictions": {
+            "type": "array",
+            "description": "The outputs of the prediction call.",
+            "items": {}
+          }
+        }
+      },
+      "PromptFeedback": {
+        "type": "object",
+        "description": "A set of the feedback metadata the prompt specified in `GenerateContentRequest.content`.",
+        "properties": {
+          "blockReason": {
+            "type": "string",
+            "description": "Optional. If set, the prompt was blocked and no candidates are returned. Rephrase the prompt.",
+            "enum": [
+              "BLOCK_REASON_UNSPECIFIED",
+              "SAFETY",
+              "OTHER",
+              "BLOCKLIST",
+              "PROHIBITED_CONTENT",
+              "IMAGE_SAFETY"
+            ]
+          },
+          "safetyRatings": {
+            "type": "array",
+            "description": "Ratings for safety of the prompt. There is at most one rating per category.",
+            "items": {
+              "$ref": "#/components/schemas/SafetyRating"
+            }
+          }
+        }
+      },
+      "ResponseFormatConfig": {
+        "type": "object",
+        "description": "Configuration for the response output format. This is a flat object where each optional sub-field configures a specific output modality.",
+        "properties": {
+          "text": {
+            "$ref": "#/components/schemas/TextResponseFormat"
+          },
+          "image": {
+            "$ref": "#/components/schemas/ImageResponseFormat"
+          },
+          "audio": {
+            "$ref": "#/components/schemas/AudioResponseFormat"
+          }
+        }
+      },
+      "RetrievalConfig": {
+        "type": "object",
+        "description": "Retrieval config.",
+        "properties": {
+          "latLng": {
+            "$ref": "#/components/schemas/LatLng"
+          },
+          "languageCode": {
+            "type": "string",
+            "description": "Optional. The language code of the user. Language code for content. Use language tags defined by [BCP47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt)."
+          }
+        }
+      },
+      "RetrievalMetadata": {
+        "type": "object",
+        "description": "Metadata related to retrieval in the grounding flow.",
+        "properties": {
+          "googleSearchDynamicRetrievalScore": {
+            "type": "number",
+            "format": "float",
+            "description": "Optional. Score indicating how likely information from google search could help answer the prompt. The score is in the range [0, 1], where 0 is the least likely and 1 is the most likely. This score is only populated when google search grounding and dynamic retrieval is enabled. It will be compared to the threshold to determine whether to trigger google search."
+          }
+        }
+      },
+      "RetrievedContext": {
+        "type": "object",
+        "description": "Chunk from context retrieved by the file search tool.",
+        "properties": {
+          "mediaId": {
+            "type": "string",
+            "description": "Optional. The media blob resource name for multimodal file search results. Format: fileSearchStores/{file_search_store_id}/media/{blob_id}"
+          },
+          "fileSearchStore": {
+            "type": "string",
+            "description": "Optional. Name of the `FileSearchStore` containing the document. Example: `fileSearchStores/123`"
+          },
+          "uri": {
+            "type": "string",
+            "description": "Optional. URI reference of the semantic retrieval document."
+          },
+          "customMetadata": {
+            "type": "array",
+            "description": "Optional. User-provided metadata about the retrieved context.",
+            "items": {
+              "$ref": "#/components/schemas/GroundingChunkCustomMetadata"
+            }
+          },
+          "title": {
+            "type": "string",
+            "description": "Optional. Title of the document."
+          },
+          "text": {
+            "type": "string",
+            "description": "Optional. Text of the chunk."
+          },
+          "pageNumber": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Optional. Page number of the retrieved context, if applicable."
+          }
+        }
+      },
+      "ReviewSnippet": {
+        "type": "object",
+        "description": "Encapsulates a snippet of a user review that answers a question about the features of a specific place in Google Maps.",
+        "properties": {
+          "reviewId": {
+            "type": "string",
+            "description": "The ID of the review snippet."
+          },
+          "googleMapsUri": {
+            "type": "string",
+            "description": "A link that corresponds to the user review on Google Maps."
+          },
+          "title": {
+            "type": "string",
+            "description": "Title of the review."
+          }
+        }
+      },
+      "SafetyFeedback": {
+        "type": "object",
+        "description": "Safety feedback for an entire request. This field is populated if content in the input and/or response is blocked due to safety settings. SafetyFeedback may not exist for every HarmCategory. Each SafetyFeedback will return the safety settings used by the request as well as the lowest HarmProbability that should be allowed in order to return a result.",
+        "properties": {
+          "setting": {
+            "$ref": "#/components/schemas/SafetySetting"
+          },
+          "rating": {
+            "$ref": "#/components/schemas/SafetyRating"
+          }
+        }
+      },
+      "SafetyRating": {
+        "type": "object",
+        "description": "Safety rating for a piece of content. The safety rating contains the category of harm and the harm probability level in that category for a piece of content. Content is classified for safety across a number of harm categories and the probability of the harm classification is included here.",
+        "properties": {
+          "probability": {
+            "type": "string",
+            "description": "Required. The probability of harm for this content.",
+            "enum": [
+              "HARM_PROBABILITY_UNSPECIFIED",
+              "NEGLIGIBLE",
+              "LOW",
+              "MEDIUM",
+              "HIGH"
+            ]
+          },
+          "blocked": {
+            "type": "boolean",
+            "description": "Was this content blocked because of this rating?"
+          },
+          "category": {
+            "type": "string",
+            "description": "Required. The category for this rating.",
+            "enum": [
+              "HARM_CATEGORY_UNSPECIFIED",
+              "HARM_CATEGORY_DEROGATORY",
+              "HARM_CATEGORY_TOXICITY",
+              "HARM_CATEGORY_VIOLENCE",
+              "HARM_CATEGORY_SEXUAL",
+              "HARM_CATEGORY_MEDICAL",
+              "HARM_CATEGORY_DANGEROUS",
+              "HARM_CATEGORY_HARASSMENT",
+              "HARM_CATEGORY_HATE_SPEECH",
+              "HARM_CATEGORY_SEXUALLY_EXPLICIT",
+              "HARM_CATEGORY_DANGEROUS_CONTENT",
+              "HARM_CATEGORY_CIVIC_INTEGRITY"
+            ]
+          }
+        }
+      },
+      "SafetySetting": {
+        "type": "object",
+        "description": "Safety setting, affecting the safety-blocking behavior. Passing a safety setting for a category changes the allowed probability that content is blocked.",
+        "properties": {
+          "category": {
+            "type": "string",
+            "description": "Required. The category for this setting.",
+            "enum": [
+              "HARM_CATEGORY_UNSPECIFIED",
+              "HARM_CATEGORY_DEROGATORY",
+              "HARM_CATEGORY_TOXICITY",
+              "HARM_CATEGORY_VIOLENCE",
+              "HARM_CATEGORY_SEXUAL",
+              "HARM_CATEGORY_MEDICAL",
+              "HARM_CATEGORY_DANGEROUS",
+              "HARM_CATEGORY_HARASSMENT",
+              "HARM_CATEGORY_HATE_SPEECH",
+              "HARM_CATEGORY_SEXUALLY_EXPLICIT",
+              "HARM_CATEGORY_DANGEROUS_CONTENT",
+              "HARM_CATEGORY_CIVIC_INTEGRITY"
+            ]
+          },
+          "threshold": {
+            "type": "string",
+            "description": "Required. Controls the probability threshold at which harm is blocked.",
+            "enum": [
+              "HARM_BLOCK_THRESHOLD_UNSPECIFIED",
+              "BLOCK_LOW_AND_ABOVE",
+              "BLOCK_MEDIUM_AND_ABOVE",
+              "BLOCK_ONLY_HIGH",
+              "BLOCK_NONE",
+              "OFF"
+            ]
+          }
+        }
+      },
+      "Schema": {
+        "type": "object",
+        "description": "The `Schema` object allows the definition of input and output data types. These types can be objects, but also primitives and arrays. Represents a select subset of an [OpenAPI 3.0 schema object](https://spec.openapis.org/oas/v3.0.3#schema).",
+        "properties": {
+          "maximum": {
+            "type": "number",
+            "format": "double",
+            "description": "Optional. Maximum value of the Type.INTEGER and Type.NUMBER"
+          },
+          "minLength": {
+            "type": "string",
+            "format": "int64",
+            "description": "Optional. SCHEMA FIELDS FOR TYPE STRING Minimum length of the Type.STRING"
+          },
+          "maxProperties": {
+            "type": "string",
+            "format": "int64",
+            "description": "Optional. Maximum number of the properties for Type.OBJECT."
+          },
+          "format": {
+            "type": "string",
+            "description": "Optional. The format of the data. Any value is allowed, but most do not trigger any special functionality."
+          },
+          "minItems": {
+            "type": "string",
+            "format": "int64",
+            "description": "Optional. Minimum number of the elements for Type.ARRAY."
+          },
+          "pattern": {
+            "type": "string",
+            "description": "Optional. Pattern of the Type.STRING to restrict a string to a regular expression."
+          },
+          "anyOf": {
+            "type": "array",
+            "description": "Optional. The value should be validated against any (one or more) of the subschemas in the list.",
+            "items": {
+              "$ref": "#/components/schemas/Schema"
+            }
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional. A brief description of the parameter. This could contain examples of use. Parameter description may be formatted as Markdown."
+          },
+          "maxLength": {
+            "type": "string",
+            "format": "int64",
+            "description": "Optional. Maximum length of the Type.STRING"
+          },
+          "type": {
+            "type": "string",
+            "description": "Required. Data type.",
+            "enum": [
+              "TYPE_UNSPECIFIED",
+              "STRING",
+              "NUMBER",
+              "INTEGER",
+              "BOOLEAN",
+              "ARRAY",
+              "OBJECT",
+              "NULL"
+            ]
+          },
+          "items": {
+            "$ref": "#/components/schemas/Schema"
+          },
+          "propertyOrdering": {
+            "type": "array",
+            "description": "Optional. The order of the properties. Not a standard field in open api spec. Used to determine the order of the properties in the response.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "required": {
+            "type": "array",
+            "description": "Optional. Required properties of Type.OBJECT.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "enum": {
+            "type": "array",
+            "description": "Optional. Possible values of the element of Type.STRING with enum format. For example we can define an Enum Direction as : {type:STRING, format:enum, enum:[\"EAST\", NORTH\", \"SOUTH\", \"WEST\"]}",
+            "items": {
+              "type": "string"
+            }
+          },
+          "default": {
+            "description": "Optional. Default value of the field. Per JSON Schema, this field is intended for documentation generators and doesn't affect validation. Thus it's included here and ignored so that developers who send schemas with a `default` field don't get unknown-field errors."
+          },
+          "minProperties": {
+            "type": "string",
+            "format": "int64",
+            "description": "Optional. Minimum number of the properties for Type.OBJECT."
+          },
+          "minimum": {
+            "type": "number",
+            "format": "double",
+            "description": "Optional. SCHEMA FIELDS FOR TYPE INTEGER and NUMBER Minimum value of the Type.INTEGER and Type.NUMBER"
+          },
+          "title": {
+            "type": "string",
+            "description": "Optional. The title of the schema."
+          },
+          "nullable": {
+            "type": "boolean",
+            "description": "Optional. Indicates if the value may be null."
+          },
+          "properties": {
+            "type": "object",
+            "description": "Optional. Properties of Type.OBJECT.",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/Schema"
+            }
+          },
+          "maxItems": {
+            "type": "string",
+            "format": "int64",
+            "description": "Optional. Maximum number of the elements for Type.ARRAY."
+          },
+          "example": {
+            "description": "Optional. Example of the object. Will only populated when the object is the root."
+          }
+        }
+      },
+      "SearchEntryPoint": {
+        "type": "object",
+        "description": "Google search entry point.",
+        "properties": {
+          "renderedContent": {
+            "type": "string",
+            "description": "Optional. Web content snippet that can be embedded in a web page or an app webview."
+          },
+          "sdkBlob": {
+            "type": "string",
+            "format": "byte",
+            "description": "Optional. Base64 encoded JSON representing array of tuple."
+          }
+        }
+      },
+      "SearchTypes": {
+        "type": "object",
+        "description": "Different types of search that can be enabled on the GoogleSearch tool.",
+        "properties": {
+          "imageSearch": {
+            "$ref": "#/components/schemas/ImageSearch"
+          },
+          "webSearch": {
+            "$ref": "#/components/schemas/WebSearch"
+          }
+        }
+      },
+      "SemanticRetrieverChunk": {
+        "type": "object",
+        "description": "Identifier for a `Chunk` retrieved via Semantic Retriever specified in the `GenerateAnswerRequest` using `SemanticRetrieverConfig`.",
+        "properties": {
+          "source": {
+            "type": "string",
+            "description": "Output only. Name of the source matching the request's `SemanticRetrieverConfig.source`. Example: `corpora/123` or `corpora/123/documents/abc`"
+          },
+          "chunk": {
+            "type": "string",
+            "description": "Output only. Name of the `Chunk` containing the attributed text. Example: `corpora/123/documents/abc/chunks/xyz`"
+          }
+        }
+      },
+      "SemanticRetrieverConfig": {
+        "type": "object",
+        "description": "Configuration for retrieving grounding content from a `Corpus` or `Document` created using the Semantic Retriever API.",
+        "properties": {
+          "metadataFilters": {
+            "type": "array",
+            "description": "Optional. Filters for selecting `Document`s and/or `Chunk`s from the resource.",
+            "items": {
+              "$ref": "#/components/schemas/MetadataFilter"
+            }
+          },
+          "minimumRelevanceScore": {
+            "type": "number",
+            "format": "float",
+            "description": "Optional. Minimum relevance score for retrieved relevant `Chunk`s."
+          },
+          "source": {
+            "type": "string",
+            "description": "Required. Name of the resource for retrieval. Example: `corpora/123` or `corpora/123/documents/abc`."
+          },
+          "query": {
+            "$ref": "#/components/schemas/Content"
+          },
+          "maxChunksCount": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Optional. Maximum number of relevant `Chunk`s to retrieve."
+          }
+        }
+      },
+      "SpeakerVoiceConfig": {
+        "type": "object",
+        "description": "The configuration for a single speaker in a multi speaker setup.",
+        "properties": {
+          "voiceConfig": {
+            "$ref": "#/components/schemas/VoiceConfig"
+          },
+          "speaker": {
+            "type": "string",
+            "description": "Required. The name of the speaker to use. Should be the same as in the prompt."
+          }
+        }
+      },
+      "SpeechConfig": {
+        "type": "object",
+        "description": "Config for speech generation and transcription.",
+        "properties": {
+          "voiceConfig": {
+            "$ref": "#/components/schemas/VoiceConfig"
+          },
+          "multiSpeakerVoiceConfig": {
+            "$ref": "#/components/schemas/MultiSpeakerVoiceConfig"
+          },
+          "languageCode": {
+            "type": "string",
+            "description": "Optional. The IETF [BCP-47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt) language code that the user configured the app to use. Used for speech recognition and synthesis. Valid values are: `de-DE`, `en-AU`, `en-GB`, `en-IN`, `en-US`, `es-US`, `fr-FR`, `hi-IN`, `pt-BR`, `ar-XA`, `es-ES`, `fr-CA`, `id-ID`, `it-IT`, `ja-JP`, `tr-TR`, `vi-VN`, `bn-IN`, `gu-IN`, `kn-IN`, `ml-IN`, `mr-IN`, `ta-IN`, `te-IN`, `nl-NL`, `ko-KR`, `cmn-CN`, `pl-PL`, `ru-RU`, and `th-TH`."
+          }
+        }
+      },
+      "Status": {
+        "type": "object",
+        "description": "The `Status` type defines a logical error model that is suitable for different programming environments, including REST APIs and RPC APIs. It is used by [gRPC](https://github.com/grpc). Each `Status` message contains three pieces of data: error code, error message, and error details. You can find out more about this error model and how to work with it in the [API Design Guide](https://cloud.google.com/apis/design/errors).",
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the google.rpc.Status.details field, or localized by the client."
+          },
+          "code": {
+            "type": "integer",
+            "format": "int32",
+            "description": "The status code, which should be an enum value of google.rpc.Code."
+          },
+          "details": {
+            "type": "array",
+            "description": "A list of messages that carry the error details. There is a common set of message types for APIs to use.",
+            "items": {
+              "type": "object",
+              "additionalProperties": {
+                "description": "Properties of the object. Contains field @type with type URL."
+              }
+            }
+          }
+        }
+      },
+      "StreamableHttpTransport": {
+        "type": "object",
+        "description": "A transport that can stream HTTP requests and responses. Next ID: 6",
+        "properties": {
+          "headers": {
+            "type": "object",
+            "description": "Optional: Fields for authentication headers, timeouts, etc., if needed.",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "sseReadTimeout": {
+            "type": "string",
+            "format": "google-duration",
+            "description": "Timeout for SSE read operations."
+          },
+          "timeout": {
+            "type": "string",
+            "format": "google-duration",
+            "description": "HTTP timeout for regular operations."
+          },
+          "terminateOnClose": {
+            "type": "boolean",
+            "description": "Whether to close the client session when the transport closes."
+          },
+          "url": {
+            "type": "string",
+            "description": "The full URL for the MCPServer endpoint. Example: \"https://api.example.com/mcp\""
+          }
+        }
+      },
+      "TextCompletion": {
+        "type": "object",
+        "description": "Output text returned from a model.",
+        "properties": {
+          "output": {
+            "type": "string",
+            "description": "Output only. The generated text returned from the model."
+          },
+          "citationMetadata": {
+            "$ref": "#/components/schemas/CitationMetadata"
+          },
+          "safetyRatings": {
+            "type": "array",
+            "description": "Ratings for the safety of a response. There is at most one rating per category.",
+            "items": {
+              "$ref": "#/components/schemas/SafetyRating"
+            }
+          }
+        }
+      },
+      "TextPrompt": {
+        "type": "object",
+        "description": "Text given to the model as a prompt. The Model will use this TextPrompt to Generate a text completion.",
+        "properties": {
+          "text": {
+            "type": "string",
+            "description": "Required. The prompt text."
+          }
+        }
+      },
+      "TextResponseFormat": {
+        "type": "object",
+        "description": "Configuration for text output format.",
+        "properties": {
+          "schema": {
+            "description": "Optional. The JSON schema that the output should conform to. Only applicable when mime_type is APPLICATION_JSON."
+          },
+          "mimeType": {
+            "type": "string",
+            "description": "Optional. The MIME type of the text output.",
+            "enum": [
+              "MIME_TYPE_UNSPECIFIED",
+              "APPLICATION_JSON",
+              "TEXT_PLAIN"
+            ]
+          }
+        }
+      },
+      "ThinkingConfig": {
+        "type": "object",
+        "description": "Config for thinking features.",
+        "properties": {
+          "includeThoughts": {
+            "type": "boolean",
+            "description": "Indicates whether to include thoughts in the response. If true, thoughts are returned only when available."
+          },
+          "thinkingBudget": {
+            "type": "integer",
+            "format": "int32",
+            "description": "The number of thoughts tokens that the model should generate."
+          },
+          "thinkingLevel": {
+            "type": "string",
+            "description": "Optional. Controls the maximum depth of the model's internal reasoning process before it produces a response. The default value is model-dependent. Refer to the [Thinking levels guide](https://ai.google.dev/gemini-api/docs/thinking#thinking-levels) for more details. Recommended for Gemini 3 or later models. Use with earlier models results in an error.",
+            "enum": [
+              "THINKING_LEVEL_UNSPECIFIED",
+              "MINIMAL",
+              "LOW",
+              "MEDIUM",
+              "HIGH"
+            ]
+          }
+        }
+      },
+      "Tool": {
+        "type": "object",
+        "description": "Tool details that the model may use to generate response. A `Tool` is a piece of code that enables the system to interact with external systems to perform an action, or set of actions, outside of knowledge and scope of the model. Next ID: 16",
+        "properties": {
+          "googleSearchRetrieval": {
+            "$ref": "#/components/schemas/GoogleSearchRetrieval"
+          },
+          "codeExecution": {
+            "$ref": "#/components/schemas/CodeExecution"
+          },
+          "googleSearch": {
+            "$ref": "#/components/schemas/GoogleSearch"
+          },
+          "mcpServers": {
+            "type": "array",
+            "description": "Optional. MCP Servers to connect to.",
+            "items": {
+              "$ref": "#/components/schemas/McpServer"
+            }
+          },
+          "computerUse": {
+            "$ref": "#/components/schemas/ComputerUse"
+          },
+          "fileSearch": {
+            "$ref": "#/components/schemas/FileSearch"
+          },
+          "functionDeclarations": {
+            "type": "array",
+            "description": "Optional. A list of `FunctionDeclarations` available to the model that can be used for function calling. The model or system does not execute the function. Instead the defined function may be returned as a FunctionCall with arguments to the client side for execution. The model may decide to call a subset of these functions by populating FunctionCall in the response. The next conversation turn may contain a FunctionResponse with the Content.role \"function\" generation context for the next model turn.",
+            "items": {
+              "$ref": "#/components/schemas/FunctionDeclaration"
+            }
+          },
+          "urlContext": {
+            "$ref": "#/components/schemas/UrlContext"
+          },
+          "googleMaps": {
+            "$ref": "#/components/schemas/GoogleMaps"
+          }
+        }
+      },
+      "ToolCall": {
+        "type": "object",
+        "description": "A predicted server-side `ToolCall` returned from the model. This message contains information about a tool that the model wants to invoke. The client is NOT expected to execute this `ToolCall`. Instead, the client should pass this `ToolCall` back to the API in a subsequent turn within a `Content` message, along with the corresponding `ToolResponse`.",
+        "properties": {
+          "toolType": {
+            "type": "string",
+            "description": "Required. The type of tool that was called.",
+            "enum": [
+              "TOOL_TYPE_UNSPECIFIED",
+              "GOOGLE_SEARCH_WEB",
+              "GOOGLE_SEARCH_IMAGE",
+              "URL_CONTEXT",
+              "GOOGLE_MAPS",
+              "FILE_SEARCH"
+            ]
+          },
+          "id": {
+            "type": "string",
+            "description": "Optional. Unique identifier of the tool call. The server returns the tool response with the matching `id`."
+          },
+          "args": {
+            "type": "object",
+            "description": "Optional. The tool call arguments. Example: {\"arg1\" : \"value1\", \"arg2\" : \"value2\" , ...}",
+            "additionalProperties": {
+              "description": "Properties of the object."
+            }
+          }
+        }
+      },
+      "ToolConfig": {
+        "type": "object",
+        "description": "The Tool configuration containing parameters for specifying `Tool` use in the request.",
+        "properties": {
+          "retrievalConfig": {
+            "$ref": "#/components/schemas/RetrievalConfig"
+          },
+          "functionCallingConfig": {
+            "$ref": "#/components/schemas/FunctionCallingConfig"
+          },
+          "includeServerSideToolInvocations": {
+            "type": "boolean",
+            "description": "Optional. If true, the API response will include the server-side tool calls and responses within the `Content` message. This allows clients to observe the server's tool interactions."
+          }
+        }
+      },
+      "ToolResponse": {
+        "type": "object",
+        "description": "The output from a server-side `ToolCall` execution. This message contains the results of a tool invocation that was initiated by a `ToolCall` from the model. The client should pass this `ToolResponse` back to the API in a subsequent turn within a `Content` message, along with the corresponding `ToolCall`.",
+        "properties": {
+          "response": {
+            "type": "object",
+            "description": "Optional. The tool response.",
+            "additionalProperties": {
+              "description": "Properties of the object."
+            }
+          },
+          "id": {
+            "type": "string",
+            "description": "Optional. The identifier of the tool call this response is for."
+          },
+          "toolType": {
+            "type": "string",
+            "description": "Required. The type of tool that was called, matching the `tool_type` in the corresponding `ToolCall`.",
+            "enum": [
+              "TOOL_TYPE_UNSPECIFIED",
+              "GOOGLE_SEARCH_WEB",
+              "GOOGLE_SEARCH_IMAGE",
+              "URL_CONTEXT",
+              "GOOGLE_MAPS",
+              "FILE_SEARCH"
+            ]
+          }
+        }
+      },
+      "TopCandidates": {
+        "type": "object",
+        "description": "Candidates with top log probabilities at each decoding step.",
+        "properties": {
+          "candidates": {
+            "type": "array",
+            "description": "Sorted by log probability in descending order.",
+            "items": {
+              "$ref": "#/components/schemas/LogprobsResultCandidate"
+            }
+          }
+        }
+      },
+      "TranslationConfig": {
+        "type": "object",
+        "description": "Config for translation features.",
+        "properties": {
+          "echoTargetLanguage": {
+            "type": "boolean",
+            "description": "Optional. If true, the model will generate audio when the target language is spoken, essentially it will parrot the input. If false, we will not produce audio for the target language."
+          },
+          "targetLanguageCode": {
+            "type": "string",
+            "description": "Required. The target language for translation. Supported values are BCP-47 language codes (e.g. \"en\", \"es\", \"fr\")."
+          }
+        }
+      },
+      "UrlContext": {
+        "type": "object",
+        "description": "Tool to support URL context retrieval.",
+        "properties": {}
+      },
+      "UrlContextMetadata": {
+        "type": "object",
+        "description": "Metadata related to url context retrieval tool.",
+        "properties": {
+          "urlMetadata": {
+            "type": "array",
+            "description": "List of url context.",
+            "items": {
+              "$ref": "#/components/schemas/UrlMetadata"
+            }
+          }
+        }
+      },
+      "UrlMetadata": {
+        "type": "object",
+        "description": "Context of the a single url retrieval.",
+        "properties": {
+          "retrievedUrl": {
+            "type": "string",
+            "description": "Retrieved url by the tool."
+          },
+          "urlRetrievalStatus": {
+            "type": "string",
+            "description": "Status of the url retrieval.",
+            "enum": [
+              "URL_RETRIEVAL_STATUS_UNSPECIFIED",
+              "URL_RETRIEVAL_STATUS_SUCCESS",
+              "URL_RETRIEVAL_STATUS_ERROR",
+              "URL_RETRIEVAL_STATUS_PAYWALL",
+              "URL_RETRIEVAL_STATUS_UNSAFE"
+            ]
+          }
+        }
+      },
+      "UsageMetadata": {
+        "type": "object",
+        "description": "Metadata on the generation request's token usage.",
+        "properties": {
+          "toolUsePromptTokensDetails": {
+            "type": "array",
+            "description": "Output only. List of modalities that were processed for tool-use request inputs.",
+            "items": {
+              "$ref": "#/components/schemas/ModalityTokenCount"
+            }
+          },
+          "totalTokenCount": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Total token count for the generation request (prompt + thoughts + response candidates)."
+          },
+          "candidatesTokenCount": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Total number of tokens across all the generated response candidates."
+          },
+          "serviceTier": {
+            "type": "string",
+            "description": "Output only. Service tier of the request.",
+            "enum": [
+              "unspecified",
+              "standard",
+              "flex",
+              "priority"
+            ]
+          },
+          "cachedContentTokenCount": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Number of tokens in the cached part of the prompt (the cached content)"
+          },
+          "thoughtsTokenCount": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Output only. Number of tokens of thoughts for thinking models."
+          },
+          "promptTokenCount": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Number of tokens in the prompt. When `cached_content` is set, this is still the total effective prompt size meaning this includes the number of tokens in the cached content."
+          },
+          "toolUsePromptTokenCount": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Output only. Number of tokens present in tool-use prompt(s)."
+          },
+          "candidatesTokensDetails": {
+            "type": "array",
+            "description": "Output only. List of modalities that were returned in the response.",
+            "items": {
+              "$ref": "#/components/schemas/ModalityTokenCount"
+            }
+          },
+          "promptTokensDetails": {
+            "type": "array",
+            "description": "Output only. List of modalities that were processed in the request input.",
+            "items": {
+              "$ref": "#/components/schemas/ModalityTokenCount"
+            }
+          },
+          "cacheTokensDetails": {
+            "type": "array",
+            "description": "Output only. List of modalities of the cached content in the request input.",
+            "items": {
+              "$ref": "#/components/schemas/ModalityTokenCount"
+            }
+          }
+        }
+      },
+      "VideoMetadata": {
+        "type": "object",
+        "description": "Deprecated: Use `GenerateContentRequest.processing_options` instead. Metadata describes the input video content.",
+        "deprecated": true,
+        "properties": {
+          "startOffset": {
+            "type": "string",
+            "format": "google-duration",
+            "description": "Optional. The start offset of the video."
+          },
+          "endOffset": {
+            "type": "string",
+            "format": "google-duration",
+            "description": "Optional. The end offset of the video."
+          },
+          "fps": {
+            "type": "number",
+            "format": "double",
+            "description": "Optional. The frame rate of the video sent to the model. If not specified, the default value will be 1.0. The fps range is (0.0, 24.0]."
+          }
+        }
+      },
+      "VoiceConfig": {
+        "type": "object",
+        "description": "The configuration for the voice to use.",
+        "properties": {
+          "prebuiltVoiceConfig": {
+            "$ref": "#/components/schemas/PrebuiltVoiceConfig"
+          }
+        }
+      },
+      "Web": {
+        "type": "object",
+        "description": "Chunk from the web.",
+        "properties": {
+          "uri": {
+            "type": "string",
+            "description": "Output only. URI reference of the chunk."
+          },
+          "title": {
+            "type": "string",
+            "description": "Output only. Title of the chunk."
+          }
+        }
+      },
+      "WebSearch": {
+        "type": "object",
+        "description": "Standard web search for grounding and related configurations.",
+        "properties": {}
+      }
     }
-  },
-  "servicePath": "",
-  "title": "Gemini API",
-  "version": "v1beta",
-  "version_module": true
+  }
 }

--- a/providers/solana-foundation/google/translate/openapi.json
+++ b/providers/solana-foundation/google/translate/openapi.json
@@ -1,52 +1,1085 @@
 {
-  "externalDocs": {
-    "url": "https://cloud.google.com/translate/docs/quickstarts"
-  },
+  "openapi": "3.0.3",
   "info": {
-    "contact": {
-      "name": "Google",
-      "url": "https://google.com",
-      "x-twitter": "youtube"
-    },
-    "description": "Integrates text translation into your website or application.",
-    "license": {
-      "name": "Creative Commons Attribution 3.0",
-      "url": "http://creativecommons.org/licenses/by/3.0/"
-    },
-    "termsOfService": "https://developers.google.com/terms/",
     "title": "Cloud Translation API",
-    "version": "v3",
-    "x-apiClientRegistration": {
-      "url": "https://console.developers.google.com"
-    },
-    "x-apisguru-categories": [
-      "analytics",
-      "media"
-    ],
-    "x-logo": {
-      "url": "https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png"
-    },
-    "x-origin": [
-      {
-        "format": "openapi",
-        "url": "https://translation.googleapis.com/$discovery/rest?version=v3",
-        "version": "3.0"
-      }
-    ],
-    "x-preferred": false,
-    "x-providerName": "googleapis.com",
-    "x-serviceName": "translate"
+    "description": "Translate text and documents across 130+ languages. Supports language detection, romanization, synchronous and batch translation, glossaries for domain terminology, adaptive MT datasets, custom models, and document formatting.",
+    "version": "v3"
   },
-  "openapi": "3.0.0",
-  "paths": {},
   "servers": [
     {
       "url": "https://translate.google.gateway-402.com"
     }
   ],
-  "tags": [
-    {
-      "name": "projects"
+  "paths": {
+    "/v3/projects/{projectsId}/locations/{locationsId}/supportedLanguages": {
+      "get": {
+        "operationId": "translate.projects.locations.getSupportedLanguages",
+        "summary": "Returns a list of supported languages for translation.",
+        "parameters": [
+          {
+            "name": "projectsId",
+            "in": "path",
+            "required": true,
+            "description": "Identifier for the `project` segment of the resource path.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "locationsId",
+            "in": "path",
+            "required": true,
+            "description": "Identifier for the `location` segment of the resource path.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "displayLanguageCode",
+            "in": "query",
+            "required": false,
+            "description": "Optional. The language to use to return localized, human readable names of supported languages. If missing, then display names are not returned in a response.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "model",
+            "in": "query",
+            "required": false,
+            "description": "Optional. Get supported languages of this model. The format depends on model type: - AutoML Translation models: `projects/{project-number-or-id}/locations/{location-id}/models/{model-id}` - General (built-in) models: `projects/{project-number-or-id}/locations/{location-id}/models/general/nmt`, Returns languages supported by the specified model. If missing, we get supported languages of Google general NMT model.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SupportedLanguages"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v3/projects/{projectsId}/locations/{locationsId}:adaptiveMtTranslate": {
+      "post": {
+        "operationId": "translate.projects.locations.adaptiveMtTranslate",
+        "summary": "Translate text using Adaptive MT.",
+        "parameters": [
+          {
+            "name": "projectsId",
+            "in": "path",
+            "required": true,
+            "description": "Identifier for the `project` segment of the resource path.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "locationsId",
+            "in": "path",
+            "required": true,
+            "description": "Identifier for the `location` segment of the resource path.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AdaptiveMtTranslateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AdaptiveMtTranslateResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v3/projects/{projectsId}/locations/{locationsId}:detectLanguage": {
+      "post": {
+        "operationId": "translate.projects.locations.detectLanguage",
+        "summary": "Detects the language of text within a request.",
+        "parameters": [
+          {
+            "name": "projectsId",
+            "in": "path",
+            "required": true,
+            "description": "Identifier for the `project` segment of the resource path.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "locationsId",
+            "in": "path",
+            "required": true,
+            "description": "Identifier for the `location` segment of the resource path.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DetectLanguageRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DetectLanguageResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v3/projects/{projectsId}/locations/{locationsId}:refineText": {
+      "post": {
+        "operationId": "translate.projects.locations.refineText",
+        "summary": "Refines the input translated text to improve the quality.",
+        "parameters": [
+          {
+            "name": "projectsId",
+            "in": "path",
+            "required": true,
+            "description": "Identifier for the `project` segment of the resource path.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "locationsId",
+            "in": "path",
+            "required": true,
+            "description": "Identifier for the `location` segment of the resource path.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RefineTextRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RefineTextResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v3/projects/{projectsId}/locations/{locationsId}:romanizeText": {
+      "post": {
+        "operationId": "translate.projects.locations.romanizeText",
+        "summary": "Romanize input text written in non-Latin scripts to Latin text.",
+        "parameters": [
+          {
+            "name": "projectsId",
+            "in": "path",
+            "required": true,
+            "description": "Identifier for the `project` segment of the resource path.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "locationsId",
+            "in": "path",
+            "required": true,
+            "description": "Identifier for the `location` segment of the resource path.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RomanizeTextRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RomanizeTextResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v3/projects/{projectsId}/locations/{locationsId}:translateDocument": {
+      "post": {
+        "operationId": "translate.projects.locations.translateDocument",
+        "summary": "Translates documents in synchronous mode.",
+        "parameters": [
+          {
+            "name": "projectsId",
+            "in": "path",
+            "required": true,
+            "description": "Identifier for the `project` segment of the resource path.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "locationsId",
+            "in": "path",
+            "required": true,
+            "description": "Identifier for the `location` segment of the resource path.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TranslateDocumentRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TranslateDocumentResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v3/projects/{projectsId}/locations/{locationsId}:translateText": {
+      "post": {
+        "operationId": "translate.projects.locations.translateText",
+        "summary": "Translates input text and returns translated text.",
+        "parameters": [
+          {
+            "name": "projectsId",
+            "in": "path",
+            "required": true,
+            "description": "Identifier for the `project` segment of the resource path.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "locationsId",
+            "in": "path",
+            "required": true,
+            "description": "Identifier for the `location` segment of the resource path.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TranslateTextRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TranslateTextResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v3/projects/{projectsId}/supportedLanguages": {
+      "get": {
+        "operationId": "translate.projects.getSupportedLanguages",
+        "summary": "Returns a list of supported languages for translation.",
+        "parameters": [
+          {
+            "name": "projectsId",
+            "in": "path",
+            "required": true,
+            "description": "Identifier for the `project` segment of the resource path.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "displayLanguageCode",
+            "in": "query",
+            "required": false,
+            "description": "Optional. The language to use to return localized, human readable names of supported languages. If missing, then display names are not returned in a response.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "model",
+            "in": "query",
+            "required": false,
+            "description": "Optional. Get supported languages of this model. The format depends on model type: - AutoML Translation models: `projects/{project-number-or-id}/locations/{location-id}/models/{model-id}` - General (built-in) models: `projects/{project-number-or-id}/locations/{location-id}/models/general/nmt`, Returns languages supported by the specified model. If missing, we get supported languages of Google general NMT model.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SupportedLanguages"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v3/projects/{projectsId}:detectLanguage": {
+      "post": {
+        "operationId": "translate.projects.detectLanguage",
+        "summary": "Detects the language of text within a request.",
+        "parameters": [
+          {
+            "name": "projectsId",
+            "in": "path",
+            "required": true,
+            "description": "Identifier for the `project` segment of the resource path.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DetectLanguageRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DetectLanguageResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v3/projects/{projectsId}:romanizeText": {
+      "post": {
+        "operationId": "translate.projects.romanizeText",
+        "summary": "Romanize input text written in non-Latin scripts to Latin text.",
+        "parameters": [
+          {
+            "name": "projectsId",
+            "in": "path",
+            "required": true,
+            "description": "Identifier for the `project` segment of the resource path.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RomanizeTextRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RomanizeTextResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v3/projects/{projectsId}:translateText": {
+      "post": {
+        "operationId": "translate.projects.translateText",
+        "summary": "Translates input text and returns translated text.",
+        "parameters": [
+          {
+            "name": "projectsId",
+            "in": "path",
+            "required": true,
+            "description": "Identifier for the `project` segment of the resource path.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TranslateTextRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TranslateTextResponse"
+                }
+              }
+            }
+          }
+        }
+      }
     }
-  ]
+  },
+  "components": {
+    "schemas": {
+      "AdaptiveMtTranslateRequest": {
+        "type": "object",
+        "description": "The request for sending an AdaptiveMt translation query.",
+        "properties": {
+          "dataset": {
+            "type": "string",
+            "description": "Required. The resource name for the dataset to use for adaptive MT translation. `projects/{project}/locations/{location-id}/adaptiveMtDatasets/{dataset}`"
+          },
+          "content": {
+            "type": "array",
+            "description": "Required. The content of the input in string format.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "referenceSentenceConfig": {
+            "$ref": "#/components/schemas/ReferenceSentenceConfig"
+          },
+          "glossaryConfig": {
+            "$ref": "#/components/schemas/GlossaryConfig"
+          }
+        }
+      },
+      "AdaptiveMtTranslateResponse": {
+        "type": "object",
+        "description": "An AdaptiveMtTranslate response.",
+        "properties": {
+          "languageCode": {
+            "type": "string",
+            "description": "Output only. The translation's language code."
+          },
+          "glossaryTranslations": {
+            "type": "array",
+            "description": "Text translation response if a glossary is provided in the request. This could be the same as 'translation' above if no terms apply.",
+            "items": {
+              "$ref": "#/components/schemas/AdaptiveMtTranslation"
+            }
+          },
+          "translations": {
+            "type": "array",
+            "description": "Output only. The translation.",
+            "items": {
+              "$ref": "#/components/schemas/AdaptiveMtTranslation"
+            }
+          }
+        }
+      },
+      "AdaptiveMtTranslation": {
+        "type": "object",
+        "description": "An AdaptiveMt translation.",
+        "properties": {
+          "translatedText": {
+            "type": "string",
+            "description": "Output only. The translated text."
+          }
+        }
+      },
+      "DetectLanguageRequest": {
+        "type": "object",
+        "description": "The request message for language detection.",
+        "properties": {
+          "labels": {
+            "type": "object",
+            "description": "Optional. The labels with user-defined metadata for the request. Label keys and values can be no longer than 63 characters (Unicode codepoints), can only contain lowercase letters, numeric characters, underscores and dashes. International characters are allowed. Label values are optional. Label keys must start with a letter. See https://cloud.google.com/translate/docs/advanced/labels for more information.",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "documentInputConfig": {
+            "$ref": "#/components/schemas/DocumentInputConfig"
+          },
+          "content": {
+            "type": "string",
+            "description": "The content of the input stored as a string."
+          },
+          "model": {
+            "type": "string",
+            "description": "Optional. The language detection model to be used. Format: `projects/{project-number-or-id}/locations/{location-id}/models/language-detection/{model-id}` Only one language detection model is currently supported: `projects/{project-number-or-id}/locations/{location-id}/models/language-detection/default`. If not specified, the default model is used."
+          },
+          "mimeType": {
+            "type": "string",
+            "description": "Optional. The format of the source text, for example, \"text/html\", \"text/plain\". If left blank, the MIME type defaults to \"text/html\"."
+          }
+        }
+      },
+      "DetectLanguageResponse": {
+        "type": "object",
+        "description": "The response message for language detection.",
+        "properties": {
+          "languages": {
+            "type": "array",
+            "description": "The most probable language detected by the Translation API. For each request, the Translation API will always return only one result.",
+            "items": {
+              "$ref": "#/components/schemas/DetectedLanguage"
+            }
+          }
+        }
+      },
+      "DetectedLanguage": {
+        "type": "object",
+        "description": "The response message for language detection.",
+        "properties": {
+          "languageCode": {
+            "type": "string",
+            "description": "The ISO-639 language code of the source content in the request, detected automatically."
+          },
+          "confidence": {
+            "type": "number",
+            "format": "float",
+            "description": "The confidence of the detection result for this language."
+          }
+        }
+      },
+      "DocumentInputConfig": {
+        "type": "object",
+        "description": "A document translation request input config.",
+        "properties": {
+          "content": {
+            "type": "string",
+            "format": "byte",
+            "description": "Document's content represented as a stream of bytes."
+          },
+          "gcsSource": {
+            "$ref": "#/components/schemas/GcsSource"
+          },
+          "mimeType": {
+            "type": "string",
+            "description": "Specifies the input document's mime_type. If not specified it will be determined using the file extension for gcs_source provided files. For a file provided through bytes content the mime_type must be provided. Currently supported mime types are: - application/pdf - application/vnd.openxmlformats-officedocument.wordprocessingml.document - application/vnd.openxmlformats-officedocument.presentationml.presentation - application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+          }
+        }
+      },
+      "DocumentOutputConfig": {
+        "type": "object",
+        "description": "A document translation request output config.",
+        "properties": {
+          "gcsDestination": {
+            "$ref": "#/components/schemas/GcsDestination"
+          },
+          "mimeType": {
+            "type": "string",
+            "description": "Optional. Specifies the translated document's mime_type. If not specified, the translated file's mime type will be the same as the input file's mime type. Currently only support the output mime type to be the same as input mime type. - application/pdf - application/vnd.openxmlformats-officedocument.wordprocessingml.document - application/vnd.openxmlformats-officedocument.presentationml.presentation - application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+          }
+        }
+      },
+      "DocumentTranslation": {
+        "type": "object",
+        "description": "A translated document message.",
+        "properties": {
+          "byteStreamOutputs": {
+            "type": "array",
+            "description": "The array of translated documents. It is expected to be size 1 for now. We may produce multiple translated documents in the future for other type of file formats.",
+            "items": {
+              "type": "string",
+              "format": "byte"
+            }
+          },
+          "mimeType": {
+            "type": "string",
+            "description": "The translated document's mime type."
+          },
+          "detectedLanguageCode": {
+            "type": "string",
+            "description": "The detected language for the input document. If the user did not provide the source language for the input document, this field will have the language code automatically detected. If the source language was passed, auto-detection of the language does not occur and this field is empty."
+          }
+        }
+      },
+      "GcsDestination": {
+        "type": "object",
+        "description": "The Google Cloud Storage location for the output content.",
+        "properties": {
+          "outputUriPrefix": {
+            "type": "string",
+            "description": "Required. The bucket used in 'output_uri_prefix' must exist and there must be no files under 'output_uri_prefix'. 'output_uri_prefix' must end with \"/\" and start with \"gs://\". One 'output_uri_prefix' can only be used by one batch translation job at a time. Otherwise an INVALID_ARGUMENT (400) error is returned."
+          }
+        }
+      },
+      "GcsSource": {
+        "type": "object",
+        "description": "The Google Cloud Storage location for the input content.",
+        "properties": {
+          "inputUri": {
+            "type": "string",
+            "description": "Required. Source data URI. For example, `gs://my_bucket/my_object`."
+          }
+        }
+      },
+      "GlossaryConfig": {
+        "type": "object",
+        "description": "Configures which glossary is used for a specific target language and defines options for applying that glossary.",
+        "properties": {
+          "contextualTranslationEnabled": {
+            "type": "boolean",
+            "description": "Optional. If set to true, the glossary will be used for contextual translation."
+          },
+          "glossary": {
+            "type": "string",
+            "description": "Required. The `glossary` to be applied for this translation. The format depends on the glossary: - User-provided custom glossary: `projects/{project-number-or-id}/locations/{location-id}/glossaries/{glossary-id}`"
+          },
+          "ignoreCase": {
+            "type": "boolean",
+            "description": "Optional. Indicates match is case insensitive. The default value is `false` if missing."
+          }
+        }
+      },
+      "ReferenceSentenceConfig": {
+        "type": "object",
+        "description": "Message of caller-provided reference configuration.",
+        "properties": {
+          "referenceSentencePairLists": {
+            "type": "array",
+            "description": "Reference sentences pair lists. Each list will be used as the references to translate the sentence under \"content\" field at the corresponding index. Length of the list is required to be equal to the length of \"content\" field.",
+            "items": {
+              "$ref": "#/components/schemas/ReferenceSentencePairList"
+            }
+          },
+          "targetLanguageCode": {
+            "type": "string",
+            "description": "Target language code."
+          },
+          "sourceLanguageCode": {
+            "type": "string",
+            "description": "Source language code."
+          }
+        }
+      },
+      "ReferenceSentencePair": {
+        "type": "object",
+        "description": "A pair of sentences used as reference in source and target languages.",
+        "properties": {
+          "sourceSentence": {
+            "type": "string",
+            "description": "Source sentence in the sentence pair."
+          },
+          "targetSentence": {
+            "type": "string",
+            "description": "Target sentence in the sentence pair."
+          }
+        }
+      },
+      "ReferenceSentencePairList": {
+        "type": "object",
+        "description": "A list of reference sentence pairs.",
+        "properties": {
+          "referenceSentencePairs": {
+            "type": "array",
+            "description": "Reference sentence pairs.",
+            "items": {
+              "$ref": "#/components/schemas/ReferenceSentencePair"
+            }
+          }
+        }
+      },
+      "RefineTextRequest": {
+        "type": "object",
+        "description": "Request message for RefineText.",
+        "properties": {
+          "sourceLanguageCode": {
+            "type": "string",
+            "description": "Required. The BCP-47 language code of the source text in the request, for example, \"en-US\"."
+          },
+          "targetLanguageCode": {
+            "type": "string",
+            "description": "Required. The BCP-47 language code for translation output, for example, \"zh-CN\"."
+          },
+          "refinementEntries": {
+            "type": "array",
+            "description": "Required. The source texts and original translations in the source and target languages.",
+            "items": {
+              "$ref": "#/components/schemas/RefinementEntry"
+            }
+          }
+        }
+      },
+      "RefineTextResponse": {
+        "type": "object",
+        "description": "Response message for RefineText.",
+        "properties": {
+          "refinedTranslations": {
+            "type": "array",
+            "description": "The refined translations obtained from the original translations.",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "RefinementEntry": {
+        "type": "object",
+        "description": "A single refinement entry for RefineTextRequest.",
+        "properties": {
+          "sourceText": {
+            "type": "string",
+            "description": "Required. The source text to be refined."
+          },
+          "originalTranslation": {
+            "type": "string",
+            "description": "Required. The original translation of the source text."
+          }
+        }
+      },
+      "Romanization": {
+        "type": "object",
+        "description": "A single romanization response.",
+        "properties": {
+          "romanizedText": {
+            "type": "string",
+            "description": "Romanized text. If an error occurs during romanization, this field might be excluded from the response."
+          },
+          "detectedLanguageCode": {
+            "type": "string",
+            "description": "The ISO-639 language code of source text in the initial request, detected automatically, if no source language was passed within the initial request. If the source language was passed, auto-detection of the language does not occur and this field is empty."
+          }
+        }
+      },
+      "RomanizeTextRequest": {
+        "type": "object",
+        "description": "The request message for synchronous romanization.",
+        "properties": {
+          "contents": {
+            "type": "array",
+            "description": "Required. The content of the input in string format.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "sourceLanguageCode": {
+            "type": "string",
+            "description": "Optional. The ISO-639 language code of the input text if known, for example, \"hi\" or \"zh\". Supported language codes are listed in [Language Support](https://cloud.google.com/translate/docs/languages#roman). If the source language isn't specified, the API attempts to identify the source language automatically and returns the source language for each content in the response."
+          }
+        }
+      },
+      "RomanizeTextResponse": {
+        "type": "object",
+        "description": "The response message for synchronous romanization.",
+        "properties": {
+          "romanizations": {
+            "type": "array",
+            "description": "Text romanization responses. This field has the same length as `contents`.",
+            "items": {
+              "$ref": "#/components/schemas/Romanization"
+            }
+          }
+        }
+      },
+      "SupportedLanguage": {
+        "type": "object",
+        "description": "A single supported language response corresponds to information related to one supported language.",
+        "properties": {
+          "languageCode": {
+            "type": "string",
+            "description": "Supported language code, generally consisting of its ISO 639-1 identifier, for example, 'en', 'ja'. In certain cases, ISO-639 codes including language and region identifiers are returned (for example, 'zh-TW' and 'zh-CN')."
+          },
+          "supportSource": {
+            "type": "boolean",
+            "description": "Can be used as a source language."
+          },
+          "displayName": {
+            "type": "string",
+            "description": "Human-readable name of the language localized in the display language specified in the request."
+          },
+          "supportTarget": {
+            "type": "boolean",
+            "description": "Can be used as a target language."
+          }
+        }
+      },
+      "SupportedLanguages": {
+        "type": "object",
+        "description": "The response message for discovering supported languages.",
+        "properties": {
+          "languages": {
+            "type": "array",
+            "description": "A list of supported language responses. This list contains an entry for each language the Translation API supports.",
+            "items": {
+              "$ref": "#/components/schemas/SupportedLanguage"
+            }
+          }
+        }
+      },
+      "TranslateDocumentRequest": {
+        "type": "object",
+        "description": "A document translation request.",
+        "properties": {
+          "documentInputConfig": {
+            "$ref": "#/components/schemas/DocumentInputConfig"
+          },
+          "labels": {
+            "type": "object",
+            "description": "Optional. The labels with user-defined metadata for the request. Label keys and values can be no longer than 63 characters (Unicode codepoints), can only contain lowercase letters, numeric characters, underscores and dashes. International characters are allowed. Label values are optional. Label keys must start with a letter. See https://cloud.google.com/translate/docs/advanced/labels for more information.",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "enableRotationCorrection": {
+            "type": "boolean",
+            "description": "Optional. If true, enable auto rotation correction in DVS."
+          },
+          "targetLanguageCode": {
+            "type": "string",
+            "description": "Required. The ISO-639 language code to use for translation of the input document, set to one of the language codes listed in [Language Support](https://cloud.google.com/translate/docs/languages)."
+          },
+          "customizedAttribution": {
+            "type": "string",
+            "description": "Optional. This flag is to support user customized attribution. If not provided, the default is `Machine Translated by Google`. Customized attribution should follow rules in https://cloud.google.com/translate/attribution#attribution_and_logos"
+          },
+          "enableShadowRemovalNativePdf": {
+            "type": "boolean",
+            "description": "Optional. If true, use the text removal server to remove the shadow text on background image for native pdf translation. Shadow removal feature can only be enabled when is_translate_native_pdf_only: false && pdf_native_only: false"
+          },
+          "documentOutputConfig": {
+            "$ref": "#/components/schemas/DocumentOutputConfig"
+          },
+          "glossaryConfig": {
+            "$ref": "#/components/schemas/TranslateTextGlossaryConfig"
+          },
+          "sourceLanguageCode": {
+            "type": "string",
+            "description": "Optional. The ISO-639 language code of the input document if known, for example, \"en-US\" or \"sr-Latn\". Supported language codes are listed in [Language Support](https://cloud.google.com/translate/docs/languages). If the source language isn't specified, the API attempts to identify the source language automatically and returns the source language within the response. Source language must be specified if the request contains a glossary or a custom model."
+          },
+          "model": {
+            "type": "string",
+            "description": "Optional. The `model` type requested for this translation. The format depends on model type: - AutoML Translation models: `projects/{project-number-or-id}/locations/{location-id}/models/{model-id}` - General (built-in) models: `projects/{project-number-or-id}/locations/{location-id}/models/general/nmt`, If not provided, the default Google model (NMT) will be used for translation."
+          },
+          "isTranslateNativePdfOnly": {
+            "type": "boolean",
+            "description": "Optional. is_translate_native_pdf_only field for external customers. If true, the page limit of online native pdf translation is 300 and only native pdf pages will be translated."
+          }
+        }
+      },
+      "TranslateDocumentResponse": {
+        "type": "object",
+        "description": "A translated document response message.",
+        "properties": {
+          "glossaryDocumentTranslation": {
+            "$ref": "#/components/schemas/DocumentTranslation"
+          },
+          "model": {
+            "type": "string",
+            "description": "Only present when 'model' is present in the request. 'model' is normalized to have a project number. For example: If the 'model' field in TranslateDocumentRequest is: `projects/{project-id}/locations/{location-id}/models/general/nmt` then `model` here would be normalized to `projects/{project-number}/locations/{location-id}/models/general/nmt`."
+          },
+          "documentTranslation": {
+            "$ref": "#/components/schemas/DocumentTranslation"
+          },
+          "glossaryConfig": {
+            "$ref": "#/components/schemas/TranslateTextGlossaryConfig"
+          }
+        }
+      },
+      "TranslateTextGlossaryConfig": {
+        "type": "object",
+        "description": "Configures which glossary is used for a specific target language and defines options for applying that glossary.",
+        "properties": {
+          "glossary": {
+            "type": "string",
+            "description": "Required. The `glossary` to be applied for this translation. The format depends on the glossary: - User-provided custom glossary: `projects/{project-number-or-id}/locations/{location-id}/glossaries/{glossary-id}`"
+          },
+          "ignoreCase": {
+            "type": "boolean",
+            "description": "Optional. Indicates match is case insensitive. The default value is `false` if missing."
+          },
+          "contextualTranslationEnabled": {
+            "type": "boolean",
+            "description": "Optional. If set to true, the glossary will be used for contextual translation."
+          }
+        }
+      },
+      "TranslateTextRequest": {
+        "type": "object",
+        "description": "The request message for synchronous translation.",
+        "properties": {
+          "targetLanguageCode": {
+            "type": "string",
+            "description": "Required. The ISO-639 language code to use for translation of the input text, set to one of the language codes listed in [Language Support](https://cloud.google.com/translate/docs/languages)."
+          },
+          "labels": {
+            "type": "object",
+            "description": "Optional. The labels with user-defined metadata for the request. Label keys and values can be no longer than 63 characters (Unicode codepoints), can only contain lowercase letters, numeric characters, underscores and dashes. International characters are allowed. Label values are optional. Label keys must start with a letter. See https://cloud.google.com/translate/docs/advanced/labels for more information.",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "contents": {
+            "type": "array",
+            "description": "Required. The content of the input in string format. We recommend the total content be less than 30,000 codepoints. The max length of this field is 1024. Use BatchTranslateText for larger text.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "mimeType": {
+            "type": "string",
+            "description": "Optional. The format of the source text, for example, \"text/html\", \"text/plain\". If left blank, the MIME type defaults to \"text/html\"."
+          },
+          "model": {
+            "type": "string",
+            "description": "Optional. The `model` type requested for this translation. The format depends on model type: - AutoML Translation models: `projects/{project-number-or-id}/locations/{location-id}/models/{model-id}` - General (built-in) models: `projects/{project-number-or-id}/locations/{location-id}/models/general/nmt`, - Translation LLM models: `projects/{project-number-or-id}/locations/{location-id}/models/general/translation-llm`, For global (non-regionalized) requests, use `location-id` `global`. For example, `projects/{project-number-or-id}/locations/global/models/general/nmt`. If not provided, the default Google model (NMT) will be used"
+          },
+          "glossaryConfig": {
+            "$ref": "#/components/schemas/TranslateTextGlossaryConfig"
+          },
+          "transliterationConfig": {
+            "$ref": "#/components/schemas/TransliterationConfig"
+          },
+          "sourceLanguageCode": {
+            "type": "string",
+            "description": "Optional. The ISO-639 language code of the input text if known, for example, \"en-US\" or \"sr-Latn\". Supported language codes are listed in [Language Support](https://cloud.google.com/translate/docs/languages). If the source language isn't specified, the API attempts to identify the source language automatically and returns the source language within the response."
+          }
+        }
+      },
+      "TranslateTextResponse": {
+        "type": "object",
+        "properties": {
+          "translations": {
+            "type": "array",
+            "description": "Text translation responses with no glossary applied. This field has the same length as `contents`.",
+            "items": {
+              "$ref": "#/components/schemas/Translation"
+            }
+          },
+          "glossaryTranslations": {
+            "type": "array",
+            "description": "Text translation responses if a glossary is provided in the request. This can be the same as `translations` if no terms apply. This field has the same length as `contents`.",
+            "items": {
+              "$ref": "#/components/schemas/Translation"
+            }
+          }
+        }
+      },
+      "Translation": {
+        "type": "object",
+        "description": "A single translation response.",
+        "properties": {
+          "model": {
+            "type": "string",
+            "description": "Only present when `model` is present in the request. `model` here is normalized to have project number. For example: If the `model` requested in TranslationTextRequest is `projects/{project-id}/locations/{location-id}/models/general/nmt` then `model` here would be normalized to `projects/{project-number}/locations/{location-id}/models/general/nmt`."
+          },
+          "translatedText": {
+            "type": "string",
+            "description": "Text translated into the target language. If an error occurs during translation, this field might be excluded from the response."
+          },
+          "glossaryConfig": {
+            "$ref": "#/components/schemas/TranslateTextGlossaryConfig"
+          },
+          "detectedLanguageCode": {
+            "type": "string",
+            "description": "The ISO-639 language code of source text in the initial request, detected automatically, if no source language was passed within the initial request. If the source language was passed, auto-detection of the language does not occur and this field is empty."
+          }
+        }
+      },
+      "TransliterationConfig": {
+        "type": "object",
+        "description": "Configures transliteration feature on top of translation.",
+        "properties": {
+          "enableTransliteration": {
+            "type": "boolean",
+            "description": "If true, source text in romanized form can be translated to the target language."
+          }
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
## Summary

Five Google providers shipped with `"paths": {}` in their committed `openapi.json`, so the catalog exposed **zero callable endpoints** for them. Searches surfaced the providers (e.g. `solana-foundation/google/translate`) but Pay had no route to validate a request against — they ranked below working alternatives and couldn't actually be called. The gateway's `/openapi.json` served the same empty doc.

This regenerates each spec from a **fresh Google Discovery document**, filtered to exactly the endpoints the gateway exposes (per the agent-gateway `services/proxy/providers/google/<provider>.yml` allow-list):

| Provider | Endpoints |
|---|---:|
| `translate` | 11 |
| `documentai` | 6 |
| `generativelanguage` | 20 |
| `addressvalidation` | 1 |
| `airquality` | 4 |

### Why they were empty

The previously-committed specs were derived from apis.guru OpenAPI conversions. For `generativelanguage`/`addressvalidation`/`airquality` that conversion emitted components but **no paths**; for `translate`/`documentai` the conversion keyed operations under Google's collapsed `{+parent}` templates, which didn't survive downstream path-matching. Re-deriving straight from Discovery (which carries the expanded `flatPath` + full schemas) sidesteps both.

### What each spec contains

- Self-contained **OpenAPI 3.0** doc — local `$ref`s only (no remote refs), component schemas **pruned to the reachable set**, `servers[0].url` pointed at the gateway.
- Path params carry descriptions (synthesized for the `{+parent}`-expansion segments like `projectsId`/`locationsId`; Google's own descriptions where present).
- Operation summaries mirror the Google method descriptions, consistent with the existing Google specs in this repo.

### Validation

`pay catalog check . --no-probe` (the same check `validate.yml` runs) **passes** — 1041 endpoints across 77 providers. The only findings on these files are the same summary-phrasing/`reused-summary` **warnings** that existing shipped specs (`vision`, `language`, `texttospeech`, …) already carry; no errors.

### Notes / follow-ups

- These are committed snapshots; refresh in a follow-up if Google's API surface changes (per CONTRIBUTING).
- One dangling `$ref` in Google's *own* `generativelanguage` discovery (`MediaResolution`, referenced but never defined) is emitted as a documented permissive placeholder.
- Separately, the agent-gateway `translate.yml` declares the project-level `translateText`/`romanizeText` with `/verb` (slash) where Google uses `:verb` (colon); worth normalizing there so gateway routing matches these specs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)