### PR TITLE
Add Qwen2.5 32B GPU inference provider (rowanhere)

### DIFF
--- a/providers/rowanhere/gpu-inference/PAY.md
+++ b/providers/rowanhere/gpu-inference/PAY.md
@@ -9,9 +9,17 @@ endpoints:
   - method: POST
     path: /api/chat
     description: Chat completion with Qwen2.5 32B. Charged per request.
+    pricing:
+      - type: metered
+        unit: requests
+        price_usd: 0.001
   - method: POST
     path: /api/generate
     description: Text generation with Qwen2.5 32B. Charged per request.
+    pricing:
+      - type: metered
+        unit: requests
+        price_usd: 0.001
 ---
 
 ## Qwen2.5 32B GPU Inference

--- a/providers/rowanhere/gpu-inference/PAY.md
+++ b/providers/rowanhere/gpu-inference/PAY.md
@@ -9,17 +9,23 @@ endpoints:
   - method: POST
     path: /api/chat
     description: Chat completion with Qwen2.5 32B. Charged per request.
-    pricing:
-      - type: metered
-        unit: requests
-        price_usd: 0.001
+    metering:
+      dimensions:
+        - direction: usage
+          unit: requests
+          scale: 1
+          tiers:
+            - price_usd: 0.001
   - method: POST
     path: /api/generate
     description: Text generation with Qwen2.5 32B. Charged per request.
-    pricing:
-      - type: metered
-        unit: requests
-        price_usd: 0.001
+    metering:
+      dimensions:
+        - direction: usage
+          unit: requests
+          scale: 1
+          tiers:
+            - price_usd: 0.001
 ---
 
 ## Qwen2.5 32B GPU Inference

--- a/providers/rowanhere/gpu-inference/PAY.md
+++ b/providers/rowanhere/gpu-inference/PAY.md
@@ -1,0 +1,31 @@
+---
+name: gpu-inference
+title: "Qwen2.5 32B GPU Inference"
+description: "High-performance Qwen2.5 32B language model served from a dedicated RTX 4090 GPU. Fast inference for chat and text generation tasks."
+use_case: "Use for chat completions and text generation requiring a large 32B parameter model with fast GPU inference."
+category: ai_ml
+service_url: https://rowanhere.duckdns.org
+endpoints:
+  - method: POST
+    path: /api/chat
+    description: Chat completion with Qwen2.5 32B. Charged per request.
+  - method: POST
+    path: /api/generate
+    description: Text generation with Qwen2.5 32B. Charged per request.
+---
+
+## Qwen2.5 32B GPU Inference
+
+RTX 4090-powered inference for the Qwen2.5 32B model via Ollama. Per-request USDC payments on Solana mainnet, no API key required.
+
+### Example
+
+```bash
+pay curl -X POST https://rowanhere.duckdns.org/api/chat \
+  -H "Content-Type: application/json" \
+  -d '{"model":"qwen2.5:32b","messages":[{"role":"user","content":"Hello"}]}'
+```
+
+### Pricing
+
+$0.001 per request, paid in USDC on Solana mainnet.


### PR DESCRIPTION
## New Provider: Qwen2.5 32B GPU Inference

- **Model:** Qwen2.5 32B (Q4_K_M quantization)
- **Hardware:** RTX 4090 via RunPod
- **Endpoint:** https://rowanhere.duckdns.org
- **Pricing:** $0.001 USDC per request on Solana mainnet
- **Inference server:** Ollama

Supports /api/chat and /api/generate endpoints. Validated with `pay catalog check`.