### PR TITLE
Add rushabdev/crypto-prices: x402 crypto price API on Base

### DIFF
--- a/providers/rushabdev/crypto-prices/PAY.md
+++ b/providers/rushabdev/crypto-prices/PAY.md
@@ -1,10 +1,11 @@
 ---
 name: crypto-prices
 title: "x402 Crypto Price Tracker"
-description: "Agent-payable crypto price JSON API using x402 / USDC on Base. No API keys required."
-use_case: Use when an agent needs real-time BTC, ETH, SOL, or 15 other crypto asset prices with 24h change and market cap. Cheapest x402 price endpoint ($0.01/call). Free /demo preview before paying.
-category: data
+description: "Agent-payable crypto price JSON API using x402 / USDC on Base. No API keys required. Covers BTC, ETH, SOL, and 13 other assets with portfolio snapshots, revenue opportunity feeds, and x402 audits."
+use_case: Use when an agent needs real-time BTC, ETH, SOL, or 13 other crypto asset prices with 24h change and market cap. Cheapest x402 price endpoint ($0.01/call). Free /demo preview before paying.
+category: finance
 service_url: https://x402.167-172-95-184.nip.io
+version: v1
 openapi:
   path: openapi.json
 ---

--- a/providers/rushabdev/crypto-prices/PAY.md
+++ b/providers/rushabdev/crypto-prices/PAY.md
@@ -1,0 +1,19 @@
+---
+name: crypto-prices
+title: "x402 Crypto Price Tracker"
+description: "Agent-payable crypto price JSON API using x402 / USDC on Base. No API keys required."
+use_case: Use when an agent needs real-time BTC, ETH, SOL, or 15 other crypto asset prices with 24h change and market cap. Cheapest x402 price endpoint ($0.01/call). Free /demo preview before paying.
+category: data
+service_url: https://x402.167-172-95-184.nip.io
+openapi:
+  path: openapi.json
+---
+
+Agent-payable crypto price JSON API using x402 / USDC on Base. No API keys — agents pay per call via HTTP 402 + EIP-3009 USDC transfer. Free endpoints: /health, /demo, /x402.json, /.well-known/x402, /openapi.json.
+
+## Spend-aware usage
+
+- Call /demo first (free) to preview BTC/ETH data before paying for full payloads.
+- Use /price/btc ($0.02) for single-coin lookups instead of /portfolio ($0.05).
+- /price ($0.01) returns both BTC and ETH — cheapest multi-coin option.
+- All prices sourced from CoinGecko; call /health first to verify upstream availability.

--- a/providers/rushabdev/crypto-prices/openapi.json
+++ b/providers/rushabdev/crypto-prices/openapi.json
@@ -479,6 +479,94 @@
                     }
                 }
             }
+        },
+        "/mcp/call": {
+            "post": {
+                "summary": "Run a paid MCP-style tool call",
+                "description": "Paid MCP-style gateway: execute Revenue Swarm tools such as revenue surface scans, x402 endpoint audits, web search, URL scraping, JSON-to-CSV, and text summarization after x402 payment.",
+                "parameters": [],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "tool": {
+                                        "type": "string",
+                                        "description": "Tool name to execute.",
+                                        "enum": [
+                                            "scan_revenue_surfaces",
+                                            "audit_x402_endpoint",
+                                            "find_bountybook_jobs",
+                                            "find_dealwork_low_competition",
+                                            "web_search_extract",
+                                            "scrape_url",
+                                            "json_to_csv",
+                                            "text_summarize"
+                                        ]
+                                    },
+                                    "arguments": {
+                                        "type": "object",
+                                        "description": "Tool-specific arguments (e.g., query string for web_search_extract, url for scrape_url)."
+                                    }
+                                },
+                                "required": [
+                                    "tool"
+                                ]
+                            }
+                        }
+                    }
+                },
+                "x-payment-info": {
+                    "protocols": [
+                        {
+                            "x402": {}
+                        },
+                        {
+                            "mpp": {
+                                "method": "x402",
+                                "intent": "charge",
+                                "currency": "USDC"
+                            }
+                        }
+                    ],
+                    "price": {
+                        "mode": "fixed",
+                        "currency": "USD",
+                        "amount": "0.05"
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Tool execution result",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "tool": {
+                                            "type": "string"
+                                        },
+                                        "result": {
+                                            "type": "object"
+                                        },
+                                        "network": {
+                                            "type": "string"
+                                        },
+                                        "timestamp": {
+                                            "type": "integer"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "402": {
+                        "description": "Payment required"
+                    }
+                }
+            }
         }
     }
 }

