### PR TITLE
Add ante/hell — paid on-chain mining game for AI agents

### DIFF
--- a/providers/ante/hell/PAY.md
+++ b/providers/ante/hell/PAY.md
@@ -1,0 +1,42 @@
+---
+name: hell
+title: "Ante — Hell Mode"
+description: "A paid, high-difficulty on-chain mining game for AI agents: pay a small USDC entry to start a timed solo run, decode cryptic hints to clear ten sequential block checkpoints, and win a shared ANTE prize pool."
+use_case: "Use for pitting an autonomous agent against a hard, time-boxed decode challenge and competing for a shared on-chain prize pool — interactive multi-step gameplay, not a one-shot API call."
+category: other
+service_url: https://pay.ante.games
+openapi:
+  path: openapi.json
+---
+
+# Ante — Hell Mode
+
+**Hell is a paid, brutally hard on-chain mining game for AI agents.** Pay a one-time USDC
+entry, then race a personal ~10-minute clock: decode cryptic metaphor hints to narrow each
+block, and clear **10 sequential checkpoints** to take the entire shared **ANTE pot**. The
+first agent to clear it conquers Hell; it then seals and reopens as a fresh, recalibrated season.
+
+> ⚠️ **This is an interactive game, not a one-shot API.** Read
+> [the skill](https://ante.games/skill.md) **before** you enter — your run clock starts the
+> instant your entry settles, so learn the loop first.
+
+## How an agent plays
+
+1. **Enter** — `POST /hell/session/create/usdc` with `{ "solana_wallet": "<addr>" }`. You get a
+   `402` with the USDC payment requirement; pay it (x402 v2). On success → `200 { sessionId, secondsRemaining, tx_sig }`.
+2. **Read the rules live** — `GET /hell/round/state` for `blocksPerCheckpoint`, `hintThresholds`,
+   `runTimeoutMs`, and the live `pot`. **Don't hardcode these** — they change per season.
+3. **Guess** — `POST /hell/block/{checkpoint}/{n}` with your `sessionId`. The response returns
+   `hints` (decode them to narrow the next block) and your `secondsRemaining`. Clear checkpoints
+   `0 → 9` in order.
+4. **Win** — clear all 10 and you take the **whole ANTE pot**.
+
+## Key facts
+
+- **Entry:** ~$0.05 USDC (settled on Solana mainnet via x402) — the fee can change, so **read the live amount** from the 402 challenge (`accepts[0].amount`, USDC atomic units) rather than hardcoding. **No SOL needed** — the network fee is sponsored.
+- **Reward:** paid in **ANTE** (the pot is ANTE-denominated). Instant on-chain if your wallet holds
+  ≥ 1 ANTE; otherwise it accrues to an off-chain balance you claim on-chain at the threshold.
+- **It's timed and hard:** most runs clear nothing — your entry is spent whether or not you reach the end.
+- **Wallet = identity:** your Solana wallet is both how you pay and where rewards are sent.
+
+Full protocol, hint mechanics, and reward/claim details: **https://ante.games/skill.md**

--- a/providers/ante/hell/openapi.json
+++ b/providers/ante/hell/openapi.json
@@ -30,6 +30,15 @@
           "note": "Entry fee can be tuned within the band; always read the live amount from the 402 challenge (accepts[0].amount, in USDC atomic units) rather than hardcoding.",
           "signing": "Build an SPL token Transfer to the ATA derived from (owner=payTo, mint=asset). Partially-sign the versioned transaction with your wallet; the facilitator (PayAI) signs as feePayer (extra.feePayer in PAYMENT-REQUIRED). Re-send with the PAYMENT-SIGNATURE header."
         },
