### PR TITLE
Add solsentry/threat-intel — Solana operator-risk API (x402)

### DIFF
--- a/providers/solsentry/threat-intel/PAY.md
+++ b/providers/solsentry/threat-intel/PAY.md
@@ -23,7 +23,7 @@ metered and are out of scope for this listing.
 
 Per-call pricing (USDC on Solana mainnet; the authoritative price is returned in
 the live `402` challenge): operator $0.002 · token $0.003 · predictions $0.002 ·
-contract-analysis $0.005 · lookalike-check $0.003 · tx-preview $0.008 ·
+contract-analysis $0.01 · lookalike-check $0.003 · tx-preview $0.008 ·
 holders $0.005 · drain-trace $0.05 · dossier $0.50.
 
 ## Spend-aware usage

--- a/providers/solsentry/threat-intel/PAY.md
+++ b/providers/solsentry/threat-intel/PAY.md
@@ -1,0 +1,44 @@
+---
+name: threat-intel
+title: "SolSentry Threat Intelligence"
+description: "Solana operator-risk and threat-intelligence API: serial-rugger verdicts, token and contract pre-sign risk scores, address-poisoning lookalike checks, holder concentration, and post-rug fund-flow traces — keyed to deployer operators, not just tokens."
+use_case: "Use for pre-sign safety checks before an agent swaps, sends, or signs on Solana: screen a token mint, contract/program, or operator wallet for rug risk, detect lookalike (poisoned) destination addresses, and trace stolen funds."
+category: security
+service_url: https://api.solsentry.app
+openapi:
+  path: openapi.json
+---
+
+SolSentry operator-risk and threat-intelligence data via x402 payments. Where
+market-data APIs tell you *what* a token is doing, SolSentry tells you *who*
+deployed it and whether that operator has rugged before — risk scoring backed by
+83,000+ resolved predictions at 97.8% precision on CRITICAL-tier verdicts
+(auditable per-mint at /v1/predictions/{mint}).
+
+All paid endpoints live under the `/x402/` path prefix and return an HTTP `402`
+with a `Payment-Required` header on unauthenticated requests. The agent selects a
+rail, signs a USDC payment on Solana mainnet, and replays the request with an
+`X-Payment` header. The free public dashboard endpoints under `/v1/` are not
+metered and are out of scope for this listing.
+
+Per-call pricing (USDC on Solana mainnet; the authoritative price is returned in
+the live `402` challenge): operator $0.002 · token $0.003 · predictions $0.002 ·
+contract-analysis $0.005 · lookalike-check $0.003 · tx-preview $0.008 ·
+holders $0.005 · drain-trace $0.05 · dossier $0.50.
+
+## Spend-aware usage
+
+- For a single pre-sign decision, call `/x402/v1/token/{mint}` (token verdict) or
+  `/x402/v1/contract-analysis/{program_id}` (program safety) — one cheap call each.
+  Don't fan out to the heavier flow endpoints unless the cheap verdict is risky.
+- Use `/x402/v1/operator/{wallet}` to check whether a deployer is a known serial
+  rugger before trusting any token it created — this is the cheapest high-signal call.
+- Use `/x402/v1/lookalike-check` before sending funds to a freshly-pasted address;
+  it flags address-poisoning siblings of wallets the agent has transacted with.
+- `/x402/v1/predictions/{mint}` returns the per-mint risk prediction and resolved
+  outcome — prefer it over re-deriving risk from raw market data.
+- Reserve `/x402/v1/drain-trace/{wallet}` and `/x402/v1/dossier/{wallet}` for
+  post-incident forensics or high-value due-diligence; they are multi-hop / AI-heavy
+  and priced accordingly. Start with the cheap verdict endpoints first.
+- `/x402/v1/holders/{mint}` returns holder count and top-holder concentration in a
+  single call — use it instead of chaining raw RPC `getTokenLargestAccounts`.

--- a/providers/solsentry/threat-intel/PAY.md
+++ b/providers/solsentry/threat-intel/PAY.md
@@ -12,8 +12,8 @@ openapi:
 SolSentry operator-risk and threat-intelligence data via x402 payments. Where
 market-data APIs tell you *what* a token is doing, SolSentry tells you *who*
 deployed it and whether that operator has rugged before — risk scoring backed by
-83,000+ resolved predictions at 97.8% precision on CRITICAL-tier verdicts
-(auditable per-mint at /v1/predictions/{mint}).
+200,000+ recorded predictions at 94.4% CRITICAL precision (live value
+published at /v1/stats; auditable per-mint at /v1/predictions/{mint}).
 
 All paid endpoints live under the `/x402/` path prefix and return an HTTP `402`
 with a `Payment-Required` header on unauthenticated requests. The agent selects a