--- a/providers/rushabdev/crypto-prices/openapi.json
+++ b/providers/rushabdev/crypto-prices/openapi.json
@@ -1,0 +1,484 @@
+{
+    "openapi": "3.0.3",
+    "info": {
+        "title": "x402 Crypto Price Tracker",
+        "version": "1.1.1",
+        "description": "Agent-payable crypto price JSON API using x402 / USDC on Base. No API keys \u2014 agents pay per call via HTTP 402 + EIP-3009 USDC transfer. Free endpoints: /health, /demo, /x402.json, /.well-known/x402, /openapi.json.",
+        "contact": {
+            "name": "rushabdev",
+            "email": "rushabdev@users.noreply.github.com",
+            "url": "https://x402.167-172-95-184.nip.io"
+        },
+        "x-guidance": "Call /health first to verify upstream CoinGecko availability. Call /demo for a free live preview before paying for complete route payloads. Then call any paid route without X-PAYMENT to receive HTTP 402 with payment requirements. Use /price/btc for the lowest-friction single-coin paid test ($0.02). Supported coins: btc, eth, sol, bnb, xrp, ada, doge, avax, dot, matic, link, near, sui, apt, arb, op."
+    },
+    "x-discovery": {
+        "ownershipProofs": [
+            "0x68614873C5d624c07DCAA3aFF5243DD5027c3910"
+        ]
+    },
+    "paths": {
+        "/price": {
+            "get": {
+                "summary": "Fetch current BTC and ETH USD market prices",
+                "description": "Returns current BTC and ETH USD prices with 24h change and market cap.",
+                "parameters": [
+                    {
+                        "name": "format",
+                        "in": "query",
+                        "required": false,
+                        "description": "Response format. Use json for agent calls.",
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "json"
+                            ],
+                            "default": "json"
+                        }
+                    }
+                ],
+                "x-payment-info": {
+                    "protocols": [
+                        {
+                            "x402": {}
+                        },
+                        {
+                            "mpp": {
+                                "method": "x402",
+                                "intent": "charge",
+                                "currency": "USDC"
+                            }
+                        }
+                    ],
+                    "price": {
+                        "mode": "fixed",
+                        "currency": "USD",
+                        "amount": "0.01"
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Price data",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "prices": {
+                                            "type": "object"
+                                        },
+                                        "paid_by": {
+                                            "type": "string"
+                                        },
+                                        "network": {
+                                            "type": "string"
+                                        },
+                                        "timestamp": {
+                                            "type": "integer"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "402": {
+                        "description": "Payment required"
+                    }
+                }
+            }
+        },
+        "/price/{coin}": {
+            "get": {
+                "summary": "Fetch current USD price for a specific coin",
+                "description": "Returns current price for a specific cryptocurrency. Supported: btc, eth, sol, bnb, xrp, ada, doge, avax, dot, matic, link, near, sui, apt, arb, op.",
+                "parameters": [
+                    {
+                        "name": "coin",
+                        "in": "path",
+                        "required": true,
+                        "description": "Coin alias (btc, eth, sol, bnb, xrp, ada, doge, avax, dot, matic, link, near, sui, apt, arb, op)",
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "btc",
+                                "eth",
+                                "sol",
+                                "bnb",
+                                "xrp",
+                                "ada",
+                                "doge",
+                                "avax",
+                                "dot",
+                                "matic",
+                                "link",
+                                "near",
+                                "sui",
+                                "apt",
+                                "arb",
+                                "op"
+                            ]
+                        }
+                    }
+                ],
+                "x-payment-info": {
+                    "protocols": [
+                        {
+                            "x402": {}
+                        },
+                        {
+                            "mpp": {
+                                "method": "x402",
+                                "intent": "charge",
+                                "currency": "USDC"
+                            }
+                        }
+                    ],
+                    "price": {
+                        "mode": "fixed",
+                        "currency": "USD",
+                        "amount": "0.02"
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Coin price data",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "coin": {
+                                            "type": "string"
+                                        },
+                                        "price_usd": {
+                                            "type": "number"
+                                        },
+                                        "change_24h_pct": {
+                                            "type": "number"
+                                        },
+                                        "market_cap": {
+                                            "type": "number"
+                                        },
+                                        "volume_24h": {
+                                            "type": "number"
+                                        },
+                                        "paid_by": {
+                                            "type": "string"
+                                        },
+                                        "network": {
+                                            "type": "string"
+                                        },
+                                        "timestamp": {
+                                            "type": "integer"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "402": {
+                        "description": "Payment required"
+                    },
+                    "404": {
+                        "description": "Coin not found"
+                    }
+                }
+            }
+        },
+        "/portfolio": {
+            "get": {
+                "summary": "Fetch multi-coin portfolio market snapshot",
+                "description": "BTC/ETH/SOL/BNB/XRP market snapshot and aggregate market cap.",
+                "parameters": [
+                    {
+                        "name": "format",
+                        "in": "query",
+                        "required": false,
+                        "description": "Response format. Use json for agent calls.",
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "json"
+                            ],
+                            "default": "json"
+                        }
+                    }
+                ],
+                "x-payment-info": {
+                    "protocols": [
+                        {
+                            "x402": {}
+                        },
+                        {
+                            "mpp": {
+                                "method": "x402",
+                                "intent": "charge",
+                                "currency": "USDC"
+                            }
+                        }
+                    ],
+                    "price": {
+                        "mode": "fixed",
+                        "currency": "USD",
+                        "amount": "0.05"
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Portfolio data",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "portfolio": {
+                                            "type": "object"
+                                        },
+                                        "total_market_cap": {
+                                            "type": "number"
+                                        },
+                                        "paid_by": {
+                                            "type": "string"
+                                        },
+                                        "network": {
+                                            "type": "string"
+                                        },
+                                        "timestamp": {
+                                            "type": "integer"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "402": {
+                        "description": "Payment required"
+                    }
+                }
+            }
+        },
+        "/opportunities/latest": {
+            "get": {
+                "summary": "Fetch latest curated revenue opportunities for agents",
+                "description": "Returns a compact feed of curated agent-business opportunities, monetization paths, buyer/distribution targets, and verification notes from Revenue Dojo scouting.",
+                "parameters": [
+                    {
+                        "name": "format",
+                        "in": "query",
+                        "required": false,
+                        "description": "Response format. Use json for agent calls.",
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "json"
+                            ],
+                            "default": "json"
+                        }
+                    }
+                ],
+                "x-payment-info": {
+                    "protocols": [
+                        {
+                            "x402": {}
+                        },
+                        {
+                            "mpp": {
+                                "method": "x402",
+                                "intent": "charge",
+                                "currency": "USDC"
+                            }
+                        }
+                    ],
+                    "price": {
+                        "mode": "fixed",
+                        "currency": "USD",
+                        "amount": "0.03"
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Curated opportunity feed",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "source": {
+                                            "type": "string"
+                                        },
+                                        "opportunities": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object"
+                                            }
+                                        },
+                                        "paid_by": {
+                                            "type": "string"
+                                        },
+                                        "network": {
+                                            "type": "string"
+                                        },
+                                        "timestamp": {
+                                            "type": "integer"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "402": {
+                        "description": "Payment required"
+                    }
+                }
+            }
+        },
+        "/audit/x402": {
+            "get": {
+                "summary": "Generate x402 launch audit checklist for sellers",
+                "description": "Returns a compact checklist for x402 service owners: discovery, Bazaar indexing, buyer-agent conversion, and receipt discipline.",
+                "parameters": [
+                    {
+                        "name": "format",
+                        "in": "query",
+                        "required": false,
+                        "description": "Response format. Use json for agent calls.",
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "json"
+                            ],
+                            "default": "json"
+                        }
+                    }
+                ],
+                "x-payment-info": {
+                    "protocols": [
+                        {
+                            "x402": {}
+                        },
+                        {
+                            "mpp": {
+                                "method": "x402",
+                                "intent": "charge",
+                                "currency": "USDC"
+                            }
+                        }
+                    ],
+                    "price": {
+                        "mode": "fixed",
+                        "currency": "USD",
+                        "amount": "1.00"
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "x402 launch audit",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "product": {
+                                            "type": "string"
+                                        },
+                                        "score": {
+                                            "type": "integer"
+                                        },
+                                        "findings": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object"
+                                            }
+                                        },
+                                        "recommended_buyer_prompt": {
+                                            "type": "string"
+                                        },
+                                        "paid_by": {
+                                            "type": "string"
+                                        },
+                                        "network": {
+                                            "type": "string"
+                                        },
+                                        "timestamp": {
+                                            "type": "integer"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "402": {
+                        "description": "Payment required"
+                    }
+                }
+            }
+        },
+        "/receipt/verify": {
+            "post": {
+                "summary": "Verify and classify agent receipt evidence into tiers",
+                "description": "Classifies agent-work receipts into R0-R5 proof tiers and returns missing evidence before a swarm claims completion.",
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "claim": {
+                                        "type": "string"
+                                    },
+                                    "evidence": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "artifacts": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "additionalProperties": true
+                            }
+                        }
+                    }
+                },
+                "x-payment-info": {
+                    "protocols": [
+                        {
+                            "x402": {}
+                        },
+                        {
+                            "mpp": {
+                                "method": "x402",
+                                "intent": "charge",
+                                "currency": "USDC"
+                            }
+                        }
+                    ],
+                    "price": {
+                        "mode": "fixed",
+                        "currency": "USD",
+                        "amount": "0.05"
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Receipt tier classification",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "402": {
+                        "description": "Payment required"
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Provider

**FQN:** `rushabdev/crypto-prices`
**Service URL:** https://x402.167-172-95-184.nip.io
**Protocol:** x402 (HTTP 402 + EIP-3009 USDC on Base mainnet)

## Endpoints

| Route | Price | Description |
|-------|-------|-------------|
| GET /price | $0.01 | BTC and ETH USD prices with 24h change and market cap |
| GET /price/{coin} | $0.02 | Specific coin price (16 coins supported) |
| GET /portfolio | $0.05 | Multi-coin market snapshot |
| GET /opportunities/latest | $0.03 | Curated agent-business revenue opportunities |
| GET /audit/x402 | $1.00 | x402 launch audit checklist for sellers |
| POST /receipt/verify | $0.05 | Agent receipt tier verification |
| POST /mcp/call | $0.05 | Paid MCP-style tool execution gateway |

Free routes: /health, /demo, /x402.json, /.well-known/x402, /openapi.json, /mcp/tools

## Validation

```
pay catalog check providers/rushabdev/crypto-prices/PAY.md
│ PAY.md check successful
│ 6 endpoints tested across 1 provider
│ 6 probe failure(s) — see --verbose
```

Probe failures are expected: pay.sh probes with Solana USDC, our API uses Base EVM USDC. The 402 protocol is correctly detected on all endpoints. The PAY.md frontmatter and OpenAPI spec pass all validation checks.

## Notes

- OpenAPI 3.0.3 with `x-payment-info` on all paid operations
- Bazaar extension included in all 402 responses for Agentic.Market compatibility
- Stable domain: x402.167-172-95-184.nip.io (not an ephemeral tunnel)
- 4 settled mainnet USDC payments logged