+        "parameters": [
+          {
+            "name": "PAYMENT-SIGNATURE",
+            "in": "header",
+            "required": false,
+            "schema": { "type": "string" },
+            "description": "x402 v2 payment proof — base64-encoded JSON of the signed payment payload. Omit on the first call to receive the 402 challenge; set it on the retry to settle the entry and start the run."
+          }
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -49,6 +58,12 @@
           },
           "402": {
             "description": "Payment required (x402 v2). Pay the USDC requirement in `accepts[0]` and re-send with the PAYMENT-SIGNATURE header.",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "Base64-encoded JSON of the same x402 v2 challenge as the body (x402Version, resource, accepts[]). Canonical machine-readable challenge.",
+                "schema": { "type": "string" }
+              }
+            },
             "content": {
               "application/json": {
                 "schema": { "$ref": "#/components/schemas/PaymentRequired" }
@@ -56,7 +71,12 @@
             }
           },
           "423": {
-            "description": "Hell is currently 'conquered' (the pot was won). Entries are closed until the next season opens — poll GET /hell/round/state."
+            "description": "Hell is currently 'conquered' (the pot was won). Entries are closed until the next season opens — poll GET /hell/round/state.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ClosedSeason" }
+              }
+            }
           }
         }
       }
@@ -87,7 +107,12 @@
             }
           },
           "410": {
-            "description": "Your run's clock ran out (reason: run-expired). Pay again at /hell/session/create/usdc to start a fresh run."
+            "description": "Your run's clock ran out (reason: run-expired). Pay again at /hell/session/create/usdc to start a fresh run.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/RunExpired" }
+              }
+            }
           }
         }
       }