--- a/providers/solsentry/threat-intel/openapi.json
+++ b/providers/solsentry/threat-intel/openapi.json
@@ -459,7 +459,7 @@
       "get": {
         "operationId": "lookalike_check",
         "summary": "Check a destination address for poisoned lookalikes",
-        "description": "Checks a destination address against poisoned lookalike siblings of wallets the caller has transacted with. Returns match, similarity_score and the matched address. Run before sending funds.",
+        "description": "Checks a destination address against poisoned lookalike siblings of wallets the caller has transacted with. Returns a suspect verdict with confidence and per-signal findings (prefix/suffix collisions against the matched contact). Run before sending funds.",
         "parameters": [
           {
             "name": "destination",
@@ -726,7 +726,7 @@
       "get": {
         "operationId": "holders",
         "summary": "Fetch holder count and top-holder concentration for a mint",
-        "description": "Returns holder_count, top_holders and concentration_pct for a mint in one call (replaces chaining raw getTokenLargestAccounts RPC).",
+        "description": "Returns the holder count and top-1/top-10 holder concentration for a mint in one call (replaces chaining raw getTokenLargestAccounts RPC).",
         "parameters": [
           {
             "name": "mint",
@@ -828,7 +828,7 @@
       "get": {
         "operationId": "drain_trace",
         "summary": "Trace post-rug fund flows from a wallet to their terminus",
-        "description": "Multi-hop SOL/token flow trace from a rug wallet to its terminus (CEX, bridge, mixer) with USD amounts and labels. Forensic / post-incident use.",
+        "description": "Multi-hop SOL/token flow trace from a rug wallet to its terminus (CEX, bridge, mixer) with SOL amounts and labels. Forensic / post-incident use.",
         "parameters": [
           {
             "name": "wallet",
@@ -952,7 +952,7 @@
       "get": {
         "operationId": "dossier",
         "summary": "Generate a full identity dossier for a deployer wallet",
-        "description": "Deep identity dossier for a deployer wallet: SNS trace, deployment history, fund-flow summary and an AI-written risk narrative. High-value due-diligence.",
+        "description": "Deep identity dossier for a deployer wallet: SNS trace, deployment history, fund-flow summary and a compiled evidence-backed risk narrative. High-value due-diligence.",
         "parameters": [
           {
             "name": "wallet",

--- a/providers/solsentry/threat-intel/openapi.json
+++ b/providers/solsentry/threat-intel/openapi.json
@@ -1096,6 +1096,42 @@
           "priceUsd": "0.50"
         }
       }
+    },
+    "/x402/v1/xwatch/{user_id}": {
+      "post": {
+        "summary": "Activate a 30-day X-account watch (handle changes, deleted posts, profile edits)",
+        "description": "Activates a 30-day watch on a numeric X user id. While active, the account's posts are archived at create time (so a later delete preserves the content), @handle changes are recorded with timestamps, and profile edits are tracked. Read the accumulated report at /v1/xwatch/{user_id}. History covers the watch period only.",
+        "parameters": [
+          {
+            "name": "user_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "1234567890"
+            },
+            "description": "Numeric X (Twitter) user id — immutable, unlike the @handle",
+            "example": "1234567890"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Watch activated; includes the current report"
+          },
+          "402": {
+            "description": "Payment required (x402 challenge)"
+          }
+        },
+        "x-pricing": {
+          "supportedPaymentMethods": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "unit": "requests",
+          "priceUsd": "5.00"
+        },
+        "operationId": "activateXwatch"
+      }
     }
   }
 }

--- a/providers/solsentry/threat-intel/openapi.json
+++ b/providers/solsentry/threat-intel/openapi.json
@@ -1,0 +1,414 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "SolSentry Threat Intelligence",
+    "version": "v1",
+    "description": "Solana operator-risk and threat-intelligence API. Pre-sign safety verdicts, serial-rugger detection, lookalike (address-poisoning) checks, holder concentration, and post-rug fund-flow tracing. Paid endpoints are gated by x402 (USDC on Solana mainnet)."
+  },
+  "servers": [
+    {
+      "url": "https://api.solsentry.app"
+    }
+  ],
+  "paths": {
+    "/x402/v1/operator/{wallet}": {
+      "get": {
+        "summary": "Fetch operator risk profile for a deployer wallet",
+        "description": "Returns risk_level, risk_score, confirmed_rugs, total_tokens and rug_rate for a deployer wallet. The cheapest high-signal call: is this operator a known serial rugger?",
+        "parameters": [
+          {
+            "name": "wallet",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
+            },
+            "description": "Solana base58 deployer wallet",
+            "example": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Operator risk profile"
+          },
+          "402": {
+            "description": "Payment required (x402 challenge)"
+          }
+        },
+        "x-pricing": {
+          "supportedPaymentMethods": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "unit": "requests",
+          "priceUsd": "0.002"
+        }
+      }
+    },
+    "/x402/v1/token/{mint}": {
+      "get": {
+        "summary": "Fetch pre-sign risk verdict for a token mint",
+        "description": "Returns risk_level, risk_score, deploying operator info and Token-2022 authority flags for a mint. One-call pre-sign verdict for a token.",
+        "parameters": [
+          {
+            "name": "mint",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "So11111111111111111111111111111111111111112"
+            },
+            "description": "Solana SPL mint address",
+            "example": "So11111111111111111111111111111111111111112"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Token risk verdict"
+          },
+          "402": {
+            "description": "Payment required (x402 challenge)"
+          }
+        },
+        "x-pricing": {
+          "supportedPaymentMethods": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "unit": "requests",
+          "priceUsd": "0.003"
+        }
+      }
+    },
+    "/x402/v1/predictions/{mint}": {
+      "get": {
+        "summary": "Fetch risk prediction and resolved outcome for a mint",
+        "description": "Returns the SolSentry risk prediction for a mint plus the resolved outcome if known (auditable accuracy record).",
+        "parameters": [
+          {
+            "name": "mint",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "So11111111111111111111111111111111111111112"
+            },
+            "description": "Solana SPL mint address",
+            "example": "So11111111111111111111111111111111111111112"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Prediction record"
+          },
+          "402": {
+            "description": "Payment required (x402 challenge)"
+          }
+        },
+        "x-pricing": {
+          "supportedPaymentMethods": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "unit": "requests",
+          "priceUsd": "0.002"
+        }
+      }
+    },
+    "/x402/v1/contract-analysis/{program_id}": {
+      "get": {
+        "summary": "Check program or contract safety before signing",
+        "description": "Known-entity lookup + Token-2022 authority scan + account-info read for a program or mint an agent is about to interact with. Returns a pre-sign risk assessment.",
+        "parameters": [
+          {
+            "name": "program_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+            },
+            "description": "Solana program or mint address",
+            "example": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Contract risk assessment"
+          },
+          "402": {
+            "description": "Payment required (x402 challenge)"
+          }
+        },
+        "x-pricing": {
+          "supportedPaymentMethods": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "unit": "requests",
+          "priceUsd": "0.005"
+        }
+      }
+    },
+    "/x402/v1/lookalike-check": {
+      "get": {
+        "summary": "Check a destination address for poisoned lookalikes",
+        "description": "Checks a destination address against poisoned lookalike siblings of wallets the caller has transacted with. Returns match, similarity_score and the matched address. Run before sending funds.",
+        "parameters": [
+          {
+            "name": "destination",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
+            },
+            "description": "Destination address to validate",
+            "example": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
+          },
+          {
+            "name": "contacts",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Comma-separated known-good addresses to compare against"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Lookalike verdict"
+          },
+          "402": {
+            "description": "Payment required (x402 challenge)"
+          }
+        },
+        "x-pricing": {
+          "supportedPaymentMethods": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "unit": "requests",
+          "priceUsd": "0.003"
+        }
+      }
+    },
+    "/x402/v1/tx-preview": {
+      "post": {
+        "summary": "Generate a pre-sign risk bundle for a transaction",
+        "description": "Accepts a transaction description and returns a structured pre-sign risk bundle (operator, token, contract and counterparty signals) so an agent can decide whether to sign.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "description": "Transaction to assess. Provide tx_base64 or parsed_tx; the remaining fields add caller context that sharpens the verdict.",
+                "properties": {
+                  "tx_base64": {
+                    "type": "string",
+                    "description": "Base64-encoded unsigned Solana transaction (one of tx_base64 / parsed_tx required)"
+                  },
+                  "parsed_tx": {
+                    "type": "object",
+                    "description": "Pre-parsed transaction in Helius parsed shape (bypasses the decoder)"
+                  },
+                  "signer_self_set": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Wallets the caller owns (transfers close-to-self are treated as safe)"
+                  },
+                  "prior_contacts": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Caller's prior recipient addresses, used for the lookalike check"
+                  },
+                  "token_metadata": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "mint": {
+                          "type": "string"
+                        },
+                        "symbol": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "description": "Known token metadata for the impersonator check"
+                  },
+                  "known_drainers": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Attacker-controlled wallets already known to the caller"
+                  },
+                  "known_safe_destinations": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "known_safe_authorities": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "additionalProperties": false,
+                "example": {
+                  "tx_base64": "AQAB...",
+                  "prior_contacts": [
+                    "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Pre-sign risk bundle"
+          },
+          "402": {
+            "description": "Payment required (x402 challenge)"
+          }
+        },
+        "x-pricing": {
+          "supportedPaymentMethods": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "unit": "requests",
+          "priceUsd": "0.008"
+        }
+      }
+    },
+    "/x402/v1/holders/{mint}": {
+      "get": {
+        "summary": "Fetch holder count and top-holder concentration for a mint",
+        "description": "Returns holder_count, top_holders and concentration_pct for a mint in one call (replaces chaining raw getTokenLargestAccounts RPC).",
+        "parameters": [
+          {
+            "name": "mint",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "So11111111111111111111111111111111111111112"
+            },
+            "description": "Solana SPL mint address",
+            "example": "So11111111111111111111111111111111111111112"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Holder concentration"
+          },
+          "402": {
+            "description": "Payment required (x402 challenge)"
+          }
+        },
+        "x-pricing": {
+          "supportedPaymentMethods": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "unit": "requests",
+          "priceUsd": "0.005"
+        }
+      }
+    },
+    "/x402/v1/drain-trace/{wallet}": {
+      "get": {
+        "summary": "Trace post-rug fund flows from a wallet to their terminus",
+        "description": "Multi-hop SOL/token flow trace from a rug wallet to its terminus (CEX, bridge, mixer) with USD amounts and labels. Forensic / post-incident use.",
+        "parameters": [
+          {
+            "name": "wallet",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
+            },
+            "description": "Source wallet to trace from",
+            "example": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
+          },
+          {
+            "name": "max_hops",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            },
+            "description": "Max hops to follow"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Fund-flow trace"
+          },
+          "402": {
+            "description": "Payment required (x402 challenge)"
+          }
+        },
+        "x-pricing": {
+          "supportedPaymentMethods": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "unit": "requests",
+          "priceUsd": "0.05"
+        }
+      }
+    },
+    "/x402/v1/dossier/{wallet}": {
+      "get": {
+        "summary": "Generate a full identity dossier for a deployer wallet",
+        "description": "Deep identity dossier for a deployer wallet: SNS trace, deployment history, fund-flow summary and an AI-written risk narrative. High-value due-diligence.",
+        "parameters": [
+          {
+            "name": "wallet",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
+            },
+            "description": "Deployer wallet",
+            "example": "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Dossier report"
+          },
+          "402": {
+            "description": "Payment required (x402 challenge)"
+          }
+        },
+        "x-pricing": {
+          "supportedPaymentMethods": [
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "unit": "requests",
+          "priceUsd": "0.50"
+        }
+      }
+    }
+  }
+}

