### PR TITLE
Add CrowdPull Pay skill

### DIFF
--- a/providers/standscout/crowdpull/PAY.md
+++ b/providers/standscout/crowdpull/PAY.md
@@ -9,15 +9,16 @@ openapi:
   path: openapi.json
 ---
 
-CrowdPull packages public-data jobs as small paid calls. Start with the
-storefront or source catalog when the user is still choosing a route. Use the
-smoke endpoint when you only need to prove payment and discovery. Use the
-marketplace routes when the task is concrete enough to cap the query, location,
-and result count.
+CrowdPull packages public-data jobs as small paid calls. Use the normal
+CrowdPull storefront at `https://crowdpull.click/api/storefront` when the user
+is still choosing a route. Use the Pay.sh smoke endpoint when you only need to
+prove payment and discovery. Use the marketplace routes when the task is
+concrete enough to cap the query, location, and result count.
 
 ## Spend-aware usage
 
-- Call the free storefront first when the user has not picked a job yet.
+- Check `https://crowdpull.click/api/storefront` first when the user has not
+  picked a job yet.
 - Use `/api/smoke/discovery` for directory checks. It is intentionally tiny and
   does not start a scrape.
 - Keep `maxItems` low on the first marketplace call. Increase the cap only

--- a/providers/standscout/crowdpull/PAY.md
+++ b/providers/standscout/crowdpull/PAY.md
@@ -1,0 +1,26 @@
+---
+name: crowdpull
+title: "CrowdPull"
+description: "Buy capped public-data jobs for marketplace leads, source catalogs, cached checks, and tiny payment smoke tests. Returns source-linked JSON rows and job tokens."
+use_case: "Use for agent workflows that need public marketplace leads, quick source discovery, cached local listings, or a tiny paid call to prove stablecoin payment works."
+category: data
+service_url: https://pay.crowdpull.click
+openapi:
+  path: openapi.json
+---
+
+CrowdPull packages public-data jobs as small paid calls. Start with the
+storefront or source catalog when the user is still choosing a route. Use the
+smoke endpoint when you only need to prove payment and discovery. Use the
+marketplace routes when the task is concrete enough to cap the query, location,
+and result count.
+
+## Spend-aware usage
+
+- Call the free storefront first when the user has not picked a job yet.
+- Use `/api/smoke/discovery` for directory checks. It is intentionally tiny and
+  does not start a scrape.
+- Keep `maxItems` low on the first marketplace call. Increase the cap only
+  after the first result set looks useful.
+- Prefer `/api/instant/marketplace-leads` before a live workflow when cached
+  rows are good enough for the task.