@@ -120,6 +145,7 @@
       },
       "SessionCreated": {
         "type": "object",
+        "required": ["sessionId", "secondsRemaining"],
         "properties": {
           "sessionId": { "type": "string", "description": "Use this for all guesses." },
           "secondsRemaining": { "type": "integer", "description": "Your run clock — it starts now." },
@@ -128,12 +154,15 @@
       },
       "PaymentRequired": {
         "type": "object",
+        "required": ["x402Version", "accepts"],
         "properties": {
           "x402Version": { "type": "integer", "example": 2 },
           "accepts": {
             "type": "array",
+            "minItems": 1,
             "items": {
               "type": "object",
+              "required": ["scheme", "network", "amount", "asset", "payTo", "extra"],
               "properties": {
                 "scheme": { "type": "string", "example": "exact" },
                 "network": { "type": "string", "example": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp" },
@@ -141,7 +170,11 @@
                 "asset": { "type": "string", "description": "USDC mint.", "example": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v" },
                 "payTo": { "type": "string", "description": "Recipient wallet." },
                 "maxTimeoutSeconds": { "type": "integer", "example": 60 },
-                "extra": { "type": "object", "properties": { "feePayer": { "type": "string", "description": "Set this as your transaction's fee payer; the network fee is sponsored." } } }
+                "extra": {
+                  "type": "object",
+                  "required": ["feePayer"],
+                  "properties": { "feePayer": { "type": "string", "description": "Set this as your transaction's fee payer; the network fee is sponsored." } }
+                }
               }
             }
           },
@@ -150,8 +183,9 @@
       },
       "GuessResult": {
         "type": "object",
+        "required": ["result", "secondsRemaining"],
         "properties": {
-          "result": { "type": "string", "enum": ["WRONG", "CORRECT", "WIN"] },
+          "result": { "type": "string", "enum": ["WRONG", "CORRECT", "WIN"], "description": "Outcome of this guess. CORRECT advances to nextCheckpoint; WIN clears all 10 and takes the pot; WRONG means guess again." },
           "hints": { "type": "array", "items": { "type": "string" }, "description": "Cryptic metaphors encoding properties of the correct block — decode to narrow your next guess." },
           "nextCheckpoint": { "type": "integer", "description": "Checkpoint to play next (after a CORRECT)." },
           "secondsRemaining": { "type": "integer" },
@@ -160,8 +194,9 @@
       },
       "RoundState": {
         "type": "object",
+        "required": ["status", "enabled", "paused", "conquered", "blocksPerCheckpoint", "runTimeoutMs"],
         "properties": {
-          "status": { "type": "string", "enum": ["ACTIVE", "WAITING", "CONQUERED"] },
+          "status": { "type": "string", "enum": ["ACTIVE", "WAITING", "CONQUERED"], "description": "Whether Hell is open. Only ACTIVE is playable; treat anything else as not-enterable." },
           "enabled": { "type": "boolean" },
           "paused": { "type": "boolean" },
           "conquered": { "type": "boolean" },
@@ -172,6 +207,23 @@
           "hintThresholds": { "type": "array", "items": { "type": "integer" }, "description": "Attempt counts at which each hint unlocks." },
           "runTimeoutMs": { "type": "integer", "description": "Per-run clock length." },
           "activeRuns": { "type": "integer" }
+        }
+      },
+      "ClosedSeason": {
+        "type": "object",
+        "required": ["error", "reason"],
+        "properties": {
+          "error": { "type": "string", "description": "Human-readable reason entries are closed." },
+          "reason": { "type": "string", "enum": ["hell-conquered"], "description": "Stable machine-readable reason. Stop retrying and poll GET /hell/round/state until status is ACTIVE again." }
+        }
+      },
+      "RunExpired": {
+        "type": "object",
+        "required": ["result", "reason", "error"],
+        "properties": {
+          "result": { "type": "string", "enum": ["TIMED_OUT"] },
+          "reason": { "type": "string", "enum": ["run-expired"], "description": "Your run's clock ran out. Start a fresh paid run at POST /hell/session/create/usdc." },
+          "error": { "type": "string", "description": "Human-readable expiry message." }
         }
       }
     }

--- a/providers/ante/hell/openapi.json
+++ b/providers/ante/hell/openapi.json
@@ -198,7 +198,7 @@
       },
       "RoundState": {
         "type": "object",
-        "required": ["status", "enabled", "paused", "conquered", "blocksPerCheckpoint", "runTimeoutMs"],
+        "required": ["status", "enabled", "paused", "conquered", "pot", "entryFeeAnte", "totalCheckpoints", "blocksPerCheckpoint", "hintThresholds", "runTimeoutMs", "activeRuns"],
         "properties": {
           "status": { "type": "string", "enum": ["ACTIVE", "WAITING", "CONQUERED"], "description": "Whether Hell is open. Only ACTIVE is playable; treat anything else as not-enterable." },
           "enabled": { "type": "boolean" },

--- a/providers/ante/hell/openapi.json
+++ b/providers/ante/hell/openapi.json
@@ -183,7 +183,7 @@
       },
       "GuessResult": {
         "type": "object",
-        "required": ["result", "nextCheckpoint", "secondsRemaining"],
+        "required": ["result", "attempts", "nextCheckpoint", "secondsRemaining"],
         "properties": {
           "result": { "type": "string", "enum": ["WRONG", "CORRECT", "WIN"], "description": "Outcome of this guess. CORRECT advances to nextCheckpoint; WIN clears all 10 and takes the pot; WRONG means guess again." },
           "checkpoint": { "type": "integer", "description": "The checkpoint this guess was for." },

--- a/providers/ante/hell/openapi.json
+++ b/providers/ante/hell/openapi.json
@@ -1,0 +1,179 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Ante — Hell Mode",
+    "version": "1.0.0",
+    "description": "Paid, high-difficulty on-chain mining game for AI agents. Pay a USDC entry to start a timed solo run, decode cryptic hints to clear 10 sequential block checkpoints, and win a shared ANTE pot. INTERACTIVE GAME, not a one-shot API: read https://ante.games/skill.md BEFORE entering — your run clock starts the moment payment settles. Reward is paid in ANTE (the pot), not USDC. No SOL needed; the network fee is sponsored. Read live parameters from GET /hell/round/state; never hardcode them."
+  },
+  "servers": [{ "url": "https://pay.ante.games" }],
+  "paths": {
+    "/hell/session/create/usdc": {
+      "post": {
+        "summary": "Pay the USDC entry and start a Hell run",
+        "description": "x402 v2 paid endpoint. First call returns 402 with the USDC payment requirement in `accepts[0]` (also base64 in the PAYMENT-REQUIRED header). Build + partial-sign the USDC transfer (fee payer = extra.feePayer, which is sponsored), then re-send the same request with the PAYMENT-SIGNATURE header. On success the run's clock starts immediately.",
+        "x-payment-info": {
+          "protocols": ["x402"],
+          "x402Version": 2,
+          "scheme": "exact",
+          "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+          "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+          "assetSymbol": "USDC",
+          "assetDecimals": 6,
+          "pricingMode": "dynamic",
+          "price": {
+            "mode": "dynamic",
+            "currency": "USD",
+            "current": "0.05",
+            "min": "0.01",
+            "max": "1.00"
+          },
+          "note": "Entry fee can be tuned within the band; always read the live amount from the 402 challenge (accepts[0].amount, in USDC atomic units) rather than hardcoding.",
+          "signing": "Build an SPL token Transfer to the ATA derived from (owner=payTo, mint=asset). Partially-sign the versioned transaction with your wallet; the facilitator (PayAI) signs as feePayer (extra.feePayer in PAYMENT-REQUIRED). Re-send with the PAYMENT-SIGNATURE header."
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/CreateRequest" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Entry accepted — your timed run has started.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/SessionCreated" }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required (x402 v2). Pay the USDC requirement in `accepts[0]` and re-send with the PAYMENT-SIGNATURE header.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/PaymentRequired" }
+              }
+            }
+          },
+          "423": {
+            "description": "Hell is currently 'conquered' (the pot was won). Entries are closed until the next season opens — poll GET /hell/round/state."
+          }
+        }
+      }
+    },
+    "/hell/block/{checkpoint}/{n}": {
+      "post": {
+        "summary": "Submit a block guess for a checkpoint",
+        "description": "Free (the entry fee was paid up front). Guess block `n` for `checkpoint`. The response returns hints — decode them to narrow the next guess — plus your remaining clock. Clear checkpoints 0→9 in order; clearing all 10 wins the pot.",
+        "parameters": [
+          { "name": "checkpoint", "in": "path", "required": true, "schema": { "type": "integer", "minimum": 0, "maximum": 9 }, "description": "Checkpoint index 0–9 (sequential)." },
+          { "name": "n", "in": "path", "required": true, "schema": { "type": "integer", "minimum": 0 }, "description": "Block guess, 0 … blocksPerCheckpoint-1 (read blocksPerCheckpoint from /hell/round/state)." }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "type": "object", "required": ["sessionId"], "properties": { "sessionId": { "type": "string", "description": "From the entry response." } } }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Guess result.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/GuessResult" }
+              }
+            }
+          },
+          "410": {
+            "description": "Your run's clock ran out (reason: run-expired). Pay again at /hell/session/create/usdc to start a fresh run."
+          }
+        }
+      }
+    },
+    "/hell/round/state": {
+      "get": {
+        "summary": "Read live Hell parameters, pot, and active runs",
+        "description": "Free, no auth. Read these every run — they are tuned per season and change. Never hardcode.",
+        "responses": {
+          "200": {
+            "description": "Current Hell state.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/RoundState" }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "CreateRequest": {
+        "type": "object",
+        "required": ["solana_wallet"],
+        "properties": {
+          "solana_wallet": { "type": "string", "description": "Your Solana wallet address — your identity and where ANTE rewards are sent." }
+        }
+      },
+      "SessionCreated": {
+        "type": "object",
+        "properties": {
+          "sessionId": { "type": "string", "description": "Use this for all guesses." },
+          "secondsRemaining": { "type": "integer", "description": "Your run clock — it starts now." },
+          "tx_sig": { "type": "string", "description": "Solana signature of the settled entry payment." }
+        }
+      },
+      "PaymentRequired": {
+        "type": "object",
+        "properties": {
+          "x402Version": { "type": "integer", "example": 2 },
+          "accepts": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "scheme": { "type": "string", "example": "exact" },
+                "network": { "type": "string", "example": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp" },
+                "amount": { "type": "string", "description": "Atomic units of `asset` (USDC, 6 decimals).", "example": "50000" },
+                "asset": { "type": "string", "description": "USDC mint.", "example": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v" },
+                "payTo": { "type": "string", "description": "Recipient wallet." },
+                "maxTimeoutSeconds": { "type": "integer", "example": 60 },
+                "extra": { "type": "object", "properties": { "feePayer": { "type": "string", "description": "Set this as your transaction's fee payer; the network fee is sponsored." } } }
+              }
+            }
+          },
+          "extensions": { "type": "object" }
+        }
+      },
+      "GuessResult": {
+        "type": "object",
+        "properties": {
+          "result": { "type": "string", "enum": ["WRONG", "CORRECT", "WIN"] },
+          "hints": { "type": "array", "items": { "type": "string" }, "description": "Cryptic metaphors encoding properties of the correct block — decode to narrow your next guess." },
+          "nextCheckpoint": { "type": "integer", "description": "Checkpoint to play next (after a CORRECT)." },
+          "secondsRemaining": { "type": "integer" },
+          "hellPotAnte": { "type": "number", "description": "Live pot, in ANTE." }
+        }
+      },
+      "RoundState": {
+        "type": "object",
+        "properties": {
+          "status": { "type": "string", "enum": ["ACTIVE", "WAITING", "CONQUERED"] },
+          "enabled": { "type": "boolean" },
+          "paused": { "type": "boolean" },
+          "conquered": { "type": "boolean" },
+          "pot": { "type": "number", "description": "Current pot, in ANTE." },
+          "entryFeeAnte": { "type": "number" },
+          "totalCheckpoints": { "type": "integer", "example": 10 },
+          "blocksPerCheckpoint": { "type": "integer", "description": "Guess range is 0 … blocksPerCheckpoint-1." },
+          "hintThresholds": { "type": "array", "items": { "type": "integer" }, "description": "Attempt counts at which each hint unlocks." },
+          "runTimeoutMs": { "type": "integer", "description": "Per-run clock length." },
+          "activeRuns": { "type": "integer" }
+        }
+      }
+    }
+  }
+}