--- a/providers/solsentry/threat-intel/openapi.json
+++ b/providers/solsentry/threat-intel/openapi.json
@@ -576,6 +576,10 @@
               "schema": {
                 "type": "object",
                 "description": "Transaction to assess. Provide tx_base64 or parsed_tx; the remaining fields add caller context that sharpens the verdict.",
+                "anyOf": [
+                  {"required": ["tx_base64"]},
+                  {"required": ["parsed_tx"]}
+                ],
                 "properties": {
                   "tx_base64": {
                     "type": "string",

--- a/providers/solsentry/threat-intel/openapi.json
+++ b/providers/solsentry/threat-intel/openapi.json
@@ -451,7 +451,7 @@
           ],
           "pricingMode": "fixed",
           "unit": "requests",
-          "priceUsd": "0.005"
+          "priceUsd": "0.01"
         }
       }
     },

--- a/providers/solsentry/threat-intel/openapi.json
+++ b/providers/solsentry/threat-intel/openapi.json
@@ -13,6 +13,7 @@
   "paths": {
     "/x402/v1/operator/{wallet}": {
       "get": {
+        "operationId": "operator_risk",
         "summary": "Fetch operator risk profile for a deployer wallet",
         "description": "Returns risk_level, risk_score, confirmed_rugs, total_tokens and rug_rate for a deployer wallet. The cheapest high-signal call: is this operator a known serial rugger?",
         "parameters": [
@@ -30,7 +31,74 @@
         ],
         "responses": {
           "200": {
-            "description": "Operator risk profile"
+            "description": "Operator risk profile. When the wallet is not a known operator, known=false and only wallet/known/risk_level/confirmed_rugs are returned.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": ["wallet", "known"],
+                  "properties": {
+                    "wallet": {
+                      "type": "string"
+                    },
+                    "known": {
+                      "type": "boolean",
+                      "description": "false = wallet not in the operator graph"
+                    },
+                    "operator_id": {
+                      "type": ["string", "null"]
+                    },
+                    "risk_level": {
+                      "type": "string",
+                      "enum": ["CRITICAL", "HIGH", "MEDIUM", "LOW", "UNKNOWN"]
+                    },
+                    "risk_score": {
+                      "type": "number",
+                      "description": "0-100 derived risk score"
+                    },
+                    "risk_label": {
+                      "type": "string"
+                    },
+                    "summary": {
+                      "type": "string",
+                      "description": "Plain-language verdict"
+                    },
+                    "confirmed_rugs": {
+                      "type": "integer"
+                    },
+                    "confirmed_safe": {
+                      "type": "integer"
+                    },
+                    "total_tokens": {
+                      "type": "integer"
+                    },
+                    "pending": {
+                      "type": "integer",
+                      "description": "Deployments still awaiting outcome resolution"
+                    },
+                    "rug_rate_pct": {
+                      "type": "number",
+                      "description": "confirmed_rugs / total_tokens as a percentage"
+                    },
+                    "tags": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "patterns": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "latency_ms": {
+                      "type": "number"
+                    }
+                  }
+                }
+              }
+            }
           },
           "402": {
             "description": "Payment required (x402 challenge)"
@@ -48,6 +116,7 @@
     },
     "/x402/v1/token/{mint}": {
       "get": {
+        "operationId": "token_risk",
         "summary": "Fetch pre-sign risk verdict for a token mint",
         "description": "Returns risk_level, risk_score, deploying operator info and Token-2022 authority flags for a mint. One-call pre-sign verdict for a token.",
         "parameters": [
@@ -65,7 +134,96 @@
         ],
         "responses": {
           "200": {
-            "description": "Token risk verdict"
+            "description": "Token risk verdict. Enrichment fields (launch_platform, authority flags, token_extensions) are present when scan data exists.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": ["mint", "known", "risk_level"],
+                  "properties": {
+                    "mint": {
+                      "type": "string"
+                    },
+                    "known": {
+                      "type": "boolean"
+                    },
+                    "risk_score": {
+                      "type": "number",
+                      "description": "0-100"
+                    },
+                    "risk_level": {
+                      "type": "string",
+                      "enum": ["CRITICAL", "HIGH", "MEDIUM", "LOW", "UNKNOWN"]
+                    },
+                    "final_outcome": {
+                      "type": "string",
+                      "description": "confirmed_scam | confirmed_safe | pending"
+                    },
+                    "flags": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "summary": {
+                      "type": "string",
+                      "description": "Plain-language verdict"
+                    },
+                    "is_bundle": {
+                      "type": "boolean",
+                      "description": "Coordinated bundle-buy cluster detected at launch"
+                    },
+                    "dev_wallet": {
+                      "type": ["string", "null"],
+                      "description": "Deploying operator wallet, when attributed"
+                    },
+                    "operator": {
+                      "type": ["object", "null"],
+                      "description": "Rap sheet of the deploying operator, when known",
+                      "properties": {
+                        "wallet": {
+                          "type": "string"
+                        },
+                        "risk_level": {
+                          "type": "string"
+                        },
+                        "confirmed_rugs": {
+                          "type": "integer"
+                        },
+                        "risk_label": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "symbol": {
+                      "type": ["string", "null"]
+                    },
+                    "predicted_at": {
+                      "type": ["string", "null"]
+                    },
+                    "launch_platform": {
+                      "type": "string"
+                    },
+                    "has_mint_authority": {
+                      "type": "boolean"
+                    },
+                    "has_freeze_authority": {
+                      "type": "boolean"
+                    },
+                    "token_extensions": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "description": "Token-2022 extensions present on the mint"
+                    },
+                    "latency_ms": {
+                      "type": "number"
+                    }
+                  }
+                }
+              }
+            }
           },
           "402": {
             "description": "Payment required (x402 challenge)"
@@ -83,6 +241,7 @@
     },
     "/x402/v1/predictions/{mint}": {
       "get": {
+        "operationId": "predictions",
         "summary": "Fetch risk prediction and resolved outcome for a mint",
         "description": "Returns the SolSentry risk prediction for a mint plus the resolved outcome if known (auditable accuracy record).",
         "parameters": [
@@ -100,7 +259,96 @@
         ],
         "responses": {
           "200": {
-            "description": "Prediction record"
+            "description": "Auditable prediction record: every scan of the mint with predicted risk, resolved outcome and was_correct flag.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": ["mint", "known", "predictions"],
+                  "properties": {
+                    "mint": {
+                      "type": "string"
+                    },
+                    "known": {
+                      "type": "boolean",
+                      "description": "false = mint never scanned (predictions is empty)"
+                    },
+                    "summary": {
+                      "type": "object",
+                      "properties": {
+                        "scan_count": {
+                          "type": "integer"
+                        },
+                        "resolved_count": {
+                          "type": "integer"
+                        },
+                        "correct_count": {
+                          "type": "integer"
+                        },
+                        "fp_event_count": {
+                          "type": "integer"
+                        },
+                        "ever_critical": {
+                          "type": "boolean"
+                        },
+                        "ever_high": {
+                          "type": "boolean"
+                        },
+                        "final_outcome": {
+                          "type": ["string", "null"]
+                        },
+                        "risk_level_distribution": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "integer"
+                          }
+                        }
+                      }
+                    },
+                    "predictions": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "tracking_id": {
+                            "type": ["string", "null"]
+                          },
+                          "agent_id": {
+                            "type": ["string", "null"]
+                          },
+                          "predicted_at": {
+                            "type": ["string", "null"]
+                          },
+                          "predicted_risk": {
+                            "type": ["number", "null"],
+                            "description": "0-100 risk score at scan time"
+                          },
+                          "dev_wallet": {
+                            "type": ["string", "null"]
+                          },
+                          "final_outcome": {
+                            "type": ["string", "null"]
+                          },
+                          "resolved_at": {
+                            "type": ["string", "null"]
+                          },
+                          "was_correct": {
+                            "type": ["boolean", "null"],
+                            "description": "null = not yet resolved"
+                          },
+                          "scan_flags": {
+                            "type": "object"
+                          }
+                        }
+                      }
+                    },
+                    "latency_ms": {
+                      "type": "number"
+                    }
+                  }
+                }
+              }
+            }
           },
           "402": {
             "description": "Payment required (x402 challenge)"
@@ -118,6 +366,7 @@
     },
     "/x402/v1/contract-analysis/{program_id}": {
       "get": {
+        "operationId": "contract_analysis",
         "summary": "Check program or contract safety before signing",
         "description": "Known-entity lookup + Token-2022 authority scan + account-info read for a program or mint an agent is about to interact with. Returns a pre-sign risk assessment.",
         "parameters": [
@@ -135,7 +384,62 @@
         ],
         "responses": {
           "200": {
-            "description": "Contract risk assessment"
+            "description": "Contract risk assessment",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": ["address", "risk_score", "verdict"],
+                  "properties": {
+                    "address": {
+                      "type": "string"
+                    },
+                    "kind": {
+                      "type": "string",
+                      "description": "program | mint | account"
+                    },
+                    "known_label": {
+                      "type": ["string", "null"],
+                      "description": "Label from the known-entity registry, if any"
+                    },
+                    "known_category": {
+                      "type": ["string", "null"]
+                    },
+                    "risk_score": {
+                      "type": "integer",
+                      "description": "0-100"
+                    },
+                    "verdict": {
+                      "type": "string"
+                    },
+                    "flags": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "authorities": {
+                      "type": "object",
+                      "description": "Mint/freeze/other authorities found on the account"
+                    },
+                    "extensions": {
+                      "type": "object",
+                      "description": "Token-2022 extensions and their risk-relevant settings"
+                    },
+                    "explanation": {
+                      "type": "string",
+                      "description": "Plain-language rationale"
+                    },
+                    "fetched_at": {
+                      "type": "string"
+                    },
+                    "latency_ms": {
+                      "type": "number"
+                    }
+                  }
+                }
+              }
+            }
           },
           "402": {
             "description": "Payment required (x402 challenge)"
@@ -153,6 +457,7 @@
     },
     "/x402/v1/lookalike-check": {
       "get": {
+        "operationId": "lookalike_check",
         "summary": "Check a destination address for poisoned lookalikes",
         "description": "Checks a destination address against poisoned lookalike siblings of wallets the caller has transacted with. Returns match, similarity_score and the matched address. Run before sending funds.",
         "parameters": [
@@ -170,16 +475,80 @@
           {
             "name": "contacts",
             "in": "query",
-            "required": false,
+            "required": true,
             "schema": {
-              "type": "string"
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             },
-            "description": "Comma-separated known-good addresses to compare against"
+            "style": "form",
+            "explode": false,
+            "description": "Known-good addresses to compare against (comma-separated on the wire). At least one is required."
           }
         ],
         "responses": {
           "200": {
-            "description": "Lookalike verdict"
+            "description": "Lookalike verdict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": ["destination", "suspect", "confidence"],
+                  "properties": {
+                    "destination": {
+                      "type": "string"
+                    },
+                    "suspect": {
+                      "type": "boolean",
+                      "description": "true when the top finding is medium or strong confidence"
+                    },
+                    "confidence": {
+                      "type": "string",
+                      "enum": ["none", "weak", "medium", "strong"],
+                      "description": "Confidence of the top finding"
+                    },
+                    "findings": {
+                      "type": "array",
+                      "description": "Top candidate lookalikes, ranked by confidence (max 5)",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "original_contact": {
+                            "type": "string",
+                            "description": "The known-good contact this destination resembles"
+                          },
+                          "prefix_match": {
+                            "type": "integer",
+                            "description": "Matching characters at the start"
+                          },
+                          "suffix_match": {
+                            "type": "integer",
+                            "description": "Matching characters at the end"
+                          },
+                          "confidence": {
+                            "type": "string",
+                            "enum": ["weak", "medium", "strong"]
+                          },
+                          "reasons": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "contacts_checked": {
+                      "type": "integer"
+                    },
+                    "latency_ms": {
+                      "type": "number"
+                    }
+                  }
+                }
+              }
+            }
           },
           "402": {
             "description": "Payment required (x402 challenge)"
@@ -197,6 +566,7 @@
     },
     "/x402/v1/tx-preview": {
       "post": {
+        "operationId": "tx_preview",
         "summary": "Generate a pre-sign risk bundle for a transaction",
         "description": "Accepts a transaction description and returns a structured pre-sign risk bundle (operator, token, contract and counterparty signals) so an agent can decide whether to sign.",
         "requestBody": {
@@ -280,7 +650,59 @@
         },
         "responses": {
           "200": {
-            "description": "Pre-sign risk bundle"
+            "description": "Pre-sign risk bundle",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": ["risk_score", "verdict", "findings", "decode_ok"],
+                  "properties": {
+                    "risk_score": {
+                      "type": "integer",
+                      "description": "0-100 aggregate across all detectors"
+                    },
+                    "verdict": {
+                      "type": "string",
+                      "enum": ["block", "warn", "safe"]
+                    },
+                    "findings": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "detector": {
+                            "type": "string"
+                          },
+                          "severity": {
+                            "type": "string",
+                            "enum": ["CRITICAL", "HIGH", "MEDIUM", "LOW"]
+                          },
+                          "summary": {
+                            "type": "string"
+                          },
+                          "detail": {
+                            "type": "object"
+                          }
+                        }
+                      }
+                    },
+                    "detectors_run": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "decode_ok": {
+                      "type": "boolean",
+                      "description": "false = tx_base64 could not be decoded; verdict based on partial signals"
+                    },
+                    "latency_ms": {
+                      "type": "number"
+                    }
+                  }
+                }
+              }
+            }
           },
           "402": {
             "description": "Payment required (x402 challenge)"
@@ -298,6 +720,7 @@
     },
     "/x402/v1/holders/{mint}": {
       "get": {
+        "operationId": "holders",
         "summary": "Fetch holder count and top-holder concentration for a mint",
         "description": "Returns holder_count, top_holders and concentration_pct for a mint in one call (replaces chaining raw getTokenLargestAccounts RPC).",
         "parameters": [
@@ -315,7 +738,73 @@
         ],
         "responses": {
           "200": {
-            "description": "Holder concentration"
+            "description": "Holder concentration",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": ["mint", "count", "confidence", "top1", "top10"],
+                  "properties": {
+                    "mint": {
+                      "type": "string"
+                    },
+                    "count": {
+                      "type": "integer",
+                      "description": "Estimated total holders (>= 1)"
+                    },
+                    "confidence": {
+                      "type": "number",
+                      "description": "0.0-1.0; >= 0.6 is reliable for display"
+                    },
+                    "source": {
+                      "type": "string",
+                      "description": "Data path that produced the result (helius_das, getLargest, ...)"
+                    },
+                    "top1": {
+                      "type": "number",
+                      "description": "Top-1 wallet share of supply, percent"
+                    },
+                    "top10": {
+                      "type": "number",
+                      "description": "Top-10 wallets share of supply, percent"
+                    },
+                    "sampled": {
+                      "type": "integer",
+                      "description": "Accounts actually counted (vs estimated)"
+                    },
+                    "supply": {
+                      "type": "number",
+                      "description": "Circulating supply in UI units"
+                    },
+                    "largest": {
+                      "type": "array",
+                      "description": "Top-N account breakdown (present when available)",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "wallet": {
+                            "type": "string"
+                          },
+                          "amount": {
+                            "type": "number"
+                          },
+                          "pct": {
+                            "type": "number"
+                          }
+                        }
+                      }
+                    },
+                    "display": {
+                      "type": "string",
+                      "description": "Human-readable holder-count one-liner"
+                    },
+                    "latency_ms": {
+                      "type": "number"
+                    }
+                  }
+                }
+              }
+            }
           },
           "402": {
             "description": "Payment required (x402 challenge)"
@@ -333,6 +822,7 @@
     },
     "/x402/v1/drain-trace/{wallet}": {
       "get": {
+        "operationId": "drain_trace",
         "summary": "Trace post-rug fund flows from a wallet to their terminus",
         "description": "Multi-hop SOL/token flow trace from a rug wallet to its terminus (CEX, bridge, mixer) with USD amounts and labels. Forensic / post-incident use.",
         "parameters": [
@@ -359,7 +849,86 @@
         ],
         "responses": {
           "200": {
-            "description": "Fund-flow trace"
+            "description": "Fund-flow trace",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": ["wallet", "hop_count", "hops"],
+                  "properties": {
+                    "wallet": {
+                      "type": "string"
+                    },
+                    "origin_token": {
+                      "type": ["string", "null"]
+                    },
+                    "origin_risk": {
+                      "type": "number"
+                    },
+                    "hop_count": {
+                      "type": "integer"
+                    },
+                    "total_sol_drained": {
+                      "type": "number"
+                    },
+                    "reached_cex": {
+                      "type": "boolean"
+                    },
+                    "reached_mixer": {
+                      "type": "boolean"
+                    },
+                    "hops": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "hop_number": {
+                            "type": "integer"
+                          },
+                          "from": {
+                            "type": "string"
+                          },
+                          "to": {
+                            "type": "string"
+                          },
+                          "amount_sol": {
+                            "type": "number"
+                          },
+                          "tx_signature": {
+                            "type": "string"
+                          },
+                          "timestamp": {
+                            "type": ["string", "integer", "null"]
+                          },
+                          "destination_label": {
+                            "type": ["string", "null"],
+                            "description": "Known-entity label of the destination (CEX, bridge, mixer), when identified"
+                          },
+                          "destination_category": {
+                            "type": "string",
+                            "description": "cex | bridge | mixer | unknown"
+                          }
+                        }
+                      }
+                    },
+                    "endpoints": {
+                      "type": "array",
+                      "description": "Terminal destinations reached by the trace"
+                    },
+                    "spl_outflows": {
+                      "type": "array",
+                      "description": "SPL-token outflows detected alongside SOL flows"
+                    },
+                    "trace_time_ms": {
+                      "type": "number"
+                    },
+                    "latency_ms": {
+                      "type": "number"
+                    }
+                  }
+                }
+              }
+            }
           },
           "402": {
             "description": "Payment required (x402 challenge)"
@@ -377,6 +946,7 @@
     },
     "/x402/v1/dossier/{wallet}": {
       "get": {
+        "operationId": "dossier",
         "summary": "Generate a full identity dossier for a deployer wallet",
         "description": "Deep identity dossier for a deployer wallet: SNS trace, deployment history, fund-flow summary and an AI-written risk narrative. High-value due-diligence.",
         "parameters": [
@@ -394,7 +964,120 @@
         ],
         "responses": {
           "200": {
-            "description": "Dossier report"
+            "description": "Dossier report",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": ["wallet", "built_at", "confidence"],
+                  "properties": {
+                    "wallet": {
+                      "type": "string"
+                    },
+                    "built_at": {
+                      "type": "string"
+                    },
+                    "elapsed_s": {
+                      "type": "number"
+                    },
+                    "schema_version": {
+                      "type": "integer"
+                    },
+                    "operator_id": {
+                      "type": ["string", "null"]
+                    },
+                    "risk_level": {
+                      "type": ["string", "null"]
+                    },
+                    "rug_rate_pct": {
+                      "type": ["number", "null"]
+                    },
+                    "total_tokens": {
+                      "type": ["integer", "null"]
+                    },
+                    "confirmed_rugs": {
+                      "type": ["integer", "null"]
+                    },
+                    "genesis": {
+                      "type": ["object", "null"],
+                      "description": "First on-chain activity: {signature, slot, blockTime, age_days}"
+                    },
+                    "first_funder": {
+                      "type": ["object", "null"],
+                      "description": "Wallet that first funded this one, with labels"
+                    },
+                    "second_funder": {
+                      "type": ["object", "null"]
+                    },
+                    "assets": {
+                      "type": "object",
+                      "description": "Identity assets: SNS domains, vanity patterns, payment UUIDs"
+                    },
+                    "token_authority_map": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "integer"
+                      },
+                      "description": "authority wallet -> token count"
+                    },
+                    "timing_siblings": {
+                      "type": "array",
+                      "description": "Wallets that co-deployed within the timing window"
+                    },
+                    "cex_exits": {
+                      "type": "array",
+                      "description": "Detected fund exits to centralized exchanges"
+                    },
+                    "identity_signals": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "kind": {
+                            "type": "string",
+                            "description": "sns | vanity | payment_uuid | first_funder_cex | ..."
+                          },
+                          "confidence": {
+                            "type": "string",
+                            "enum": ["HIGH", "MEDIUM", "LOW"]
+                          },
+                          "description": {
+                            "type": "string"
+                          },
+                          "evidence": {
+                            "type": "object"
+                          }
+                        }
+                      }
+                    },
+                    "confidence": {
+                      "type": "string",
+                      "enum": ["HIGH", "MEDIUM", "LOW"],
+                      "description": "Overall identity confidence"
+                    },
+                    "sources": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "cached": {
+                      "type": "boolean",
+                      "description": "true = served from the 7-day dossier cache"
+                    },
+                    "latency_ms": {
+                      "type": "number"
+                    }
+                  }
+                }
+              }
+            }
           },
           "402": {
             "description": "Payment required (x402 challenge)"


### PR DESCRIPTION
Adds **solsentry/threat-intel** — Solana operator-risk and threat-intelligence API, paid per-call via x402 (USDC, Solana mainnet).

## What it is

SolSentry scores rug risk at the **operator level**: serial-rugger verdicts for deployer wallets, pre-sign token/contract risk, address-poisoning lookalike checks, holder concentration, and post-rug fund-flow traces. Complements the market-data providers already in the catalog (prices/flows) with "who deployed this and have they rugged before".

- 9 endpoints, all under `/x402/v1/*`, all returning a live x402 `402` challenge (scheme `exact`, Solana mainnet, USDC, `payTo` treasury) — verified live before this PR.
- Fixed per-request pricing from $0.002 (operator verdict) to $0.50 (full dossier); the authoritative price is the one in the live 402 challenge, mirrored in `x-pricing` per operation.
- Free dashboard endpoints under `/v1/*` are out of scope for this listing.

## Validation

`pay catalog check providers/solsentry/threat-intel/PAY.md` — **successful**, Solana-compat gate **PASS (2/2)**. The two probeable endpoints (`GET /x402/v1/lookalike-check`, `POST /x402/v1/tx-preview`) verify green (`402 x402 USDC`); the remaining seven use templated path params, so the probe reports them as indeterminate (`method_not_allowed`) — same behavior as other templated-path providers in the registry. Each was manually verified to return a valid Solana-mainnet USDC 402 challenge with the listed price.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