--- a/providers/standscout/crowdpull/openapi.json
+++ b/providers/standscout/crowdpull/openapi.json
@@ -1,0 +1,412 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "CrowdPull Pay.sh API",
+    "version": "v1",
+    "description": "Solana USDC gateway for small CrowdPull public-data jobs. Agents can inspect the catalog for free, then pay per capped request."
+  },
+  "servers": [
+    {
+      "url": "https://pay.crowdpull.click"
+    }
+  ],
+  "paths": {
+    "/api/storefront": {
+      "get": {
+        "summary": "Browse CrowdPull paid data SKUs",
+        "description": "Free catalog of CrowdPull departments and SKUs. Use this before spending.",
+        "operationId": "getCrowdPullStorefront",
+        "responses": {
+          "200": {
+            "description": "Storefront catalog",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StorefrontResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/smoke/discovery": {
+      "post": {
+        "summary": "Run a tiny paid discovery smoke call",
+        "description": "Tiny paid canary that proves payment, route discovery, and service metadata without starting a scrape.",
+        "operationId": "runDiscoverySmoke",
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DiscoverySmokeRequest"
+              },
+              "example": {
+                "includeRoutes": false,
+                "includeExamples": true
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Discovery smoke result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DiscoverySmokeResponse"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "x-payment-info": {
+          "protocols": [
+            "mpp",
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "0.001",
+          "asset": "USDC",
+          "chains": [
+            {
+              "network": "solana:mainnet",
+              "name": "Solana"
+            }
+          ]
+        }
+      }
+    },
+    "/api/actors/list": {
+      "post": {
+        "summary": "Search CrowdPull source catalog",
+        "description": "Search the CrowdPull public-data source catalog and return matching paid route choices.",
+        "operationId": "searchCrowdPullSources",
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SourceCatalogRequest"
+              },
+              "example": {
+                "query": "marketplace leads",
+                "limit": 5
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Matching sources and route choices",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "x-payment-info": {
+          "protocols": [
+            "mpp",
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "0.005",
+          "asset": "USDC",
+          "chains": [
+            {
+              "network": "solana:mainnet",
+              "name": "Solana"
+            }
+          ]
+        }
+      }
+    },
+    "/api/instant/marketplace-leads": {
+      "post": {
+        "summary": "Check cached marketplace leads",
+        "description": "Check cached marketplace leads first, with an option to start a live refresh when needed.",
+        "operationId": "getInstantMarketplaceLeads",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MarketplaceLeadRequest"
+              },
+              "example": {
+                "input": {
+                  "query": "couch",
+                  "location": "Detroit, MI",
+                  "maxItems": 5,
+                  "refreshLive": false
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Cached marketplace result or refresh token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "x-payment-info": {
+          "protocols": [
+            "mpp",
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "0.01",
+          "asset": "USDC",
+          "chains": [
+            {
+              "network": "solana:mainnet",
+              "name": "Solana"
+            }
+          ]
+        }
+      }
+    },
+    "/api/workflows/marketplace-leads": {
+      "post": {
+        "summary": "Start a marketplace lead workflow",
+        "description": "Start a capped marketplace lead bundle for public listings across supported local-market sources.",
+        "operationId": "startMarketplaceLeadWorkflow",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MarketplaceLeadWorkflowRequest"
+              },
+              "example": {
+                "input": {
+                  "query": "full length mirror",
+                  "location": "New York, NY",
+                  "maxItems": 10,
+                  "sources": [
+                    "offerup-scraper"
+                  ],
+                  "includeDetails": false
+                },
+                "options": {
+                  "waitForFinishSeconds": 10
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Workflow token and started jobs",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "x-payment-info": {
+          "protocols": [
+            "mpp",
+            "x402"
+          ],
+          "pricingMode": "fixed",
+          "price": "0.19",
+          "asset": "USDC",
+          "chains": [
+            {
+              "network": "solana:mainnet",
+              "name": "Solana"
+            }
+          ]
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "StorefrontResponse": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "departments": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "skus": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          }
+        },
+        "additionalProperties": true
+      },
+      "DiscoverySmokeRequest": {
+        "type": "object",
+        "properties": {
+          "includeRoutes": {
+            "type": "boolean",
+            "default": false
+          },
+          "includeExamples": {
+            "type": "boolean",
+            "default": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "DiscoverySmokeResponse": {
+        "type": "object",
+        "properties": {
+          "ok": {
+            "type": "boolean"
+          },
+          "transactionId": {
+            "type": "string"
+          },
+          "counts": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        },
+        "additionalProperties": true
+      },
+      "SourceCatalogRequest": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string"
+          },
+          "family": {
+            "type": "string"
+          },
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 20,
+            "default": 5
+          }
+        },
+        "additionalProperties": false
+      },
+      "MarketplaceLeadRequest": {
+        "type": "object",
+        "required": [
+          "input"
+        ],
+        "properties": {
+          "input": {
+            "type": "object",
+            "description": "Marketplace lookup settings. Start with a narrow query and low result cap.",
+            "required": [
+              "query"
+            ],
+            "properties": {
+              "query": {
+                "type": "string",
+                "description": "Item or category to search for, such as couch, mirror, or dining table."
+              },
+              "location": {
+                "type": "string"
+              },
+              "maxItems": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 25,
+                "default": 5
+              },
+              "refreshLive": {
+                "type": "boolean",
+                "default": false
+              }
+            },
+            "additionalProperties": true
+          }
+        },
+        "additionalProperties": true
+      },
+      "MarketplaceLeadWorkflowRequest": {
+        "type": "object",
+        "required": [
+          "input"
+        ],
+        "properties": {
+          "input": {
+            "type": "object",
+            "description": "Live marketplace workflow settings. Keep the first call narrow, then raise caps if the results look useful.",
+            "required": [
+              "query"
+            ],
+            "properties": {
+              "query": {
+                "type": "string",
+                "description": "Item or category to search for, such as full length mirror, couch, or used bike."
+              },
+              "location": {
+                "type": "string"
+              },
+              "maxItems": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 50,
+                "default": 10
+              },
+              "sources": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "includeDetails": {
+                "type": "boolean",
+                "default": false
+              }
+            },
+            "additionalProperties": true
+          },
+          "options": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        },
+        "additionalProperties": true
+      }
+    }
+  }
+}

--- a/providers/standscout/crowdpull/openapi.json
+++ b/providers/standscout/crowdpull/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "CrowdPull Pay.sh API",
     "version": "v1",
-    "description": "Solana USDC gateway for small CrowdPull public-data jobs. Agents can inspect the catalog for free, then pay per capped request."
+    "description": "Solana USDC gateway for small CrowdPull public-data jobs. Agents can use the CrowdPull storefront to choose a route, then pay per capped request."
   },
   "servers": [
     {
@@ -11,25 +11,6 @@
     }
   ],
   "paths": {
-    "/api/storefront": {
-      "get": {
-        "summary": "Browse CrowdPull paid data SKUs",
-        "description": "Free catalog of CrowdPull departments and SKUs. Use this before spending.",
-        "operationId": "getCrowdPullStorefront",
-        "responses": {
-          "200": {
-            "description": "Storefront catalog",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/StorefrontResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/api/smoke/discovery": {
       "post": {
         "summary": "Run a tiny paid discovery smoke call",
@@ -254,29 +235,6 @@
   },
   "components": {
     "schemas": {
-      "StorefrontResponse": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "departments": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "additionalProperties": true
-            }
-          },
-          "skus": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "additionalProperties": true
-            }
-          }
-        },
-        "additionalProperties": true
-      },
       "DiscoverySmokeRequest": {
         "type": "object",
         "properties": {


### PR DESCRIPTION
## Summary
- Adds CrowdPull as a Pay.sh provider under providers/standscout/crowdpull
- Uses the live Solana USDC gateway at https://pay.crowdpull.click
- Commits the co-located OpenAPI snapshot required by the registry

## Validation
- npx -y @solana/pay@latest catalog check providers/standscout/crowdpull/PAY.md
- npx -y @solana/pay@latest catalog check . --changed-from origin/main

Both checks passed with 5 endpoints tested across 1 provider and 4/4 gates compatible with Solana.