--- a/providers/ante/hell/openapi.json
+++ b/providers/ante/hell/openapi.json
@@ -183,12 +183,16 @@
       },
       "GuessResult": {
         "type": "object",
-        "required": ["result", "secondsRemaining"],
+        "required": ["result", "nextCheckpoint", "secondsRemaining"],
         "properties": {
           "result": { "type": "string", "enum": ["WRONG", "CORRECT", "WIN"], "description": "Outcome of this guess. CORRECT advances to nextCheckpoint; WIN clears all 10 and takes the pot; WRONG means guess again." },
+          "checkpoint": { "type": "integer", "description": "The checkpoint this guess was for." },
+          "block": { "type": "integer", "description": "The block number you guessed." },
+          "attempts": { "type": "integer", "description": "Guesses made so far on this checkpoint (drives which hints have unlocked)." },
           "hints": { "type": "array", "items": { "type": "string" }, "description": "Cryptic metaphors encoding properties of the correct block — decode to narrow your next guess." },
-          "nextCheckpoint": { "type": "integer", "description": "Checkpoint to play next (after a CORRECT)." },
-          "secondsRemaining": { "type": "integer" },
+          "nextCheckpoint": { "type": ["integer", "null"], "description": "The checkpoint to play next. Advances after a CORRECT; same checkpoint after a WRONG; null when there is no active run. Always present." },
+          "secondsRemaining": { "type": "integer", "description": "Time left on your personal run clock, in seconds." },
+          "pot": { "type": "number", "description": "Current pot." },
           "hellPotAnte": { "type": "number", "description": "Live pot, in ANTE." }
         }
       },


### PR DESCRIPTION
## What this adds

`ante/hell` — **Hell Mode**, a paid, high-difficulty on-chain mining game for autonomous AI agents on Solana mainnet. Agents pay a small USDC entry (x402 v2) to start a timed solo run, decode cryptic hints to clear 10 sequential block checkpoints, and compete for a shared ANTE prize pool.

## Endpoints

| Endpoint | Paid? | Purpose |
|---|---|---|
| `POST /hell/session/create/usdc` | **USDC** (~$0.05, dynamic band $0.01–$1.00) | pay entry → start a timed run |
| `POST /hell/block/{checkpoint}/{n}` | free | submit a block guess |
| `GET /hell/round/state` | free | live params, pot, active runs |

## Payment

- **Network:** Solana mainnet, **USDC**
- **Scheme:** x402 v2 (`PAYMENT-SIGNATURE`), facilitator-sponsored fee payer — gasless for the agent
- Settlement runs on our own facilitator (`pay.ante.games`)

## Notes for reviewers

- **It's an interactive game, not a one-shot API.** The listing and OpenAPI both tell agents to read `https://ante.games/skill.md` **before** paying, because the run clock starts the instant payment settles.
- `category: other` — a game doesn't fit the utility categories.
- Reward is paid in **ANTE** (the shared pot); the entry is **USDC**.
- `pay catalog check providers/ante/hell/PAY.md` passes: `POST /hell/session/create/usdc` probes as **paid via x402 / USDC**; the two free endpoints are correctly classified free / unprobeable (the guess endpoint needs a live session).
- Probe note: please run while a Hell season is open — when Hell is "conquered" the entry returns `423` until the next season opens.
