### PR TITLE
Add AgentBodega

### DIFF
--- a/providers/agentbodegastore/agentbodega/PAY.md
+++ b/providers/agentbodegastore/agentbodega/PAY.md
@@ -1,33 +1,47 @@
 ---
 name: agentbodega
 title: "AgentBodega"
-description: "Pay-per-call utility APIs for agents: official app and cloud status checks, launch and agent-readiness audits, x402 inspection, domain checks, signed artifacts, directory packaging, and receipts."
-use_case: "Use when an agent needs a cheap preflight before retrying, deploying, buying another API call, checking cloud/provider health, auditing launch readiness, inspecting x402 metadata, or creating a short-lived artifact with a receipt."
+description: "Pay-per-call APIs for agents across status monitoring, web search, public data, social research, media conversion, real-estate intelligence, agent readiness, and payment discovery. Pay with USDC on Solana mainnet or Base through x402."
+use_case: "Use when an agent needs a bounded, machine-readable result without opening an account or integrating another vendor API. Inspect the catalog first, select the narrowest route that solves the task, and pay only for that call."
 category: devtools
 service_url: https://agentbodega.store
 openapi:
   path: openapi.json
 ---
 
-AgentBodega is a small paid utility shelf for agents. The cheap calls are meant
-to answer the question an agent usually has right before it wastes more money or
-time: is the upstream service down, is this site agent-ready, does this payable
-endpoint expose a real x402 challenge, or is this domain actually ready to
-launch?
+AgentBodega is a catalog of paid, machine-readable tools built for autonomous
+agents. Its 71 paid offerings cover focused checks, searches, conversions, and
+reports. Each offering publishes its accepted inputs, required fields, output
+schema, current price, and example request before payment, so a caller can make
+a spend-aware decision without guessing the contract.
 
-The status routes use official status sources where possible, including scoped
-AWS, Google Cloud, Azure, DigitalOcean, and Linode public health checks priced by
-small units instead of giant all-cloud dumps. The launch and agent-readiness routes inspect public
-metadata, OpenAPI, MCP cards, Agent
-Skills, auth docs, x402 discovery, link headers, markdown access, DNS, HTTPS,
-SPF, DMARC, MX, and DKIM hints. Responses include receipts so a caller can trace
-what was paid for and what was returned.
+Paid endpoints use x402 v2 and accept USDC on either:
+
+- **Solana mainnet**: SPL USDC mint
+  `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`.
+- **Base mainnet**: USDC contract
+  `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`.
+
+Call a paid endpoint without a payment signature to receive its HTTP `402`
+challenge. Read the `PAYMENT-REQUIRED` header, choose one advertised rail, sign
+the exact requirement, and retry with `PAYMENT-SIGNATURE`. Successful paid
+responses include a settlement receipt. The lowest-priced checks currently
+start at **$0.005 USDC per successful call**.
+
+The catalog includes official service and cloud health checks; public web,
+market, social, and real-estate research; media and document conversion; domain
+and username availability; launch and agent-readiness audits; x402 inspection;
+and packaged reports. Full metadata is available from `/api/directory`, while
+`/.well-known/x402` exposes the live payment requirements and route examples.
 
 ## Spend-aware usage
 
+- Read `/api/directory` and `/.well-known/x402` before spending. They show the
+  live route list, current prices, input contracts, output examples, and payment
+  rails.
 - Start with a direct status alias such as `/api/status/openai`,
   `/api/status/github`, or `/api/status/cloudflare` when you only need one
-  service. Those calls are usually the cheapest useful check.
+  service. These are the cheapest useful checks at $0.005 each.
 - Use `/api/status/bundle` or `/api/status/stack` when the user is debugging a
   deploy path and wants one answer across several dependencies.
 - Use `/api/cloud/status/check` for one cloud provider target, or
@@ -38,5 +52,5 @@ what was paid for and what was returned.
   problem is discovery, protocol metadata, or commerce.
 - Cache a receipt and result inside the agent session instead of repeating the
   same check during a retry loop.
-- Read `/.well-known/x402` and `/api/directory` before spending. They show the
-  live endpoint list, prices, payment rails, and example request bodies.
+- Set a client-side maximum before signing. A `402` challenge is a quote, not a
+  completed charge; settlement occurs only after the signed retry succeeds.

--- a/providers/agentbodegastore/agentbodega/PAY.md
+++ b/providers/agentbodegastore/agentbodega/PAY.md
@@ -1,8 +1,8 @@
 ---
 name: agentbodega
 title: "AgentBodega"
-description: "Pay-per-call utility APIs for agents: official status checks, launch and agent-readiness audits, x402 inspection, domain checks, signed artifacts, directory packaging, and receipts."
-use_case: "Use when an agent needs a cheap preflight check before retrying, deploying, buying another API call, auditing launch readiness, inspecting x402 metadata, or creating a short-lived artifact with a receipt."
+description: "Pay-per-call utility APIs for agents: official app and cloud status checks, launch and agent-readiness audits, x402 inspection, domain checks, signed artifacts, directory packaging, and receipts."
+use_case: "Use when an agent needs a cheap preflight check before retrying, deploying, buying another API call, checking AWS/GCP/Azure public health, auditing launch readiness, inspecting x402 metadata, or creating a short-lived artifact with a receipt."
 category: devtools
 service_url: https://agentbodega.store
 openapi:
@@ -15,8 +15,10 @@ time: is the upstream service down, is this site agent-ready, does this payable
 endpoint expose a real x402 challenge, or is this domain actually ready to
 launch?
 
-The status routes use official status sources where possible. The launch and
-agent-readiness routes inspect public metadata, OpenAPI, MCP cards, Agent
+The status routes use official status sources where possible, including scoped
+AWS, Google Cloud, and Azure public health checks priced by small units instead
+of giant all-cloud dumps. The launch and agent-readiness routes inspect public
+metadata, OpenAPI, MCP cards, Agent
 Skills, auth docs, x402 discovery, link headers, markdown access, DNS, HTTPS,
 SPF, DMARC, MX, and DKIM hints. Responses include receipts so a caller can trace
 what was paid for and what was returned.
@@ -28,6 +30,9 @@ what was paid for and what was returned.
   service. Those calls are usually the cheapest useful check.
 - Use `/api/status/bundle` or `/api/status/stack` when the user is debugging a
   deploy path and wants one answer across several dependencies.
+- Use `/api/cloud/status/check` for one cloud provider target, or
+  `/api/cloud/status/bundle` and `/api/cloud/status/stack` when the user wants a
+  bounded AWS/GCP/Azure stack check.
 - Use `/api/audit/agent-launch` only when you need the full launch/readiness
   report. The focused checks are cheaper when you already know whether the
   problem is discovery, protocol metadata, or commerce.

--- a/providers/agentbodegastore/agentbodega/PAY.md
+++ b/providers/agentbodegastore/agentbodega/PAY.md
@@ -2,7 +2,7 @@
 name: agentbodega
 title: "AgentBodega"
 description: "Pay-per-call utility APIs for agents: official app and cloud status checks, launch and agent-readiness audits, x402 inspection, domain checks, signed artifacts, directory packaging, and receipts."
-use_case: "Use when an agent needs a cheap preflight check before retrying, deploying, buying another API call, checking AWS/GCP/Azure public health, auditing launch readiness, inspecting x402 metadata, or creating a short-lived artifact with a receipt."
+use_case: "Use when an agent needs a cheap preflight before retrying, deploying, buying another API call, checking cloud/provider health, auditing launch readiness, inspecting x402 metadata, or creating a short-lived artifact with a receipt."
 category: devtools
 service_url: https://agentbodega.store
 openapi:
@@ -16,8 +16,8 @@ endpoint expose a real x402 challenge, or is this domain actually ready to
 launch?
 
 The status routes use official status sources where possible, including scoped
-AWS, Google Cloud, and Azure public health checks priced by small units instead
-of giant all-cloud dumps. The launch and agent-readiness routes inspect public
+AWS, Google Cloud, Azure, DigitalOcean, and Linode public health checks priced by
+small units instead of giant all-cloud dumps. The launch and agent-readiness routes inspect public
 metadata, OpenAPI, MCP cards, Agent
 Skills, auth docs, x402 discovery, link headers, markdown access, DNS, HTTPS,
 SPF, DMARC, MX, and DKIM hints. Responses include receipts so a caller can trace
@@ -32,7 +32,7 @@ what was paid for and what was returned.
   deploy path and wants one answer across several dependencies.
 - Use `/api/cloud/status/check` for one cloud provider target, or
   `/api/cloud/status/bundle` and `/api/cloud/status/stack` when the user wants a
-  bounded AWS/GCP/Azure stack check.
+  bounded cloud-provider stack check.
 - Use `/api/audit/agent-launch` only when you need the full launch/readiness
   report. The focused checks are cheaper when you already know whether the
   problem is discovery, protocol metadata, or commerce.

--- a/providers/agentbodegastore/agentbodega/PAY.md
+++ b/providers/agentbodegastore/agentbodega/PAY.md
@@ -1,0 +1,37 @@
+---
+name: agentbodega
+title: "AgentBodega"
+description: "Pay-per-call utility APIs for agents: official status checks, launch and agent-readiness audits, x402 inspection, domain checks, signed artifacts, directory packaging, and receipts."
+use_case: "Use when an agent needs a cheap preflight check before retrying, deploying, buying another API call, auditing launch readiness, inspecting x402 metadata, or creating a short-lived artifact with a receipt."
+category: devtools
+service_url: https://agentbodega.store
+openapi:
+  path: openapi.json
+---
+
+AgentBodega is a small paid utility shelf for agents. The cheap calls are meant
+to answer the question an agent usually has right before it wastes more money or
+time: is the upstream service down, is this site agent-ready, does this payable
+endpoint expose a real x402 challenge, or is this domain actually ready to
+launch?
+
+The status routes use official status sources where possible. The launch and
+agent-readiness routes inspect public metadata, OpenAPI, MCP cards, Agent
+Skills, auth docs, x402 discovery, link headers, markdown access, DNS, HTTPS,
+SPF, DMARC, MX, and DKIM hints. Responses include receipts so a caller can trace
+what was paid for and what was returned.
+
+## Spend-aware usage
+
+- Start with a direct status alias such as `/api/status/openai`,
+  `/api/status/github`, or `/api/status/cloudflare` when you only need one
+  service. Those calls are usually the cheapest useful check.
+- Use `/api/status/bundle` or `/api/status/stack` when the user is debugging a
+  deploy path and wants one answer across several dependencies.
+- Use `/api/audit/agent-launch` only when you need the full launch/readiness
+  report. The focused checks are cheaper when you already know whether the
+  problem is discovery, protocol metadata, or commerce.
+- Cache a receipt and result inside the agent session instead of repeating the
+  same check during a retry loop.
+- Read `/.well-known/x402` and `/api/directory` before spending. They show the
+  live endpoint list, prices, payment rails, and example request bodies.

--- a/providers/agentbodegastore/agentbodega/openapi.json
+++ b/providers/agentbodegastore/agentbodega/openapi.json
@@ -1,0 +1,2709 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "AgentBodega",
+    "version": "0.1.0",
+    "description": "Small x402-payable utility APIs for agents: endpoint inspection, launch checks, and hosted artifacts.",
+    "contact": {
+      "name": "AgentBodega",
+      "email": "support@agentbodega.store",
+      "url": "https://agentbodega.store"
+    },
+    "x-guidance": "Start with GET /api/directory and GET /.well-known/x402 to inspect available services and prices. Use the $0.001 status endpoints for smoke tests, then call larger bundle or audit endpoints only after checking the live 402 challenge and spend cap."
+  },
+  "servers": [
+    {
+      "url": "https://agentbodega.store"
+    }
+  ],
+  "x-discovery": {
+    "tags": [
+      "x402",
+      "agent-tools",
+      "mcp-tools",
+      "paid-utilities"
+    ],
+    "endpointCount": 31
+  },
+  "paths": {
+    "/api/directory": {
+      "get": {
+        "summary": "List payable agent utility endpoints.",
+        "operationId": "list_directory",
+        "security": [],
+        "tags": [
+          "directory",
+          "discovery"
+        ],
+        "responses": {
+          "200": {
+            "description": "Service directory.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/status/suggest": {
+      "post": {
+        "summary": "Create official status coverage request",
+        "operationId": "status_service_suggestion",
+        "security": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "name"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "minLength": 2,
+                    "maxLength": 120,
+                    "description": "Service name, for example Stripe or Railway."
+                  },
+                  "homepage": {
+                    "type": "string",
+                    "format": "uri",
+                    "maxLength": 300
+                  },
+                  "domain": {
+                    "type": "string",
+                    "maxLength": 253,
+                    "description": "Plain domain if the homepage URL is not known."
+                  },
+                  "statusPage": {
+                    "type": "string",
+                    "format": "uri",
+                    "maxLength": 300
+                  },
+                  "sourceUrl": {
+                    "type": "string",
+                    "format": "uri",
+                    "maxLength": 300,
+                    "description": "Machine-readable status API URL if known."
+                  },
+                  "category": {
+                    "type": "string",
+                    "maxLength": 64
+                  },
+                  "priority": {
+                    "type": "string",
+                    "enum": [
+                      "low",
+                      "normal",
+                      "high",
+                      "urgent"
+                    ],
+                    "default": "normal"
+                  },
+                  "useCase": {
+                    "type": "string",
+                    "maxLength": 1000
+                  },
+                  "requestedBy": {
+                    "type": "string",
+                    "maxLength": 120
+                  },
+                  "contact": {
+                    "type": "string",
+                    "maxLength": 160
+                  }
+                },
+                "additionalProperties": true
+              },
+              "example": {
+                "name": "Railway",
+                "homepage": "https://railway.com",
+                "priority": "normal",
+                "useCase": "Official deploy status checks."
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Free route result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Suggestion accepted.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Invalid suggestion."
+          }
+        },
+        "tags": [
+          "status",
+          "suggestion",
+          "coverage-request",
+          "agent-feedback"
+        ]
+      }
+    },
+    "/api/inspect/x402": {
+      "post": {
+        "summary": "Check x402 payment metadata",
+        "operationId": "x402_inspector",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.01"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "url"
+                ],
+                "properties": {
+                  "url": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "method": {
+                    "type": "string",
+                    "enum": [
+                      "GET",
+                      "HEAD",
+                      "POST"
+                    ],
+                    "default": "GET"
+                  },
+                  "headers": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "body": {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  "timeoutMs": {
+                    "type": "integer",
+                    "minimum": 500,
+                    "maximum": 8000,
+                    "default": 5000
+                  }
+                },
+                "additionalProperties": false
+              },
+              "example": {
+                "url": "https://example.com/api/paid"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Utility result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        }
+      }
+    },
+    "/api/status/check": {
+      "post": {
+        "summary": "Check one official status source",
+        "operationId": "official_status_check",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "service"
+                ],
+                "properties": {
+                  "service": {
+                    "type": "string",
+                    "description": "Service id from /api/status/catalog, for example github or gitlab."
+                  },
+                  "includeComponents": {
+                    "type": "boolean",
+                    "default": true
+                  },
+                  "includeIncidentDetails": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Optional deep incident history/timeline fetch. For Status.io providers this parses the public history page; for Statuspage providers it uses /api/v2/incidents.json."
+                  },
+                  "incidentLimit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 20,
+                    "default": 5,
+                    "description": "Maximum recent incidents to return when includeIncidentDetails is true."
+                  },
+                  "component": {
+                    "type": "string",
+                    "description": "Optional component selector, alias, id, or name. For Anthropic examples: api, code, console, claude-ai, cowork, government."
+                  },
+                  "components": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "maxItems": 12,
+                    "description": "Optional component selectors when the caller wants a scoped provider status."
+                  }
+                },
+                "additionalProperties": false
+              },
+              "example": {
+                "service": "github",
+                "includeComponents": true
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Utility result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        }
+      }
+    },
+    "/api/status/bundle": {
+      "post": {
+        "summary": "Check deploy readiness services",
+        "operationId": "status_bundle_check",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.005"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "bundle": {
+                    "type": "string",
+                    "enum": [
+                      "vibe-deploy-readiness",
+                      "ai-app-stack",
+                      "source-and-ci",
+                      "deploy-platforms",
+                      "all"
+                    ],
+                    "default": "vibe-deploy-readiness"
+                  },
+                  "services": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "minItems": 1,
+                    "maxItems": 20,
+                    "description": "Optional explicit service ids from /api/status/catalog."
+                  },
+                  "includeComponents": {
+                    "type": "boolean",
+                    "default": false
+                  }
+                },
+                "additionalProperties": false
+              },
+              "example": {
+                "bundle": "vibe-deploy-readiness",
+                "includeComponents": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Utility result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        }
+      }
+    },
+    "/api/status/stack": {
+      "post": {
+        "summary": "Check a custom service stack",
+        "operationId": "status_stack_bundle",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.005"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "services"
+                ],
+                "properties": {
+                  "services": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "minItems": 3,
+                    "maxItems": 20,
+                    "description": "Service ids from /api/status/catalog. Stack pricing requires at least three stack roles and no repeated capped layer, for example one data layer and one deploy host."
+                  },
+                  "includeComponents": {
+                    "type": "boolean",
+                    "default": false
+                  }
+                },
+                "additionalProperties": false
+              },
+              "example": {
+                "services": [
+                  "github",
+                  "npm",
+                  "vercel",
+                  "supabase",
+                  "openai"
+                ],
+                "includeComponents": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Utility result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        }
+      }
+    },
+    "/api/status/github": {
+      "post": {
+        "summary": "Check GitHub status before retrying",
+        "operationId": "official_status_github",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "includeComponents": {
+                    "type": "boolean",
+                    "default": true
+                  },
+                  "includeIncidentDetails": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Optional deep incident history/timeline fetch. For Status.io providers this parses the public history page; for Statuspage providers it uses /api/v2/incidents.json."
+                  },
+                  "incidentLimit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 20,
+                    "default": 5,
+                    "description": "Maximum recent incidents to return when includeIncidentDetails is true."
+                  },
+                  "component": {
+                    "type": "string",
+                    "description": "Optional component selector, alias, id, or name. For Anthropic examples: api, code, console, claude-ai, cowork, government."
+                  },
+                  "components": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "maxItems": 12,
+                    "description": "Optional component selectors when the caller wants a scoped provider status."
+                  }
+                },
+                "additionalProperties": false
+              },
+              "example": {
+                "includeComponents": true
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Utility result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        }
+      }
+    },
+    "/api/status/gitlab": {
+      "post": {
+        "summary": "Check GitLab.com status before retrying",
+        "operationId": "official_status_gitlab",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "includeComponents": {
+                    "type": "boolean",
+                    "default": true
+                  },
+                  "includeIncidentDetails": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Optional deep incident history/timeline fetch. For Status.io providers this parses the public history page; for Statuspage providers it uses /api/v2/incidents.json."
+                  },
+                  "incidentLimit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 20,
+                    "default": 5,
+                    "description": "Maximum recent incidents to return when includeIncidentDetails is true."
+                  },
+                  "component": {
+                    "type": "string",
+                    "description": "Optional component selector, alias, id, or name. For Anthropic examples: api, code, console, claude-ai, cowork, government."
+                  },
+                  "components": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "maxItems": 12,
+                    "description": "Optional component selectors when the caller wants a scoped provider status."
+                  }
+                },
+                "additionalProperties": false
+              },
+              "example": {
+                "includeComponents": true
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Utility result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        }
+      }
+    },
+    "/api/status/bitbucket": {
+      "post": {
+        "summary": "Check Bitbucket status before retrying",
+        "operationId": "official_status_bitbucket",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "includeComponents": {
+                    "type": "boolean",
+                    "default": true
+                  },
+                  "includeIncidentDetails": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Optional deep incident history/timeline fetch. For Status.io providers this parses the public history page; for Statuspage providers it uses /api/v2/incidents.json."
+                  },
+                  "incidentLimit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 20,
+                    "default": 5,
+                    "description": "Maximum recent incidents to return when includeIncidentDetails is true."
+                  },
+                  "component": {
+                    "type": "string",
+                    "description": "Optional component selector, alias, id, or name. For Anthropic examples: api, code, console, claude-ai, cowork, government."
+                  },
+                  "components": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "maxItems": 12,
+                    "description": "Optional component selectors when the caller wants a scoped provider status."
+                  }
+                },
+                "additionalProperties": false
+              },
+              "example": {
+                "includeComponents": true
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Utility result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        }
+      }
+    },
+    "/api/status/npm": {
+      "post": {
+        "summary": "Check npm status before retrying",
+        "operationId": "official_status_npm",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "includeComponents": {
+                    "type": "boolean",
+                    "default": true
+                  },
+                  "includeIncidentDetails": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Optional deep incident history/timeline fetch. For Status.io providers this parses the public history page; for Statuspage providers it uses /api/v2/incidents.json."
+                  },
+                  "incidentLimit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 20,
+                    "default": 5,
+                    "description": "Maximum recent incidents to return when includeIncidentDetails is true."
+                  },
+                  "component": {
+                    "type": "string",
+                    "description": "Optional component selector, alias, id, or name. For Anthropic examples: api, code, console, claude-ai, cowork, government."
+                  },
+                  "components": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "maxItems": 12,
+                    "description": "Optional component selectors when the caller wants a scoped provider status."
+                  }
+                },
+                "additionalProperties": false
+              },
+              "example": {
+                "includeComponents": true
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Utility result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        }
+      }
+    },
+    "/api/status/vercel": {
+      "post": {
+        "summary": "Check Vercel status before retrying",
+        "operationId": "official_status_vercel",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "includeComponents": {
+                    "type": "boolean",
+                    "default": true
+                  },
+                  "includeIncidentDetails": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Optional deep incident history/timeline fetch. For Status.io providers this parses the public history page; for Statuspage providers it uses /api/v2/incidents.json."
+                  },
+                  "incidentLimit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 20,
+                    "default": 5,
+                    "description": "Maximum recent incidents to return when includeIncidentDetails is true."
+                  },
+                  "component": {
+                    "type": "string",
+                    "description": "Optional component selector, alias, id, or name. For Anthropic examples: api, code, console, claude-ai, cowork, government."
+                  },
+                  "components": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "maxItems": 12,
+                    "description": "Optional component selectors when the caller wants a scoped provider status."
+                  }
+                },
+                "additionalProperties": false
+              },
+              "example": {
+                "includeComponents": true
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Utility result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        }
+      }
+    },
+    "/api/status/netlify": {
+      "post": {
+        "summary": "Check Netlify status before retrying",
+        "operationId": "official_status_netlify",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "includeComponents": {
+                    "type": "boolean",
+                    "default": true
+                  },
+                  "includeIncidentDetails": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Optional deep incident history/timeline fetch. For Status.io providers this parses the public history page; for Statuspage providers it uses /api/v2/incidents.json."
+                  },
+                  "incidentLimit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 20,
+                    "default": 5,
+                    "description": "Maximum recent incidents to return when includeIncidentDetails is true."
+                  },
+                  "component": {
+                    "type": "string",
+                    "description": "Optional component selector, alias, id, or name. For Anthropic examples: api, code, console, claude-ai, cowork, government."
+                  },
+                  "components": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "maxItems": 12,
+                    "description": "Optional component selectors when the caller wants a scoped provider status."
+                  }
+                },
+                "additionalProperties": false
+              },
+              "example": {
+                "includeComponents": true
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Utility result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        }
+      }
+    },
+    "/api/status/render": {
+      "post": {
+        "summary": "Check Render status before retrying",
+        "operationId": "official_status_render",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "includeComponents": {
+                    "type": "boolean",
+                    "default": true
+                  },
+                  "includeIncidentDetails": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Optional deep incident history/timeline fetch. For Status.io providers this parses the public history page; for Statuspage providers it uses /api/v2/incidents.json."
+                  },
+                  "incidentLimit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 20,
+                    "default": 5,
+                    "description": "Maximum recent incidents to return when includeIncidentDetails is true."
+                  },
+                  "component": {
+                    "type": "string",
+                    "description": "Optional component selector, alias, id, or name. For Anthropic examples: api, code, console, claude-ai, cowork, government."
+                  },
+                  "components": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "maxItems": 12,
+                    "description": "Optional component selectors when the caller wants a scoped provider status."
+                  }
+                },
+                "additionalProperties": false
+              },
+              "example": {
+                "includeComponents": true
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Utility result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        }
+      }
+    },
+    "/api/status/fly": {
+      "post": {
+        "summary": "Check Fly.io status before retrying",
+        "operationId": "official_status_fly",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "includeComponents": {
+                    "type": "boolean",
+                    "default": true
+                  },
+                  "includeIncidentDetails": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Optional deep incident history/timeline fetch. For Status.io providers this parses the public history page; for Statuspage providers it uses /api/v2/incidents.json."
+                  },
+                  "incidentLimit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 20,
+                    "default": 5,
+                    "description": "Maximum recent incidents to return when includeIncidentDetails is true."
+                  },
+                  "component": {
+                    "type": "string",
+                    "description": "Optional component selector, alias, id, or name. For Anthropic examples: api, code, console, claude-ai, cowork, government."
+                  },
+                  "components": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "maxItems": 12,
+                    "description": "Optional component selectors when the caller wants a scoped provider status."
+                  }
+                },
+                "additionalProperties": false
+              },
+              "example": {
+                "includeComponents": true
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Utility result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        }
+      }
+    },
+    "/api/status/coinbase": {
+      "post": {
+        "summary": "Check Coinbase status before retrying",
+        "operationId": "official_status_coinbase",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "includeComponents": {
+                    "type": "boolean",
+                    "default": true
+                  },
+                  "includeIncidentDetails": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Optional deep incident history/timeline fetch. For Status.io providers this parses the public history page; for Statuspage providers it uses /api/v2/incidents.json."
+                  },
+                  "incidentLimit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 20,
+                    "default": 5,
+                    "description": "Maximum recent incidents to return when includeIncidentDetails is true."
+                  },
+                  "component": {
+                    "type": "string",
+                    "description": "Optional component selector, alias, id, or name. For Anthropic examples: api, code, console, claude-ai, cowork, government."
+                  },
+                  "components": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "maxItems": 12,
+                    "description": "Optional component selectors when the caller wants a scoped provider status."
+                  }
+                },
+                "additionalProperties": false
+              },
+              "example": {
+                "includeComponents": true
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Utility result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        }
+      }
+    },
+    "/api/status/cursor": {
+      "post": {
+        "summary": "Check Cursor status before retrying",
+        "operationId": "official_status_cursor",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "includeComponents": {
+                    "type": "boolean",
+                    "default": true
+                  },
+                  "includeIncidentDetails": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Optional deep incident history/timeline fetch. For Status.io providers this parses the public history page; for Statuspage providers it uses /api/v2/incidents.json."
+                  },
+                  "incidentLimit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 20,
+                    "default": 5,
+                    "description": "Maximum recent incidents to return when includeIncidentDetails is true."
+                  },
+                  "component": {
+                    "type": "string",
+                    "description": "Optional component selector, alias, id, or name. For Anthropic examples: api, code, console, claude-ai, cowork, government."
+                  },
+                  "components": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "maxItems": 12,
+                    "description": "Optional component selectors when the caller wants a scoped provider status."
+                  }
+                },
+                "additionalProperties": false
+              },
+              "example": {
+                "includeComponents": true
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Utility result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        }
+      }
+    },
+    "/api/status/bambulab": {
+      "post": {
+        "summary": "Check Bambu Lab status before retrying",
+        "operationId": "official_status_bambulab",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "includeComponents": {
+                    "type": "boolean",
+                    "default": true
+                  },
+                  "includeIncidentDetails": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Optional deep incident history/timeline fetch. For Status.io providers this parses the public history page; for Statuspage providers it uses /api/v2/incidents.json."
+                  },
+                  "incidentLimit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 20,
+                    "default": 5,
+                    "description": "Maximum recent incidents to return when includeIncidentDetails is true."
+                  },
+                  "component": {
+                    "type": "string",
+                    "description": "Optional component selector, alias, id, or name. For Anthropic examples: api, code, console, claude-ai, cowork, government."
+                  },
+                  "components": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "maxItems": 12,
+                    "description": "Optional component selectors when the caller wants a scoped provider status."
+                  }
+                },
+                "additionalProperties": false
+              },
+              "example": {
+                "includeComponents": true
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Utility result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        }
+      }
+    },
+    "/api/status/ring": {
+      "post": {
+        "summary": "Check Ring status before retrying",
+        "operationId": "official_status_ring",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "includeComponents": {
+                    "type": "boolean",
+                    "default": true
+                  },
+                  "includeIncidentDetails": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Optional deep incident history/timeline fetch. For Status.io providers this parses the public history page; for Statuspage providers it uses /api/v2/incidents.json."
+                  },
+                  "incidentLimit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 20,
+                    "default": 5,
+                    "description": "Maximum recent incidents to return when includeIncidentDetails is true."
+                  },
+                  "component": {
+                    "type": "string",
+                    "description": "Optional component selector, alias, id, or name. For Anthropic examples: api, code, console, claude-ai, cowork, government."
+                  },
+                  "components": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "maxItems": 12,
+                    "description": "Optional component selectors when the caller wants a scoped provider status."
+                  }
+                },
+                "additionalProperties": false
+              },
+              "example": {
+                "includeComponents": true
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Utility result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        }
+      }
+    },
+    "/api/status/cloudflare": {
+      "post": {
+        "summary": "Check Cloudflare status before retrying",
+        "operationId": "official_status_cloudflare",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "includeComponents": {
+                    "type": "boolean",
+                    "default": true
+                  },
+                  "includeIncidentDetails": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Optional deep incident history/timeline fetch. For Status.io providers this parses the public history page; for Statuspage providers it uses /api/v2/incidents.json."
+                  },
+                  "incidentLimit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 20,
+                    "default": 5,
+                    "description": "Maximum recent incidents to return when includeIncidentDetails is true."
+                  },
+                  "component": {
+                    "type": "string",
+                    "description": "Optional component selector, alias, id, or name. For Anthropic examples: api, code, console, claude-ai, cowork, government."
+                  },
+                  "components": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "maxItems": 12,
+                    "description": "Optional component selectors when the caller wants a scoped provider status."
+                  }
+                },
+                "additionalProperties": false
+              },
+              "example": {
+                "includeComponents": true
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Utility result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        }
+      }
+    },
+    "/api/status/supabase": {
+      "post": {
+        "summary": "Check Supabase status before retrying",
+        "operationId": "official_status_supabase",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "includeComponents": {
+                    "type": "boolean",
+                    "default": true
+                  },
+                  "includeIncidentDetails": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Optional deep incident history/timeline fetch. For Status.io providers this parses the public history page; for Statuspage providers it uses /api/v2/incidents.json."
+                  },
+                  "incidentLimit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 20,
+                    "default": 5,
+                    "description": "Maximum recent incidents to return when includeIncidentDetails is true."
+                  },
+                  "component": {
+                    "type": "string",
+                    "description": "Optional component selector, alias, id, or name. For Anthropic examples: api, code, console, claude-ai, cowork, government."
+                  },
+                  "components": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "maxItems": 12,
+                    "description": "Optional component selectors when the caller wants a scoped provider status."
+                  }
+                },
+                "additionalProperties": false
+              },
+              "example": {
+                "includeComponents": true
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Utility result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        }
+      }
+    },
+    "/api/status/convex": {
+      "post": {
+        "summary": "Check Convex status before retrying",
+        "operationId": "official_status_convex",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "includeComponents": {
+                    "type": "boolean",
+                    "default": true
+                  },
+                  "includeIncidentDetails": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Optional deep incident history/timeline fetch. For Status.io providers this parses the public history page; for Statuspage providers it uses /api/v2/incidents.json."
+                  },
+                  "incidentLimit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 20,
+                    "default": 5,
+                    "description": "Maximum recent incidents to return when includeIncidentDetails is true."
+                  },
+                  "component": {
+                    "type": "string",
+                    "description": "Optional component selector, alias, id, or name. For Anthropic examples: api, code, console, claude-ai, cowork, government."
+                  },
+                  "components": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "maxItems": 12,
+                    "description": "Optional component selectors when the caller wants a scoped provider status."
+                  }
+                },
+                "additionalProperties": false
+              },
+              "example": {
+                "includeComponents": true
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Utility result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        }
+      }
+    },
+    "/api/status/clerk": {
+      "post": {
+        "summary": "Check Clerk status before retrying",
+        "operationId": "official_status_clerk",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "includeComponents": {
+                    "type": "boolean",
+                    "default": true
+                  },
+                  "includeIncidentDetails": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Optional deep incident history/timeline fetch. For Status.io providers this parses the public history page; for Statuspage providers it uses /api/v2/incidents.json."
+                  },
+                  "incidentLimit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 20,
+                    "default": 5,
+                    "description": "Maximum recent incidents to return when includeIncidentDetails is true."
+                  },
+                  "component": {
+                    "type": "string",
+                    "description": "Optional component selector, alias, id, or name. For Anthropic examples: api, code, console, claude-ai, cowork, government."
+                  },
+                  "components": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "maxItems": 12,
+                    "description": "Optional component selectors when the caller wants a scoped provider status."
+                  }
+                },
+                "additionalProperties": false
+              },
+              "example": {
+                "includeComponents": true
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Utility result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        }
+      }
+    },
+    "/api/status/openai": {
+      "post": {
+        "summary": "Check OpenAI status before retrying",
+        "operationId": "official_status_openai",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "includeComponents": {
+                    "type": "boolean",
+                    "default": true
+                  },
+                  "includeIncidentDetails": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Optional deep incident history/timeline fetch. For Status.io providers this parses the public history page; for Statuspage providers it uses /api/v2/incidents.json."
+                  },
+                  "incidentLimit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 20,
+                    "default": 5,
+                    "description": "Maximum recent incidents to return when includeIncidentDetails is true."
+                  },
+                  "component": {
+                    "type": "string",
+                    "description": "Optional component selector, alias, id, or name. For Anthropic examples: api, code, console, claude-ai, cowork, government."
+                  },
+                  "components": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "maxItems": 12,
+                    "description": "Optional component selectors when the caller wants a scoped provider status."
+                  }
+                },
+                "additionalProperties": false
+              },
+              "example": {
+                "includeComponents": true
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Utility result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        }
+      }
+    },
+    "/api/status/anthropic": {
+      "post": {
+        "summary": "Check Anthropic Claude status before retrying",
+        "operationId": "official_status_anthropic",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "includeComponents": {
+                    "type": "boolean",
+                    "default": true
+                  },
+                  "includeIncidentDetails": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Optional deep incident history/timeline fetch. For Status.io providers this parses the public history page; for Statuspage providers it uses /api/v2/incidents.json."
+                  },
+                  "incidentLimit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 20,
+                    "default": 5,
+                    "description": "Maximum recent incidents to return when includeIncidentDetails is true."
+                  },
+                  "component": {
+                    "type": "string",
+                    "description": "Optional component selector, alias, id, or name. For Anthropic examples: api, code, console, claude-ai, cowork, government."
+                  },
+                  "components": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "maxItems": 12,
+                    "description": "Optional component selectors when the caller wants a scoped provider status."
+                  }
+                },
+                "additionalProperties": false
+              },
+              "example": {
+                "includeComponents": true
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Utility result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        }
+      }
+    },
+    "/api/check/domain": {
+      "post": {
+        "summary": "Check DNS and email launch basics",
+        "operationId": "domain_launch_check",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.02"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "domain"
+                ],
+                "properties": {
+                  "domain": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Domain name to inspect, without a URL scheme."
+                  },
+                  "dkimSelectors": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "maxItems": 10,
+                    "description": "Optional DKIM selectors to check, such as google or selector1."
+                  }
+                },
+                "additionalProperties": false
+              },
+              "example": {
+                "domain": "example.com",
+                "dkimSelectors": [
+                  "google",
+                  "selector1"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Utility result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        }
+      }
+    },
+    "/api/artifacts": {
+      "post": {
+        "summary": "Create a temporary hosted artifact",
+        "operationId": "hosted_artifact",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.01"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "kind",
+                  "content"
+                ],
+                "properties": {
+                  "kind": {
+                    "type": "string",
+                    "enum": [
+                      "text",
+                      "json",
+                      "svg",
+                      "redirect"
+                    ]
+                  },
+                  "content": {
+                    "description": "Artifact body. Use a string for text, SVG, and redirects, or any JSON value when kind is json."
+                  },
+                  "contentType": {
+                    "type": "string",
+                    "description": "Optional MIME type override."
+                  },
+                  "ttlSeconds": {
+                    "type": "integer",
+                    "minimum": 60,
+                    "maximum": 604800,
+                    "default": 86400,
+                    "description": "Artifact lifetime in seconds."
+                  },
+                  "filename": {
+                    "type": "string",
+                    "maxLength": 120,
+                    "description": "Optional display filename."
+                  }
+                },
+                "additionalProperties": false
+              },
+              "example": {
+                "kind": "json",
+                "content": {
+                  "ok": true,
+                  "message": "hello agent"
+                },
+                "ttlSeconds": 3600
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Utility result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "artifactUrl",
+                    "expiresAt"
+                  ],
+                  "properties": {
+                    "artifactUrl": {
+                      "type": "string",
+                      "format": "uri"
+                    },
+                    "expiresAt": {
+                      "type": "string",
+                      "format": "date-time"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        }
+      }
+    },
+    "/api/audit/agent-launch": {
+      "post": {
+        "summary": "Check agent launch readiness",
+        "operationId": "agent_launch_audit",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.03"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "url"
+                ],
+                "properties": {
+                  "url": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "siteType": {
+                    "type": "string",
+                    "enum": [
+                      "all",
+                      "content",
+                      "api"
+                    ],
+                    "default": "all"
+                  },
+                  "includeEvidence": {
+                    "type": "boolean",
+                    "default": true
+                  }
+                },
+                "additionalProperties": false
+              },
+              "example": {
+                "url": "https://example.com",
+                "siteType": "all",
+                "includeEvidence": true
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Utility result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        }
+      }
+    },
+    "/api/check/agent-discoverability": {
+      "post": {
+        "summary": "Check agent discoverability signals",
+        "operationId": "agent_discoverability_check",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.01"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "url"
+                ],
+                "properties": {
+                  "url": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "includeEvidence": {
+                    "type": "boolean",
+                    "default": true
+                  }
+                },
+                "additionalProperties": false
+              },
+              "example": {
+                "url": "https://example.com",
+                "includeEvidence": true
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Utility result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        }
+      }
+    },
+    "/api/check/agent-protocols": {
+      "post": {
+        "summary": "Check agent protocol metadata",
+        "operationId": "agent_protocol_check",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.02"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "url"
+                ],
+                "properties": {
+                  "url": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "includeEvidence": {
+                    "type": "boolean",
+                    "default": true
+                  }
+                },
+                "additionalProperties": false
+              },
+              "example": {
+                "url": "https://example.com",
+                "includeEvidence": true
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Utility result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        }
+      }
+    },
+    "/api/check/agent-commerce": {
+      "post": {
+        "summary": "Check agent commerce metadata",
+        "operationId": "agent_commerce_check",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.01"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "url"
+                ],
+                "properties": {
+                  "url": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "includeEvidence": {
+                    "type": "boolean",
+                    "default": true
+                  }
+                },
+                "additionalProperties": false
+              },
+              "example": {
+                "url": "https://example.com",
+                "includeEvidence": true
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Utility result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        }
+      }
+    },
+    "/api/audit/agent-batch": {
+      "post": {
+        "summary": "Check agent readiness for URLs",
+        "operationId": "agent_readiness_batch",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.05"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "urls"
+                ],
+                "properties": {
+                  "urls": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "format": "uri"
+                    },
+                    "minItems": 1,
+                    "maxItems": 5
+                  },
+                  "scope": {
+                    "type": "string",
+                    "enum": [
+                      "all",
+                      "discoverability",
+                      "protocols",
+                      "commerce"
+                    ],
+                    "default": "all"
+                  },
+                  "includeEvidence": {
+                    "type": "boolean",
+                    "default": false
+                  }
+                },
+                "additionalProperties": false
+              },
+              "example": {
+                "urls": [
+                  "https://example.com",
+                  "https://example.org"
+                ],
+                "scope": "all",
+                "includeEvidence": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Utility result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        }
+      }
+    },
+    "/api/badge/agent-ready": {
+      "post": {
+        "summary": "Generate an agent-ready badge",
+        "operationId": "agent_ready_badge",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.01"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "url"
+                ],
+                "properties": {
+                  "url": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "scope": {
+                    "type": "string",
+                    "enum": [
+                      "all",
+                      "discoverability",
+                      "protocols",
+                      "commerce"
+                    ],
+                    "default": "all"
+                  },
+                  "includeEvidence": {
+                    "type": "boolean",
+                    "default": false
+                  }
+                },
+                "additionalProperties": false
+              },
+              "example": {
+                "url": "https://example.com",
+                "scope": "all",
+                "includeEvidence": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Utility result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        }
+      }
+    },
+    "/api/package/x402-directory": {
+      "post": {
+        "summary": "Create x402 directory listing data",
+        "operationId": "x402_directory_pack",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.01"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "url"
+                ],
+                "properties": {
+                  "url": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "name": {
+                    "type": "string",
+                    "maxLength": 80
+                  },
+                  "tags": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "maxItems": 12
+                  }
+                },
+                "additionalProperties": false
+              },
+              "example": {
+                "url": "https://example.com",
+                "name": "Example x402 API",
+                "tags": [
+                  "x402",
+                  "agents"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Utility result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "x402": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-PAYMENT",
+        "description": "Base64url-encoded x402 payment payload."
+      }
+    }
+  }
+}

--- a/providers/agentbodegastore/agentbodega/openapi.json
+++ b/providers/agentbodegastore/agentbodega/openapi.json
@@ -3,13 +3,13 @@
   "info": {
     "title": "AgentBodega",
     "version": "0.1.0",
-    "description": "Small x402-payable utility APIs for agents: endpoint inspection, launch checks, and hosted artifacts.",
+    "description": "AgentBodega provides pay-per-call data and utility APIs for agents across status monitoring, web search, public data, social research, media conversion, real-estate intelligence, agent readiness, and payment discovery. Paid endpoints accept USDC on Solana mainnet and Base through x402.",
     "contact": {
       "name": "AgentBodega",
       "email": "support@agentbodega.store",
       "url": "https://agentbodega.store"
     },
-    "x-guidance": "Start with GET /api/directory and GET /.well-known/x402 to inspect available services and prices. Use the $0.001 status endpoints for smoke tests, then call larger bundle or audit endpoints only after checking the live 402 challenge and spend cap."
+    "x-guidance": "Inspect GET /api/directory and GET /.well-known/x402 before spending. This committed registry snapshot covers all current paid routes; the live catalog URL remains the source for newly added routes and prices. Paid calls return an x402 v2 challenge accepting Solana mainnet USDC and Base USDC."
   },
   "servers": [
     {
@@ -19,11 +19,65 @@
   "x-discovery": {
     "tags": [
       "x402",
+      "mpp",
+      "payment-auth",
+      "l402",
+      "lightning",
       "agent-tools",
       "mcp-tools",
       "paid-utilities"
     ],
-    "endpointCount": 35
+    "endpointCount": 71,
+    "totalEndpointCount": 71,
+    "surface": {
+      "label": "Full Catalog",
+      "mode": "full",
+      "filters": {},
+      "routeCount": 81,
+      "paidRouteCount": 71,
+      "fullCatalog": "https://agentbodega.store/openapi.json"
+    },
+    "layout": {
+      "bodega": {
+        "id": "agentbodega",
+        "name": "AgentBodega"
+      },
+      "hierarchy": [
+        "department",
+        "aisle",
+        "shelf",
+        "offering"
+      ],
+      "requiredLevels": [
+        "department",
+        "aisle",
+        "offering"
+      ],
+      "optionalLevels": [
+        "shelf"
+      ],
+      "idFormat": "stable-slug",
+      "sourceOfTruth": "src/catalog/taxonomy.ts",
+      "taxonomyEndpoint": "/api/taxonomy",
+      "note": "AgentBodega is the single store root. Each offering carries stable department, aisle, optional shelf, and offering IDs; shelves are optional and only appear when they add useful grouping."
+    },
+    "payments": {
+      "x402": "https://agentbodega.store/.well-known/x402",
+      "mpp": "https://agentbodega.store/openapi.json",
+      "l402": "https://agentbodega.store/.well-known/l402-services"
+    },
+    "directory": "https://agentbodega.store/api/directory",
+    "taxonomy": "https://agentbodega.store/api/taxonomy",
+    "storefront": "https://agentbodega.store/api/storefront",
+    "registry": "https://agentbodega.store/registry/index.json",
+    "related": {
+      "fullDirectory": "https://agentbodega.store/api/directory",
+      "fullOpenapi": "https://agentbodega.store/openapi.json",
+      "summaryOpenapi": "https://agentbodega.store/openapi.summary.json",
+      "fullX402": "https://agentbodega.store/.well-known/x402",
+      "summaryX402": "https://agentbodega.store/.well-known/x402.summary.json",
+      "registry": "https://agentbodega.store/registry/index.json"
+    }
   },
   "paths": {
     "/api/directory": {
@@ -50,9 +104,633 @@
         }
       }
     },
+    "/api/proxies-sx/status": {
+      "get": {
+        "summary": "Fetch proxy egress support status",
+        "operationId": "get_proxies_sx_status",
+        "security": [],
+        "tags": [
+          "proxies-sx",
+          "egress",
+          "discovery"
+        ],
+        "responses": {
+          "200": {
+            "description": "Safe Proxies.sx capability metadata. Does not expose proxy credentials or runner internals.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/.well-known/l402-services": {
+      "get": {
+        "summary": "List L402/Lightning payable service metadata.",
+        "operationId": "list_l402_services",
+        "security": [],
+        "tags": [
+          "l402",
+          "lightning",
+          "payment",
+          "discovery"
+        ],
+        "responses": {
+          "200": {
+            "description": "L402 discovery companion document for AgentBodega paid endpoints.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/taxonomy": {
+      "get": {
+        "summary": "Fetch AgentBodega taxonomy decisions",
+        "operationId": "get_taxonomy",
+        "security": [],
+        "tags": [
+          "directory",
+          "taxonomy",
+          "discovery"
+        ],
+        "responses": {
+          "200": {
+            "description": "Stable department, aisle, optional shelf, and offering taxonomy for website and machine surfaces.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/storefront": {
+      "get": {
+        "summary": "Fetch homepage-ready AgentBodega storefront data",
+        "operationId": "get_storefront",
+        "security": [],
+        "tags": [
+          "directory",
+          "storefront",
+          "taxonomy",
+          "discovery"
+        ],
+        "responses": {
+          "200": {
+            "description": "Plug-and-play homepage data for redesigned web clients, including hero copy, metrics, department cards, quickstart copy, and taxonomy.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/route-intent": {
+      "post": {
+        "summary": "Find AgentBodega routes for an intent",
+        "description": "Purpose: Free bot-facing route selector. Accepts a plain-language goal, budget, output preference, and constraints, then returns the cheapest useful AgentBodega endpoints with required inputs, example requests, prices, and x402 handoff notes.\nBest use: Use this when an agent needs free bot-facing route selector. Accepts a plain-language goal, budget, output preference, and constraints, then returns the cheapest useful AgentBodega endpoints with required inputs, example requests, prices, and x402 handoff notes.\nPrice: free discovery or intake route; paid fulfillment, when needed, happens on the recommended x402 endpoint.\nFulfillment: Managed AgentBodega HTTP+JSON endpoint. Upstream provider details are intentionally not disclosed unless the response explicitly includes managed source metadata.\n\nInput: send a JSON request body.\nRequired fields: goal.\nOptional fields: budgetUsd, preferredOutput, constraints, maxResults, includeExamples.\n\nAccepted fields:\n- goal (required, string): Plain-language task or end goal, for example: check deploy dependencies before launch, summarize real estate listings, or find a weather forecast endpoint. Constraints: min length: 3; max length: 2000.\n- budgetUsd (optional, number): Optional maximum per-call price in USD for recommended paid endpoints. Constraints: min: 0; max: 10.\n- preferredOutput (optional, string): Optional desired output shape such as status JSON, cited answer, markdown, image URL, listing rows, or briefing. Constraints: max length: 120.\n- constraints (optional, array): Optional hard constraints, keywords, providers, departments, or exclusions the route selector should consider. Constraints: max items: 12.\n- maxResults (optional, integer): Maximum number of endpoint recommendations to return. Constraints: default: 5; min: 1; max: 10.\n- includeExamples (optional, boolean): Set false to omit example request bodies and output examples from recommendations. Constraints: default: true.\n\nExample request body:\n```json\n{\n  \"goal\": \"Find the cheapest AgentBodega route to check whether my deploy stack is healthy before retrying a failed launch.\",\n  \"budgetUsd\": 0.01,\n  \"preferredOutput\": \"status JSON\",\n  \"constraints\": [\n    \"GitHub\",\n    \"npm\",\n    \"Vercel\",\n    \"Cloudflare\"\n  ],\n  \"maxResults\": 4,\n  \"includeExamples\": true\n}\n```",
+        "operationId": "intent_router",
+        "security": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "goal"
+                ],
+                "properties": {
+                  "goal": {
+                    "type": "string",
+                    "minLength": 3,
+                    "maxLength": 2000,
+                    "description": "Plain-language task or end goal, for example: check deploy dependencies before launch, summarize real estate listings, or find a weather forecast endpoint."
+                  },
+                  "budgetUsd": {
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 10,
+                    "description": "Optional maximum per-call price in USD for recommended paid endpoints."
+                  },
+                  "preferredOutput": {
+                    "type": "string",
+                    "maxLength": 120,
+                    "description": "Optional desired output shape such as status JSON, cited answer, markdown, image URL, listing rows, or briefing."
+                  },
+                  "constraints": {
+                    "type": "array",
+                    "maxItems": 12,
+                    "items": {
+                      "type": "string",
+                      "maxLength": 160,
+                      "description": "Constraints item value for AgentBodega Intent Router. Constraints: max length: 160."
+                    },
+                    "description": "Optional hard constraints, keywords, providers, departments, or exclusions the route selector should consider."
+                  },
+                  "maxResults": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 10,
+                    "default": 5,
+                    "description": "Maximum number of endpoint recommendations to return."
+                  },
+                  "includeExamples": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Set false to omit example request bodies and output examples from recommendations."
+                  }
+                },
+                "additionalProperties": false
+              },
+              "example": {
+                "goal": "Find the cheapest AgentBodega route to check whether my deploy stack is healthy before retrying a failed launch.",
+                "budgetUsd": 0.01,
+                "preferredOutput": "status JSON",
+                "constraints": [
+                  "GitHub",
+                  "npm",
+                  "Vercel",
+                  "Cloudflare"
+                ],
+                "maxResults": 4,
+                "includeExamples": true
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Free route result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "requested",
+                    "recommendations",
+                    "discovery"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "requested": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "recommendations": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    },
+                    "cheapestUsefulPath": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "estimatedTotalUsd": {
+                      "type": "string"
+                    },
+                    "discovery": {
+                      "type": "object",
+                      "additionalProperties": true
+                    }
+                  },
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Suggestion accepted.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "requested",
+                    "recommendations",
+                    "discovery"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "requested": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "recommendations": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    },
+                    "cheapestUsefulPath": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "estimatedTotalUsd": {
+                      "type": "string"
+                    },
+                    "discovery": {
+                      "type": "object",
+                      "additionalProperties": true
+                    }
+                  },
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Invalid or missing AgentBodega key."
+          },
+          "422": {
+            "description": "Invalid input."
+          }
+        },
+        "tags": [
+          "intent-router",
+          "route-selection",
+          "catalog",
+          "discovery",
+          "agent-tools",
+          "x402"
+        ]
+      }
+    },
+    "/api/logicnodes/agent": {
+      "post": {
+        "summary": "Fetch AgentBodega discovery recommendations",
+        "description": "Purpose: Free JSON task endpoint for agent registries. Accepts a task description and returns matching AgentBodega resources, required inputs, examples, output shapes, prices, and x402 call instructions without executing paid calls.\nBest use: Use this when an agent needs free JSON task endpoint for agent registries. Accepts a task description and returns matching AgentBodega resources, required inputs, examples, output shapes, prices, and x402 call instructions without executing paid calls.\nPrice: free discovery or intake route; paid fulfillment, when needed, happens on the recommended x402 endpoint.\nFulfillment: Managed AgentBodega HTTP+JSON endpoint. Upstream provider details are intentionally not disclosed unless the response explicitly includes managed source metadata.\n\nInput: send a JSON request body.\nRequired fields: none.\nOptional fields: task, query, input, limit.\n\nAccepted fields:\n- task (optional, string): Plain-language request, for example: find status and cloud health APIs for deploy checks. Constraints: max length: 2000.\n- query (optional, string): Optional shorter search query. Used when task is omitted. Constraints: max length: 1000.\n- input (optional, object): Optional LogicNodes-style input object. task, query, prompt, and description are read if present.\n- limit (optional, integer): Maximum matching AgentBodega resources to return. Constraints: default: 5; min: 1; max: 10.\n\nExample request body:\n```json\n{\n  \"task\": \"Find AgentBodega APIs for deploy status, cloud health, and x402 readiness checks.\",\n  \"limit\": 5\n}\n```",
+        "operationId": "logicnodes_agent_discovery",
+        "security": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "task": {
+                    "type": "string",
+                    "maxLength": 2000,
+                    "description": "Plain-language request, for example: find status and cloud health APIs for deploy checks."
+                  },
+                  "query": {
+                    "type": "string",
+                    "maxLength": 1000,
+                    "description": "Optional shorter search query. Used when task is omitted."
+                  },
+                  "input": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "description": "Optional LogicNodes-style input object. task, query, prompt, and description are read if present."
+                  },
+                  "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 10,
+                    "default": 5,
+                    "description": "Maximum matching AgentBodega resources to return."
+                  }
+                },
+                "additionalProperties": true
+              },
+              "example": {
+                "task": "Find AgentBodega APIs for deploy status, cloud health, and x402 readiness checks.",
+                "limit": 5
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Free route result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "agent",
+                    "recommendations",
+                    "discovery"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "agent": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "recommendations": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    },
+                    "discovery": {
+                      "type": "object",
+                      "additionalProperties": true
+                    }
+                  },
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Suggestion accepted.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "agent",
+                    "recommendations",
+                    "discovery"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "agent": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "recommendations": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    },
+                    "discovery": {
+                      "type": "object",
+                      "additionalProperties": true
+                    }
+                  },
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Invalid or missing AgentBodega key."
+          },
+          "422": {
+            "description": "Invalid input."
+          }
+        },
+        "tags": [
+          "agent-registry",
+          "logicnodes",
+          "discovery",
+          "x402",
+          "api-calls",
+          "catalog"
+        ]
+      }
+    },
+    "/api/referrals/catalog": {
+      "get": {
+        "summary": "Fetch AgentBodega referral program details",
+        "description": "Purpose: Return the free AgentBodega referral and wallet-bound discount policy, including headers agents can use before paid x402 calls.\nBest use: Use this when an agent needs return the free AgentBodega referral and wallet-bound discount policy, including headers agents can use before paid x402 calls.\nPrice: free discovery or intake route; paid fulfillment, when needed, happens on the recommended x402 endpoint.\nFulfillment: Managed AgentBodega HTTP+JSON endpoint. Upstream provider details are intentionally not disclosed unless the response explicitly includes managed source metadata.\n\nInput: send a JSON request body.\nRequired fields: none.\nOptional fields: none.\n\nExample request body:\n```json\n{}\n```",
+        "operationId": "referral_catalog",
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Free route result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "program",
+                    "offers",
+                    "antiAbuse"
+                  ],
+                  "properties": {
+                    "program": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "offers": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    },
+                    "antiAbuse": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Suggestion accepted.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "program",
+                    "offers",
+                    "antiAbuse"
+                  ],
+                  "properties": {
+                    "program": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "offers": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    },
+                    "antiAbuse": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Invalid or missing AgentBodega key."
+          },
+          "422": {
+            "description": "Invalid input."
+          }
+        },
+        "tags": [
+          "referral",
+          "discount",
+          "affiliate",
+          "growth",
+          "x402",
+          "agent-tools"
+        ]
+      }
+    },
+    "/api/referrals/claim": {
+      "post": {
+        "summary": "Create AgentBodega Referral Link",
+        "description": "Purpose: Validate a referrer Base/EVM wallet address and return copyable referral links and headers. The wallet address itself is the referral code.\nBest use: Use this when an agent needs validate a referrer Base/EVM wallet address and return copyable referral links and headers. The wallet address itself is the referral code.\nPrice: free discovery or intake route; paid fulfillment, when needed, happens on the recommended x402 endpoint.\nFulfillment: Managed AgentBodega HTTP+JSON endpoint. Upstream provider details are intentionally not disclosed unless the response explicitly includes managed source metadata.\n\nInput: send a JSON request body.\nRequired fields: referrerAddress.\nOptional fields: source.\n\nAccepted fields:\n- referrerAddress (required, string): Base/EVM wallet address that should receive any referral discount grant. Constraints: min length: 42; max length: 42.\n- source (optional, string): Optional campaign/source label for the link. Constraints: max length: 120.\n\nExample request body:\n```json\n{\n  \"referrerAddress\": \"0xe8799C2dedA78ECcEB329D1E8FE9F110bf55E4F8\",\n  \"source\": \"agent-readme\"\n}\n```",
+        "operationId": "referral_claim",
+        "security": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "referrerAddress"
+                ],
+                "properties": {
+                  "referrerAddress": {
+                    "type": "string",
+                    "minLength": 42,
+                    "maxLength": 42,
+                    "description": "Base/EVM wallet address that should receive any referral discount grant."
+                  },
+                  "source": {
+                    "type": "string",
+                    "maxLength": 120,
+                    "description": "Optional campaign/source label for the link."
+                  }
+                },
+                "additionalProperties": false
+              },
+              "example": {
+                "referrerAddress": "0xe8799C2dedA78ECcEB329D1E8FE9F110bf55E4F8",
+                "source": "agent-readme"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Free route result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "referrerAddress",
+                    "referral"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "referrerAddress": {
+                      "type": "string"
+                    },
+                    "referral": {
+                      "type": "object",
+                      "additionalProperties": true
+                    }
+                  },
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Suggestion accepted.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "referrerAddress",
+                    "referral"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "referrerAddress": {
+                      "type": "string"
+                    },
+                    "referral": {
+                      "type": "object",
+                      "additionalProperties": true
+                    }
+                  },
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Invalid or missing AgentBodega key."
+          },
+          "422": {
+            "description": "Invalid input."
+          }
+        },
+        "tags": [
+          "referral",
+          "discount",
+          "affiliate",
+          "wallet-bound",
+          "agent-tools"
+        ]
+      }
+    },
     "/api/status/suggest": {
       "post": {
         "summary": "Create official status coverage request",
+        "description": "Purpose: Submit a missing service or official status page for future coverage. The route is free and persists demand signals for review.\nBest use: Use this when an agent needs submit a missing service or official status page for future coverage. The route is free and persists demand signals for review.\nPrice: free discovery or intake route; paid fulfillment, when needed, happens on the recommended x402 endpoint.\nFulfillment: Managed AgentBodega HTTP+JSON endpoint. Upstream provider details are intentionally not disclosed unless the response explicitly includes managed source metadata.\n\nInput: send a JSON request body.\nRequired fields: name.\nOptional fields: homepage, domain, statusPage, sourceUrl, category, priority, useCase, requestedBy, contact.\n\nAccepted fields:\n- name (required, string): Service name, for example Stripe or Railway. Constraints: min length: 2; max length: 120.\n- homepage (optional, string): Homepage value for Suggest Official Status Coverage. Constraints: format: uri; max length: 300. Constraints: format: uri; max length: 300.\n- domain (optional, string): Plain domain if the homepage URL is not known. Constraints: max length: 253.\n- statusPage (optional, string): Status Page value for Suggest Official Status Coverage. Constraints: format: uri; max length: 300. Constraints: format: uri; max length: 300.\n- sourceUrl (optional, string): Machine-readable status API URL if known. Constraints: format: uri; max length: 300.\n- category (optional, string): Category value for Suggest Official Status Coverage. Constraints: max length: 64. Constraints: max length: 64.\n- priority (optional, string): Priority filter for Suggest Official Status Coverage. Accepted values: \"low\", \"normal\", \"high\", \"urgent\". Constraints: accepted values: \"low\", \"normal\", \"high\", \"urgent\"; default: \"normal\". Constraints: accepted values: \"low\", \"normal\", \"high\", \"urgent\"; default: \"normal\".\n- useCase (optional, string): Use Case value for Suggest Official Status Coverage. Constraints: max length: 1000. Constraints: max length: 1000.\n- requestedBy (optional, string): Requested By value for Suggest Official Status Coverage. Constraints: max length: 120. Constraints: max length: 120.\n- contact (optional, string): Contact value for Suggest Official Status Coverage. Constraints: max length: 160. Constraints: max length: 160.\n\nExample request body:\n```json\n{\n  \"name\": \"Linear\",\n  \"homepage\": \"https://linear.app\",\n  \"priority\": \"normal\",\n  \"useCase\": \"Official project-management status checks.\"\n}\n```",
         "operationId": "status_service_suggestion",
         "security": [],
         "requestBody": {
@@ -74,7 +752,8 @@
                   "homepage": {
                     "type": "string",
                     "format": "uri",
-                    "maxLength": 300
+                    "maxLength": 300,
+                    "description": "Homepage value for Suggest Official Status Coverage. Constraints: format: uri; max length: 300."
                   },
                   "domain": {
                     "type": "string",
@@ -84,7 +763,8 @@
                   "statusPage": {
                     "type": "string",
                     "format": "uri",
-                    "maxLength": 300
+                    "maxLength": 300,
+                    "description": "Status Page value for Suggest Official Status Coverage. Constraints: format: uri; max length: 300."
                   },
                   "sourceUrl": {
                     "type": "string",
@@ -94,7 +774,8 @@
                   },
                   "category": {
                     "type": "string",
-                    "maxLength": 64
+                    "maxLength": 64,
+                    "description": "Category value for Suggest Official Status Coverage. Constraints: max length: 64."
                   },
                   "priority": {
                     "type": "string",
@@ -104,28 +785,32 @@
                       "high",
                       "urgent"
                     ],
-                    "default": "normal"
+                    "default": "normal",
+                    "description": "Priority filter for Suggest Official Status Coverage. Accepted values: \"low\", \"normal\", \"high\", \"urgent\". Constraints: accepted values: \"low\", \"normal\", \"high\", \"urgent\"; default: \"normal\"."
                   },
                   "useCase": {
                     "type": "string",
-                    "maxLength": 1000
+                    "maxLength": 1000,
+                    "description": "Use Case value for Suggest Official Status Coverage. Constraints: max length: 1000."
                   },
                   "requestedBy": {
                     "type": "string",
-                    "maxLength": 120
+                    "maxLength": 120,
+                    "description": "Requested By value for Suggest Official Status Coverage. Constraints: max length: 120."
                   },
                   "contact": {
                     "type": "string",
-                    "maxLength": 160
+                    "maxLength": 160,
+                    "description": "Contact value for Suggest Official Status Coverage. Constraints: max length: 160."
                   }
                 },
                 "additionalProperties": true
               },
               "example": {
-                "name": "Railway",
-                "homepage": "https://railway.com",
+                "name": "Linear",
+                "homepage": "https://linear.app",
                 "priority": "normal",
-                "useCase": "Official deploy status checks."
+                "useCase": "Official project-management status checks."
               }
             }
           }
@@ -153,8 +838,11 @@
               }
             }
           },
+          "401": {
+            "description": "Invalid or missing AgentBodega key."
+          },
           "422": {
-            "description": "Invalid suggestion."
+            "description": "Invalid input."
           }
         },
         "tags": [
@@ -168,6 +856,7 @@
     "/api/inspect/x402": {
       "post": {
         "summary": "Check x402 payment metadata",
+        "description": "Purpose: Inspect a URL for x402 payment challenges, payable metadata, discovery links, OpenAPI, MCP, Agent Skills, and Bazaar-readiness signals.\nBest use: Use this when an agent needs inspect a URL for x402 payment challenges, payable metadata, discovery links, OpenAPI, MCP, Agent Skills, and Bazaar-readiness signals.\nPrice: $0.005 per successful paid call. Direct Base x402 authorization is verified before execution and settled only after successful fulfillment.\nFulfillment: Managed AgentBodega HTTP+JSON endpoint. Upstream provider details are intentionally not disclosed unless the response explicitly includes managed source metadata.\n\nInput: send a JSON request body.\nRequired fields: url.\nOptional fields: method, headers, body, timeoutMs.\n\nAccepted fields:\n- url (required, string): Url value for x402 Endpoint Inspector. Constraints: format: uri. Constraints: format: uri.\n- method (optional, string): Method filter for x402 Endpoint Inspector. Accepted values: \"GET\", \"HEAD\", \"POST\". Constraints: accepted values: \"GET\", \"HEAD\", \"POST\"; default: \"GET\". Constraints: accepted values: \"GET\", \"HEAD\", \"POST\"; default: \"GET\".\n- headers (optional, object): Headers object for configuring x402 Endpoint Inspector.\n- body (optional, object): Body object for configuring x402 Endpoint Inspector.\n- timeoutMs (optional, integer): Timeout Ms numeric value for x402 Endpoint Inspector. Constraints: default: 5000; min: 500; max: 8000. Constraints: default: 5000; min: 500; max: 8000.\n\nExample request body:\n```json\n{\n  \"url\": \"https://example.com/api/paid\"\n}\n```",
         "operationId": "x402_inspector",
         "security": [
           {
@@ -178,11 +867,25 @@
           "price": {
             "mode": "fixed",
             "currency": "USD",
-            "amount": "0.01"
+            "amount": "0.005"
           },
+          "pricingMode": "fixed",
           "protocols": [
             {
-              "x402": {}
+              "x402": {
+                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                "currency": "USDC",
+                "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "payTo": "4tWJRwNyhGr88QTiV2yzMoGsaxZiCSRDepf9JTdBEgyi"
+              }
+            },
+            {
+              "x402": {
+                "network": "eip155:8453",
+                "currency": "USDC",
+                "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                "payTo": "0xe8799C2dedA78ECcEB329D1E8FE9F110bf55E4F8"
+              }
             }
           ]
         },
@@ -198,7 +901,8 @@
                 "properties": {
                   "url": {
                     "type": "string",
-                    "format": "uri"
+                    "format": "uri",
+                    "description": "Url value for x402 Endpoint Inspector. Constraints: format: uri."
                   },
                   "method": {
                     "type": "string",
@@ -207,23 +911,27 @@
                       "HEAD",
                       "POST"
                     ],
-                    "default": "GET"
+                    "default": "GET",
+                    "description": "Method filter for x402 Endpoint Inspector. Accepted values: \"GET\", \"HEAD\", \"POST\". Constraints: accepted values: \"GET\", \"HEAD\", \"POST\"; default: \"GET\"."
                   },
                   "headers": {
                     "type": "object",
                     "additionalProperties": {
                       "type": "string"
-                    }
+                    },
+                    "description": "Headers object for configuring x402 Endpoint Inspector."
                   },
                   "body": {
                     "type": "object",
-                    "additionalProperties": true
+                    "additionalProperties": true,
+                    "description": "Body object for configuring x402 Endpoint Inspector."
                   },
                   "timeoutMs": {
                     "type": "integer",
                     "minimum": 500,
                     "maximum": 8000,
-                    "default": 5000
+                    "default": 5000,
+                    "description": "Timeout Ms numeric value for x402 Endpoint Inspector. Constraints: default: 5000; min: 500; max: 8000."
                   }
                 },
                 "additionalProperties": false
@@ -249,12 +957,8708 @@
           "402": {
             "description": "Payment Required"
           }
-        }
+        },
+        "tags": [
+          "x402",
+          "inspection",
+          "agent-tools",
+          "bazaar",
+          "openapi"
+        ]
+      }
+    },
+    "/api/public-data/catalog": {
+      "post": {
+        "summary": "Get categorized Public Data department metadata",
+        "description": "Purpose: Return AgentBodega's Public Data department offerings grouped by category with full input/output schemas, prices, route paths, and workflow guidance.\nBest use: Use this when an agent needs return AgentBodega's Public Data department offerings grouped by category with full input/output schemas, prices, route paths, and workflow guidance.\nPrice: $0.005 per successful paid call. Direct Base x402 authorization is verified before execution and settled only after successful fulfillment.\nFulfillment: Managed AgentBodega HTTP+JSON endpoint. Upstream provider details are intentionally not disclosed unless the response explicitly includes managed source metadata.\n\nInput: send a JSON request body.\nRequired fields: none.\nOptional fields: query, category, name, includeSchemas, limit.\n\nAccepted fields:\n- query (optional, string): Optional text filter matched against endpoint name, title, category, description, tags, and path.\n- category (optional, string): Optional Public Data department/category to return. Constraints: accepted values: \"catalog\", \"workflow-bundles\", \"cached-results\", \"recurring-monitoring\", \"discovery-verification\", \"data-enrichment\", \"marketplace-listings\", \"real-estate-rentals\", \"ecommerce-products-reviews\", \"health-prices\", \"jobs-hiring\", \"facebook-data\", \"social-video-intelligence\", \"news\", \"public-records\".\n- name (optional, string): Optional exact endpoint name, such as osha-violations-scraper or marketplace-leads.\n- includeSchemas (optional, boolean): Include each endpoint's full input and output schemas. Constraints: default: true.\n- limit (optional, integer): Maximum number of endpoints to return after filters. Constraints: default: 28; min: 1; max: 50.\n\nExample request body:\n```json\n{\n  \"category\": \"public-records\",\n  \"includeSchemas\": true,\n  \"limit\": 10\n}\n```",
+        "operationId": "public_data_catalog",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.005"
+          },
+          "pricingMode": "fixed",
+          "protocols": [
+            {
+              "x402": {
+                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                "currency": "USDC",
+                "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "payTo": "4tWJRwNyhGr88QTiV2yzMoGsaxZiCSRDepf9JTdBEgyi"
+              }
+            },
+            {
+              "x402": {
+                "network": "eip155:8453",
+                "currency": "USDC",
+                "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                "payTo": "0xe8799C2dedA78ECcEB329D1E8FE9F110bf55E4F8"
+              }
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "query": {
+                    "type": "string",
+                    "description": "Optional text filter matched against endpoint name, title, category, description, tags, and path."
+                  },
+                  "category": {
+                    "type": "string",
+                    "enum": [
+                      "catalog",
+                      "workflow-bundles",
+                      "cached-results",
+                      "recurring-monitoring",
+                      "discovery-verification",
+                      "data-enrichment",
+                      "marketplace-listings",
+                      "real-estate-rentals",
+                      "ecommerce-products-reviews",
+                      "health-prices",
+                      "jobs-hiring",
+                      "facebook-data",
+                      "social-video-intelligence",
+                      "news",
+                      "public-records"
+                    ],
+                    "description": "Optional Public Data department/category to return."
+                  },
+                  "name": {
+                    "type": "string",
+                    "description": "Optional exact endpoint name, such as osha-violations-scraper or marketplace-leads."
+                  },
+                  "includeSchemas": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Include each endpoint's full input and output schemas."
+                  },
+                  "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 50,
+                    "default": 28,
+                    "description": "Maximum number of endpoints to return after filters."
+                  }
+                },
+                "additionalProperties": false
+              },
+              "example": {
+                "category": "public-records",
+                "includeSchemas": true,
+                "limit": 10
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Utility result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "department",
+                    "categories",
+                    "endpoints"
+                  ],
+                  "properties": {
+                    "department": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "categories": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    },
+                    "endpoints": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    }
+                  },
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "tags": [
+          "public-data-department",
+          "public-data",
+          "catalog",
+          "marketplace-listings",
+          "real-estate",
+          "ecommerce",
+          "facebook-data",
+          "jobs",
+          "public-records",
+          "x402"
+        ]
+      }
+    },
+    "/api/social-media/catalog": {
+      "post": {
+        "summary": "Get Social Media department metadata",
+        "description": "Purpose: Return AgentBodega's Social Media department: configured public social/video data routes plus available and staged coverage families for social, creator, video, audio, ad-library, and UGC research products.\nBest use: Use this when an agent needs return AgentBodega's Social Media department: configured public social/video data routes plus available and staged coverage families for social, creator, video, audio, ad-library, and UGC research products.\nPrice: $0.005 per successful paid call. Direct Base x402 authorization is verified before execution and settled only after successful fulfillment.\nFulfillment: Managed AgentBodega HTTP+JSON endpoint. Upstream provider details are intentionally not disclosed unless the response explicitly includes managed source metadata.\n\nInput: send a JSON request body.\nRequired fields: none.\nOptional fields: platform, query, includeSchemas, includeExternalPattern, includeCoverageMap, limit.\n\nAccepted fields:\n- platform (optional, string): Optional platform or product-family focus. Use x or twitter for X/Twitter, ugc for creator research, ads for ad-library intelligence, or all for the full Social Media department. Constraints: accepted values: \"all\", \"x\", \"twitter\", \"tiktok\", \"instagram\", \"facebook\", \"reddit\", \"youtube\", \"linkedin\", \"threads\", \"bluesky\", \"pinterest\", \"twitch\", \"snapchat\", \"github\", \"spotify\", \"soundcloud\", \"rumble\", \"truthsocial\", \"web\", \"amazon\", \"inference\", \"ads\", \"link-in-bio\", \"ugc\"; default: \"all\".\n- query (optional, string): Optional text filter matched against platform, endpoint title, category, description, tags, and X/Twitter use cases.\n- includeSchemas (optional, boolean): Include full schemas for configured AgentBodega social data endpoints. Constraints: default: true.\n- includeExternalPattern (optional, boolean): Include read-only X/Twitter product specs. Rows with configured false are staged and are not advertised as payable resources. Constraints: default: true.\n- includeCoverageMap (optional, boolean): Include white-labeled Social Media coverage families, including staged platform/product families that are not yet payable resources. Constraints: default: true.\n- limit (optional, integer): Maximum configured endpoints and pattern rows to return. Constraints: default: 20; min: 1; max: 50.\n\nExample request body:\n```json\n{\n  \"platform\": \"all\",\n  \"includeExternalPattern\": true,\n  \"includeCoverageMap\": true,\n  \"includeSchemas\": true,\n  \"limit\": 50\n}\n```",
+        "operationId": "social_media_catalog",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.005"
+          },
+          "pricingMode": "fixed",
+          "protocols": [
+            {
+              "x402": {
+                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                "currency": "USDC",
+                "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "payTo": "4tWJRwNyhGr88QTiV2yzMoGsaxZiCSRDepf9JTdBEgyi"
+              }
+            },
+            {
+              "x402": {
+                "network": "eip155:8453",
+                "currency": "USDC",
+                "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                "payTo": "0xe8799C2dedA78ECcEB329D1E8FE9F110bf55E4F8"
+              }
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "platform": {
+                    "type": "string",
+                    "enum": [
+                      "all",
+                      "x",
+                      "twitter",
+                      "tiktok",
+                      "instagram",
+                      "facebook",
+                      "reddit",
+                      "youtube",
+                      "linkedin",
+                      "threads",
+                      "bluesky",
+                      "pinterest",
+                      "twitch",
+                      "snapchat",
+                      "github",
+                      "spotify",
+                      "soundcloud",
+                      "rumble",
+                      "truthsocial",
+                      "web",
+                      "amazon",
+                      "inference",
+                      "ads",
+                      "link-in-bio",
+                      "ugc"
+                    ],
+                    "default": "all",
+                    "description": "Optional platform or product-family focus. Use x or twitter for X/Twitter, ugc for creator research, ads for ad-library intelligence, or all for the full Social Media department."
+                  },
+                  "query": {
+                    "type": "string",
+                    "description": "Optional text filter matched against platform, endpoint title, category, description, tags, and X/Twitter use cases."
+                  },
+                  "includeSchemas": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Include full schemas for configured AgentBodega social data endpoints."
+                  },
+                  "includeExternalPattern": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Include read-only X/Twitter product specs. Rows with configured false are staged and are not advertised as payable resources."
+                  },
+                  "includeCoverageMap": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Include white-labeled Social Media coverage families, including staged platform/product families that are not yet payable resources."
+                  },
+                  "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 50,
+                    "default": 20,
+                    "description": "Maximum configured endpoints and pattern rows to return."
+                  }
+                },
+                "additionalProperties": false
+              },
+              "example": {
+                "platform": "all",
+                "includeExternalPattern": true,
+                "includeCoverageMap": true,
+                "includeSchemas": true,
+                "limit": 50
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Utility result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "department",
+                    "endpoints",
+                    "xTwitterReadOnlyPattern",
+                    "socialCoveragePattern"
+                  ],
+                  "properties": {
+                    "department": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "endpoints": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    },
+                    "xTwitterReadOnlyPattern": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    },
+                    "socialCoveragePattern": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    },
+                    "categories": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    },
+                    "nextSteps": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "tags": [
+          "social-media",
+          "x",
+          "twitter",
+          "tiktok",
+          "facebook",
+          "instagram",
+          "reddit",
+          "youtube",
+          "linkedin",
+          "threads",
+          "bluesky",
+          "pinterest",
+          "twitch",
+          "spotify",
+          "ads",
+          "ugc",
+          "public-data",
+          "creator-research",
+          "social-listening"
+        ]
+      }
+    },
+    "/api/web/search": {
+      "post": {
+        "summary": "Search the web and return ranked current results",
+        "description": "Purpose: Search the public web and return normalized, source-neutral results with titles, URLs, domains, snippets, freshness controls, and strict result caps for agent research workflows.\nBest use: Use this when an agent needs search the public web and return normalized, source-neutral results with titles, URLs, domains, snippets, freshness controls, and strict result caps for agent research workflows.\nPrice: $0.005 per successful paid call. Direct Base x402 authorization is verified before execution and settled only after successful fulfillment.\nFulfillment: Managed AgentBodega HTTP+JSON endpoint. Upstream provider details are intentionally not disclosed unless the response explicitly includes managed source metadata.\n\nInput: send a JSON request body.\nRequired fields: query.\nOptional fields: limit, site, freshness, includeSnippets, timeoutMs.\n\nAccepted fields:\n- query (required, string): Natural-language search query or keyword query to run against public web results. Constraints: min length: 2; max length: 240.\n- limit (optional, integer): Maximum normalized results to return. Constraints: default: 5; min: 1; max: 10.\n- site (optional, string): Optional public domain scope, such as example.com. URL-like values are normalized to the hostname. Constraints: max length: 120.\n- freshness (optional, string): Optional freshness preference. Use any when recency is not required. Constraints: accepted values: \"any\", \"day\", \"week\", \"month\", \"year\"; default: \"any\".\n- includeSnippets (optional, boolean): Set false to omit result snippets and return titles, URLs, domains, and rank only. Constraints: default: true.\n- timeoutMs (optional, integer): Search timeout in milliseconds. Constraints: default: 6000; min: 1000; max: 10000.\n\nExample request body:\n```json\n{\n  \"query\": \"agent payment APIs\",\n  \"limit\": 5,\n  \"freshness\": \"any\",\n  \"includeSnippets\": true\n}\n```",
+        "operationId": "web_search",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.005"
+          },
+          "pricingMode": "fixed",
+          "protocols": [
+            {
+              "x402": {
+                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                "currency": "USDC",
+                "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "payTo": "4tWJRwNyhGr88QTiV2yzMoGsaxZiCSRDepf9JTdBEgyi"
+              }
+            },
+            {
+              "x402": {
+                "network": "eip155:8453",
+                "currency": "USDC",
+                "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                "payTo": "0xe8799C2dedA78ECcEB329D1E8FE9F110bf55E4F8"
+              }
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "query"
+                ],
+                "properties": {
+                  "query": {
+                    "type": "string",
+                    "minLength": 2,
+                    "maxLength": 240,
+                    "description": "Natural-language search query or keyword query to run against public web results."
+                  },
+                  "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 10,
+                    "default": 5,
+                    "description": "Maximum normalized results to return."
+                  },
+                  "site": {
+                    "type": "string",
+                    "maxLength": 120,
+                    "description": "Optional public domain scope, such as example.com. URL-like values are normalized to the hostname."
+                  },
+                  "freshness": {
+                    "type": "string",
+                    "enum": [
+                      "any",
+                      "day",
+                      "week",
+                      "month",
+                      "year"
+                    ],
+                    "default": "any",
+                    "description": "Optional freshness preference. Use any when recency is not required."
+                  },
+                  "includeSnippets": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Set false to omit result snippets and return titles, URLs, domains, and rank only."
+                  },
+                  "timeoutMs": {
+                    "type": "integer",
+                    "minimum": 1000,
+                    "maximum": 10000,
+                    "default": 6000,
+                    "description": "Search timeout in milliseconds."
+                  }
+                },
+                "additionalProperties": false
+              },
+              "example": {
+                "query": "agent payment APIs",
+                "limit": 5,
+                "freshness": "any",
+                "includeSnippets": true
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Utility result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "tool",
+                    "requested",
+                    "source",
+                    "search",
+                    "results",
+                    "limits"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "tool": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "requested": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "source": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "search": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "results": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    },
+                    "limits": {
+                      "type": "object",
+                      "additionalProperties": true
+                    }
+                  },
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "tags": [
+          "search-web",
+          "web",
+          "search",
+          "source-discovery",
+          "citations",
+          "research",
+          "x402"
+        ]
+      }
+    },
+    "/api/web/similar": {
+      "post": {
+        "summary": "Find web pages similar to a supplied URL",
+        "description": "Purpose: Find related pages, substitutes, competitor pages, or supporting sources from a topic, task, or public seed URL, with normalized source-neutral results and strict search/fetch caps.\nBest use: Use this when an agent needs find related pages, substitutes, competitor pages, or supporting sources from a topic, task, or public seed URL, with normalized source-neutral results and strict search/fetch caps.\nPrice: $0.005 per successful paid call. Direct Base x402 authorization is verified before execution and settled only after successful fulfillment.\nFulfillment: Managed AgentBodega HTTP+JSON endpoint. Upstream provider details are intentionally not disclosed unless the response explicitly includes managed source metadata.\n\nInput: send a JSON request body.\nRequired fields: query.\nOptional fields: url, intent, site, excludeDomains, limit, freshness, includeSnippets, timeoutMs.\n\nAccepted fields:\n- query (required, string): Topic, task, competitor name, or public HTTP/HTTPS URL used as the seed for finding similar pages. Constraints: min length: 2; max length: 240.\n- url (optional, string): Optional public HTTP or HTTPS seed URL. When present, AgentBodega fetches bounded metadata/text and derives the similarity query from the page. Constraints: format: uri.\n- intent (optional, string): Similarity mode. Related finds nearby pages, alternatives finds substitutes, competitors finds competing services, and sources finds supporting references. Constraints: accepted values: \"related\", \"alternatives\", \"competitors\", \"sources\"; default: \"related\".\n- site (optional, string): Optional public domain scope for the search, such as example.com. URL-like values are normalized to the hostname. Constraints: max length: 120.\n- excludeDomains (optional, array): Optional domains to omit from returned matches. The seed URL domain is omitted automatically. Constraints: max items: 10.\n- limit (optional, integer): Maximum similar pages to return. Constraints: default: 5; min: 1; max: 10.\n- freshness (optional, string): Optional freshness preference. Use any when recency is not required. Constraints: accepted values: \"any\", \"day\", \"week\", \"month\", \"year\"; default: \"any\".\n- includeSnippets (optional, boolean): Set false to omit snippets and return only titles, URLs, domains, ranks, and similarity reasons. Constraints: default: true.\n- timeoutMs (optional, integer): Search and optional seed-page fetch timeout in milliseconds. Constraints: default: 6000; min: 1000; max: 10000.\n\nExample request body:\n```json\n{\n  \"query\": \"x402 paid API marketplace\",\n  \"intent\": \"alternatives\",\n  \"limit\": 5,\n  \"freshness\": \"any\",\n  \"includeSnippets\": true\n}\n```",
+        "operationId": "web_similar",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.005"
+          },
+          "pricingMode": "fixed",
+          "protocols": [
+            {
+              "x402": {
+                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                "currency": "USDC",
+                "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "payTo": "4tWJRwNyhGr88QTiV2yzMoGsaxZiCSRDepf9JTdBEgyi"
+              }
+            },
+            {
+              "x402": {
+                "network": "eip155:8453",
+                "currency": "USDC",
+                "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                "payTo": "0xe8799C2dedA78ECcEB329D1E8FE9F110bf55E4F8"
+              }
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "query"
+                ],
+                "properties": {
+                  "query": {
+                    "type": "string",
+                    "minLength": 2,
+                    "maxLength": 240,
+                    "description": "Topic, task, competitor name, or public HTTP/HTTPS URL used as the seed for finding similar pages."
+                  },
+                  "url": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "Optional public HTTP or HTTPS seed URL. When present, AgentBodega fetches bounded metadata/text and derives the similarity query from the page."
+                  },
+                  "intent": {
+                    "type": "string",
+                    "enum": [
+                      "related",
+                      "alternatives",
+                      "competitors",
+                      "sources"
+                    ],
+                    "default": "related",
+                    "description": "Similarity mode. Related finds nearby pages, alternatives finds substitutes, competitors finds competing services, and sources finds supporting references."
+                  },
+                  "site": {
+                    "type": "string",
+                    "maxLength": 120,
+                    "description": "Optional public domain scope for the search, such as example.com. URL-like values are normalized to the hostname."
+                  },
+                  "excludeDomains": {
+                    "type": "array",
+                    "maxItems": 10,
+                    "items": {
+                      "type": "string",
+                      "maxLength": 120,
+                      "description": "Exclude Domains item value for Similar Page Finder. Constraints: max length: 120."
+                    },
+                    "description": "Optional domains to omit from returned matches. The seed URL domain is omitted automatically."
+                  },
+                  "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 10,
+                    "default": 5,
+                    "description": "Maximum similar pages to return."
+                  },
+                  "freshness": {
+                    "type": "string",
+                    "enum": [
+                      "any",
+                      "day",
+                      "week",
+                      "month",
+                      "year"
+                    ],
+                    "default": "any",
+                    "description": "Optional freshness preference. Use any when recency is not required."
+                  },
+                  "includeSnippets": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Set false to omit snippets and return only titles, URLs, domains, ranks, and similarity reasons."
+                  },
+                  "timeoutMs": {
+                    "type": "integer",
+                    "minimum": 1000,
+                    "maximum": 10000,
+                    "default": 6000,
+                    "description": "Search and optional seed-page fetch timeout in milliseconds."
+                  }
+                },
+                "additionalProperties": false
+              },
+              "example": {
+                "query": "x402 paid API marketplace",
+                "intent": "alternatives",
+                "limit": 5,
+                "freshness": "any",
+                "includeSnippets": true
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Utility result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "tool",
+                    "requested",
+                    "source",
+                    "seed",
+                    "similar",
+                    "limits"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "tool": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "requested": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "source": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "seed": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "similar": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    },
+                    "search": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "limits": {
+                      "type": "object",
+                      "additionalProperties": true
+                    }
+                  },
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "tags": [
+          "search-web",
+          "web",
+          "similar",
+          "related-pages",
+          "alternatives",
+          "competitor-research",
+          "source-discovery",
+          "research",
+          "x402"
+        ]
+      }
+    },
+    "/api/web/answer": {
+      "post": {
+        "summary": "Generate a sourced answer from current web results",
+        "description": "Purpose: Answer a public-web research question with cited source URLs, concise extractive evidence, confidence, source fetch status, and strict search/source caps.\nBest use: Use this when an agent needs answer a public-web research question with cited source URLs, concise extractive evidence, confidence, source fetch status, and strict search/source caps.\nPrice: $0.01 per successful paid call. Direct Base x402 authorization is verified before execution and settled only after successful fulfillment.\nFulfillment: Managed AgentBodega HTTP+JSON endpoint. Upstream provider details are intentionally not disclosed unless the response explicitly includes managed source metadata.\n\nInput: send a JSON request body.\nRequired fields: query.\nOptional fields: limit, maxSources, site, freshness, answerStyle, includeSourceText, timeoutMs.\n\nAccepted fields:\n- query (required, string): Question or research task to answer from public web results. Constraints: min length: 2; max length: 240.\n- limit (optional, integer): Maximum search results to inspect before building the answer. Constraints: default: 5; min: 1; max: 10.\n- maxSources (optional, integer): Maximum result pages to fetch and cite. Constraints: default: 3; min: 1; max: 5.\n- site (optional, string): Optional public domain scope, such as example.com. URL-like values are normalized to the hostname. Constraints: max length: 120.\n- freshness (optional, string): Optional freshness preference. Use any when recency is not required. Constraints: accepted values: \"any\", \"day\", \"week\", \"month\", \"year\"; default: \"any\".\n- answerStyle (optional, string): Brief returns a shorter answer; standard includes more evidence. Constraints: accepted values: \"brief\", \"standard\"; default: \"standard\".\n- includeSourceText (optional, boolean): Set true to include short source text excerpts used for the answer. Constraints: default: false.\n- timeoutMs (optional, integer): Search and source fetch timeout in milliseconds. Constraints: default: 6000; min: 1000; max: 10000.\n\nExample request body:\n```json\n{\n  \"query\": \"What are x402 paid APIs?\",\n  \"maxSources\": 3,\n  \"answerStyle\": \"standard\",\n  \"freshness\": \"any\"\n}\n```",
+        "operationId": "web_answer",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.01"
+          },
+          "pricingMode": "fixed",
+          "protocols": [
+            {
+              "x402": {
+                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                "currency": "USDC",
+                "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "payTo": "4tWJRwNyhGr88QTiV2yzMoGsaxZiCSRDepf9JTdBEgyi"
+              }
+            },
+            {
+              "x402": {
+                "network": "eip155:8453",
+                "currency": "USDC",
+                "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                "payTo": "0xe8799C2dedA78ECcEB329D1E8FE9F110bf55E4F8"
+              }
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "query"
+                ],
+                "properties": {
+                  "query": {
+                    "type": "string",
+                    "minLength": 2,
+                    "maxLength": 240,
+                    "description": "Question or research task to answer from public web results."
+                  },
+                  "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 10,
+                    "default": 5,
+                    "description": "Maximum search results to inspect before building the answer."
+                  },
+                  "maxSources": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 5,
+                    "default": 3,
+                    "description": "Maximum result pages to fetch and cite."
+                  },
+                  "site": {
+                    "type": "string",
+                    "maxLength": 120,
+                    "description": "Optional public domain scope, such as example.com. URL-like values are normalized to the hostname."
+                  },
+                  "freshness": {
+                    "type": "string",
+                    "enum": [
+                      "any",
+                      "day",
+                      "week",
+                      "month",
+                      "year"
+                    ],
+                    "default": "any",
+                    "description": "Optional freshness preference. Use any when recency is not required."
+                  },
+                  "answerStyle": {
+                    "type": "string",
+                    "enum": [
+                      "brief",
+                      "standard"
+                    ],
+                    "default": "standard",
+                    "description": "Brief returns a shorter answer; standard includes more evidence."
+                  },
+                  "includeSourceText": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Set true to include short source text excerpts used for the answer."
+                  },
+                  "timeoutMs": {
+                    "type": "integer",
+                    "minimum": 1000,
+                    "maximum": 10000,
+                    "default": 6000,
+                    "description": "Search and source fetch timeout in milliseconds."
+                  }
+                },
+                "additionalProperties": false
+              },
+              "example": {
+                "query": "What are x402 paid APIs?",
+                "maxSources": 3,
+                "answerStyle": "standard",
+                "freshness": "any"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Utility result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "tool",
+                    "requested",
+                    "source",
+                    "answer",
+                    "sources",
+                    "search",
+                    "limits"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "tool": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "requested": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "source": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "answer": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "sources": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    },
+                    "search": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "limits": {
+                      "type": "object",
+                      "additionalProperties": true
+                    }
+                  },
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "tags": [
+          "search-web",
+          "web",
+          "answer",
+          "citations",
+          "source-grounded",
+          "research",
+          "summary",
+          "x402"
+        ]
+      }
+    },
+    "/api/web/research-brief": {
+      "post": {
+        "summary": "Generate a sourced web research brief",
+        "description": "Purpose: Bundle public web search, capped source fetching, extractive summarization, and citations into one structured research brief for agents that need an answer plus supporting sources.\nBest use: Use this when an agent needs bundle public web search, capped source fetching, extractive summarization, and citations into one structured research brief for agents that need an answer plus supporting sources.\nPrice: $0.03 per successful paid call. Direct Base x402 authorization is verified before execution and settled only after successful fulfillment.\nFulfillment: Managed AgentBodega HTTP+JSON endpoint. Upstream provider details are intentionally not disclosed unless the response explicitly includes managed source metadata.\n\nInput: send a JSON request body.\nRequired fields: query.\nOptional fields: limit, maxSources, site, freshness, format, includeSourceText, timeoutMs.\n\nAccepted fields:\n- query (required, string): Research question, monitoring topic, competitor query, or decision prompt to investigate from public web sources. Constraints: min length: 2; max length: 240.\n- limit (optional, integer): Maximum public web results to inspect before selecting sources for the brief. Constraints: default: 8; min: 1; max: 10.\n- maxSources (optional, integer): Maximum result pages to fetch, cite, and use as evidence. Constraints: default: 5; min: 1; max: 5.\n- site (optional, string): Optional public domain scope, such as example.com. URL-like values are normalized to the hostname. Constraints: max length: 120.\n- freshness (optional, string): Optional freshness preference. Use day or week for current research and any for evergreen topics. Constraints: accepted values: \"any\", \"day\", \"week\", \"month\", \"year\"; default: \"any\".\n- format (optional, string): Output shape preference. Brief returns a compact narrative, bullets emphasizes extracted evidence, and json keeps sections highly structured. Constraints: accepted values: \"brief\", \"bullets\", \"json\"; default: \"brief\".\n- includeSourceText (optional, boolean): Set true to include short source text excerpts used for the brief. Constraints: default: false.\n- timeoutMs (optional, integer): Search and source fetch timeout in milliseconds. Constraints: default: 6000; min: 1000; max: 10000.\n\nExample request body:\n```json\n{\n  \"query\": \"best x402 paid API discovery surfaces for agents\",\n  \"limit\": 8,\n  \"maxSources\": 5,\n  \"freshness\": \"week\",\n  \"format\": \"brief\"\n}\n```",
+        "operationId": "web_research_brief",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.03"
+          },
+          "pricingMode": "fixed",
+          "protocols": [
+            {
+              "x402": {
+                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                "currency": "USDC",
+                "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "payTo": "4tWJRwNyhGr88QTiV2yzMoGsaxZiCSRDepf9JTdBEgyi"
+              }
+            },
+            {
+              "x402": {
+                "network": "eip155:8453",
+                "currency": "USDC",
+                "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                "payTo": "0xe8799C2dedA78ECcEB329D1E8FE9F110bf55E4F8"
+              }
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "query"
+                ],
+                "properties": {
+                  "query": {
+                    "type": "string",
+                    "minLength": 2,
+                    "maxLength": 240,
+                    "description": "Research question, monitoring topic, competitor query, or decision prompt to investigate from public web sources."
+                  },
+                  "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 10,
+                    "default": 8,
+                    "description": "Maximum public web results to inspect before selecting sources for the brief."
+                  },
+                  "maxSources": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 5,
+                    "default": 5,
+                    "description": "Maximum result pages to fetch, cite, and use as evidence."
+                  },
+                  "site": {
+                    "type": "string",
+                    "maxLength": 120,
+                    "description": "Optional public domain scope, such as example.com. URL-like values are normalized to the hostname."
+                  },
+                  "freshness": {
+                    "type": "string",
+                    "enum": [
+                      "any",
+                      "day",
+                      "week",
+                      "month",
+                      "year"
+                    ],
+                    "default": "any",
+                    "description": "Optional freshness preference. Use day or week for current research and any for evergreen topics."
+                  },
+                  "format": {
+                    "type": "string",
+                    "enum": [
+                      "brief",
+                      "bullets",
+                      "json"
+                    ],
+                    "default": "brief",
+                    "description": "Output shape preference. Brief returns a compact narrative, bullets emphasizes extracted evidence, and json keeps sections highly structured."
+                  },
+                  "includeSourceText": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Set true to include short source text excerpts used for the brief."
+                  },
+                  "timeoutMs": {
+                    "type": "integer",
+                    "minimum": 1000,
+                    "maximum": 10000,
+                    "default": 6000,
+                    "description": "Search and source fetch timeout in milliseconds."
+                  }
+                },
+                "additionalProperties": false
+              },
+              "example": {
+                "query": "best x402 paid API discovery surfaces for agents",
+                "limit": 8,
+                "maxSources": 5,
+                "freshness": "week",
+                "format": "brief"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Utility result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "tool",
+                    "requested",
+                    "source",
+                    "brief",
+                    "citations",
+                    "sources",
+                    "search",
+                    "limits"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "tool": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "requested": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "source": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "brief": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "citations": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    },
+                    "sources": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    },
+                    "search": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "limits": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "providerMessage": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "tags": [
+          "search-web",
+          "web",
+          "research-brief",
+          "citations",
+          "source-grounded",
+          "summary",
+          "decision-support",
+          "x402"
+        ]
+      }
+    },
+    "/api/developer/jwt/inspect": {
+      "post": {
+        "summary": "Fetch decoded JWT claims and validation metadata",
+        "description": "Purpose: Decode one compact JWT without requiring a secret and return normalized header, claim timing, issuer and audience checks, signature presence, warnings, and safe debugging guidance for agent and API workflows.\nBest use: Use this when an agent needs decode one compact JWT without requiring a secret and return normalized header, claim timing, issuer and audience checks, signature presence, warnings, and safe debugging guidance for agent and API workflows.\nPrice: $0.005 per successful paid call. Direct Base x402 authorization is verified before execution and settled only after successful fulfillment.\nFulfillment: Managed AgentBodega HTTP+JSON endpoint. Upstream provider details are intentionally not disclosed unless the response explicitly includes managed source metadata.\n\nInput: send a JSON request body.\nRequired fields: token.\nOptional fields: expectedIssuer, expectedAudience, now, includeRaw.\n\nAccepted fields:\n- token (required, string): Compact JWT string with three dot-separated Base64URL segments. Constraints: min length: 20; max length: 8192.\n- expectedIssuer (optional, string): Optional issuer value to compare with the token iss claim. Constraints: max length: 300.\n- expectedAudience (optional, string): Optional audience value to compare with the token aud claim. Constraints: max length: 300.\n- now (optional, integer): Optional Unix timestamp in seconds for exp, nbf, and iat checks. Defaults to current time. Constraints: min: 0.\n- includeRaw (optional, boolean): Set true to include the raw header and payload objects. The signature is never returned. Constraints: default: false.\n\nExample request body:\n```json\n{\n  \"token\": \"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL2lzc3Vlci5leGFtcGxlIiwiYXVkIjoiYWdlbnQtYXBpIiwic3ViIjoidXNlcl8xMjMiLCJleHAiOjE4OTM0NTYwMDAsImlhdCI6MTcwNDA2NzIwMH0.signature\",\n  \"expectedIssuer\": \"https://issuer.example\",\n  \"expectedAudience\": \"agent-api\",\n  \"includeRaw\": false\n}\n```",
+        "operationId": "jwt_inspector",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.005"
+          },
+          "pricingMode": "fixed",
+          "protocols": [
+            {
+              "x402": {
+                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                "currency": "USDC",
+                "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "payTo": "4tWJRwNyhGr88QTiV2yzMoGsaxZiCSRDepf9JTdBEgyi"
+              }
+            },
+            {
+              "x402": {
+                "network": "eip155:8453",
+                "currency": "USDC",
+                "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                "payTo": "0xe8799C2dedA78ECcEB329D1E8FE9F110bf55E4F8"
+              }
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "token"
+                ],
+                "properties": {
+                  "token": {
+                    "type": "string",
+                    "minLength": 20,
+                    "maxLength": 8192,
+                    "description": "Compact JWT string with three dot-separated Base64URL segments."
+                  },
+                  "expectedIssuer": {
+                    "type": "string",
+                    "maxLength": 300,
+                    "description": "Optional issuer value to compare with the token iss claim."
+                  },
+                  "expectedAudience": {
+                    "type": "string",
+                    "maxLength": 300,
+                    "description": "Optional audience value to compare with the token aud claim."
+                  },
+                  "now": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Optional Unix timestamp in seconds for exp, nbf, and iat checks. Defaults to current time."
+                  },
+                  "includeRaw": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Set true to include the raw header and payload objects. The signature is never returned."
+                  }
+                },
+                "additionalProperties": false
+              },
+              "example": {
+                "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL2lzc3Vlci5leGFtcGxlIiwiYXVkIjoiYWdlbnQtYXBpIiwic3ViIjoidXNlcl8xMjMiLCJleHAiOjE4OTM0NTYwMDAsImlhdCI6MTcwNDA2NzIwMH0.signature",
+                "expectedIssuer": "https://issuer.example",
+                "expectedAudience": "agent-api",
+                "includeRaw": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Utility result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "tool",
+                    "requested",
+                    "token",
+                    "header",
+                    "claims",
+                    "checks",
+                    "warnings",
+                    "limits"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "tool": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "requested": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "token": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "header": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "claims": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "checks": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "warnings": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "limits": {
+                      "type": "object",
+                      "additionalProperties": true
+                    }
+                  },
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "tags": [
+          "developer-utilities",
+          "jwt",
+          "auth-debug",
+          "token-inspection",
+          "api-debug",
+          "security",
+          "x402"
+        ]
+      }
+    },
+    "/api/developer/webhook/debug": {
+      "post": {
+        "summary": "Fetch webhook request and signature diagnostics",
+        "description": "Purpose: Inspect one webhook delivery payload with normalized headers, JSON parsing, safe redaction, timestamp replay-window checks, optional HMAC signature verification, warnings, and compact debugging guidance.\nBest use: Use this when an agent needs inspect one webhook delivery payload with normalized headers, JSON parsing, safe redaction, timestamp replay-window checks, optional HMAC signature verification, warnings, and compact debugging guidance.\nPrice: $0.005 per successful paid call. Direct Base x402 authorization is verified before execution and settled only after successful fulfillment.\nFulfillment: Managed AgentBodega HTTP+JSON endpoint. Upstream provider details are intentionally not disclosed unless the response explicitly includes managed source metadata.\n\nInput: send a JSON request body.\nRequired fields: headers, body.\nOptional fields: method, url, expectedContentType, signatureHeader, signatureSecret, signatureAlgorithm, timestampHeader, timestampToleranceSeconds, redactFields, includeBody.\n\nAccepted fields:\n- method (optional, string): HTTP method used by the webhook delivery. Constraints: accepted values: \"POST\", \"PUT\", \"PATCH\", \"DELETE\", \"GET\"; default: \"POST\".\n- url (optional, string): Optional public destination URL or callback URL to include in the debugging report. Constraints: format: uri; max length: 500.\n- headers (required, object): Webhook headers as received. Header names are normalized case-insensitively and values are capped before analysis.\n- body (required, any): Webhook request body as a string or JSON object. Objects are canonicalized before hashing and parsing.\n- expectedContentType (optional, string): Optional content type expectation, such as application/json. Constraints: max length: 120.\n- signatureHeader (optional, string): Optional header name that contains the webhook signature, for example x-hub-signature-256 or stripe-signature. Constraints: max length: 120.\n- signatureSecret (optional, string): Optional shared secret for HMAC verification. The secret is used only for this run and is not returned. Constraints: max length: 512.\n- signatureAlgorithm (optional, string): HMAC algorithm used when signatureSecret and signatureHeader are supplied. Constraints: accepted values: \"sha256\", \"sha1\", \"sha512\"; default: \"sha256\".\n- timestampHeader (optional, string): Optional header name that contains a delivery timestamp, used for replay-window checks. Constraints: max length: 120.\n- timestampToleranceSeconds (optional, integer): Allowed absolute timestamp age in seconds when timestampHeader is supplied. Constraints: default: 300; min: 1; max: 86400.\n- redactFields (optional, array): Case-insensitive JSON field names to redact before returning parsed body details. Constraints: max items: 20.\n- includeBody (optional, boolean): Set true to include a capped, redacted body excerpt in the response. Constraints: default: false.\n\nExample request body:\n```json\n{\n  \"method\": \"POST\",\n  \"url\": \"https://api.example.com/webhooks/orders\",\n  \"headers\": {\n    \"content-type\": \"application/json\",\n    \"x-event-type\": \"order.created\",\n    \"x-delivery-id\": \"evt_123\",\n    \"x-signature\": \"sha256=example\"\n  },\n  \"body\": {\n    \"id\": \"evt_123\",\n    \"type\": \"order.created\",\n    \"data\": {\n      \"orderId\": \"ord_123\",\n      \"amount\": 4900,\n      \"customerEmail\": \"buyer@example.com\"\n    }\n  },\n  \"expectedContentType\": \"application/json\",\n  \"signatureHeader\": \"x-signature\",\n  \"signatureAlgorithm\": \"sha256\",\n  \"timestampHeader\": \"x-webhook-timestamp\",\n  \"redactFields\": [\n    \"customerEmail\"\n  ],\n  \"includeBody\": false\n}\n```",
+        "operationId": "webhook_debugger",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.005"
+          },
+          "pricingMode": "fixed",
+          "protocols": [
+            {
+              "x402": {
+                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                "currency": "USDC",
+                "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "payTo": "4tWJRwNyhGr88QTiV2yzMoGsaxZiCSRDepf9JTdBEgyi"
+              }
+            },
+            {
+              "x402": {
+                "network": "eip155:8453",
+                "currency": "USDC",
+                "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                "payTo": "0xe8799C2dedA78ECcEB329D1E8FE9F110bf55E4F8"
+              }
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "headers",
+                  "body"
+                ],
+                "properties": {
+                  "method": {
+                    "type": "string",
+                    "enum": [
+                      "POST",
+                      "PUT",
+                      "PATCH",
+                      "DELETE",
+                      "GET"
+                    ],
+                    "default": "POST",
+                    "description": "HTTP method used by the webhook delivery."
+                  },
+                  "url": {
+                    "type": "string",
+                    "format": "uri",
+                    "maxLength": 500,
+                    "description": "Optional public destination URL or callback URL to include in the debugging report."
+                  },
+                  "headers": {
+                    "type": "object",
+                    "description": "Webhook headers as received. Header names are normalized case-insensitively and values are capped before analysis.",
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "maxProperties": 64
+                  },
+                  "body": {
+                    "description": "Webhook request body as a string or JSON object. Objects are canonicalized before hashing and parsing.",
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "maxLength": 16384
+                      },
+                      {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    ]
+                  },
+                  "expectedContentType": {
+                    "type": "string",
+                    "maxLength": 120,
+                    "description": "Optional content type expectation, such as application/json."
+                  },
+                  "signatureHeader": {
+                    "type": "string",
+                    "maxLength": 120,
+                    "description": "Optional header name that contains the webhook signature, for example x-hub-signature-256 or stripe-signature."
+                  },
+                  "signatureSecret": {
+                    "type": "string",
+                    "maxLength": 512,
+                    "description": "Optional shared secret for HMAC verification. The secret is used only for this run and is not returned."
+                  },
+                  "signatureAlgorithm": {
+                    "type": "string",
+                    "enum": [
+                      "sha256",
+                      "sha1",
+                      "sha512"
+                    ],
+                    "default": "sha256",
+                    "description": "HMAC algorithm used when signatureSecret and signatureHeader are supplied."
+                  },
+                  "timestampHeader": {
+                    "type": "string",
+                    "maxLength": 120,
+                    "description": "Optional header name that contains a delivery timestamp, used for replay-window checks."
+                  },
+                  "timestampToleranceSeconds": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 86400,
+                    "default": 300,
+                    "description": "Allowed absolute timestamp age in seconds when timestampHeader is supplied."
+                  },
+                  "redactFields": {
+                    "type": "array",
+                    "description": "Case-insensitive JSON field names to redact before returning parsed body details.",
+                    "maxItems": 20,
+                    "items": {
+                      "type": "string",
+                      "maxLength": 80,
+                      "description": "Redact Fields item value for Webhook Debugger. Constraints: max length: 80."
+                    }
+                  },
+                  "includeBody": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Set true to include a capped, redacted body excerpt in the response."
+                  }
+                },
+                "additionalProperties": false
+              },
+              "example": {
+                "method": "POST",
+                "url": "https://api.example.com/webhooks/orders",
+                "headers": {
+                  "content-type": "application/json",
+                  "x-event-type": "order.created",
+                  "x-delivery-id": "evt_123",
+                  "x-signature": "sha256=example"
+                },
+                "body": {
+                  "id": "evt_123",
+                  "type": "order.created",
+                  "data": {
+                    "orderId": "ord_123",
+                    "amount": 4900,
+                    "customerEmail": "buyer@example.com"
+                  }
+                },
+                "expectedContentType": "application/json",
+                "signatureHeader": "x-signature",
+                "signatureAlgorithm": "sha256",
+                "timestampHeader": "x-webhook-timestamp",
+                "redactFields": [
+                  "customerEmail"
+                ],
+                "includeBody": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Utility result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "tool",
+                    "requested",
+                    "headers",
+                    "payload",
+                    "signature",
+                    "timestamp",
+                    "warnings",
+                    "limits"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "tool": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "requested": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "headers": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "payload": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "signature": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "timestamp": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "warnings": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "limits": {
+                      "type": "object",
+                      "additionalProperties": true
+                    }
+                  },
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "tags": [
+          "developer-utilities",
+          "webhook",
+          "debug",
+          "hmac",
+          "signature",
+          "headers",
+          "json",
+          "api-debug",
+          "x402"
+        ]
+      }
+    },
+    "/api/web/fetch": {
+      "post": {
+        "summary": "Fetch a web page as clean structured content",
+        "description": "Purpose: Fetch one public URL and return normalized page metadata, cleaned text, markdown, links, status, content type, and extraction limits for agent workflows.\nBest use: Use this when an agent needs fetch one public URL and return normalized page metadata, cleaned text, markdown, links, status, content type, and extraction limits for agent workflows.\nPrice: $0.005 per successful paid call. Direct Base x402 authorization is verified before execution and settled only after successful fulfillment.\nFulfillment: Managed AgentBodega HTTP+JSON endpoint. Upstream provider details are intentionally not disclosed unless the response explicitly includes managed source metadata.\n\nInput: send a JSON request body.\nRequired fields: url.\nOptional fields: includeHtml, includeLinks, maxBytes, maxLinks, timeoutMs.\n\nAccepted fields:\n- url (required, string): Public HTTP or HTTPS URL to fetch. Local, private, and non-web schemes are rejected. Constraints: format: uri.\n- includeHtml (optional, boolean): Set true to return a truncated sanitized HTML excerpt. Constraints: default: false.\n- includeLinks (optional, boolean): Set true to extract normalized outbound and same-page links up to maxLinks. Constraints: default: true.\n- maxBytes (optional, integer): Maximum response body bytes to read before truncating extraction. Constraints: default: 32768; min: 1024; max: 65536.\n- maxLinks (optional, integer): Maximum links to return when includeLinks is true. Constraints: default: 20; min: 0; max: 50.\n- timeoutMs (optional, integer): Fetch timeout in milliseconds. Constraints: default: 5000; min: 1000; max: 10000.\n\nExample request body:\n```json\n{\n  \"url\": \"https://example.com\",\n  \"includeLinks\": true,\n  \"maxBytes\": 32768,\n  \"maxLinks\": 10\n}\n```",
+        "operationId": "web_fetch",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.005"
+          },
+          "pricingMode": "fixed",
+          "protocols": [
+            {
+              "x402": {
+                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                "currency": "USDC",
+                "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "payTo": "4tWJRwNyhGr88QTiV2yzMoGsaxZiCSRDepf9JTdBEgyi"
+              }
+            },
+            {
+              "x402": {
+                "network": "eip155:8453",
+                "currency": "USDC",
+                "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                "payTo": "0xe8799C2dedA78ECcEB329D1E8FE9F110bf55E4F8"
+              }
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "url"
+                ],
+                "properties": {
+                  "url": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "Public HTTP or HTTPS URL to fetch. Local, private, and non-web schemes are rejected."
+                  },
+                  "includeHtml": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Set true to return a truncated sanitized HTML excerpt."
+                  },
+                  "includeLinks": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Set true to extract normalized outbound and same-page links up to maxLinks."
+                  },
+                  "maxBytes": {
+                    "type": "integer",
+                    "minimum": 1024,
+                    "maximum": 65536,
+                    "default": 32768,
+                    "description": "Maximum response body bytes to read before truncating extraction."
+                  },
+                  "maxLinks": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 50,
+                    "default": 20,
+                    "description": "Maximum links to return when includeLinks is true."
+                  },
+                  "timeoutMs": {
+                    "type": "integer",
+                    "minimum": 1000,
+                    "maximum": 10000,
+                    "default": 5000,
+                    "description": "Fetch timeout in milliseconds."
+                  }
+                },
+                "additionalProperties": false
+              },
+              "example": {
+                "url": "https://example.com",
+                "includeLinks": true,
+                "maxBytes": 32768,
+                "maxLinks": 10
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Utility result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "tool",
+                    "requested",
+                    "fetched",
+                    "metadata",
+                    "text",
+                    "links",
+                    "limits"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "tool": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "requested": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "fetched": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "metadata": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "text": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "links": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    },
+                    "htmlExcerpt": {
+                      "type": "string"
+                    },
+                    "limits": {
+                      "type": "object",
+                      "additionalProperties": true
+                    }
+                  },
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "tags": [
+          "search-web",
+          "web",
+          "fetch",
+          "page-extraction",
+          "metadata",
+          "links",
+          "markdown",
+          "content-extraction",
+          "x402"
+        ]
+      }
+    },
+    "/api/search/link-preview": {
+      "post": {
+        "summary": "Fetch metadata and preview for a web link",
+        "description": "Purpose: Fetch one public URL and return compact source-neutral preview metadata: title, description, canonical URL, site name, type, image URL when present, and which HTML signals supplied each field.\nBest use: Use this when an agent needs fetch one public URL and return compact source-neutral preview metadata: title, description, canonical URL, site name, type, image URL when present, and which HTML signals supplied each field.\nPrice: $0.005 per successful paid call. Direct Base x402 authorization is verified before execution and settled only after successful fulfillment.\nFulfillment: Managed AgentBodega HTTP+JSON endpoint. Upstream provider details are intentionally not disclosed unless the response explicitly includes managed source metadata.\n\nInput: send a JSON request body.\nRequired fields: url.\nOptional fields: includeImage, maxBytes, timeoutMs.\n\nAccepted fields:\n- url (required, string): Public HTTP or HTTPS URL to preview. Local, private, credentialed, and non-web URLs are rejected. Constraints: format: uri.\n- includeImage (optional, boolean): Set false to omit preview image metadata while still returning title, description, and canonical URL. Constraints: default: true.\n- maxBytes (optional, integer): Maximum response body bytes to read while extracting preview tags. Constraints: default: 32768; min: 1024; max: 65536.\n- timeoutMs (optional, integer): Fetch timeout in milliseconds. Constraints: default: 5000; min: 1000; max: 10000.\n\nExample request body:\n```json\n{\n  \"url\": \"https://example.com\",\n  \"includeImage\": true,\n  \"maxBytes\": 32768\n}\n```",
+        "operationId": "link_preview",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.005"
+          },
+          "pricingMode": "fixed",
+          "protocols": [
+            {
+              "x402": {
+                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                "currency": "USDC",
+                "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "payTo": "4tWJRwNyhGr88QTiV2yzMoGsaxZiCSRDepf9JTdBEgyi"
+              }
+            },
+            {
+              "x402": {
+                "network": "eip155:8453",
+                "currency": "USDC",
+                "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                "payTo": "0xe8799C2dedA78ECcEB329D1E8FE9F110bf55E4F8"
+              }
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "url"
+                ],
+                "properties": {
+                  "url": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "Public HTTP or HTTPS URL to preview. Local, private, credentialed, and non-web URLs are rejected."
+                  },
+                  "includeImage": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Set false to omit preview image metadata while still returning title, description, and canonical URL."
+                  },
+                  "maxBytes": {
+                    "type": "integer",
+                    "minimum": 1024,
+                    "maximum": 65536,
+                    "default": 32768,
+                    "description": "Maximum response body bytes to read while extracting preview tags."
+                  },
+                  "timeoutMs": {
+                    "type": "integer",
+                    "minimum": 1000,
+                    "maximum": 10000,
+                    "default": 5000,
+                    "description": "Fetch timeout in milliseconds."
+                  }
+                },
+                "additionalProperties": false
+              },
+              "example": {
+                "url": "https://example.com",
+                "includeImage": true,
+                "maxBytes": 32768
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Utility result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "tool",
+                    "requested",
+                    "fetched",
+                    "preview",
+                    "signals",
+                    "limits"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "tool": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "requested": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "fetched": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "preview": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "signals": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "limits": {
+                      "type": "object",
+                      "additionalProperties": true
+                    }
+                  },
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "tags": [
+          "search-web",
+          "web",
+          "link-preview",
+          "open-graph",
+          "metadata",
+          "page-extraction",
+          "x402"
+        ]
+      }
+    },
+    "/api/documents/any-to-markdown": {
+      "post": {
+        "summary": "Convert one public URL to markdown",
+        "description": "Purpose: Convert one public URL into cleaned markdown with page metadata, normalized links, byte limits, truncation flags, and text statistics for RAG, notes, and agent content workflows.\nBest use: Use this when an agent needs convert one public URL into cleaned markdown with page metadata, normalized links, byte limits, truncation flags, and text statistics for RAG, notes, and agent content workflows.\nPrice: $0.01 per successful paid call. Direct Base x402 authorization is verified before execution and settled only after successful fulfillment.\nFulfillment: Managed AgentBodega HTTP+JSON endpoint. Upstream provider details are intentionally not disclosed unless the response explicitly includes managed source metadata.\n\nInput: send a JSON request body.\nRequired fields: url.\nOptional fields: includeLinks, maxBytes, maxLinks, timeoutMs.\n\nAccepted fields:\n- url (required, string): Public HTTP or HTTPS URL to convert into clean markdown. Local, private, and non-web schemes are rejected. Constraints: format: uri.\n- includeLinks (optional, boolean): Set true to include normalized links that were visible in the source content. Constraints: default: true.\n- maxBytes (optional, integer): Maximum response body bytes to read before truncating the markdown extraction. Constraints: default: 32768; min: 1024; max: 65536.\n- maxLinks (optional, integer): Maximum links to return when includeLinks is true. Constraints: default: 20; min: 0; max: 50.\n- timeoutMs (optional, integer): Fetch and extraction timeout in milliseconds. Constraints: default: 5000; min: 1000; max: 10000.\n\nExample request body:\n```json\n{\n  \"url\": \"https://example.com\",\n  \"includeLinks\": true,\n  \"maxBytes\": 32768,\n  \"maxLinks\": 10\n}\n```",
+        "operationId": "any_to_markdown",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.01"
+          },
+          "pricingMode": "fixed",
+          "protocols": [
+            {
+              "x402": {
+                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                "currency": "USDC",
+                "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "payTo": "4tWJRwNyhGr88QTiV2yzMoGsaxZiCSRDepf9JTdBEgyi"
+              }
+            },
+            {
+              "x402": {
+                "network": "eip155:8453",
+                "currency": "USDC",
+                "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                "payTo": "0xe8799C2dedA78ECcEB329D1E8FE9F110bf55E4F8"
+              }
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "url"
+                ],
+                "properties": {
+                  "url": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "Public HTTP or HTTPS URL to convert into clean markdown. Local, private, and non-web schemes are rejected."
+                  },
+                  "includeLinks": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Set true to include normalized links that were visible in the source content."
+                  },
+                  "maxBytes": {
+                    "type": "integer",
+                    "minimum": 1024,
+                    "maximum": 65536,
+                    "default": 32768,
+                    "description": "Maximum response body bytes to read before truncating the markdown extraction."
+                  },
+                  "maxLinks": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 50,
+                    "default": 20,
+                    "description": "Maximum links to return when includeLinks is true."
+                  },
+                  "timeoutMs": {
+                    "type": "integer",
+                    "minimum": 1000,
+                    "maximum": 10000,
+                    "default": 5000,
+                    "description": "Fetch and extraction timeout in milliseconds."
+                  }
+                },
+                "additionalProperties": false
+              },
+              "example": {
+                "url": "https://example.com",
+                "includeLinks": true,
+                "maxBytes": 32768,
+                "maxLinks": 10
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Utility result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "tool",
+                    "requested",
+                    "fetched",
+                    "metadata",
+                    "text",
+                    "links",
+                    "limits"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "tool": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "requested": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "fetched": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "metadata": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "text": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "links": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    },
+                    "limits": {
+                      "type": "object",
+                      "additionalProperties": true
+                    }
+                  },
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "tags": [
+          "documents-content",
+          "markdown",
+          "content-extraction",
+          "rag-prep",
+          "clean-text",
+          "links",
+          "metadata",
+          "x402"
+        ]
+      }
+    },
+    "/api/documents/rag-prep": {
+      "post": {
+        "summary": "Generate chunks for retrieval-augmented generation",
+        "description": "Purpose: Prepare one public URL or raw text payload for retrieval workflows with cleaned text, stable chunk IDs, overlap-aware chunks, token estimates, keyword hints, optional entity hints, JSONL or markdown formatting, and strict size caps.\nBest use: Use this when an agent needs prepare one public URL or raw text payload for retrieval workflows with cleaned text, stable chunk IDs, overlap-aware chunks, token estimates, keyword hints, optional entity hints, JSONL or markdown formatting, and strict size caps.\nPrice: $0.01 per successful paid call. Direct Base x402 authorization is verified before execution and settled only after successful fulfillment.\nFulfillment: Managed AgentBodega HTTP+JSON endpoint. Upstream provider details are intentionally not disclosed unless the response explicitly includes managed source metadata.\n\nInput: send a JSON request body.\nRequired fields: source.\nOptional fields: sourceType, chunkSizeChars, chunkOverlapChars, maxChunks, outputFormat, includeMarkdown, includeLinks, includeKeywords, includeEntities, artifactMode, maxBytes, maxLinks, timeoutMs.\n\nAccepted fields:\n- source (required, string): Required source to prepare for RAG. Pass a public HTTP/HTTPS URL when sourceType is url, or raw text when sourceType is text. Constraints: max length: 49152.\n- sourceType (optional, string): How to interpret source. auto treats HTTP/HTTPS strings as URLs and everything else as raw text. Constraints: accepted values: \"auto\", \"url\", \"text\"; default: \"auto\".\n- chunkSizeChars (optional, integer): Target maximum character count per chunk before overlap is applied. Constraints: default: 1200; min: 200; max: 3000.\n- chunkOverlapChars (optional, integer): Characters copied from the end of the previous chunk into the next chunk. Constraints: default: 120; min: 0; max: 1000.\n- maxChunks (optional, integer): Maximum number of chunks returned. Constraints: default: 50; min: 1; max: 100.\n- outputFormat (optional, string): Response format helper. json returns structured chunks; jsonl and markdown also include a formatted output string or artifact. Constraints: accepted values: \"json\", \"jsonl\", \"markdown\"; default: \"json\".\n- includeMarkdown (optional, boolean): For URL sources, include the extracted markdown when it fits the response caps. Constraints: default: true.\n- includeLinks (optional, boolean): For URL sources, include normalized links visible in the source content. Constraints: default: true.\n- includeKeywords (optional, boolean): Include lightweight frequency-based keyword hints. Constraints: default: true.\n- includeEntities (optional, boolean): Include simple capitalized-phrase entity hints. This is deterministic extraction, not LLM inference. Constraints: default: false.\n- artifactMode (optional, string): For jsonl or markdown output, auto creates a short-lived signed artifact when the formatted output is small enough for stateless artifact delivery. Constraints: accepted values: \"auto\", \"inline\", \"artifact\"; default: \"auto\".\n- maxBytes (optional, integer): For URL sources, maximum response body bytes to read before extraction is truncated. Constraints: default: 32768; min: 1024; max: 65536.\n- maxLinks (optional, integer): For URL sources, maximum links to return when includeLinks is true. Constraints: default: 20; min: 0; max: 50.\n- timeoutMs (optional, integer): For URL sources, fetch timeout in milliseconds. Constraints: default: 5000; min: 1000; max: 10000.\n\nExample request body:\n```json\n{\n  \"source\": \"https://example.com\",\n  \"sourceType\": \"url\",\n  \"chunkSizeChars\": 900,\n  \"chunkOverlapChars\": 100,\n  \"maxChunks\": 12,\n  \"outputFormat\": \"jsonl\",\n  \"includeLinks\": true,\n  \"includeKeywords\": true,\n  \"artifactMode\": \"auto\"\n}\n```",
+        "operationId": "rag_prep",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.01"
+          },
+          "pricingMode": "fixed",
+          "protocols": [
+            {
+              "x402": {
+                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                "currency": "USDC",
+                "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "payTo": "4tWJRwNyhGr88QTiV2yzMoGsaxZiCSRDepf9JTdBEgyi"
+              }
+            },
+            {
+              "x402": {
+                "network": "eip155:8453",
+                "currency": "USDC",
+                "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                "payTo": "0xe8799C2dedA78ECcEB329D1E8FE9F110bf55E4F8"
+              }
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "source"
+                ],
+                "properties": {
+                  "source": {
+                    "type": "string",
+                    "maxLength": 49152,
+                    "description": "Required source to prepare for RAG. Pass a public HTTP/HTTPS URL when sourceType is url, or raw text when sourceType is text."
+                  },
+                  "sourceType": {
+                    "type": "string",
+                    "enum": [
+                      "auto",
+                      "url",
+                      "text"
+                    ],
+                    "default": "auto",
+                    "description": "How to interpret source. auto treats HTTP/HTTPS strings as URLs and everything else as raw text."
+                  },
+                  "chunkSizeChars": {
+                    "type": "integer",
+                    "minimum": 200,
+                    "maximum": 3000,
+                    "default": 1200,
+                    "description": "Target maximum character count per chunk before overlap is applied."
+                  },
+                  "chunkOverlapChars": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 1000,
+                    "default": 120,
+                    "description": "Characters copied from the end of the previous chunk into the next chunk."
+                  },
+                  "maxChunks": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 100,
+                    "default": 50,
+                    "description": "Maximum number of chunks returned."
+                  },
+                  "outputFormat": {
+                    "type": "string",
+                    "enum": [
+                      "json",
+                      "jsonl",
+                      "markdown"
+                    ],
+                    "default": "json",
+                    "description": "Response format helper. json returns structured chunks; jsonl and markdown also include a formatted output string or artifact."
+                  },
+                  "includeMarkdown": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "For URL sources, include the extracted markdown when it fits the response caps."
+                  },
+                  "includeLinks": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "For URL sources, include normalized links visible in the source content."
+                  },
+                  "includeKeywords": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Include lightweight frequency-based keyword hints."
+                  },
+                  "includeEntities": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Include simple capitalized-phrase entity hints. This is deterministic extraction, not LLM inference."
+                  },
+                  "artifactMode": {
+                    "type": "string",
+                    "enum": [
+                      "auto",
+                      "inline",
+                      "artifact"
+                    ],
+                    "default": "auto",
+                    "description": "For jsonl or markdown output, auto creates a short-lived signed artifact when the formatted output is small enough for stateless artifact delivery."
+                  },
+                  "maxBytes": {
+                    "type": "integer",
+                    "minimum": 1024,
+                    "maximum": 65536,
+                    "default": 32768,
+                    "description": "For URL sources, maximum response body bytes to read before extraction is truncated."
+                  },
+                  "maxLinks": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 50,
+                    "default": 20,
+                    "description": "For URL sources, maximum links to return when includeLinks is true."
+                  },
+                  "timeoutMs": {
+                    "type": "integer",
+                    "minimum": 1000,
+                    "maximum": 10000,
+                    "default": 5000,
+                    "description": "For URL sources, fetch timeout in milliseconds."
+                  }
+                },
+                "additionalProperties": false
+              },
+              "example": {
+                "source": "https://example.com",
+                "sourceType": "url",
+                "chunkSizeChars": 900,
+                "chunkOverlapChars": 100,
+                "maxChunks": 12,
+                "outputFormat": "jsonl",
+                "includeLinks": true,
+                "includeKeywords": true,
+                "artifactMode": "auto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Utility result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "tool",
+                    "requested",
+                    "source",
+                    "document",
+                    "chunks",
+                    "limits"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "tool": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "requested": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "source": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "document": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "chunks": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    },
+                    "keywords": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    },
+                    "entities": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    },
+                    "output": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "limits": {
+                      "type": "object",
+                      "additionalProperties": true
+                    }
+                  },
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "tags": [
+          "documents-content",
+          "rag-prep",
+          "chunking",
+          "jsonl",
+          "markdown",
+          "clean-text",
+          "keywords",
+          "retrieval",
+          "x402"
+        ]
+      }
+    },
+    "/api/media/image/convert": {
+      "post": {
+        "summary": "Convert image files between supported formats",
+        "description": "Purpose: Create a short-lived signed download URL that converts one public image into JPG, PNG, WebP, or AVIF with capped size, fit, quality, and TTL controls. Useful for HEIC-to-JPG-style agent workflows without exposing backend media infrastructure.\nBest use: Use this when an agent needs create a short-lived signed download URL that converts one public image into JPG, PNG, WebP, or AVIF with capped size, fit, quality, and TTL controls. Useful for HEIC-to-JPG-style agent workflows without exposing backend media infrastructure.\nPrice: $0.01 per successful paid call. Direct Base x402 authorization is verified before execution and settled only after successful fulfillment.\nFulfillment: Managed AgentBodega HTTP+JSON endpoint. Upstream provider details are intentionally not disclosed unless the response explicitly includes managed source metadata.\n\nInput: send a JSON request body.\nRequired fields: imageUrl, targetFormat.\nOptional fields: width, height, fit, quality, background, filename, ttlSeconds.\n\nAccepted fields:\n- imageUrl (required, string): Public HTTP or HTTPS image URL to convert. Local, private, credentialed, intranet, and redirecting URLs are rejected. Constraints: format: uri.\n- targetFormat (required, string): Output image format. Use jpg or jpeg for HEIC-to-JPG-style conversion; png, webp, and avif are also accepted when supported by the image backend. Constraints: accepted values: \"jpg\", \"jpeg\", \"png\", \"webp\", \"avif\".\n- width (optional, integer): Optional output width in pixels. If omitted, the source width is preserved when the backend supports it. Constraints: min: 1; max: 4096.\n- height (optional, integer): Optional output height in pixels. If omitted, the source height is preserved when the backend supports it. Constraints: min: 1; max: 4096.\n- fit (optional, string): Resize mode used when width or height is supplied. scale-down preserves the image unless it is larger than the requested bounds. Constraints: accepted values: \"scale-down\", \"contain\", \"cover\", \"crop\", \"pad\"; default: \"scale-down\".\n- quality (optional, integer): Output quality for lossy formats. Values above 95 are rejected to keep route cost and response size bounded. Constraints: default: 85; min: 1; max: 95.\n- background (optional, string): Optional CSS color used by padded or transparent-to-JPEG conversions, for example #ffffff. Constraints: max length: 40.\n- filename (optional, string): Optional download filename. The service normalizes the extension to match targetFormat. Constraints: max length: 120.\n- ttlSeconds (optional, integer): How long the signed conversion download URL should remain usable, in seconds. Constraints: default: 3600; min: 60; max: 86400.\n\nExample request body:\n```json\n{\n  \"imageUrl\": \"https://upload.wikimedia.org/wikipedia/commons/3/3f/JPEG_example_flower.jpg\",\n  \"targetFormat\": \"webp\",\n  \"width\": 800,\n  \"fit\": \"scale-down\",\n  \"quality\": 85,\n  \"ttlSeconds\": 3600\n}\n```",
+        "operationId": "image_format_converter",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.01"
+          },
+          "pricingMode": "fixed",
+          "protocols": [
+            {
+              "x402": {
+                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                "currency": "USDC",
+                "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "payTo": "4tWJRwNyhGr88QTiV2yzMoGsaxZiCSRDepf9JTdBEgyi"
+              }
+            },
+            {
+              "x402": {
+                "network": "eip155:8453",
+                "currency": "USDC",
+                "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                "payTo": "0xe8799C2dedA78ECcEB329D1E8FE9F110bf55E4F8"
+              }
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "imageUrl",
+                  "targetFormat"
+                ],
+                "properties": {
+                  "imageUrl": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "Public HTTP or HTTPS image URL to convert. Local, private, credentialed, intranet, and redirecting URLs are rejected."
+                  },
+                  "targetFormat": {
+                    "type": "string",
+                    "enum": [
+                      "jpg",
+                      "jpeg",
+                      "png",
+                      "webp",
+                      "avif"
+                    ],
+                    "description": "Output image format. Use jpg or jpeg for HEIC-to-JPG-style conversion; png, webp, and avif are also accepted when supported by the image backend."
+                  },
+                  "width": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 4096,
+                    "description": "Optional output width in pixels. If omitted, the source width is preserved when the backend supports it."
+                  },
+                  "height": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 4096,
+                    "description": "Optional output height in pixels. If omitted, the source height is preserved when the backend supports it."
+                  },
+                  "fit": {
+                    "type": "string",
+                    "enum": [
+                      "scale-down",
+                      "contain",
+                      "cover",
+                      "crop",
+                      "pad"
+                    ],
+                    "default": "scale-down",
+                    "description": "Resize mode used when width or height is supplied. scale-down preserves the image unless it is larger than the requested bounds."
+                  },
+                  "quality": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 95,
+                    "default": 85,
+                    "description": "Output quality for lossy formats. Values above 95 are rejected to keep route cost and response size bounded."
+                  },
+                  "background": {
+                    "type": "string",
+                    "maxLength": 40,
+                    "description": "Optional CSS color used by padded or transparent-to-JPEG conversions, for example #ffffff."
+                  },
+                  "filename": {
+                    "type": "string",
+                    "maxLength": 120,
+                    "description": "Optional download filename. The service normalizes the extension to match targetFormat."
+                  },
+                  "ttlSeconds": {
+                    "type": "integer",
+                    "minimum": 60,
+                    "maximum": 86400,
+                    "default": 3600,
+                    "description": "How long the signed conversion download URL should remain usable, in seconds."
+                  }
+                },
+                "additionalProperties": false
+              },
+              "example": {
+                "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/3/3f/JPEG_example_flower.jpg",
+                "targetFormat": "webp",
+                "width": 800,
+                "fit": "scale-down",
+                "quality": 85,
+                "ttlSeconds": 3600
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Utility result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "tool",
+                    "requested",
+                    "source",
+                    "conversion",
+                    "download",
+                    "limits"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "tool": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "requested": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "source": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "conversion": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "download": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "limits": {
+                      "type": "object",
+                      "additionalProperties": true
+                    }
+                  },
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "tags": [
+          "edge-ai-automation",
+          "media",
+          "image",
+          "image-conversion",
+          "heic",
+          "jpg",
+          "jpeg",
+          "png",
+          "webp",
+          "avif",
+          "agent-tools",
+          "x402"
+        ]
+      }
+    },
+    "/api/real-estate/listings/search": {
+      "post": {
+        "summary": "Search real estate listings",
+        "description": "Purpose: Search current public home and rental listings by city, neighborhood, exact ZIP, listing type, price range, bedroom range, bathroom range, square footage, amenities, URL, address, or property id. Search mode requires market or zipCode; URL mode requires searchUrls; lookup mode requires addresses, zpids, or propertyIds. Advertised filters are rechecked against normalized rows before results are returned.\nBest use: Use this when an agent needs search current public home and rental listings by city, neighborhood, exact ZIP, listing type, price range, bedroom range, bathroom range, square footage, amenities, URL, address, or property id. Search mode requires market or zipCode; URL mode requires searchUrls; lookup mode requires addresses, zpids, or propertyIds. Advertised filters are rechecked against normalized rows before results are returned.\nPrice: $0.05 per successful paid call. Direct Base x402 authorization is verified before execution and settled only after successful fulfillment.\nFulfillment: Managed AgentBodega HTTP+JSON endpoint. Upstream provider details are intentionally not disclosed unless the response explicitly includes managed source metadata.\n\nInput: send a JSON request body.\nRequired fields: conditional by mode.\nRequired combinations: Choose one mode and provide its required selector: search requires market or zipCode; url requires searchUrls; lookup requires addresses, zpids, or propertyIds. Search filters are rechecked against normalized rows before results are returned.\nOptional fields: source, mode, market, listingType, priceMin, priceMax, bedsMin, bedsMax, bathsMin, bathsMax, homeTypes, propertyType, bedrooms, sortBy, daysOnMarket, sqftMin, sqftMax, lotSizeMin, lotSizeMax, yearBuiltMin, yearBuiltMax, amenities, searchUrls, addresses, zpids, propertyIds, locationSlug, state, zipCode, maxRent, petFriendly, maxPages, filterToRequestedCity, includeSchools, includeHistory, includeDetails, smartScrape, maxResults.\n\nAccepted fields:\n- source (optional, string): Optional source preference. auto routes broad home search to Zillow and apartment rental search to Apartments. Constraints: accepted values: \"auto\", \"zillow\", \"apartments\", \"realtor\"; default: \"auto\".\n- mode (optional, string): Search by market, use one or more listing/search URLs, or look up specific addresses/provider property ids. Constraints: accepted values: \"search\", \"url\", \"lookup\"; default: \"search\".\n- market (optional, string): City, ZIP, or neighborhood, such as Houston, TX 77008 or Montrose Houston TX. Use zipCode when an exact five-digit postal-code match is required.\n- listingType (optional, string): Listing inventory to search. recently_sold is available only on providers that expose current sold-result pages. Constraints: accepted values: \"for_sale\", \"recently_sold\", \"for_rent\", \"foreclosure\"; default: \"for_sale\".\n- priceMin (optional, integer): Minimum listing price or monthly rent in USD. Constraints: min: 0.\n- priceMax (optional, integer): Maximum listing price or monthly rent in USD. Constraints: min: 0.\n- bedsMin (optional, integer): Minimum bedrooms. Aggregate rental rows qualify when their advertised bedroom range overlaps this boundary. Constraints: min: 0; max: 10.\n- bedsMax (optional, integer): Maximum bedrooms. Aggregate rental rows qualify when their advertised bedroom range overlaps this boundary. Constraints: min: 0; max: 10.\n- bathsMin (optional, number): Minimum bathrooms. Half-bath values are accepted. Constraints: min: 0; max: 10.\n- bathsMax (optional, number): Maximum bathrooms. Half-bath values are accepted. Constraints: min: 0; max: 10.\n- homeTypes (optional, array): Allowed home types. Returned rows without a verifiable matching normalized home type are excluded. Constraints: max items: 7.\n- propertyType (optional, string): Rental property type used by the Apartments-backed provider. Constraints: accepted values: \"apartments\", \"houses\", \"townhomes\", \"condos\".\n- bedrooms (optional, any): Rental bedroom filter used by the Apartments-backed provider.\n- sortBy (optional, string): Managed-source collection order before AgentBodega normalizes and rechecks the requested filters. Constraints: accepted values: \"newest\", \"relevance\", \"pricea\", \"priced\", \"beds\", \"baths\", \"size\", \"lot\", \"zest\"; default: \"newest\".\n- daysOnMarket (optional, string): Maximum listing-age bucket. Returned rows without a verifiable days-on-market value are excluded when set. Constraints: accepted values: \"\", \"1\", \"7\", \"14\", \"30\", \"90\", \"6m\", \"12m\", \"24m\", \"36m\"; default: \"\".\n- sqftMin (optional, integer): Minimum interior square feet. Rows without verifiable square footage are excluded when set. Constraints: min: 0.\n- sqftMax (optional, integer): Maximum interior square feet. Rows without verifiable square footage are excluded when set. Constraints: min: 0.\n- lotSizeMin (optional, integer): Minimum lot size in square feet. Rows without a verifiable lot size are excluded when set. Constraints: min: 0.\n- lotSizeMax (optional, integer): Maximum lot size in square feet. Rows without a verifiable lot size are excluded when set. Constraints: min: 0.\n- yearBuiltMin (optional, integer): Earliest accepted construction year. Rows without a verifiable year built are excluded when set. Constraints: min: 1800; max: 2030.\n- yearBuiltMax (optional, integer): Latest accepted construction year. Rows without a verifiable year built are excluded when set. Constraints: min: 1800; max: 2030.\n- amenities (optional, array): Requested amenity filters sent to providers that expose them. Availability depends on the selected source's public listing fields. Constraints: max items: 7.\n- searchUrls (optional, array): Listing or search URLs for url mode. Constraints: max items: 3.\n- addresses (optional, array): Addresses for lookup mode. Constraints: max items: 10.\n- zpids (optional, array): Zillow property ids for lookup mode. Constraints: max items: 10.\n- propertyIds (optional, array): Provider property ids for lookup mode, currently used by the realtor-backed provider. Constraints: max items: 10.\n- locationSlug (optional, string): Provider-specific location slug for rental searches when city/state parsing is not enough.\n- state (optional, string): Two-letter state hint for rental searches. Constraints: min length: 2; max length: 2.\n- zipCode (optional, string): Exact five-digit ZIP filter for search mode. It narrows collection where supported and is always rechecked against normalized postal_code values.\n- maxRent (optional, integer): Maximum monthly rent. If omitted, priceMax is reused for rental searches. Constraints: min: 0.\n- petFriendly (optional, boolean): Rental search filter for pet-friendly listings. Constraints: default: false.\n- maxPages (optional, integer): Maximum rendered search pages for the Apartments-backed provider. Constraints: default: 1; min: 1; max: 2.\n- filterToRequestedCity (optional, boolean): Optional exact-city filter for Apartments-backed city searches.\n- includeSchools (optional, boolean): Include school data where the selected provider supports detail extraction. Constraints: default: true.\n- includeHistory (optional, boolean): Include price/tax history where the selected provider supports detail extraction. Constraints: default: true.\n- includeDetails (optional, boolean): Fetch detail-page fields such as description, agent/broker fields, photos, price history, and tax history. Detail-enriched calls are capped at 10 rows. Constraints: default: false.\n- smartScrape (optional, boolean): Opt into incremental ingestion by skipping listings already seen by the managed adapter. Leave false for a complete current search result set. Constraints: default: false.\n- maxResults (optional, integer): Maximum listing rows to return. Detail-enriched calls are capped at 10 rows. Constraints: default: 10; min: 1; max: 20.\n\nExample request body:\n```json\n{\n  \"source\": \"zillow\",\n  \"mode\": \"search\",\n  \"market\": \"Houston, TX 77008\",\n  \"zipCode\": \"77008\",\n  \"listingType\": \"for_sale\",\n  \"priceMin\": 200000,\n  \"priceMax\": 500000,\n  \"bedsMin\": 3,\n  \"bedsMax\": 4,\n  \"bathsMin\": 2,\n  \"bathsMax\": 4,\n  \"sqftMin\": 1400,\n  \"sqftMax\": 3000,\n  \"homeTypes\": [\n    \"houses\",\n    \"townhomes\"\n  ],\n  \"includeDetails\": false,\n  \"maxResults\": 10\n}\n```",
+        "operationId": "real_estate_listings_search",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.05"
+          },
+          "pricingMode": "fixed",
+          "protocols": [
+            {
+              "x402": {
+                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                "currency": "USDC",
+                "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "payTo": "4tWJRwNyhGr88QTiV2yzMoGsaxZiCSRDepf9JTdBEgyi"
+              }
+            },
+            {
+              "x402": {
+                "network": "eip155:8453",
+                "currency": "USDC",
+                "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                "payTo": "0xe8799C2dedA78ECcEB329D1E8FE9F110bf55E4F8"
+              }
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "description": "Choose one mode and provide its required selector: search requires market or zipCode; url requires searchUrls; lookup requires addresses, zpids, or propertyIds. Search filters are rechecked against normalized rows before results are returned.",
+                "anyOf": [
+                  {
+                    "title": "Market search",
+                    "properties": {
+                      "mode": {
+                        "const": "search"
+                      }
+                    },
+                    "anyOf": [
+                      {
+                        "required": [
+                          "market"
+                        ]
+                      },
+                      {
+                        "required": [
+                          "zipCode"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "title": "URL search",
+                    "properties": {
+                      "mode": {
+                        "const": "url"
+                      }
+                    },
+                    "required": [
+                      "searchUrls"
+                    ]
+                  },
+                  {
+                    "title": "Property lookup",
+                    "properties": {
+                      "mode": {
+                        "const": "lookup"
+                      }
+                    },
+                    "anyOf": [
+                      {
+                        "required": [
+                          "addresses"
+                        ]
+                      },
+                      {
+                        "required": [
+                          "zpids"
+                        ]
+                      },
+                      {
+                        "required": [
+                          "propertyIds"
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "properties": {
+                  "source": {
+                    "type": "string",
+                    "enum": [
+                      "auto",
+                      "zillow",
+                      "apartments",
+                      "realtor"
+                    ],
+                    "default": "auto",
+                    "description": "Optional source preference. auto routes broad home search to Zillow and apartment rental search to Apartments."
+                  },
+                  "mode": {
+                    "type": "string",
+                    "enum": [
+                      "search",
+                      "url",
+                      "lookup"
+                    ],
+                    "default": "search",
+                    "description": "Search by market, use one or more listing/search URLs, or look up specific addresses/provider property ids."
+                  },
+                  "market": {
+                    "type": "string",
+                    "description": "City, ZIP, or neighborhood, such as Houston, TX 77008 or Montrose Houston TX. Use zipCode when an exact five-digit postal-code match is required."
+                  },
+                  "listingType": {
+                    "type": "string",
+                    "enum": [
+                      "for_sale",
+                      "recently_sold",
+                      "for_rent",
+                      "foreclosure"
+                    ],
+                    "default": "for_sale",
+                    "description": "Listing inventory to search. recently_sold is available only on providers that expose current sold-result pages."
+                  },
+                  "priceMin": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Minimum listing price or monthly rent in USD."
+                  },
+                  "priceMax": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Maximum listing price or monthly rent in USD."
+                  },
+                  "bedsMin": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 10,
+                    "description": "Minimum bedrooms. Aggregate rental rows qualify when their advertised bedroom range overlaps this boundary."
+                  },
+                  "bedsMax": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 10,
+                    "description": "Maximum bedrooms. Aggregate rental rows qualify when their advertised bedroom range overlaps this boundary."
+                  },
+                  "bathsMin": {
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 10,
+                    "description": "Minimum bathrooms. Half-bath values are accepted."
+                  },
+                  "bathsMax": {
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 10,
+                    "description": "Maximum bathrooms. Half-bath values are accepted."
+                  },
+                  "homeTypes": {
+                    "type": "array",
+                    "maxItems": 7,
+                    "items": {
+                      "type": "string",
+                      "enum": [
+                        "houses",
+                        "townhomes",
+                        "multifamily",
+                        "condos",
+                        "land",
+                        "apartments",
+                        "manufactured"
+                      ],
+                      "description": "Home Types item filter for Real Estate Listing Search. Accepted values: \"houses\", \"townhomes\", \"multifamily\", \"condos\", \"land\", \"apartments\", \"manufactured\". Constraints: accepted values: \"houses\", \"townhomes\", \"multifamily\", \"condos\", \"land\", \"apartments\", \"manufactured\"."
+                    },
+                    "description": "Allowed home types. Returned rows without a verifiable matching normalized home type are excluded."
+                  },
+                  "propertyType": {
+                    "type": "string",
+                    "enum": [
+                      "apartments",
+                      "houses",
+                      "townhomes",
+                      "condos"
+                    ],
+                    "description": "Rental property type used by the Apartments-backed provider."
+                  },
+                  "bedrooms": {
+                    "oneOf": [
+                      {
+                        "type": "string",
+                        "enum": [
+                          "any",
+                          "studio",
+                          "1",
+                          "2",
+                          "3",
+                          "4",
+                          "5+"
+                        ]
+                      },
+                      {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 5
+                      }
+                    ],
+                    "description": "Rental bedroom filter used by the Apartments-backed provider."
+                  },
+                  "sortBy": {
+                    "type": "string",
+                    "enum": [
+                      "newest",
+                      "relevance",
+                      "pricea",
+                      "priced",
+                      "beds",
+                      "baths",
+                      "size",
+                      "lot",
+                      "zest"
+                    ],
+                    "default": "newest",
+                    "description": "Managed-source collection order before AgentBodega normalizes and rechecks the requested filters."
+                  },
+                  "daysOnMarket": {
+                    "type": "string",
+                    "enum": [
+                      "",
+                      "1",
+                      "7",
+                      "14",
+                      "30",
+                      "90",
+                      "6m",
+                      "12m",
+                      "24m",
+                      "36m"
+                    ],
+                    "default": "",
+                    "description": "Maximum listing-age bucket. Returned rows without a verifiable days-on-market value are excluded when set."
+                  },
+                  "sqftMin": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Minimum interior square feet. Rows without verifiable square footage are excluded when set."
+                  },
+                  "sqftMax": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Maximum interior square feet. Rows without verifiable square footage are excluded when set."
+                  },
+                  "lotSizeMin": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Minimum lot size in square feet. Rows without a verifiable lot size are excluded when set."
+                  },
+                  "lotSizeMax": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Maximum lot size in square feet. Rows without a verifiable lot size are excluded when set."
+                  },
+                  "yearBuiltMin": {
+                    "type": "integer",
+                    "minimum": 1800,
+                    "maximum": 2030,
+                    "description": "Earliest accepted construction year. Rows without a verifiable year built are excluded when set."
+                  },
+                  "yearBuiltMax": {
+                    "type": "integer",
+                    "minimum": 1800,
+                    "maximum": 2030,
+                    "description": "Latest accepted construction year. Rows without a verifiable year built are excluded when set."
+                  },
+                  "amenities": {
+                    "type": "array",
+                    "maxItems": 7,
+                    "items": {
+                      "type": "string",
+                      "enum": [
+                        "pool",
+                        "ac",
+                        "waterfront",
+                        "single-story",
+                        "garage",
+                        "basement",
+                        "3d-tour"
+                      ],
+                      "description": "Amenities item filter for Real Estate Listing Search. Accepted values: \"pool\", \"ac\", \"waterfront\", \"single-story\", \"garage\", \"basement\", \"3d-tour\". Constraints: accepted values: \"pool\", \"ac\", \"waterfront\", \"single-story\", \"garage\", \"basement\", \"3d-tour\"."
+                    },
+                    "description": "Requested amenity filters sent to providers that expose them. Availability depends on the selected source's public listing fields."
+                  },
+                  "searchUrls": {
+                    "type": "array",
+                    "maxItems": 3,
+                    "items": {
+                      "type": "string",
+                      "format": "uri",
+                      "description": "Search Urls item value for Real Estate Listing Search. Constraints: format: uri."
+                    },
+                    "description": "Listing or search URLs for url mode."
+                  },
+                  "addresses": {
+                    "type": "array",
+                    "maxItems": 10,
+                    "items": {
+                      "type": "string",
+                      "description": "Addresses item value for Real Estate Listing Search."
+                    },
+                    "description": "Addresses for lookup mode."
+                  },
+                  "zpids": {
+                    "type": "array",
+                    "maxItems": 10,
+                    "items": {
+                      "type": "string",
+                      "description": "Zpids item value for Real Estate Listing Search."
+                    },
+                    "description": "Zillow property ids for lookup mode."
+                  },
+                  "propertyIds": {
+                    "type": "array",
+                    "maxItems": 10,
+                    "items": {
+                      "type": "string",
+                      "description": "Property Ids item value for Real Estate Listing Search."
+                    },
+                    "description": "Provider property ids for lookup mode, currently used by the realtor-backed provider."
+                  },
+                  "locationSlug": {
+                    "type": "string",
+                    "description": "Provider-specific location slug for rental searches when city/state parsing is not enough."
+                  },
+                  "state": {
+                    "type": "string",
+                    "minLength": 2,
+                    "maxLength": 2,
+                    "description": "Two-letter state hint for rental searches."
+                  },
+                  "zipCode": {
+                    "type": "string",
+                    "pattern": "^\\d{5}$",
+                    "description": "Exact five-digit ZIP filter for search mode. It narrows collection where supported and is always rechecked against normalized postal_code values."
+                  },
+                  "maxRent": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Maximum monthly rent. If omitted, priceMax is reused for rental searches."
+                  },
+                  "petFriendly": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Rental search filter for pet-friendly listings."
+                  },
+                  "maxPages": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 2,
+                    "default": 1,
+                    "description": "Maximum rendered search pages for the Apartments-backed provider."
+                  },
+                  "filterToRequestedCity": {
+                    "type": "boolean",
+                    "description": "Optional exact-city filter for Apartments-backed city searches."
+                  },
+                  "includeSchools": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Include school data where the selected provider supports detail extraction."
+                  },
+                  "includeHistory": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Include price/tax history where the selected provider supports detail extraction."
+                  },
+                  "includeDetails": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Fetch detail-page fields such as description, agent/broker fields, photos, price history, and tax history. Detail-enriched calls are capped at 10 rows."
+                  },
+                  "smartScrape": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Opt into incremental ingestion by skipping listings already seen by the managed adapter. Leave false for a complete current search result set."
+                  },
+                  "maxResults": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 20,
+                    "default": 10,
+                    "description": "Maximum listing rows to return. Detail-enriched calls are capped at 10 rows."
+                  }
+                },
+                "additionalProperties": false
+              },
+              "example": {
+                "source": "zillow",
+                "mode": "search",
+                "market": "Houston, TX 77008",
+                "zipCode": "77008",
+                "listingType": "for_sale",
+                "priceMin": 200000,
+                "priceMax": 500000,
+                "bedsMin": 3,
+                "bedsMax": 4,
+                "bathsMin": 2,
+                "bathsMax": 4,
+                "sqftMin": 1400,
+                "sqftMax": 3000,
+                "homeTypes": [
+                  "houses",
+                  "townhomes"
+                ],
+                "includeDetails": false,
+                "maxResults": 10
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Utility result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "tool",
+                    "requested",
+                    "result_count",
+                    "results",
+                    "checkedAt"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "tool": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "requested": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "result_count": {
+                      "type": "integer"
+                    },
+                    "filter_summary": {
+                      "type": "object",
+                      "description": "Counts before and after AgentBodega rechecks the requested filters against normalized rows.",
+                      "properties": {
+                        "normalized_count": {
+                          "type": "integer"
+                        },
+                        "matched_count": {
+                          "type": "integer"
+                        },
+                        "returned_count": {
+                          "type": "integer"
+                        },
+                        "excluded_count": {
+                          "type": "integer"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "results": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "required": [
+                          "source",
+                          "listing_id",
+                          "address"
+                        ],
+                        "properties": {
+                          "source": {
+                            "type": "string",
+                            "description": "Managed source class used to normalize the listing."
+                          },
+                          "listing_id": {
+                            "type": "string"
+                          },
+                          "address": {
+                            "type": "string"
+                          },
+                          "street": {
+                            "type": "string"
+                          },
+                          "city": {
+                            "type": "string"
+                          },
+                          "state": {
+                            "type": "string"
+                          },
+                          "postal_code": {
+                            "type": "string"
+                          },
+                          "latitude": {
+                            "type": [
+                              "number",
+                              "null"
+                            ]
+                          },
+                          "longitude": {
+                            "type": [
+                              "number",
+                              "null"
+                            ]
+                          },
+                          "price_usd": {
+                            "type": [
+                              "number",
+                              "null"
+                            ]
+                          },
+                          "price_display": {
+                            "type": "string"
+                          },
+                          "zestimate_usd": {
+                            "type": [
+                              "number",
+                              "null"
+                            ]
+                          },
+                          "rent_zestimate_usd": {
+                            "type": [
+                              "number",
+                              "null"
+                            ]
+                          },
+                          "tax_assessed_value_usd": {
+                            "type": [
+                              "number",
+                              "null"
+                            ]
+                          },
+                          "beds": {
+                            "type": [
+                              "number",
+                              "null"
+                            ]
+                          },
+                          "baths": {
+                            "type": [
+                              "number",
+                              "null"
+                            ]
+                          },
+                          "sqft": {
+                            "type": [
+                              "number",
+                              "null"
+                            ]
+                          },
+                          "lot_sqft": {
+                            "type": [
+                              "number",
+                              "null"
+                            ]
+                          },
+                          "year_built": {
+                            "type": [
+                              "number",
+                              "null"
+                            ]
+                          },
+                          "home_type": {
+                            "type": "string"
+                          },
+                          "listing_status": {
+                            "type": "string"
+                          },
+                          "days_on_market": {
+                            "type": [
+                              "number",
+                              "null"
+                            ]
+                          },
+                          "description": {
+                            "type": "string"
+                          },
+                          "listing_url": {
+                            "type": "string",
+                            "format": "uri"
+                          },
+                          "image_url": {
+                            "type": "string",
+                            "format": "uri"
+                          },
+                          "photo_urls": {
+                            "type": "array",
+                            "items": {
+                              "type": "string",
+                              "format": "uri"
+                            }
+                          },
+                          "agent": {
+                            "type": "object",
+                            "additionalProperties": true
+                          },
+                          "price_history": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "additionalProperties": true
+                            }
+                          },
+                          "tax_history": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "additionalProperties": true
+                            }
+                          },
+                          "warnings": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "additionalProperties": true
+                      }
+                    },
+                    "source": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "checkedAt": {
+                      "type": "string",
+                      "format": "date-time"
+                    }
+                  },
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "tags": [
+          "real-estate",
+          "property-search",
+          "home-listings",
+          "housing",
+          "for-sale",
+          "for-rent",
+          "rentals",
+          "apartments",
+          "apartments-com",
+          "zillow",
+          "realtor",
+          "public-data"
+        ]
+      }
+    },
+    "/api/real-estate/intelligence": {
+      "post": {
+        "summary": "Generate a real estate market intelligence report",
+        "description": "Purpose: Turn up to 100 current public home or rental listings into a deterministic market report with exact ZIP and min/max price, bedroom, bathroom, and square-foot filters; price bands; value-position quadrants; inventory signals; cohort context; five decision lenses; anomaly review flags; a ranked shortlist; confidence; limitations; and optional Markdown. This report-only product returns aggregates and shortlist evidence, not every analyzed row. Requires market or zipCode and at least five usable priced listings; failed or insufficient runs are not settled.\nBest use: Use this when an agent needs turn up to 100 current public home or rental listings into a deterministic market report with exact ZIP and min/max price, bedroom, bathroom, and square-foot filters; price bands; value-position quadrants; inventory signals; cohort context; five decision lenses; anomaly review flags; a ranked shortlist; confidence; limitations; and optional Markdown. This report-only product returns aggregates and shortlist evidence, not every analyzed row. Requires market or zipCode and at least five usable priced listings; failed or insufficient runs are not settled.\nPrice: $0.75 per successful paid call. Direct Base x402 authorization is verified before execution and settled only after successful fulfillment.\nFulfillment: Managed AgentBodega HTTP+JSON endpoint. Upstream provider details are intentionally not disclosed unless the response explicitly includes managed source metadata.\n\nInput: send a JSON request body.\nRequired fields: conditional by mode.\nRequired combinations: Build a current-market report from at least five unique, priced public listings. Provide market, zipCode, or both. The service fetches up to 100 rows, verifies requested filters against normalized fields, and does not settle payment when there is not enough usable evidence. Full analyzed evidence rows are sold only by the fixed-price evidence-bundle route.\nOptional fields: market, zipCode, listingType, objective, priceMin, priceMax, bedsMin, bedsMax, bathsMin, bathsMax, sqftMin, sqftMax, homeTypes, propertyType, bedrooms, maxRent, sortBy, daysOnMarket, maxPages, maxListings, shortlistLimit, includeMarkdown.\n\nAccepted fields:\n- market (optional, string): City or neighborhood to analyze, such as Houston, TX or Montrose Houston TX. May be omitted when zipCode is provided. Constraints: min length: 2; max length: 180.\n- zipCode (optional, string): Exact five-digit ZIP to analyze. It narrows collection where supported and excludes returned rows with missing or different postal codes.\n- listingType (optional, string): Current inventory class to analyze. Historical sold-comparable analysis is not included in this version. Constraints: accepted values: \"for_sale\", \"for_rent\", \"foreclosure\"; default: \"for_sale\".\n- objective (optional, string): Ranking objective for the evidence-backed shortlist. balanced combines price, price per square foot, recency, and space when fields are available. Constraints: accepted values: \"balanced\", \"value\", \"low-price\", \"newest\", \"space\"; default: \"balanced\".\n- priceMin (optional, integer): Minimum listing price in USD. Listings without a verifiable price are excluded. Constraints: min: 0.\n- priceMax (optional, integer): Maximum listing price or monthly rent in USD. Listings without a verifiable price are excluded. Constraints: min: 0.\n- bedsMin (optional, integer): Minimum bedrooms. Listings without a verifiable bedroom count are excluded when this filter is set. Constraints: min: 0; max: 10.\n- bedsMax (optional, integer): Maximum bedrooms. Listings without a verifiable bedroom count are excluded when this filter is set. Constraints: min: 0; max: 10.\n- bathsMin (optional, number): Minimum bathrooms. Listings without a verifiable bathroom count are excluded when this filter is set. Constraints: min: 0; max: 10.\n- bathsMax (optional, number): Maximum bathrooms. Listings without a verifiable bathroom count are excluded when this filter is set. Constraints: min: 0; max: 10.\n- sqftMin (optional, integer): Minimum interior square feet. Listings without verifiable square footage are excluded when this filter is set. Constraints: min: 0.\n- sqftMax (optional, integer): Maximum interior square feet. Listings without verifiable square footage are excluded when this filter is set. Constraints: min: 0.\n- homeTypes (optional, array): Optional home-type filters for home-sale searches. Constraints: max items: 7.\n- propertyType (optional, string): Rental property type used for apartment-market reports. Constraints: accepted values: \"apartments\", \"houses\", \"townhomes\", \"condos\".\n- bedrooms (optional, any): Rental bedroom filter used for apartment-market reports.\n- maxRent (optional, integer): Maximum monthly rent in USD. If omitted, priceMax is reused for rental reports. Constraints: min: 0.\n- sortBy (optional, string): Managed-source collection order before AgentBodega computes its own shortlist ranking. Constraints: accepted values: \"newest\", \"relevance\", \"pricea\", \"priced\", \"beds\", \"baths\", \"size\", \"lot\", \"zest\"; default: \"newest\".\n- daysOnMarket (optional, string): Optional maximum listing-age bucket supported by home-sale searches. Constraints: accepted values: \"\", \"1\", \"7\", \"14\", \"30\", \"90\", \"6m\", \"12m\", \"24m\", \"36m\"; default: \"\".\n- maxPages (optional, integer): Maximum rendered result pages for apartment-market reports. Constraints: default: 1; min: 1; max: 2.\n- maxListings (optional, integer): Maximum current listings to ingest before deduplication and verification. At least five usable listings are required for a paid report. Constraints: default: 100; min: 10; max: 100.\n- shortlistLimit (optional, integer): Maximum ranked listings to include in the shortlist. Constraints: default: 10; min: 3; max: 15.\n- includeMarkdown (optional, boolean): Include a ready-to-render Markdown version alongside the structured report JSON. Constraints: default: true.\n\nExample request body:\n```json\n{\n  \"market\": \"Houston, TX 77008\",\n  \"zipCode\": \"77008\",\n  \"listingType\": \"for_sale\",\n  \"objective\": \"value\",\n  \"priceMin\": 200000,\n  \"priceMax\": 750000,\n  \"bedsMin\": 2,\n  \"bedsMax\": 4,\n  \"bathsMin\": 1.5,\n  \"bathsMax\": 4,\n  \"sqftMin\": 1000,\n  \"sqftMax\": 3500,\n  \"maxListings\": 100,\n  \"shortlistLimit\": 10,\n  \"includeMarkdown\": true\n}\n```",
+        "operationId": "real_estate_market_intelligence",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.75"
+          },
+          "pricingMode": "fixed",
+          "protocols": [
+            {
+              "x402": {
+                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                "currency": "USDC",
+                "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "payTo": "4tWJRwNyhGr88QTiV2yzMoGsaxZiCSRDepf9JTdBEgyi"
+              }
+            },
+            {
+              "x402": {
+                "network": "eip155:8453",
+                "currency": "USDC",
+                "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                "payTo": "0xe8799C2dedA78ECcEB329D1E8FE9F110bf55E4F8"
+              }
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "anyOf": [
+                  {
+                    "required": [
+                      "market"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "zipCode"
+                    ]
+                  }
+                ],
+                "description": "Build a current-market report from at least five unique, priced public listings. Provide market, zipCode, or both. The service fetches up to 100 rows, verifies requested filters against normalized fields, and does not settle payment when there is not enough usable evidence. Full analyzed evidence rows are sold only by the fixed-price evidence-bundle route.",
+                "properties": {
+                  "market": {
+                    "type": "string",
+                    "minLength": 2,
+                    "maxLength": 180,
+                    "description": "City or neighborhood to analyze, such as Houston, TX or Montrose Houston TX. May be omitted when zipCode is provided."
+                  },
+                  "zipCode": {
+                    "type": "string",
+                    "pattern": "^\\d{5}$",
+                    "description": "Exact five-digit ZIP to analyze. It narrows collection where supported and excludes returned rows with missing or different postal codes."
+                  },
+                  "listingType": {
+                    "type": "string",
+                    "enum": [
+                      "for_sale",
+                      "for_rent",
+                      "foreclosure"
+                    ],
+                    "default": "for_sale",
+                    "description": "Current inventory class to analyze. Historical sold-comparable analysis is not included in this version."
+                  },
+                  "objective": {
+                    "type": "string",
+                    "enum": [
+                      "balanced",
+                      "value",
+                      "low-price",
+                      "newest",
+                      "space"
+                    ],
+                    "default": "balanced",
+                    "description": "Ranking objective for the evidence-backed shortlist. balanced combines price, price per square foot, recency, and space when fields are available."
+                  },
+                  "priceMin": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Minimum listing price in USD. Listings without a verifiable price are excluded."
+                  },
+                  "priceMax": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Maximum listing price or monthly rent in USD. Listings without a verifiable price are excluded."
+                  },
+                  "bedsMin": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 10,
+                    "description": "Minimum bedrooms. Listings without a verifiable bedroom count are excluded when this filter is set."
+                  },
+                  "bedsMax": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 10,
+                    "description": "Maximum bedrooms. Listings without a verifiable bedroom count are excluded when this filter is set."
+                  },
+                  "bathsMin": {
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 10,
+                    "description": "Minimum bathrooms. Listings without a verifiable bathroom count are excluded when this filter is set."
+                  },
+                  "bathsMax": {
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 10,
+                    "description": "Maximum bathrooms. Listings without a verifiable bathroom count are excluded when this filter is set."
+                  },
+                  "sqftMin": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Minimum interior square feet. Listings without verifiable square footage are excluded when this filter is set."
+                  },
+                  "sqftMax": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Maximum interior square feet. Listings without verifiable square footage are excluded when this filter is set."
+                  },
+                  "homeTypes": {
+                    "type": "array",
+                    "maxItems": 7,
+                    "items": {
+                      "type": "string",
+                      "enum": [
+                        "houses",
+                        "townhomes",
+                        "multifamily",
+                        "condos",
+                        "land",
+                        "apartments",
+                        "manufactured"
+                      ],
+                      "description": "Home Types item filter for Real Estate Market Intelligence Report. Accepted values: \"houses\", \"townhomes\", \"multifamily\", \"condos\", \"land\", \"apartments\", \"manufactured\". Constraints: accepted values: \"houses\", \"townhomes\", \"multifamily\", \"condos\", \"land\", \"apartments\", \"manufactured\"."
+                    },
+                    "description": "Optional home-type filters for home-sale searches."
+                  },
+                  "propertyType": {
+                    "type": "string",
+                    "enum": [
+                      "apartments",
+                      "houses",
+                      "townhomes",
+                      "condos"
+                    ],
+                    "description": "Rental property type used for apartment-market reports."
+                  },
+                  "bedrooms": {
+                    "oneOf": [
+                      {
+                        "type": "string",
+                        "enum": [
+                          "any",
+                          "studio",
+                          "1",
+                          "2",
+                          "3",
+                          "4",
+                          "5+"
+                        ]
+                      },
+                      {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 5
+                      }
+                    ],
+                    "description": "Rental bedroom filter used for apartment-market reports."
+                  },
+                  "maxRent": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Maximum monthly rent in USD. If omitted, priceMax is reused for rental reports."
+                  },
+                  "sortBy": {
+                    "type": "string",
+                    "enum": [
+                      "newest",
+                      "relevance",
+                      "pricea",
+                      "priced",
+                      "beds",
+                      "baths",
+                      "size",
+                      "lot",
+                      "zest"
+                    ],
+                    "default": "newest",
+                    "description": "Managed-source collection order before AgentBodega computes its own shortlist ranking."
+                  },
+                  "daysOnMarket": {
+                    "type": "string",
+                    "enum": [
+                      "",
+                      "1",
+                      "7",
+                      "14",
+                      "30",
+                      "90",
+                      "6m",
+                      "12m",
+                      "24m",
+                      "36m"
+                    ],
+                    "default": "",
+                    "description": "Optional maximum listing-age bucket supported by home-sale searches."
+                  },
+                  "maxPages": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 2,
+                    "default": 1,
+                    "description": "Maximum rendered result pages for apartment-market reports."
+                  },
+                  "maxListings": {
+                    "type": "integer",
+                    "minimum": 10,
+                    "maximum": 100,
+                    "default": 100,
+                    "description": "Maximum current listings to ingest before deduplication and verification. At least five usable listings are required for a paid report."
+                  },
+                  "shortlistLimit": {
+                    "type": "integer",
+                    "minimum": 3,
+                    "maximum": 15,
+                    "default": 10,
+                    "description": "Maximum ranked listings to include in the shortlist."
+                  },
+                  "includeMarkdown": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Include a ready-to-render Markdown version alongside the structured report JSON."
+                  }
+                },
+                "additionalProperties": false
+              },
+              "example": {
+                "market": "Houston, TX 77008",
+                "zipCode": "77008",
+                "listingType": "for_sale",
+                "objective": "value",
+                "priceMin": 200000,
+                "priceMax": 750000,
+                "bedsMin": 2,
+                "bedsMax": 4,
+                "bathsMin": 1.5,
+                "bathsMax": 4,
+                "sqftMin": 1000,
+                "sqftMax": 3500,
+                "maxListings": 100,
+                "shortlistLimit": 10,
+                "includeMarkdown": true
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Utility result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "tool",
+                    "requested",
+                    "source",
+                    "report",
+                    "listings",
+                    "checkedAt"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "description": "True only when enough evidence was collected to deliver the report."
+                    },
+                    "tool": {
+                      "type": "object",
+                      "description": "AgentBodega product identity and department.",
+                      "additionalProperties": true
+                    },
+                    "requested": {
+                      "type": "object",
+                      "description": "Normalized report request and enforced limits.",
+                      "additionalProperties": true
+                    },
+                    "source": {
+                      "type": "object",
+                      "description": "Source-neutral routing and freshness metadata.",
+                      "additionalProperties": true
+                    },
+                    "report": {
+                      "type": "object",
+                      "required": [
+                        "title",
+                        "executive_summary",
+                        "insights",
+                        "sample",
+                        "benchmarks",
+                        "price_bands",
+                        "market_positions",
+                        "market_signals",
+                        "segments",
+                        "decision_lenses",
+                        "shortlist",
+                        "outliers",
+                        "evidence_manifest",
+                        "data_quality",
+                        "methodology"
+                      ],
+                      "properties": {
+                        "title": {
+                          "type": "string"
+                        },
+                        "executive_summary": {
+                          "type": "string",
+                          "description": "Deterministic summary grounded in the returned sample metrics."
+                        },
+                        "insights": {
+                          "type": "array",
+                          "description": "Concise evidence-backed observations derived from the current sample without generative inference.",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "sample": {
+                          "type": "object",
+                          "description": "Raw, duplicate, unique, eligible, and excluded row counts.",
+                          "additionalProperties": true
+                        },
+                        "benchmarks": {
+                          "type": "object",
+                          "required": [
+                            "list_price_usd",
+                            "square_feet",
+                            "price_per_sqft_usd",
+                            "days_on_market",
+                            "bedrooms"
+                          ],
+                          "properties": {
+                            "list_price_usd": {
+                              "type": "object",
+                              "required": [
+                                "count",
+                                "min",
+                                "p25",
+                                "median",
+                                "mean",
+                                "p75",
+                                "max"
+                              ],
+                              "description": "Distribution summary computed from the eligible listing sample.",
+                              "properties": {
+                                "count": {
+                                  "type": "integer",
+                                  "description": "Number of listings with a usable value for this metric."
+                                },
+                                "min": {
+                                  "type": [
+                                    "number",
+                                    "null"
+                                  ]
+                                },
+                                "p25": {
+                                  "type": [
+                                    "number",
+                                    "null"
+                                  ]
+                                },
+                                "median": {
+                                  "type": [
+                                    "number",
+                                    "null"
+                                  ]
+                                },
+                                "mean": {
+                                  "type": [
+                                    "number",
+                                    "null"
+                                  ]
+                                },
+                                "p75": {
+                                  "type": [
+                                    "number",
+                                    "null"
+                                  ]
+                                },
+                                "max": {
+                                  "type": [
+                                    "number",
+                                    "null"
+                                  ]
+                                }
+                              },
+                              "additionalProperties": false
+                            },
+                            "square_feet": {
+                              "type": "object",
+                              "required": [
+                                "count",
+                                "min",
+                                "p25",
+                                "median",
+                                "mean",
+                                "p75",
+                                "max"
+                              ],
+                              "description": "Distribution summary computed from the eligible listing sample.",
+                              "properties": {
+                                "count": {
+                                  "type": "integer",
+                                  "description": "Number of listings with a usable value for this metric."
+                                },
+                                "min": {
+                                  "type": [
+                                    "number",
+                                    "null"
+                                  ]
+                                },
+                                "p25": {
+                                  "type": [
+                                    "number",
+                                    "null"
+                                  ]
+                                },
+                                "median": {
+                                  "type": [
+                                    "number",
+                                    "null"
+                                  ]
+                                },
+                                "mean": {
+                                  "type": [
+                                    "number",
+                                    "null"
+                                  ]
+                                },
+                                "p75": {
+                                  "type": [
+                                    "number",
+                                    "null"
+                                  ]
+                                },
+                                "max": {
+                                  "type": [
+                                    "number",
+                                    "null"
+                                  ]
+                                }
+                              },
+                              "additionalProperties": false
+                            },
+                            "price_per_sqft_usd": {
+                              "type": "object",
+                              "required": [
+                                "count",
+                                "min",
+                                "p25",
+                                "median",
+                                "mean",
+                                "p75",
+                                "max"
+                              ],
+                              "description": "Distribution summary computed from the eligible listing sample.",
+                              "properties": {
+                                "count": {
+                                  "type": "integer",
+                                  "description": "Number of listings with a usable value for this metric."
+                                },
+                                "min": {
+                                  "type": [
+                                    "number",
+                                    "null"
+                                  ]
+                                },
+                                "p25": {
+                                  "type": [
+                                    "number",
+                                    "null"
+                                  ]
+                                },
+                                "median": {
+                                  "type": [
+                                    "number",
+                                    "null"
+                                  ]
+                                },
+                                "mean": {
+                                  "type": [
+                                    "number",
+                                    "null"
+                                  ]
+                                },
+                                "p75": {
+                                  "type": [
+                                    "number",
+                                    "null"
+                                  ]
+                                },
+                                "max": {
+                                  "type": [
+                                    "number",
+                                    "null"
+                                  ]
+                                }
+                              },
+                              "additionalProperties": false
+                            },
+                            "days_on_market": {
+                              "type": "object",
+                              "required": [
+                                "count",
+                                "min",
+                                "p25",
+                                "median",
+                                "mean",
+                                "p75",
+                                "max"
+                              ],
+                              "description": "Distribution summary computed from the eligible listing sample.",
+                              "properties": {
+                                "count": {
+                                  "type": "integer",
+                                  "description": "Number of listings with a usable value for this metric."
+                                },
+                                "min": {
+                                  "type": [
+                                    "number",
+                                    "null"
+                                  ]
+                                },
+                                "p25": {
+                                  "type": [
+                                    "number",
+                                    "null"
+                                  ]
+                                },
+                                "median": {
+                                  "type": [
+                                    "number",
+                                    "null"
+                                  ]
+                                },
+                                "mean": {
+                                  "type": [
+                                    "number",
+                                    "null"
+                                  ]
+                                },
+                                "p75": {
+                                  "type": [
+                                    "number",
+                                    "null"
+                                  ]
+                                },
+                                "max": {
+                                  "type": [
+                                    "number",
+                                    "null"
+                                  ]
+                                }
+                              },
+                              "additionalProperties": false
+                            },
+                            "bedrooms": {
+                              "type": "object",
+                              "required": [
+                                "count",
+                                "min",
+                                "p25",
+                                "median",
+                                "mean",
+                                "p75",
+                                "max"
+                              ],
+                              "description": "Distribution summary computed from the eligible listing sample.",
+                              "properties": {
+                                "count": {
+                                  "type": "integer",
+                                  "description": "Number of listings with a usable value for this metric."
+                                },
+                                "min": {
+                                  "type": [
+                                    "number",
+                                    "null"
+                                  ]
+                                },
+                                "p25": {
+                                  "type": [
+                                    "number",
+                                    "null"
+                                  ]
+                                },
+                                "median": {
+                                  "type": [
+                                    "number",
+                                    "null"
+                                  ]
+                                },
+                                "mean": {
+                                  "type": [
+                                    "number",
+                                    "null"
+                                  ]
+                                },
+                                "p75": {
+                                  "type": [
+                                    "number",
+                                    "null"
+                                  ]
+                                },
+                                "max": {
+                                  "type": [
+                                    "number",
+                                    "null"
+                                  ]
+                                }
+                              },
+                              "additionalProperties": false
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "price_bands": {
+                          "type": "object",
+                          "description": "Current inventory split across sample quartile price bands with counts, shares, and USD boundaries.",
+                          "additionalProperties": true
+                        },
+                        "market_positions": {
+                          "type": "object",
+                          "description": "Listings grouped by whether price and price per square foot sit above or below current sample medians.",
+                          "additionalProperties": true
+                        },
+                        "market_signals": {
+                          "type": "object",
+                          "description": "Counts for below-median value candidates, fresh inventory, older inventory, and supporting field coverage.",
+                          "additionalProperties": true
+                        },
+                        "segments": {
+                          "type": "object",
+                          "description": "Inventory groups by home type, postal code, and bedroom count.",
+                          "additionalProperties": true
+                        },
+                        "decision_lenses": {
+                          "type": "object",
+                          "description": "Top current-sample candidates under balanced, value, low-price, newest, and space ranking objectives.",
+                          "additionalProperties": true
+                        },
+                        "shortlist": {
+                          "type": "array",
+                          "description": "Listings ranked against the requested objective and the current report sample.",
+                          "items": {
+                            "type": "object",
+                            "required": [
+                              "rank",
+                              "score",
+                              "listing_id",
+                              "address",
+                              "price_usd",
+                              "reasons"
+                            ],
+                            "properties": {
+                              "rank": {
+                                "type": "integer"
+                              },
+                              "score": {
+                                "type": "number"
+                              },
+                              "listing_id": {
+                                "type": "string"
+                              },
+                              "address": {
+                                "type": "string"
+                              },
+                              "listing_url": {
+                                "type": "string"
+                              },
+                              "price_usd": {
+                                "type": "number"
+                              },
+                              "beds": {
+                                "type": [
+                                  "number",
+                                  "null"
+                                ]
+                              },
+                              "baths": {
+                                "type": [
+                                  "number",
+                                  "null"
+                                ]
+                              },
+                              "sqft": {
+                                "type": [
+                                  "number",
+                                  "null"
+                                ]
+                              },
+                              "price_per_sqft_usd": {
+                                "type": [
+                                  "number",
+                                  "null"
+                                ]
+                              },
+                              "days_on_market": {
+                                "type": [
+                                  "number",
+                                  "null"
+                                ]
+                              },
+                              "price_vs_market_pct": {
+                                "type": [
+                                  "number",
+                                  "null"
+                                ]
+                              },
+                              "price_per_sqft_vs_market_pct": {
+                                "type": [
+                                  "number",
+                                  "null"
+                                ]
+                              },
+                              "cohort": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "description": "Context against listings with the same normalized home type and bedroom count.",
+                                "additionalProperties": true
+                              },
+                              "reasons": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "additionalProperties": true
+                          }
+                        },
+                        "outliers": {
+                          "type": "object",
+                          "description": "Review flags for unusually low or high price and price per square foot using a transparent IQR rule.",
+                          "additionalProperties": true
+                        },
+                        "evidence_manifest": {
+                          "type": "object",
+                          "description": "Declares analyzed rows, returned rows, evidence scope, shortlist count, and enforced cap.",
+                          "additionalProperties": true
+                        },
+                        "data_quality": {
+                          "type": "object",
+                          "description": "Confidence label, field coverage percentages, warnings, and limitations.",
+                          "additionalProperties": true
+                        },
+                        "methodology": {
+                          "type": "object",
+                          "description": "Transparent calculation and interpretation boundaries.",
+                          "additionalProperties": true
+                        },
+                        "markdown": {
+                          "type": "string",
+                          "description": "Optional ready-to-render report."
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "listings": {
+                      "type": "array",
+                      "description": "All normalized analyzed evidence rows only for the fixed-price evidence-bundle route; empty for the report-only route.",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    },
+                    "checkedAt": {
+                      "type": "string",
+                      "format": "date-time"
+                    }
+                  },
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "tags": [
+          "real-estate",
+          "market-intelligence",
+          "market-report",
+          "listing-analysis",
+          "pricing-benchmarks",
+          "price-bands",
+          "decision-lenses",
+          "value-shortlist",
+          "housing",
+          "for-sale",
+          "for-rent",
+          "public-data",
+          "x402"
+        ]
+      }
+    },
+    "/api/real-estate/intelligence/bundle": {
+      "post": {
+        "summary": "Generate real estate intelligence with source listings",
+        "description": "Purpose: Return the complete $0.75 real-estate intelligence report plus every normalized listing that passed the requested exact ZIP and min/max price, bedroom, bathroom, square-foot, property-type, and freshness filters, capped at 100 rows. The fixed $0.85 bundle costs less than purchasing the report and enough separate 20-row listing-search calls, while the paid route itself controls evidence access so a request flag cannot obtain bundle data at the report-only price.\nBest use: Use this when an agent needs return the complete $0.75 real-estate intelligence report plus every normalized listing that passed the requested exact ZIP and min/max price, bedroom, bathroom, square-foot, property-type, and freshness filters, capped at 100 rows. The fixed $0.85 bundle costs less than purchasing the report and enough separate 20-row listing-search calls, while the paid route itself controls evidence access so a request flag cannot obtain bundle data at the report-only price.\nPrice: $0.85 per successful paid call. Direct Base x402 authorization is verified before execution and settled only after successful fulfillment.\nFulfillment: Managed AgentBodega HTTP+JSON endpoint. Upstream provider details are intentionally not disclosed unless the response explicitly includes managed source metadata.\n\nInput: send a JSON request body.\nRequired fields: conditional by mode.\nRequired combinations: Build a current-market report from at least five unique, priced public listings. Provide market, zipCode, or both. The service fetches up to 100 rows, verifies requested filters against normalized fields, and does not settle payment when there is not enough usable evidence. Full analyzed evidence rows are sold only by the fixed-price evidence-bundle route.\nOptional fields: market, zipCode, listingType, objective, priceMin, priceMax, bedsMin, bedsMax, bathsMin, bathsMax, sqftMin, sqftMax, homeTypes, propertyType, bedrooms, maxRent, sortBy, daysOnMarket, maxPages, maxListings, shortlistLimit, includeMarkdown.\n\nAccepted fields:\n- market (optional, string): City or neighborhood to analyze, such as Houston, TX or Montrose Houston TX. May be omitted when zipCode is provided. Constraints: min length: 2; max length: 180.\n- zipCode (optional, string): Exact five-digit ZIP to analyze. It narrows collection where supported and excludes returned rows with missing or different postal codes.\n- listingType (optional, string): Current inventory class to analyze. Historical sold-comparable analysis is not included in this version. Constraints: accepted values: \"for_sale\", \"for_rent\", \"foreclosure\"; default: \"for_sale\".\n- objective (optional, string): Ranking objective for the evidence-backed shortlist. balanced combines price, price per square foot, recency, and space when fields are available. Constraints: accepted values: \"balanced\", \"value\", \"low-price\", \"newest\", \"space\"; default: \"balanced\".\n- priceMin (optional, integer): Minimum listing price in USD. Listings without a verifiable price are excluded. Constraints: min: 0.\n- priceMax (optional, integer): Maximum listing price or monthly rent in USD. Listings without a verifiable price are excluded. Constraints: min: 0.\n- bedsMin (optional, integer): Minimum bedrooms. Listings without a verifiable bedroom count are excluded when this filter is set. Constraints: min: 0; max: 10.\n- bedsMax (optional, integer): Maximum bedrooms. Listings without a verifiable bedroom count are excluded when this filter is set. Constraints: min: 0; max: 10.\n- bathsMin (optional, number): Minimum bathrooms. Listings without a verifiable bathroom count are excluded when this filter is set. Constraints: min: 0; max: 10.\n- bathsMax (optional, number): Maximum bathrooms. Listings without a verifiable bathroom count are excluded when this filter is set. Constraints: min: 0; max: 10.\n- sqftMin (optional, integer): Minimum interior square feet. Listings without verifiable square footage are excluded when this filter is set. Constraints: min: 0.\n- sqftMax (optional, integer): Maximum interior square feet. Listings without verifiable square footage are excluded when this filter is set. Constraints: min: 0.\n- homeTypes (optional, array): Optional home-type filters for home-sale searches. Constraints: max items: 7.\n- propertyType (optional, string): Rental property type used for apartment-market reports. Constraints: accepted values: \"apartments\", \"houses\", \"townhomes\", \"condos\".\n- bedrooms (optional, any): Rental bedroom filter used for apartment-market reports.\n- maxRent (optional, integer): Maximum monthly rent in USD. If omitted, priceMax is reused for rental reports. Constraints: min: 0.\n- sortBy (optional, string): Managed-source collection order before AgentBodega computes its own shortlist ranking. Constraints: accepted values: \"newest\", \"relevance\", \"pricea\", \"priced\", \"beds\", \"baths\", \"size\", \"lot\", \"zest\"; default: \"newest\".\n- daysOnMarket (optional, string): Optional maximum listing-age bucket supported by home-sale searches. Constraints: accepted values: \"\", \"1\", \"7\", \"14\", \"30\", \"90\", \"6m\", \"12m\", \"24m\", \"36m\"; default: \"\".\n- maxPages (optional, integer): Maximum rendered result pages for apartment-market reports. Constraints: default: 1; min: 1; max: 2.\n- maxListings (optional, integer): Maximum current listings to ingest before deduplication and verification. At least five usable listings are required for a paid report. Constraints: default: 100; min: 10; max: 100.\n- shortlistLimit (optional, integer): Maximum ranked listings to include in the shortlist. Constraints: default: 10; min: 3; max: 15.\n- includeMarkdown (optional, boolean): Include a ready-to-render Markdown version alongside the structured report JSON. Constraints: default: true.\n\nExample request body:\n```json\n{\n  \"market\": \"Houston, TX 77008\",\n  \"zipCode\": \"77008\",\n  \"listingType\": \"for_sale\",\n  \"objective\": \"value\",\n  \"priceMin\": 200000,\n  \"priceMax\": 750000,\n  \"bedsMin\": 2,\n  \"bedsMax\": 4,\n  \"bathsMin\": 1.5,\n  \"bathsMax\": 4,\n  \"sqftMin\": 1000,\n  \"sqftMax\": 3500,\n  \"maxListings\": 100,\n  \"shortlistLimit\": 10,\n  \"includeMarkdown\": true\n}\n```",
+        "operationId": "real_estate_market_intelligence_with_listings",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.85"
+          },
+          "pricingMode": "fixed",
+          "protocols": [
+            {
+              "x402": {
+                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                "currency": "USDC",
+                "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "payTo": "4tWJRwNyhGr88QTiV2yzMoGsaxZiCSRDepf9JTdBEgyi"
+              }
+            },
+            {
+              "x402": {
+                "network": "eip155:8453",
+                "currency": "USDC",
+                "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                "payTo": "0xe8799C2dedA78ECcEB329D1E8FE9F110bf55E4F8"
+              }
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "anyOf": [
+                  {
+                    "required": [
+                      "market"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "zipCode"
+                    ]
+                  }
+                ],
+                "description": "Build a current-market report from at least five unique, priced public listings. Provide market, zipCode, or both. The service fetches up to 100 rows, verifies requested filters against normalized fields, and does not settle payment when there is not enough usable evidence. Full analyzed evidence rows are sold only by the fixed-price evidence-bundle route.",
+                "properties": {
+                  "market": {
+                    "type": "string",
+                    "minLength": 2,
+                    "maxLength": 180,
+                    "description": "City or neighborhood to analyze, such as Houston, TX or Montrose Houston TX. May be omitted when zipCode is provided."
+                  },
+                  "zipCode": {
+                    "type": "string",
+                    "pattern": "^\\d{5}$",
+                    "description": "Exact five-digit ZIP to analyze. It narrows collection where supported and excludes returned rows with missing or different postal codes."
+                  },
+                  "listingType": {
+                    "type": "string",
+                    "enum": [
+                      "for_sale",
+                      "for_rent",
+                      "foreclosure"
+                    ],
+                    "default": "for_sale",
+                    "description": "Current inventory class to analyze. Historical sold-comparable analysis is not included in this version."
+                  },
+                  "objective": {
+                    "type": "string",
+                    "enum": [
+                      "balanced",
+                      "value",
+                      "low-price",
+                      "newest",
+                      "space"
+                    ],
+                    "default": "balanced",
+                    "description": "Ranking objective for the evidence-backed shortlist. balanced combines price, price per square foot, recency, and space when fields are available."
+                  },
+                  "priceMin": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Minimum listing price in USD. Listings without a verifiable price are excluded."
+                  },
+                  "priceMax": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Maximum listing price or monthly rent in USD. Listings without a verifiable price are excluded."
+                  },
+                  "bedsMin": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 10,
+                    "description": "Minimum bedrooms. Listings without a verifiable bedroom count are excluded when this filter is set."
+                  },
+                  "bedsMax": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 10,
+                    "description": "Maximum bedrooms. Listings without a verifiable bedroom count are excluded when this filter is set."
+                  },
+                  "bathsMin": {
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 10,
+                    "description": "Minimum bathrooms. Listings without a verifiable bathroom count are excluded when this filter is set."
+                  },
+                  "bathsMax": {
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 10,
+                    "description": "Maximum bathrooms. Listings without a verifiable bathroom count are excluded when this filter is set."
+                  },
+                  "sqftMin": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Minimum interior square feet. Listings without verifiable square footage are excluded when this filter is set."
+                  },
+                  "sqftMax": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Maximum interior square feet. Listings without verifiable square footage are excluded when this filter is set."
+                  },
+                  "homeTypes": {
+                    "type": "array",
+                    "maxItems": 7,
+                    "items": {
+                      "type": "string",
+                      "enum": [
+                        "houses",
+                        "townhomes",
+                        "multifamily",
+                        "condos",
+                        "land",
+                        "apartments",
+                        "manufactured"
+                      ],
+                      "description": "Home Types item filter for Real Estate Intelligence + Evidence Bundle. Accepted values: \"houses\", \"townhomes\", \"multifamily\", \"condos\", \"land\", \"apartments\", \"manufactured\". Constraints: accepted values: \"houses\", \"townhomes\", \"multifamily\", \"condos\", \"land\", \"apartments\", \"manufactured\"."
+                    },
+                    "description": "Optional home-type filters for home-sale searches."
+                  },
+                  "propertyType": {
+                    "type": "string",
+                    "enum": [
+                      "apartments",
+                      "houses",
+                      "townhomes",
+                      "condos"
+                    ],
+                    "description": "Rental property type used for apartment-market reports."
+                  },
+                  "bedrooms": {
+                    "oneOf": [
+                      {
+                        "type": "string",
+                        "enum": [
+                          "any",
+                          "studio",
+                          "1",
+                          "2",
+                          "3",
+                          "4",
+                          "5+"
+                        ]
+                      },
+                      {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 5
+                      }
+                    ],
+                    "description": "Rental bedroom filter used for apartment-market reports."
+                  },
+                  "maxRent": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Maximum monthly rent in USD. If omitted, priceMax is reused for rental reports."
+                  },
+                  "sortBy": {
+                    "type": "string",
+                    "enum": [
+                      "newest",
+                      "relevance",
+                      "pricea",
+                      "priced",
+                      "beds",
+                      "baths",
+                      "size",
+                      "lot",
+                      "zest"
+                    ],
+                    "default": "newest",
+                    "description": "Managed-source collection order before AgentBodega computes its own shortlist ranking."
+                  },
+                  "daysOnMarket": {
+                    "type": "string",
+                    "enum": [
+                      "",
+                      "1",
+                      "7",
+                      "14",
+                      "30",
+                      "90",
+                      "6m",
+                      "12m",
+                      "24m",
+                      "36m"
+                    ],
+                    "default": "",
+                    "description": "Optional maximum listing-age bucket supported by home-sale searches."
+                  },
+                  "maxPages": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 2,
+                    "default": 1,
+                    "description": "Maximum rendered result pages for apartment-market reports."
+                  },
+                  "maxListings": {
+                    "type": "integer",
+                    "minimum": 10,
+                    "maximum": 100,
+                    "default": 100,
+                    "description": "Maximum current listings to ingest before deduplication and verification. At least five usable listings are required for a paid report."
+                  },
+                  "shortlistLimit": {
+                    "type": "integer",
+                    "minimum": 3,
+                    "maximum": 15,
+                    "default": 10,
+                    "description": "Maximum ranked listings to include in the shortlist."
+                  },
+                  "includeMarkdown": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Include a ready-to-render Markdown version alongside the structured report JSON."
+                  }
+                },
+                "additionalProperties": false
+              },
+              "example": {
+                "market": "Houston, TX 77008",
+                "zipCode": "77008",
+                "listingType": "for_sale",
+                "objective": "value",
+                "priceMin": 200000,
+                "priceMax": 750000,
+                "bedsMin": 2,
+                "bedsMax": 4,
+                "bathsMin": 1.5,
+                "bathsMax": 4,
+                "sqftMin": 1000,
+                "sqftMax": 3500,
+                "maxListings": 100,
+                "shortlistLimit": 10,
+                "includeMarkdown": true
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Utility result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "tool",
+                    "requested",
+                    "source",
+                    "report",
+                    "listings",
+                    "checkedAt"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "description": "True only when enough evidence was collected to deliver the report."
+                    },
+                    "tool": {
+                      "type": "object",
+                      "description": "AgentBodega product identity and department.",
+                      "additionalProperties": true
+                    },
+                    "requested": {
+                      "type": "object",
+                      "description": "Normalized report request and enforced limits.",
+                      "additionalProperties": true
+                    },
+                    "source": {
+                      "type": "object",
+                      "description": "Source-neutral routing and freshness metadata.",
+                      "additionalProperties": true
+                    },
+                    "report": {
+                      "type": "object",
+                      "required": [
+                        "title",
+                        "executive_summary",
+                        "insights",
+                        "sample",
+                        "benchmarks",
+                        "price_bands",
+                        "market_positions",
+                        "market_signals",
+                        "segments",
+                        "decision_lenses",
+                        "shortlist",
+                        "outliers",
+                        "evidence_manifest",
+                        "data_quality",
+                        "methodology"
+                      ],
+                      "properties": {
+                        "title": {
+                          "type": "string"
+                        },
+                        "executive_summary": {
+                          "type": "string",
+                          "description": "Deterministic summary grounded in the returned sample metrics."
+                        },
+                        "insights": {
+                          "type": "array",
+                          "description": "Concise evidence-backed observations derived from the current sample without generative inference.",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "sample": {
+                          "type": "object",
+                          "description": "Raw, duplicate, unique, eligible, and excluded row counts.",
+                          "additionalProperties": true
+                        },
+                        "benchmarks": {
+                          "type": "object",
+                          "required": [
+                            "list_price_usd",
+                            "square_feet",
+                            "price_per_sqft_usd",
+                            "days_on_market",
+                            "bedrooms"
+                          ],
+                          "properties": {
+                            "list_price_usd": {
+                              "type": "object",
+                              "required": [
+                                "count",
+                                "min",
+                                "p25",
+                                "median",
+                                "mean",
+                                "p75",
+                                "max"
+                              ],
+                              "description": "Distribution summary computed from the eligible listing sample.",
+                              "properties": {
+                                "count": {
+                                  "type": "integer",
+                                  "description": "Number of listings with a usable value for this metric."
+                                },
+                                "min": {
+                                  "type": [
+                                    "number",
+                                    "null"
+                                  ]
+                                },
+                                "p25": {
+                                  "type": [
+                                    "number",
+                                    "null"
+                                  ]
+                                },
+                                "median": {
+                                  "type": [
+                                    "number",
+                                    "null"
+                                  ]
+                                },
+                                "mean": {
+                                  "type": [
+                                    "number",
+                                    "null"
+                                  ]
+                                },
+                                "p75": {
+                                  "type": [
+                                    "number",
+                                    "null"
+                                  ]
+                                },
+                                "max": {
+                                  "type": [
+                                    "number",
+                                    "null"
+                                  ]
+                                }
+                              },
+                              "additionalProperties": false
+                            },
+                            "square_feet": {
+                              "type": "object",
+                              "required": [
+                                "count",
+                                "min",
+                                "p25",
+                                "median",
+                                "mean",
+                                "p75",
+                                "max"
+                              ],
+                              "description": "Distribution summary computed from the eligible listing sample.",
+                              "properties": {
+                                "count": {
+                                  "type": "integer",
+                                  "description": "Number of listings with a usable value for this metric."
+                                },
+                                "min": {
+                                  "type": [
+                                    "number",
+                                    "null"
+                                  ]
+                                },
+                                "p25": {
+                                  "type": [
+                                    "number",
+                                    "null"
+                                  ]
+                                },
+                                "median": {
+                                  "type": [
+                                    "number",
+                                    "null"
+                                  ]
+                                },
+                                "mean": {
+                                  "type": [
+                                    "number",
+                                    "null"
+                                  ]
+                                },
+                                "p75": {
+                                  "type": [
+                                    "number",
+                                    "null"
+                                  ]
+                                },
+                                "max": {
+                                  "type": [
+                                    "number",
+                                    "null"
+                                  ]
+                                }
+                              },
+                              "additionalProperties": false
+                            },
+                            "price_per_sqft_usd": {
+                              "type": "object",
+                              "required": [
+                                "count",
+                                "min",
+                                "p25",
+                                "median",
+                                "mean",
+                                "p75",
+                                "max"
+                              ],
+                              "description": "Distribution summary computed from the eligible listing sample.",
+                              "properties": {
+                                "count": {
+                                  "type": "integer",
+                                  "description": "Number of listings with a usable value for this metric."
+                                },
+                                "min": {
+                                  "type": [
+                                    "number",
+                                    "null"
+                                  ]
+                                },
+                                "p25": {
+                                  "type": [
+                                    "number",
+                                    "null"
+                                  ]
+                                },
+                                "median": {
+                                  "type": [
+                                    "number",
+                                    "null"
+                                  ]
+                                },
+                                "mean": {
+                                  "type": [
+                                    "number",
+                                    "null"
+                                  ]
+                                },
+                                "p75": {
+                                  "type": [
+                                    "number",
+                                    "null"
+                                  ]
+                                },
+                                "max": {
+                                  "type": [
+                                    "number",
+                                    "null"
+                                  ]
+                                }
+                              },
+                              "additionalProperties": false
+                            },
+                            "days_on_market": {
+                              "type": "object",
+                              "required": [
+                                "count",
+                                "min",
+                                "p25",
+                                "median",
+                                "mean",
+                                "p75",
+                                "max"
+                              ],
+                              "description": "Distribution summary computed from the eligible listing sample.",
+                              "properties": {
+                                "count": {
+                                  "type": "integer",
+                                  "description": "Number of listings with a usable value for this metric."
+                                },
+                                "min": {
+                                  "type": [
+                                    "number",
+                                    "null"
+                                  ]
+                                },
+                                "p25": {
+                                  "type": [
+                                    "number",
+                                    "null"
+                                  ]
+                                },
+                                "median": {
+                                  "type": [
+                                    "number",
+                                    "null"
+                                  ]
+                                },
+                                "mean": {
+                                  "type": [
+                                    "number",
+                                    "null"
+                                  ]
+                                },
+                                "p75": {
+                                  "type": [
+                                    "number",
+                                    "null"
+                                  ]
+                                },
+                                "max": {
+                                  "type": [
+                                    "number",
+                                    "null"
+                                  ]
+                                }
+                              },
+                              "additionalProperties": false
+                            },
+                            "bedrooms": {
+                              "type": "object",
+                              "required": [
+                                "count",
+                                "min",
+                                "p25",
+                                "median",
+                                "mean",
+                                "p75",
+                                "max"
+                              ],
+                              "description": "Distribution summary computed from the eligible listing sample.",
+                              "properties": {
+                                "count": {
+                                  "type": "integer",
+                                  "description": "Number of listings with a usable value for this metric."
+                                },
+                                "min": {
+                                  "type": [
+                                    "number",
+                                    "null"
+                                  ]
+                                },
+                                "p25": {
+                                  "type": [
+                                    "number",
+                                    "null"
+                                  ]
+                                },
+                                "median": {
+                                  "type": [
+                                    "number",
+                                    "null"
+                                  ]
+                                },
+                                "mean": {
+                                  "type": [
+                                    "number",
+                                    "null"
+                                  ]
+                                },
+                                "p75": {
+                                  "type": [
+                                    "number",
+                                    "null"
+                                  ]
+                                },
+                                "max": {
+                                  "type": [
+                                    "number",
+                                    "null"
+                                  ]
+                                }
+                              },
+                              "additionalProperties": false
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "price_bands": {
+                          "type": "object",
+                          "description": "Current inventory split across sample quartile price bands with counts, shares, and USD boundaries.",
+                          "additionalProperties": true
+                        },
+                        "market_positions": {
+                          "type": "object",
+                          "description": "Listings grouped by whether price and price per square foot sit above or below current sample medians.",
+                          "additionalProperties": true
+                        },
+                        "market_signals": {
+                          "type": "object",
+                          "description": "Counts for below-median value candidates, fresh inventory, older inventory, and supporting field coverage.",
+                          "additionalProperties": true
+                        },
+                        "segments": {
+                          "type": "object",
+                          "description": "Inventory groups by home type, postal code, and bedroom count.",
+                          "additionalProperties": true
+                        },
+                        "decision_lenses": {
+                          "type": "object",
+                          "description": "Top current-sample candidates under balanced, value, low-price, newest, and space ranking objectives.",
+                          "additionalProperties": true
+                        },
+                        "shortlist": {
+                          "type": "array",
+                          "description": "Listings ranked against the requested objective and the current report sample.",
+                          "items": {
+                            "type": "object",
+                            "required": [
+                              "rank",
+                              "score",
+                              "listing_id",
+                              "address",
+                              "price_usd",
+                              "reasons"
+                            ],
+                            "properties": {
+                              "rank": {
+                                "type": "integer"
+                              },
+                              "score": {
+                                "type": "number"
+                              },
+                              "listing_id": {
+                                "type": "string"
+                              },
+                              "address": {
+                                "type": "string"
+                              },
+                              "listing_url": {
+                                "type": "string"
+                              },
+                              "price_usd": {
+                                "type": "number"
+                              },
+                              "beds": {
+                                "type": [
+                                  "number",
+                                  "null"
+                                ]
+                              },
+                              "baths": {
+                                "type": [
+                                  "number",
+                                  "null"
+                                ]
+                              },
+                              "sqft": {
+                                "type": [
+                                  "number",
+                                  "null"
+                                ]
+                              },
+                              "price_per_sqft_usd": {
+                                "type": [
+                                  "number",
+                                  "null"
+                                ]
+                              },
+                              "days_on_market": {
+                                "type": [
+                                  "number",
+                                  "null"
+                                ]
+                              },
+                              "price_vs_market_pct": {
+                                "type": [
+                                  "number",
+                                  "null"
+                                ]
+                              },
+                              "price_per_sqft_vs_market_pct": {
+                                "type": [
+                                  "number",
+                                  "null"
+                                ]
+                              },
+                              "cohort": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "description": "Context against listings with the same normalized home type and bedroom count.",
+                                "additionalProperties": true
+                              },
+                              "reasons": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "additionalProperties": true
+                          }
+                        },
+                        "outliers": {
+                          "type": "object",
+                          "description": "Review flags for unusually low or high price and price per square foot using a transparent IQR rule.",
+                          "additionalProperties": true
+                        },
+                        "evidence_manifest": {
+                          "type": "object",
+                          "description": "Declares analyzed rows, returned rows, evidence scope, shortlist count, and enforced cap.",
+                          "additionalProperties": true
+                        },
+                        "data_quality": {
+                          "type": "object",
+                          "description": "Confidence label, field coverage percentages, warnings, and limitations.",
+                          "additionalProperties": true
+                        },
+                        "methodology": {
+                          "type": "object",
+                          "description": "Transparent calculation and interpretation boundaries.",
+                          "additionalProperties": true
+                        },
+                        "markdown": {
+                          "type": "string",
+                          "description": "Optional ready-to-render report."
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "listings": {
+                      "type": "array",
+                      "description": "All normalized analyzed evidence rows only for the fixed-price evidence-bundle route; empty for the report-only route.",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    },
+                    "checkedAt": {
+                      "type": "string",
+                      "format": "date-time"
+                    }
+                  },
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "tags": [
+          "real-estate",
+          "market-intelligence",
+          "market-report",
+          "evidence-bundle",
+          "analyzed-listings",
+          "listing-analysis",
+          "pricing-benchmarks",
+          "price-bands",
+          "decision-lenses",
+          "housing",
+          "for-sale",
+          "for-rent",
+          "public-data",
+          "x402"
+        ]
+      }
+    },
+    "/api/prediction-markets/search": {
+      "post": {
+        "summary": "Search prediction markets by intent",
+        "description": "Purpose: Search active or historical public prediction markets by keyword, category, venue, liquidity, volume, and end date; returns normalized read-only market rows with outcomes, prices, and source-neutral feed metadata.\nBest use: Use this when an agent needs search active or historical public prediction markets by keyword, category, venue, liquidity, volume, and end date; returns normalized read-only market rows with outcomes, prices, and source-neutral feed metadata.\nPrice: $0.01 per successful paid call. Direct Base x402 authorization is verified before execution and settled only after successful fulfillment.\nFulfillment: Managed AgentBodega HTTP+JSON endpoint. Upstream provider details are intentionally not disclosed unless the response explicitly includes managed source metadata.\n\nInput: send a JSON request body.\nRequired fields: none.\nOptional fields: query, venue, activeOnly, closed, category, limit, sort, includeRules.\n\nAccepted fields:\n- query (optional, string): Optional text filter matched against market title, slug, description, outcomes, and category labels. Constraints: max length: 160.\n- venue (optional, string): Venue selector. Use managed for AgentBodega's normalized market feed. Constraints: accepted values: \"managed\", \"polymarket\"; default: \"managed\".\n- activeOnly (optional, boolean): When true, return currently active, unresolved markets only. Constraints: default: true.\n- closed (optional, boolean): Set true only when historical or resolved markets are acceptable. Constraints: default: false.\n- category (optional, string): Optional category, event, or tag filter when the caller wants a narrower market family. Constraints: max length: 80.\n- limit (optional, integer): Maximum normalized market rows to return. Constraints: default: 10; min: 1; max: 25.\n- sort (optional, string): Sort order for returned markets. Constraints: accepted values: \"volume_desc\", \"liquidity_desc\", \"newest\", \"ending_soon\"; default: \"volume_desc\".\n- includeRules (optional, boolean): Set true to include capped market rule or description text. Constraints: default: false.\n\nExample request body:\n```json\n{\n  \"query\": \"AI agents\",\n  \"category\": \"technology\",\n  \"activeOnly\": true,\n  \"limit\": 10,\n  \"sort\": \"volume_desc\",\n  \"includeRules\": false\n}\n```",
+        "operationId": "prediction_market_search",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.01"
+          },
+          "pricingMode": "fixed",
+          "protocols": [
+            {
+              "x402": {
+                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                "currency": "USDC",
+                "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "payTo": "4tWJRwNyhGr88QTiV2yzMoGsaxZiCSRDepf9JTdBEgyi"
+              }
+            },
+            {
+              "x402": {
+                "network": "eip155:8453",
+                "currency": "USDC",
+                "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                "payTo": "0xe8799C2dedA78ECcEB329D1E8FE9F110bf55E4F8"
+              }
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "query": {
+                    "type": "string",
+                    "maxLength": 160,
+                    "description": "Optional text filter matched against market title, slug, description, outcomes, and category labels."
+                  },
+                  "venue": {
+                    "type": "string",
+                    "enum": [
+                      "managed",
+                      "polymarket"
+                    ],
+                    "default": "managed",
+                    "description": "Venue selector. Use managed for AgentBodega's normalized market feed."
+                  },
+                  "activeOnly": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "When true, return currently active, unresolved markets only."
+                  },
+                  "closed": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Set true only when historical or resolved markets are acceptable."
+                  },
+                  "category": {
+                    "type": "string",
+                    "maxLength": 80,
+                    "description": "Optional category, event, or tag filter when the caller wants a narrower market family."
+                  },
+                  "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 25,
+                    "default": 10,
+                    "description": "Maximum normalized market rows to return."
+                  },
+                  "sort": {
+                    "type": "string",
+                    "enum": [
+                      "volume_desc",
+                      "liquidity_desc",
+                      "newest",
+                      "ending_soon"
+                    ],
+                    "default": "volume_desc",
+                    "description": "Sort order for returned markets."
+                  },
+                  "includeRules": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Set true to include capped market rule or description text."
+                  }
+                },
+                "additionalProperties": false
+              },
+              "example": {
+                "query": "AI agents",
+                "category": "technology",
+                "activeOnly": true,
+                "limit": 10,
+                "sort": "volume_desc",
+                "includeRules": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Utility result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "tool",
+                    "requested",
+                    "marketFeed",
+                    "count",
+                    "markets",
+                    "limits",
+                    "checkedAt"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "description": "True when the market search completed."
+                    },
+                    "tool": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "AgentBodega tool metadata."
+                    },
+                    "requested": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Normalized filters and caps."
+                    },
+                    "marketFeed": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Provider-neutral feed metadata and public-data boundary."
+                    },
+                    "count": {
+                      "type": "integer",
+                      "description": "Number of normalized market rows returned."
+                    },
+                    "markets": {
+                      "type": "array",
+                      "description": "Normalized prediction-market rows. These are read-only market intelligence records, not trading instructions.",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "description": "Stable market id."
+                          },
+                          "slug": {
+                            "type": "string",
+                            "description": "Stable market slug when available."
+                          },
+                          "title": {
+                            "type": "string",
+                            "description": "Market question or title."
+                          },
+                          "url": {
+                            "type": "string",
+                            "description": "Public market URL when available."
+                          },
+                          "venue": {
+                            "type": "string",
+                            "description": "Normalized venue label."
+                          },
+                          "active": {
+                            "type": "boolean",
+                            "description": "Whether the market is active."
+                          },
+                          "closed": {
+                            "type": "boolean",
+                            "description": "Whether the market is closed or resolved."
+                          },
+                          "endsAt": {
+                            "type": "string",
+                            "description": "Market end timestamp when available."
+                          },
+                          "volume": {
+                            "type": "number",
+                            "description": "Reported all-time volume when available."
+                          },
+                          "liquidity": {
+                            "type": "number",
+                            "description": "Reported liquidity when available."
+                          },
+                          "outcomes": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "additionalProperties": true
+                            },
+                            "description": "Outcome labels and implied prices when available."
+                          },
+                          "categories": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            },
+                            "description": "Normalized category, event, or tag labels."
+                          },
+                          "rules": {
+                            "type": "string",
+                            "description": "Optional capped rules/description text when includeRules is true."
+                          }
+                        },
+                        "additionalProperties": true
+                      }
+                    },
+                    "limits": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Published caps for this route."
+                    },
+                    "checkedAt": {
+                      "type": "string",
+                      "description": "Server-side ISO timestamp."
+                    }
+                  },
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "tags": [
+          "prediction-markets",
+          "market-search",
+          "markets",
+          "events",
+          "probabilities",
+          "public-data",
+          "research",
+          "x402"
+        ]
+      }
+    },
+    "/api/prediction-markets/listings": {
+      "post": {
+        "summary": "Fetch prediction market listings",
+        "description": "Purpose: Return fresh public prediction-market listings sorted by volume, liquidity, newest, or ending soon with capped rows, normalized outcomes, category labels, and no trade execution.\nBest use: Use this when an agent needs return fresh public prediction-market listings sorted by volume, liquidity, newest, or ending soon with capped rows, normalized outcomes, category labels, and no trade execution.\nPrice: $0.01 per successful paid call. Direct Base x402 authorization is verified before execution and settled only after successful fulfillment.\nFulfillment: Managed AgentBodega HTTP+JSON endpoint. Upstream provider details are intentionally not disclosed unless the response explicitly includes managed source metadata.\n\nInput: send a JSON request body.\nRequired fields: none.\nOptional fields: query, venue, activeOnly, closed, category, limit, sort, includeRules.\n\nAccepted fields:\n- query (optional, string): Optional text filter matched against market title, slug, description, outcomes, and category labels. Constraints: max length: 160.\n- venue (optional, string): Venue selector. Use managed for AgentBodega's normalized market feed. Constraints: accepted values: \"managed\", \"polymarket\"; default: \"managed\".\n- activeOnly (optional, boolean): When true, return currently active, unresolved markets only. Constraints: default: true.\n- closed (optional, boolean): Set true only when historical or resolved markets are acceptable. Constraints: default: false.\n- category (optional, string): Optional category, event, or tag filter when the caller wants a narrower market family. Constraints: max length: 80.\n- limit (optional, integer): Maximum normalized market rows to return. Constraints: default: 10; min: 1; max: 25.\n- sort (optional, string): Sort order for returned markets. Constraints: accepted values: \"volume_desc\", \"liquidity_desc\", \"newest\", \"ending_soon\"; default: \"volume_desc\".\n- includeRules (optional, boolean): Set true to include capped market rule or description text. Constraints: default: false.\n\nExample request body:\n```json\n{\n  \"activeOnly\": true,\n  \"closed\": false,\n  \"limit\": 10,\n  \"sort\": \"volume_desc\",\n  \"includeRules\": false\n}\n```",
+        "operationId": "prediction_market_listings",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.01"
+          },
+          "pricingMode": "fixed",
+          "protocols": [
+            {
+              "x402": {
+                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                "currency": "USDC",
+                "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "payTo": "4tWJRwNyhGr88QTiV2yzMoGsaxZiCSRDepf9JTdBEgyi"
+              }
+            },
+            {
+              "x402": {
+                "network": "eip155:8453",
+                "currency": "USDC",
+                "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                "payTo": "0xe8799C2dedA78ECcEB329D1E8FE9F110bf55E4F8"
+              }
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "query": {
+                    "type": "string",
+                    "maxLength": 160,
+                    "description": "Optional text filter matched against market title, slug, description, outcomes, and category labels."
+                  },
+                  "venue": {
+                    "type": "string",
+                    "enum": [
+                      "managed",
+                      "polymarket"
+                    ],
+                    "default": "managed",
+                    "description": "Venue selector. Use managed for AgentBodega's normalized market feed."
+                  },
+                  "activeOnly": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "When true, return currently active, unresolved markets only."
+                  },
+                  "closed": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Set true only when historical or resolved markets are acceptable."
+                  },
+                  "category": {
+                    "type": "string",
+                    "maxLength": 80,
+                    "description": "Optional category, event, or tag filter when the caller wants a narrower market family."
+                  },
+                  "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 25,
+                    "default": 10,
+                    "description": "Maximum normalized market rows to return."
+                  },
+                  "sort": {
+                    "type": "string",
+                    "enum": [
+                      "volume_desc",
+                      "liquidity_desc",
+                      "newest",
+                      "ending_soon"
+                    ],
+                    "default": "volume_desc",
+                    "description": "Sort order for returned markets."
+                  },
+                  "includeRules": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Set true to include capped market rule or description text."
+                  }
+                },
+                "additionalProperties": false
+              },
+              "example": {
+                "activeOnly": true,
+                "closed": false,
+                "limit": 10,
+                "sort": "volume_desc",
+                "includeRules": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Utility result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "tool",
+                    "requested",
+                    "marketFeed",
+                    "count",
+                    "markets",
+                    "limits",
+                    "checkedAt"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "description": "True when the market search completed."
+                    },
+                    "tool": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "AgentBodega tool metadata."
+                    },
+                    "requested": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Normalized filters and caps."
+                    },
+                    "marketFeed": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Provider-neutral feed metadata and public-data boundary."
+                    },
+                    "count": {
+                      "type": "integer",
+                      "description": "Number of normalized market rows returned."
+                    },
+                    "markets": {
+                      "type": "array",
+                      "description": "Normalized prediction-market rows. These are read-only market intelligence records, not trading instructions.",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "description": "Stable market id."
+                          },
+                          "slug": {
+                            "type": "string",
+                            "description": "Stable market slug when available."
+                          },
+                          "title": {
+                            "type": "string",
+                            "description": "Market question or title."
+                          },
+                          "url": {
+                            "type": "string",
+                            "description": "Public market URL when available."
+                          },
+                          "venue": {
+                            "type": "string",
+                            "description": "Normalized venue label."
+                          },
+                          "active": {
+                            "type": "boolean",
+                            "description": "Whether the market is active."
+                          },
+                          "closed": {
+                            "type": "boolean",
+                            "description": "Whether the market is closed or resolved."
+                          },
+                          "endsAt": {
+                            "type": "string",
+                            "description": "Market end timestamp when available."
+                          },
+                          "volume": {
+                            "type": "number",
+                            "description": "Reported all-time volume when available."
+                          },
+                          "liquidity": {
+                            "type": "number",
+                            "description": "Reported liquidity when available."
+                          },
+                          "outcomes": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "additionalProperties": true
+                            },
+                            "description": "Outcome labels and implied prices when available."
+                          },
+                          "categories": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            },
+                            "description": "Normalized category, event, or tag labels."
+                          },
+                          "rules": {
+                            "type": "string",
+                            "description": "Optional capped rules/description text when includeRules is true."
+                          }
+                        },
+                        "additionalProperties": true
+                      }
+                    },
+                    "limits": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Published caps for this route."
+                    },
+                    "checkedAt": {
+                      "type": "string",
+                      "description": "Server-side ISO timestamp."
+                    }
+                  },
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "tags": [
+          "prediction-markets",
+          "market-listings",
+          "markets",
+          "events",
+          "probabilities",
+          "public-data",
+          "research",
+          "x402"
+        ]
+      }
+    },
+    "/api/social-media/x/user-profile": {
+      "post": {
+        "summary": "Fetch a public X user profile by username",
+        "description": "Purpose: Look up a public X/Twitter profile by username and return normalized account metadata, public metrics, verification state, bio, and profile image metadata.\nBest use: Use this when an agent needs look up a public X/Twitter profile by username and return normalized account metadata, public metrics, verification state, bio, and profile image metadata.\nPrice: $0.03 per successful paid call. Direct Base x402 authorization is verified before execution and settled only after successful fulfillment.\nFulfillment: Managed AgentBodega HTTP+JSON endpoint. Upstream provider details are intentionally not disclosed unless the response explicitly includes managed source metadata.\n\nInput: send a JSON request body.\nRequired fields: username.\nOptional fields: none.\n\nAccepted fields:\n- username (required, string): Public username or profile URL. Leading @ is accepted and normalized. Constraints: min length: 1; max length: 80.\n\nExample request body:\n```json\n{\n  \"username\": \"OpenAI\"\n}\n```",
+        "operationId": "x_user_profile",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.03"
+          },
+          "pricingMode": "fixed",
+          "protocols": [
+            {
+              "x402": {
+                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                "currency": "USDC",
+                "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "payTo": "4tWJRwNyhGr88QTiV2yzMoGsaxZiCSRDepf9JTdBEgyi"
+              }
+            },
+            {
+              "x402": {
+                "network": "eip155:8453",
+                "currency": "USDC",
+                "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                "payTo": "0xe8799C2dedA78ECcEB329D1E8FE9F110bf55E4F8"
+              }
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "username"
+                ],
+                "properties": {
+                  "username": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 80,
+                    "description": "Public username or profile URL. Leading @ is accepted and normalized."
+                  }
+                },
+                "additionalProperties": false
+              },
+              "example": {
+                "username": "OpenAI"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Utility result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "tool",
+                    "requested",
+                    "checkedAt"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "tool": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "requested": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "profile": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "tweet": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "results": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    },
+                    "result_count": {
+                      "type": "integer"
+                    },
+                    "meta": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "checkedAt": {
+                      "type": "string",
+                      "format": "date-time"
+                    }
+                  },
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "tags": [
+          "social-media",
+          "x",
+          "twitter",
+          "profile",
+          "creator-research",
+          "public-data"
+        ]
+      }
+    },
+    "/api/social-media/x/tweet": {
+      "post": {
+        "summary": "Fetch one public X post by URL or ID",
+        "description": "Purpose: Look up one public X/Twitter post by numeric id or post URL and return normalized text, author, created time, language, and public engagement metrics.\nBest use: Use this when an agent needs look up one public X/Twitter post by numeric id or post URL and return normalized text, author, created time, language, and public engagement metrics.\nPrice: $0.02 per successful paid call. Direct Base x402 authorization is verified before execution and settled only after successful fulfillment.\nFulfillment: Managed AgentBodega HTTP+JSON endpoint. Upstream provider details are intentionally not disclosed unless the response explicitly includes managed source metadata.\n\nInput: send a JSON request body.\nRequired fields: none.\nOptional fields: tweetId, tweetUrl.\n\nAccepted fields:\n- tweetId (optional, string): Numeric public post id. Required unless tweetUrl is supplied.\n- tweetUrl (optional, string): Public post URL. Required unless tweetId is supplied. Constraints: format: uri; max length: 300.\n\nExample request body:\n```json\n{\n  \"tweetId\": \"20\"\n}\n```",
+        "operationId": "x_tweet",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.02"
+          },
+          "pricingMode": "fixed",
+          "protocols": [
+            {
+              "x402": {
+                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                "currency": "USDC",
+                "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "payTo": "4tWJRwNyhGr88QTiV2yzMoGsaxZiCSRDepf9JTdBEgyi"
+              }
+            },
+            {
+              "x402": {
+                "network": "eip155:8453",
+                "currency": "USDC",
+                "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                "payTo": "0xe8799C2dedA78ECcEB329D1E8FE9F110bf55E4F8"
+              }
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "anyOf": [
+                  {
+                    "required": [
+                      "tweetId"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "tweetUrl"
+                    ]
+                  }
+                ],
+                "properties": {
+                  "tweetId": {
+                    "type": "string",
+                    "pattern": "^[0-9]{1,30}$",
+                    "description": "Numeric public post id. Required unless tweetUrl is supplied."
+                  },
+                  "tweetUrl": {
+                    "type": "string",
+                    "format": "uri",
+                    "maxLength": 300,
+                    "description": "Public post URL. Required unless tweetId is supplied."
+                  }
+                },
+                "additionalProperties": false
+              },
+              "example": {
+                "tweetId": "20"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Utility result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "tool",
+                    "requested",
+                    "checkedAt"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "tool": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "requested": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "profile": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "tweet": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "results": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    },
+                    "result_count": {
+                      "type": "integer"
+                    },
+                    "meta": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "checkedAt": {
+                      "type": "string",
+                      "format": "date-time"
+                    }
+                  },
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "tags": [
+          "social-media",
+          "x",
+          "twitter",
+          "tweet",
+          "post",
+          "public-data"
+        ]
+      }
+    },
+    "/api/social-media/x/user-timeline": {
+      "post": {
+        "summary": "Fetch a public X user timeline by username",
+        "description": "Purpose: Return recent public posts for a username with normalized post ids, text, author metadata, created time, language, and public engagement metrics.\nBest use: Use this when an agent needs return recent public posts for a username with normalized post ids, text, author metadata, created time, language, and public engagement metrics.\nPrice: $0.05 per successful paid call. Direct Base x402 authorization is verified before execution and settled only after successful fulfillment.\nFulfillment: Managed AgentBodega HTTP+JSON endpoint. Upstream provider details are intentionally not disclosed unless the response explicitly includes managed source metadata.\n\nInput: send a JSON request body.\nRequired fields: username.\nOptional fields: maxResults.\n\nAccepted fields:\n- username (required, string): Public username or profile URL. Leading @ is accepted and normalized. Constraints: min length: 1; max length: 80.\n- maxResults (optional, integer): Maximum recent posts to return. Constraints: default: 20; min: 1; max: 100.\n\nExample request body:\n```json\n{\n  \"username\": \"OpenAI\",\n  \"maxResults\": 5\n}\n```",
+        "operationId": "x_user_timeline",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.05"
+          },
+          "pricingMode": "fixed",
+          "protocols": [
+            {
+              "x402": {
+                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                "currency": "USDC",
+                "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "payTo": "4tWJRwNyhGr88QTiV2yzMoGsaxZiCSRDepf9JTdBEgyi"
+              }
+            },
+            {
+              "x402": {
+                "network": "eip155:8453",
+                "currency": "USDC",
+                "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                "payTo": "0xe8799C2dedA78ECcEB329D1E8FE9F110bf55E4F8"
+              }
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "username"
+                ],
+                "properties": {
+                  "username": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 80,
+                    "description": "Public username or profile URL. Leading @ is accepted and normalized."
+                  },
+                  "maxResults": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 100,
+                    "default": 20,
+                    "description": "Maximum recent posts to return."
+                  }
+                },
+                "additionalProperties": false
+              },
+              "example": {
+                "username": "OpenAI",
+                "maxResults": 5
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Utility result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "tool",
+                    "requested",
+                    "checkedAt"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "tool": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "requested": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "profile": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "tweet": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "results": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    },
+                    "result_count": {
+                      "type": "integer"
+                    },
+                    "meta": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "checkedAt": {
+                      "type": "string",
+                      "format": "date-time"
+                    }
+                  },
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "tags": [
+          "social-media",
+          "x",
+          "twitter",
+          "timeline",
+          "creator-research",
+          "public-data"
+        ]
+      }
+    },
+    "/api/social-media/x/tweet-search": {
+      "post": {
+        "summary": "Search public X posts by query and filters",
+        "description": "Purpose: Search public X/Twitter posts with a raw query or bounded structured filters such as words, exact phrase, hashtags, author, mention target, engagement thresholds, and date range.\nBest use: Use this when an agent needs search public X/Twitter posts with a raw query or bounded structured filters such as words, exact phrase, hashtags, author, mention target, engagement thresholds, and date range.\nPrice: $0.06 per successful paid call. Direct Base x402 authorization is verified before execution and settled only after successful fulfillment.\nFulfillment: Managed AgentBodega HTTP+JSON endpoint. Upstream provider details are intentionally not disclosed unless the response explicitly includes managed source metadata.\n\nInput: send a JSON request body.\nRequired fields: none.\nOptional fields: query, words, phrase, anyWords, noneWords, hashtags, from, to, mentioning, minReplies, minLikes, minReposts, since, until, maxResults.\n\nAccepted fields:\n- query (optional, string): Raw X/Twitter search query. If supplied, structured filter fields are ignored. Constraints: max length: 500.\n- words (optional, string): All words to include. Constraints: max length: 160.\n- phrase (optional, string): Exact phrase to include. Constraints: max length: 160.\n- anyWords (optional, array): Any of these words may match. Constraints: max items: 12.\n- noneWords (optional, array): Words to exclude. Constraints: max items: 12.\n- hashtags (optional, array): Hashtags to include, with or without #. Constraints: max items: 12.\n- from (optional, string): Only posts from this username. Constraints: max length: 80.\n- to (optional, string): Only replies to this username. Constraints: max length: 80.\n- mentioning (optional, string): Only posts mentioning this username. Constraints: max length: 80.\n- minReplies (optional, integer): Minimum reply count. Constraints: min: 0.\n- minLikes (optional, integer): Minimum like count. Constraints: min: 0.\n- minReposts (optional, integer): Minimum repost count. Constraints: min: 0.\n- since (optional, string): Start date in YYYY-MM-DD.\n- until (optional, string): End date in YYYY-MM-DD.\n- maxResults (optional, integer): Maximum posts to return. Search is capped at 20 per call. Constraints: default: 10; min: 1; max: 20.\n\nExample request body:\n```json\n{\n  \"from\": \"OpenAI\",\n  \"words\": \"agent\",\n  \"minLikes\": 10,\n  \"maxResults\": 5\n}\n```",
+        "operationId": "x_tweet_search",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.06"
+          },
+          "pricingMode": "fixed",
+          "protocols": [
+            {
+              "x402": {
+                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                "currency": "USDC",
+                "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "payTo": "4tWJRwNyhGr88QTiV2yzMoGsaxZiCSRDepf9JTdBEgyi"
+              }
+            },
+            {
+              "x402": {
+                "network": "eip155:8453",
+                "currency": "USDC",
+                "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                "payTo": "0xe8799C2dedA78ECcEB329D1E8FE9F110bf55E4F8"
+              }
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "anyOf": [
+                  {
+                    "required": [
+                      "query"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "words"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "phrase"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "hashtags"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "from"
+                    ]
+                  }
+                ],
+                "properties": {
+                  "query": {
+                    "type": "string",
+                    "maxLength": 500,
+                    "description": "Raw X/Twitter search query. If supplied, structured filter fields are ignored."
+                  },
+                  "words": {
+                    "type": "string",
+                    "maxLength": 160,
+                    "description": "All words to include."
+                  },
+                  "phrase": {
+                    "type": "string",
+                    "maxLength": 160,
+                    "description": "Exact phrase to include."
+                  },
+                  "anyWords": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "maxLength": 80,
+                      "description": "Any Words item value for X Post Search. Constraints: max length: 80."
+                    },
+                    "maxItems": 12,
+                    "description": "Any of these words may match."
+                  },
+                  "noneWords": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "maxLength": 80,
+                      "description": "None Words item value for X Post Search. Constraints: max length: 80."
+                    },
+                    "maxItems": 12,
+                    "description": "Words to exclude."
+                  },
+                  "hashtags": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "maxLength": 80,
+                      "description": "Hashtags item value for X Post Search. Constraints: max length: 80."
+                    },
+                    "maxItems": 12,
+                    "description": "Hashtags to include, with or without #."
+                  },
+                  "from": {
+                    "type": "string",
+                    "maxLength": 80,
+                    "description": "Only posts from this username."
+                  },
+                  "to": {
+                    "type": "string",
+                    "maxLength": 80,
+                    "description": "Only replies to this username."
+                  },
+                  "mentioning": {
+                    "type": "string",
+                    "maxLength": 80,
+                    "description": "Only posts mentioning this username."
+                  },
+                  "minReplies": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Minimum reply count."
+                  },
+                  "minLikes": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Minimum like count."
+                  },
+                  "minReposts": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Minimum repost count."
+                  },
+                  "since": {
+                    "type": "string",
+                    "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+                    "description": "Start date in YYYY-MM-DD."
+                  },
+                  "until": {
+                    "type": "string",
+                    "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+                    "description": "End date in YYYY-MM-DD."
+                  },
+                  "maxResults": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 20,
+                    "default": 10,
+                    "description": "Maximum posts to return. Search is capped at 20 per call."
+                  }
+                },
+                "additionalProperties": false
+              },
+              "example": {
+                "from": "OpenAI",
+                "words": "agent",
+                "minLikes": 10,
+                "maxResults": 5
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Utility result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "tool",
+                    "requested",
+                    "checkedAt"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "tool": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "requested": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "profile": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "tweet": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "results": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    },
+                    "result_count": {
+                      "type": "integer"
+                    },
+                    "meta": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "checkedAt": {
+                      "type": "string",
+                      "format": "date-time"
+                    }
+                  },
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "tags": [
+          "social-media",
+          "x",
+          "twitter",
+          "search",
+          "social-listening",
+          "creator-research",
+          "public-data"
+        ]
+      }
+    },
+    "/api/public-data/outdoor-recreation-availability": {
+      "post": {
+        "summary": "Check outdoor recreation availability",
+        "description": "Purpose: Check live public recreation availability for campgrounds, campsites, permits, lotteries, tours, and timed-entry resources over a bounded date range.\nBest use: Use this when an agent needs check live public recreation availability for campgrounds, campsites, permits, lotteries, tours, and timed-entry resources over a bounded date range.\nPrice: $0.005 per successful paid call. Direct Base x402 authorization is verified before execution and settled only after successful fulfillment.\nFulfillment: Managed AgentBodega HTTP+JSON endpoint. Upstream provider details are intentionally not disclosed unless the response explicitly includes managed source metadata.\n\nInput: send a JSON request body.\nRequired fields: resource, startDate, endDate.\nOptional fields: entityId, entityType, state, isLottery, filters, limit, includeMetadata, proxiesSx.\n\nAccepted fields:\n- resource (required, string): Outdoor recreation resource name or canonical reservation URL. Supports campground, campsite, permit, lottery, timed-entry, and tour resources.\n- entityId (optional, string): Optional known facility, campsite, permit, or timed-entry id. Skips name resolution when supplied.\n- entityType (optional, string): Optional known resource type. URLs usually imply this automatically. Constraints: accepted values: \"campground\", \"campsite\", \"permit\", \"timedentry\", \"timedentry_tour\".\n- state (optional, string): Optional state filter for name resolution, such as CA or California.\n- startDate (required, string): Start date in YYYY-MM-DD. For campgrounds this is the check-in date. Constraints: format: date.\n- endDate (required, string): End date in YYYY-MM-DD. For campgrounds this is the checkout date; returned availability covers nights before checkout. Constraints: format: date.\n- isLottery (optional, boolean): For permits, request lottery quota/application state instead of post-draw/walk-up availability. Constraints: default: false.\n- filters (optional, object): Filters object for configuring Outdoor Recreation Availability Check. Object accepts: groupSize, siteType, equipment, rvLengthFt, electric, accessibility, petsAllowed, loop, availableOnly.\n- limit (optional, integer): Maximum matching sites, divisions, or slots to return. Constraints: default: 20; min: 1; max: 50.\n- includeMetadata (optional, boolean): For campgrounds/campsites, include site/facility metadata such as equipment, accessibility, pet policy, and fees when available. Constraints: default: true.\n- proxiesSx (optional, boolean | object): Optional Proxies.sx egress hint for services that need mobile/residential fetches. Pass true for default US mobile egress, or an object with enabled, country, session, and rotation. Credentials and proxy URLs are never accepted from callers. Object accepts: enabled, country, session, rotation, pool, reason.\n\nExample request body:\n```json\n{\n  \"resource\": \"Upper Pines Campground\",\n  \"state\": \"CA\",\n  \"startDate\": \"2026-06-15\",\n  \"endDate\": \"2026-06-19\",\n  \"filters\": {\n    \"siteType\": \"TENT ONLY\",\n    \"groupSize\": 4,\n    \"availableOnly\": true\n  },\n  \"limit\": 5\n}\n```",
+        "operationId": "outdoor_recreation_availability",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.005"
+          },
+          "pricingMode": "fixed",
+          "protocols": [
+            {
+              "x402": {
+                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                "currency": "USDC",
+                "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "payTo": "4tWJRwNyhGr88QTiV2yzMoGsaxZiCSRDepf9JTdBEgyi"
+              }
+            },
+            {
+              "x402": {
+                "network": "eip155:8453",
+                "currency": "USDC",
+                "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                "payTo": "0xe8799C2dedA78ECcEB329D1E8FE9F110bf55E4F8"
+              }
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "resource",
+                  "startDate",
+                  "endDate"
+                ],
+                "properties": {
+                  "resource": {
+                    "type": "string",
+                    "description": "Outdoor recreation resource name or canonical reservation URL. Supports campground, campsite, permit, lottery, timed-entry, and tour resources."
+                  },
+                  "entityId": {
+                    "type": "string",
+                    "description": "Optional known facility, campsite, permit, or timed-entry id. Skips name resolution when supplied."
+                  },
+                  "entityType": {
+                    "type": "string",
+                    "enum": [
+                      "campground",
+                      "campsite",
+                      "permit",
+                      "timedentry",
+                      "timedentry_tour"
+                    ],
+                    "description": "Optional known resource type. URLs usually imply this automatically."
+                  },
+                  "state": {
+                    "type": "string",
+                    "description": "Optional state filter for name resolution, such as CA or California."
+                  },
+                  "startDate": {
+                    "type": "string",
+                    "format": "date",
+                    "description": "Start date in YYYY-MM-DD. For campgrounds this is the check-in date."
+                  },
+                  "endDate": {
+                    "type": "string",
+                    "format": "date",
+                    "description": "End date in YYYY-MM-DD. For campgrounds this is the checkout date; returned availability covers nights before checkout."
+                  },
+                  "isLottery": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "For permits, request lottery quota/application state instead of post-draw/walk-up availability."
+                  },
+                  "filters": {
+                    "type": "object",
+                    "properties": {
+                      "groupSize": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "description": "Group Size numeric value for Outdoor Recreation Availability Check. Constraints: min: 1."
+                      },
+                      "siteType": {
+                        "type": "string",
+                        "description": "Campground site type filter, such as tent only, RV, group, or standard."
+                      },
+                      "equipment": {
+                        "type": "string",
+                        "description": "Equipment name to match in permitted equipment, such as RV or tent."
+                      },
+                      "rvLengthFt": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "description": "Rv Length Ft numeric value for Outdoor Recreation Availability Check. Constraints: min: 1."
+                      },
+                      "electric": {
+                        "type": "boolean",
+                        "description": "Set true to enable electric behavior for Outdoor Recreation Availability Check."
+                      },
+                      "accessibility": {
+                        "type": "boolean",
+                        "description": "Set true to enable accessibility behavior for Outdoor Recreation Availability Check."
+                      },
+                      "petsAllowed": {
+                        "type": "boolean",
+                        "description": "Set true to enable pets allowed behavior for Outdoor Recreation Availability Check."
+                      },
+                      "loop": {
+                        "type": "string",
+                        "description": "Loop value for Outdoor Recreation Availability Check."
+                      },
+                      "availableOnly": {
+                        "type": "boolean",
+                        "default": true,
+                        "description": "Set true to enable available only behavior for Outdoor Recreation Availability Check. Constraints: default: true."
+                      }
+                    },
+                    "additionalProperties": false,
+                    "description": "Filters object for configuring Outdoor Recreation Availability Check."
+                  },
+                  "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 50,
+                    "default": 20,
+                    "description": "Maximum matching sites, divisions, or slots to return."
+                  },
+                  "includeMetadata": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "For campgrounds/campsites, include site/facility metadata such as equipment, accessibility, pet policy, and fees when available."
+                  },
+                  "proxiesSx": {
+                    "type": [
+                      "boolean",
+                      "object"
+                    ],
+                    "description": "Optional Proxies.sx egress hint for services that need mobile/residential fetches. Pass true for default US mobile egress, or an object with enabled, country, session, and rotation. Credentials and proxy URLs are never accepted from callers.",
+                    "properties": {
+                      "enabled": {
+                        "type": "boolean",
+                        "default": true,
+                        "description": "Set false to force direct Worker egress when service-level Proxies.sx default routing is enabled."
+                      },
+                      "country": {
+                        "type": "string",
+                        "minLength": 2,
+                        "maxLength": 2,
+                        "default": "US",
+                        "description": "Two-letter country code for the Proxies.sx pool, for example US."
+                      },
+                      "session": {
+                        "type": "string",
+                        "maxLength": 64,
+                        "description": "Optional sticky-session key. Use stable, non-secret text when you need repeated calls to keep the same mobile identity."
+                      },
+                      "rotation": {
+                        "type": "string",
+                        "enum": [
+                          "sticky",
+                          "hard",
+                          "auto5",
+                          "auto10",
+                          "auto20",
+                          "auto60",
+                          "ondemand"
+                        ],
+                        "default": "sticky",
+                        "description": "Rotation mode requested from the runner. sticky keeps the same session; hard asks for a fresh mobile IP."
+                      },
+                      "pool": {
+                        "type": "string",
+                        "enum": [
+                          "mobile",
+                          "residential",
+                          "any"
+                        ],
+                        "default": "mobile",
+                        "description": "Optional pool preference. mobile maps to the Proxies.sx mbl pool, residential maps to peer, and any lets the gateway choose."
+                      },
+                      "reason": {
+                        "type": "string",
+                        "maxLength": 160,
+                        "description": "Optional caller note for internal observability, such as blocked-direct-worker-egress."
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              },
+              "example": {
+                "resource": "Upper Pines Campground",
+                "state": "CA",
+                "startDate": "2026-06-15",
+                "endDate": "2026-06-19",
+                "filters": {
+                  "siteType": "TENT ONLY",
+                  "groupSize": 4,
+                  "availableOnly": true
+                },
+                "limit": 5
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Utility result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "kind",
+                    "requested",
+                    "resolved",
+                    "checkedAt"
+                  ],
+                  "properties": {
+                    "kind": {
+                      "type": "string",
+                      "enum": [
+                        "campground",
+                        "campsite",
+                        "permit",
+                        "timedentry",
+                        "timedentry_tour"
+                      ]
+                    },
+                    "requested": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "resolved": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "sites": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    },
+                    "divisions": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    },
+                    "slots": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    },
+                    "checkedAt": {
+                      "type": "string",
+                      "format": "date-time"
+                    }
+                  },
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "tags": [
+          "camping",
+          "permits",
+          "public-data",
+          "travel",
+          "availability",
+          "parks"
+        ]
+      }
+    },
+    "/api/public-data/news-headlines/search": {
+      "post": {
+        "summary": "Search current news headlines by topic",
+        "description": "Purpose: Search a managed public news index by topic, publisher label, lookback window, keyword query, sentiment bounds, and sort order; returns normalized headline rows with publisher article URLs.\nBest use: Use this when an agent needs search a managed public news index by topic, publisher label, lookback window, keyword query, sentiment bounds, and sort order; returns normalized headline rows with publisher article URLs.\nPrice: $0.005 per successful paid call. Direct Base x402 authorization is verified before execution and settled only after successful fulfillment.\nFulfillment: Managed AgentBodega HTTP+JSON endpoint. Upstream provider details are intentionally not disclosed unless the response explicitly includes managed source metadata.\n\nInput: send a JSON request body.\nRequired fields: none.\nOptional fields: topic, publisher, query, hours, limit, includeContent, minSentiment, maxSentiment, sort.\n\nAccepted fields:\n- topic (optional, string): Optional news topic filter. Use all for the full managed index. Constraints: accepted values: \"all\", \"tech\", \"news\", \"business\", \"science\", \"gaming\", \"culture\", \"politics\", \"sports\"; default: \"all\".\n- publisher (optional, string): Optional publisher/feed id filter when the caller already knows the feed label to narrow. Constraints: max length: 80.\n- query (optional, string): Optional case-insensitive text filter matched against title, description, topic, publisher id, URL, and keywords. Constraints: max length: 160.\n- hours (optional, integer): Lookback window in hours. Defaults to the last 24 hours and is capped at 24. Constraints: default: 24; min: 1; max: 24.\n- limit (optional, integer): Maximum headline rows to return after filtering and sorting. Constraints: default: 10; min: 1; max: 50.\n- includeContent (optional, boolean): Set true to include a capped cleaned content excerpt when available. Constraints: default: false.\n- minSentiment (optional, number): Optional lower bound for compound sentiment from -1 to 1. Constraints: min: -1; max: 1.\n- maxSentiment (optional, number): Optional upper bound for compound sentiment from -1 to 1. Constraints: min: -1; max: 1.\n- sort (optional, string): Sort order for returned headlines. Constraints: accepted values: \"published_desc\", \"published_asc\", \"sentiment_desc\", \"sentiment_asc\"; default: \"published_desc\".\n\nExample request body:\n```json\n{\n  \"topic\": \"tech\",\n  \"query\": \"ai\",\n  \"hours\": 6,\n  \"limit\": 10,\n  \"sort\": \"published_desc\",\n  \"includeContent\": false\n}\n```",
+        "operationId": "news_headline_search",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.005"
+          },
+          "pricingMode": "fixed",
+          "protocols": [
+            {
+              "x402": {
+                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                "currency": "USDC",
+                "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "payTo": "4tWJRwNyhGr88QTiV2yzMoGsaxZiCSRDepf9JTdBEgyi"
+              }
+            },
+            {
+              "x402": {
+                "network": "eip155:8453",
+                "currency": "USDC",
+                "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                "payTo": "0xe8799C2dedA78ECcEB329D1E8FE9F110bf55E4F8"
+              }
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "topic": {
+                    "type": "string",
+                    "enum": [
+                      "all",
+                      "tech",
+                      "news",
+                      "business",
+                      "science",
+                      "gaming",
+                      "culture",
+                      "politics",
+                      "sports"
+                    ],
+                    "default": "all",
+                    "description": "Optional news topic filter. Use all for the full managed index."
+                  },
+                  "publisher": {
+                    "type": "string",
+                    "maxLength": 80,
+                    "description": "Optional publisher/feed id filter when the caller already knows the feed label to narrow."
+                  },
+                  "query": {
+                    "type": "string",
+                    "maxLength": 160,
+                    "description": "Optional case-insensitive text filter matched against title, description, topic, publisher id, URL, and keywords."
+                  },
+                  "hours": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 24,
+                    "default": 24,
+                    "description": "Lookback window in hours. Defaults to the last 24 hours and is capped at 24."
+                  },
+                  "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 50,
+                    "default": 10,
+                    "description": "Maximum headline rows to return after filtering and sorting."
+                  },
+                  "includeContent": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Set true to include a capped cleaned content excerpt when available."
+                  },
+                  "minSentiment": {
+                    "type": "number",
+                    "minimum": -1,
+                    "maximum": 1,
+                    "description": "Optional lower bound for compound sentiment from -1 to 1."
+                  },
+                  "maxSentiment": {
+                    "type": "number",
+                    "minimum": -1,
+                    "maximum": 1,
+                    "description": "Optional upper bound for compound sentiment from -1 to 1."
+                  },
+                  "sort": {
+                    "type": "string",
+                    "enum": [
+                      "published_desc",
+                      "published_asc",
+                      "sentiment_desc",
+                      "sentiment_asc"
+                    ],
+                    "default": "published_desc",
+                    "description": "Sort order for returned headlines."
+                  }
+                },
+                "additionalProperties": false
+              },
+              "example": {
+                "topic": "tech",
+                "query": "ai",
+                "hours": 6,
+                "limit": 10,
+                "sort": "published_desc",
+                "includeContent": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Utility result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "tool",
+                    "requested",
+                    "feed",
+                    "count",
+                    "headlines",
+                    "limits",
+                    "checkedAt"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "description": "True when headline search completed."
+                    },
+                    "tool": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "AgentBodega tool metadata."
+                    },
+                    "requested": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Normalized request filters and caps."
+                    },
+                    "feed": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Whitelabeled managed index metadata; backend provider URLs are not disclosed."
+                    },
+                    "count": {
+                      "type": "integer",
+                      "description": "Number of headline rows returned."
+                    },
+                    "headlines": {
+                      "type": "array",
+                      "description": "Normalized headline rows.",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "description": "Stable upstream row id or deterministic fallback."
+                          },
+                          "title": {
+                            "type": "string",
+                            "description": "Headline title."
+                          },
+                          "description": {
+                            "type": "string",
+                            "description": "Short article description or summary."
+                          },
+                          "url": {
+                            "type": "string",
+                            "description": "Publisher article URL."
+                          },
+                          "topic": {
+                            "type": "string",
+                            "description": "Assigned topic bucket."
+                          },
+                          "publisher": {
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Publisher/feed label when available."
+                          },
+                          "publishedAt": {
+                            "type": "string",
+                            "description": "Article publish timestamp when available."
+                          },
+                          "insertedAt": {
+                            "type": "string",
+                            "description": "Index insertion timestamp when available."
+                          },
+                          "age": {
+                            "type": "string",
+                            "description": "Short relative age label from the managed index."
+                          },
+                          "keywords": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            },
+                            "description": "Keyword labels when available."
+                          },
+                          "sentiment": {
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Compound, positive, negative, and neutral sentiment hints when available."
+                          },
+                          "contentText": {
+                            "type": "string",
+                            "description": "Optional capped cleaned content excerpt when includeContent is true."
+                          }
+                        },
+                        "additionalProperties": true
+                      }
+                    },
+                    "limits": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Published caps for this route."
+                    },
+                    "checkedAt": {
+                      "type": "string",
+                      "description": "Server-side ISO timestamp for this search."
+                    }
+                  },
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "tags": [
+          "public-data",
+          "news",
+          "headlines",
+          "current-events",
+          "topic-filter",
+          "sentiment",
+          "publisher-links",
+          "x402"
+        ]
+      }
+    },
+    "/api/public-data/news-briefing/summary": {
+      "post": {
+        "summary": "Generate a concise current news briefing",
+        "description": "Purpose: Return a compact rolling public-news briefing with ranked items, titles, and summaries; supports a small text filter and capped item count for fast agent context.\nBest use: Use this when an agent needs return a compact rolling public-news briefing with ranked items, titles, and summaries; supports a small text filter and capped item count for fast agent context.\nPrice: $0.005 per successful paid call. Direct Base x402 authorization is verified before execution and settled only after successful fulfillment.\nFulfillment: Managed AgentBodega HTTP+JSON endpoint. Upstream provider details are intentionally not disclosed unless the response explicitly includes managed source metadata.\n\nInput: send a JSON request body.\nRequired fields: none.\nOptional fields: query, limit.\n\nAccepted fields:\n- query (optional, string): Optional case-insensitive filter matched against briefing titles and summary text. Constraints: max length: 160.\n- limit (optional, integer): Maximum briefing items to return. Constraints: default: 10; min: 1; max: 20.\n\nExample request body:\n```json\n{\n  \"query\": \"technology\",\n  \"limit\": 10\n}\n```",
+        "operationId": "news_briefing_summary",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.005"
+          },
+          "pricingMode": "fixed",
+          "protocols": [
+            {
+              "x402": {
+                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                "currency": "USDC",
+                "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "payTo": "4tWJRwNyhGr88QTiV2yzMoGsaxZiCSRDepf9JTdBEgyi"
+              }
+            },
+            {
+              "x402": {
+                "network": "eip155:8453",
+                "currency": "USDC",
+                "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                "payTo": "0xe8799C2dedA78ECcEB329D1E8FE9F110bf55E4F8"
+              }
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "query": {
+                    "type": "string",
+                    "maxLength": 160,
+                    "description": "Optional case-insensitive filter matched against briefing titles and summary text."
+                  },
+                  "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 20,
+                    "default": 10,
+                    "description": "Maximum briefing items to return."
+                  }
+                },
+                "additionalProperties": false
+              },
+              "example": {
+                "query": "technology",
+                "limit": 10
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Utility result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "tool",
+                    "requested",
+                    "briefing",
+                    "count",
+                    "items",
+                    "checkedAt"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "description": "True when the briefing was parsed."
+                    },
+                    "tool": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "AgentBodega tool metadata."
+                    },
+                    "requested": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Normalized request filters and caps."
+                    },
+                    "briefing": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Whitelabeled briefing metadata and refresh cadence."
+                    },
+                    "count": {
+                      "type": "integer",
+                      "description": "Number of briefing items returned."
+                    },
+                    "items": {
+                      "type": "array",
+                      "description": "Briefing items in source order.",
+                      "items": {
+                        "type": "object",
+                        "required": [
+                          "rank",
+                          "title",
+                          "summary"
+                        ],
+                        "properties": {
+                          "rank": {
+                            "type": "integer",
+                            "description": "One-based rank in the briefing."
+                          },
+                          "title": {
+                            "type": "string",
+                            "description": "Briefing topic or headline."
+                          },
+                          "summary": {
+                            "type": "string",
+                            "description": "Compact summary of the development."
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    },
+                    "checkedAt": {
+                      "type": "string",
+                      "description": "Server-side ISO timestamp for this briefing fetch."
+                    }
+                  },
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "tags": [
+          "public-data",
+          "news",
+          "briefing",
+          "summary",
+          "current-events",
+          "situational-awareness",
+          "x402"
+        ]
+      }
+    },
+    "/api/public-data/news/morning-briefing": {
+      "post": {
+        "summary": "Generate a curated morning news briefing",
+        "description": "Purpose: Build a source-neutral morning briefing from managed public news signals, grouped into agent-ready sections such as global news, markets, AI/technology, crypto, and science with citations and caps.\nBest use: Use this when an agent needs build a source-neutral morning briefing from managed public news signals, grouped into agent-ready sections such as global news, markets, AI/technology, crypto, and science with citations and caps.\nPrice: $0.03 per successful paid call. Direct Base x402 authorization is verified before execution and settled only after successful fulfillment.\nFulfillment: Managed AgentBodega HTTP+JSON endpoint. Upstream provider details are intentionally not disclosed unless the response explicitly includes managed source metadata.\n\nInput: send a JSON request body.\nRequired fields: none.\nOptional fields: focus, topics, hours, maxItemsPerSection, includeCitations.\n\nAccepted fields:\n- focus (optional, string): Optional focus phrase for the briefing, such as AI, crypto, markets, elections, or a company name. Constraints: max length: 160.\n- topics (optional, array): Optional topic buckets to emphasize. Defaults to news, business, tech, and science. Use all to let AgentBodega select from the full index. Constraints: max items: 6.\n- hours (optional, integer): Lookback window in hours. Defaults to the last 12 hours and is capped at 24. Constraints: default: 12; min: 1; max: 24.\n- maxItemsPerSection (optional, integer): Maximum normalized headline rows returned in each briefing section. Constraints: default: 4; min: 1; max: 8.\n- includeCitations (optional, boolean): Set false to omit the flattened citation list while keeping URLs on section items. Constraints: default: true.\n\nExample request body:\n```json\n{\n  \"focus\": \"ai markets\",\n  \"topics\": [\n    \"news\",\n    \"business\",\n    \"tech\"\n  ],\n  \"hours\": 12,\n  \"maxItemsPerSection\": 4,\n  \"includeCitations\": true\n}\n```",
+        "operationId": "news_morning_briefing",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.03"
+          },
+          "pricingMode": "fixed",
+          "protocols": [
+            {
+              "x402": {
+                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                "currency": "USDC",
+                "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "payTo": "4tWJRwNyhGr88QTiV2yzMoGsaxZiCSRDepf9JTdBEgyi"
+              }
+            },
+            {
+              "x402": {
+                "network": "eip155:8453",
+                "currency": "USDC",
+                "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                "payTo": "0xe8799C2dedA78ECcEB329D1E8FE9F110bf55E4F8"
+              }
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "focus": {
+                    "type": "string",
+                    "maxLength": 160,
+                    "description": "Optional focus phrase for the briefing, such as AI, crypto, markets, elections, or a company name."
+                  },
+                  "topics": {
+                    "type": "array",
+                    "maxItems": 6,
+                    "items": {
+                      "type": "string",
+                      "enum": [
+                        "all",
+                        "tech",
+                        "news",
+                        "business",
+                        "science",
+                        "gaming",
+                        "culture",
+                        "politics",
+                        "sports"
+                      ],
+                      "description": "Topics item filter for Morning Briefing. Accepted values: \"all\", \"tech\", \"news\", \"business\", \"science\", \"gaming\", \"culture\", \"politics\", \"sports\". Constraints: accepted values: \"all\", \"tech\", \"news\", \"business\", \"science\", \"gaming\", \"culture\", \"politics\", \"sports\"."
+                    },
+                    "description": "Optional topic buckets to emphasize. Defaults to news, business, tech, and science. Use all to let AgentBodega select from the full index."
+                  },
+                  "hours": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 24,
+                    "default": 12,
+                    "description": "Lookback window in hours. Defaults to the last 12 hours and is capped at 24."
+                  },
+                  "maxItemsPerSection": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 8,
+                    "default": 4,
+                    "description": "Maximum normalized headline rows returned in each briefing section."
+                  },
+                  "includeCitations": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Set false to omit the flattened citation list while keeping URLs on section items."
+                  }
+                },
+                "additionalProperties": false
+              },
+              "example": {
+                "focus": "ai markets",
+                "topics": [
+                  "news",
+                  "business",
+                  "tech"
+                ],
+                "hours": 12,
+                "maxItemsPerSection": 4,
+                "includeCitations": true
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Utility result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "tool",
+                    "requested",
+                    "briefing",
+                    "sections",
+                    "topStories",
+                    "limits",
+                    "checkedAt"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "description": "True when the briefing completed."
+                    },
+                    "tool": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "AgentBodega tool metadata."
+                    },
+                    "requested": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Normalized request filters and caps."
+                    },
+                    "briefing": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "High-level bundle summary, ranking/diversity policy, section count, item count, and source-disclosure policy."
+                    },
+                    "sections": {
+                      "type": "array",
+                      "description": "Briefing sections grouped by agent-relevant intent.",
+                      "items": {
+                        "type": "object",
+                        "required": [
+                          "id",
+                          "title",
+                          "count",
+                          "items"
+                        ],
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "description": "Stable section id."
+                          },
+                          "title": {
+                            "type": "string",
+                            "description": "Human-readable section title."
+                          },
+                          "summary": {
+                            "type": "string",
+                            "description": "One-line summary built from the section's highest-ranked diversified items."
+                          },
+                          "count": {
+                            "type": "integer",
+                            "description": "Number of items in this section."
+                          },
+                          "items": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "additionalProperties": true
+                            },
+                            "description": "Normalized headline rows with publisher article URLs."
+                          },
+                          "ranking": {
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Selection policy used for this section."
+                          }
+                        },
+                        "additionalProperties": true
+                      }
+                    },
+                    "topStories": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      },
+                      "description": "Highest-ranked cross-section stories."
+                    },
+                    "citations": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      },
+                      "description": "Flattened citation list when includeCitations is true."
+                    },
+                    "limits": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Published caps for this bundle route."
+                    },
+                    "checkedAt": {
+                      "type": "string",
+                      "description": "Server-side ISO timestamp for the briefing."
+                    }
+                  },
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "tags": [
+          "public-data",
+          "news",
+          "briefing",
+          "morning-briefing",
+          "markets",
+          "ai",
+          "crypto",
+          "current-events",
+          "citations",
+          "x402"
+        ]
+      }
+    },
+    "/api/public-data/classified-listing-search": {
+      "post": {
+        "summary": "Search classified listings by filters",
+        "description": "Purpose: Search public classified listings by market area, category, query, and common marketplace filters; returns normalized posting titles, prices, locations, dates, and ids without exposing collection URLs.\nBest use: Use this when an agent needs search public classified listings by market area, category, query, and common marketplace filters; returns normalized posting titles, prices, locations, dates, and ids without exposing collection URLs.\nPrice: $0.005 per successful paid call. Direct Base x402 authorization is verified before execution and settled only after successful fulfillment.\nFulfillment: Managed AgentBodega HTTP+JSON endpoint. Upstream provider details are intentionally not disclosed unless the response explicitly includes managed source metadata.\n\nInput: send a JSON request body.\nRequired fields: city, category, query.\nOptional fields: sort, postal, search_distance, min_price, max_price, min_bedrooms, max_bedrooms, hasPic, bundleDuplicates, limit, proxiesSx.\n\nAccepted fields:\n- city (required, string): Market area id, such as sfbay, newyork, losangeles, seattle, chicago, or boston.\n- category (required, string): Listing category abbreviation, such as sss, cta, apa, jjj, or zip.\n- query (required, string): Search text.\n- sort (optional, string): Sort filter for Classified Listing Search. Accepted values: \"date\", \"rel\", \"priceasc\", \"pricedsc\". Constraints: accepted values: \"date\", \"rel\", \"priceasc\", \"pricedsc\"; default: \"date\". Constraints: accepted values: \"date\", \"rel\", \"priceasc\", \"pricedsc\"; default: \"date\".\n- postal (optional, string): Optional postal code to force geo-scoping when the caller's IP region differs from the target city.\n- search_distance (optional, integer): Optional radius in miles when postal is supplied. Constraints: min: 1; max: 500.\n- min_price (optional, integer): Min price numeric value for Classified Listing Search. Constraints: min: 0. Constraints: min: 0.\n- max_price (optional, integer): Max price numeric value for Classified Listing Search. Constraints: min: 0. Constraints: min: 0.\n- min_bedrooms (optional, integer): Min bedrooms numeric value for Classified Listing Search. Constraints: min: 0. Constraints: min: 0.\n- max_bedrooms (optional, integer): Max bedrooms numeric value for Classified Listing Search. Constraints: min: 0. Constraints: min: 0.\n- hasPic (optional, boolean): Set true to enable has pic behavior for Classified Listing Search.\n- bundleDuplicates (optional, boolean): Set true to enable bundle duplicates behavior for Classified Listing Search.\n- limit (optional, integer): Limit numeric value for Classified Listing Search. Constraints: default: 25; min: 1; max: 100. Constraints: default: 25; min: 1; max: 100.\n- proxiesSx (optional, boolean | object): Optional Proxies.sx egress hint for services that need mobile/residential fetches. Pass true for default US mobile egress, or an object with enabled, country, session, and rotation. Credentials and proxy URLs are never accepted from callers. Object accepts: enabled, country, session, rotation, pool, reason.\n\nExample request body:\n```json\n{\n  \"city\": \"sfbay\",\n  \"category\": \"sss\",\n  \"query\": \"bicycle\",\n  \"sort\": \"date\",\n  \"postal\": \"94103\",\n  \"search_distance\": 25,\n  \"limit\": 10\n}\n```",
+        "operationId": "classified_listing_search",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.005"
+          },
+          "pricingMode": "fixed",
+          "protocols": [
+            {
+              "x402": {
+                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                "currency": "USDC",
+                "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "payTo": "4tWJRwNyhGr88QTiV2yzMoGsaxZiCSRDepf9JTdBEgyi"
+              }
+            },
+            {
+              "x402": {
+                "network": "eip155:8453",
+                "currency": "USDC",
+                "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                "payTo": "0xe8799C2dedA78ECcEB329D1E8FE9F110bf55E4F8"
+              }
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "city",
+                  "category",
+                  "query"
+                ],
+                "properties": {
+                  "city": {
+                    "type": "string",
+                    "description": "Market area id, such as sfbay, newyork, losangeles, seattle, chicago, or boston."
+                  },
+                  "category": {
+                    "type": "string",
+                    "description": "Listing category abbreviation, such as sss, cta, apa, jjj, or zip."
+                  },
+                  "query": {
+                    "type": "string",
+                    "description": "Search text."
+                  },
+                  "sort": {
+                    "type": "string",
+                    "enum": [
+                      "date",
+                      "rel",
+                      "priceasc",
+                      "pricedsc"
+                    ],
+                    "default": "date",
+                    "description": "Sort filter for Classified Listing Search. Accepted values: \"date\", \"rel\", \"priceasc\", \"pricedsc\". Constraints: accepted values: \"date\", \"rel\", \"priceasc\", \"pricedsc\"; default: \"date\"."
+                  },
+                  "postal": {
+                    "type": "string",
+                    "description": "Optional postal code to force geo-scoping when the caller's IP region differs from the target city."
+                  },
+                  "search_distance": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 500,
+                    "description": "Optional radius in miles when postal is supplied."
+                  },
+                  "min_price": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Min price numeric value for Classified Listing Search. Constraints: min: 0."
+                  },
+                  "max_price": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Max price numeric value for Classified Listing Search. Constraints: min: 0."
+                  },
+                  "min_bedrooms": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Min bedrooms numeric value for Classified Listing Search. Constraints: min: 0."
+                  },
+                  "max_bedrooms": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Max bedrooms numeric value for Classified Listing Search. Constraints: min: 0."
+                  },
+                  "hasPic": {
+                    "type": "boolean",
+                    "description": "Set true to enable has pic behavior for Classified Listing Search."
+                  },
+                  "bundleDuplicates": {
+                    "type": "boolean",
+                    "description": "Set true to enable bundle duplicates behavior for Classified Listing Search."
+                  },
+                  "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 100,
+                    "default": 25,
+                    "description": "Limit numeric value for Classified Listing Search. Constraints: default: 25; min: 1; max: 100."
+                  },
+                  "proxiesSx": {
+                    "type": [
+                      "boolean",
+                      "object"
+                    ],
+                    "description": "Optional Proxies.sx egress hint for services that need mobile/residential fetches. Pass true for default US mobile egress, or an object with enabled, country, session, and rotation. Credentials and proxy URLs are never accepted from callers.",
+                    "properties": {
+                      "enabled": {
+                        "type": "boolean",
+                        "default": true,
+                        "description": "Set false to force direct Worker egress when service-level Proxies.sx default routing is enabled."
+                      },
+                      "country": {
+                        "type": "string",
+                        "minLength": 2,
+                        "maxLength": 2,
+                        "default": "US",
+                        "description": "Two-letter country code for the Proxies.sx pool, for example US."
+                      },
+                      "session": {
+                        "type": "string",
+                        "maxLength": 64,
+                        "description": "Optional sticky-session key. Use stable, non-secret text when you need repeated calls to keep the same mobile identity."
+                      },
+                      "rotation": {
+                        "type": "string",
+                        "enum": [
+                          "sticky",
+                          "hard",
+                          "auto5",
+                          "auto10",
+                          "auto20",
+                          "auto60",
+                          "ondemand"
+                        ],
+                        "default": "sticky",
+                        "description": "Rotation mode requested from the runner. sticky keeps the same session; hard asks for a fresh mobile IP."
+                      },
+                      "pool": {
+                        "type": "string",
+                        "enum": [
+                          "mobile",
+                          "residential",
+                          "any"
+                        ],
+                        "default": "mobile",
+                        "description": "Optional pool preference. mobile maps to the Proxies.sx mbl pool, residential maps to peer, and any lets the gateway choose."
+                      },
+                      "reason": {
+                        "type": "string",
+                        "maxLength": 160,
+                        "description": "Optional caller note for internal observability, such as blocked-direct-worker-egress."
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              },
+              "example": {
+                "city": "sfbay",
+                "category": "sss",
+                "query": "bicycle",
+                "sort": "date",
+                "postal": "94103",
+                "search_distance": 25,
+                "limit": 10
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Utility result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "tool",
+                    "requested",
+                    "checkedAt"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "tool": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "requested": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "results": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    },
+                    "result": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "egress": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "checkedAt": {
+                      "type": "string",
+                      "format": "date-time"
+                    }
+                  },
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "tags": [
+          "classifieds",
+          "marketplace-listings",
+          "local-search",
+          "public-data",
+          "search"
+        ]
+      }
+    },
+    "/api/public-data/california-highway-traffic": {
+      "post": {
+        "summary": "Fetch California highway traffic speeds",
+        "description": "Purpose: Return live California highway speed snapshots grouped by road and direction, with optional incident and sensor detail, without exposing collection endpoints.\nBest use: Use this when an agent needs return live California highway speed snapshots grouped by road and direction, with optional incident and sensor detail, without exposing collection endpoints.\nPrice: $0.005 per successful paid call. Direct Base x402 authorization is verified before execution and settled only after successful fulfillment.\nFulfillment: Managed AgentBodega HTTP+JSON endpoint. Upstream provider details are intentionally not disclosed unless the response explicitly includes managed source metadata.\n\nInput: send a JSON request body.\nRequired fields: none.\nOptional fields: region, road, direction, minMph, includeIncidents, includeSensors, limit, proxiesSx.\n\nAccepted fields:\n- region (optional, string): California traffic region. Constraints: accepted values: \"NoCal\", \"SoCal\", \"CenCal\"; default: \"NoCal\".\n- road (optional, string): Optional road/highway filter, such as 101, 580, I-80, or CA-1.\n- direction (optional, string): Direction filter for California Highway Traffic Speeds. Accepted values: \"North\", \"South\", \"East\", \"West\". Constraints: accepted values: \"North\", \"South\", \"East\", \"West\". Constraints: accepted values: \"North\", \"South\", \"East\", \"West\".\n- minMph (optional, integer): Only return sections whose average speed is at or below this MPH. Constraints: min: 0.\n- includeIncidents (optional, boolean): Set true to enable include incidents behavior for California Highway Traffic Speeds. Constraints: default: true. Constraints: default: true.\n- includeSensors (optional, boolean): Set true to enable include sensors behavior for California Highway Traffic Speeds. Constraints: default: false. Constraints: default: false.\n- limit (optional, integer): Limit numeric value for California Highway Traffic Speeds. Constraints: default: 100; min: 1; max: 200. Constraints: default: 100; min: 1; max: 200.\n- proxiesSx (optional, boolean | object): Optional Proxies.sx egress hint for services that need mobile/residential fetches. Pass true for default US mobile egress, or an object with enabled, country, session, and rotation. Credentials and proxy URLs are never accepted from callers. Object accepts: enabled, country, session, rotation, pool, reason.\n\nExample request body:\n```json\n{\n  \"region\": \"NoCal\",\n  \"road\": \"580\",\n  \"includeIncidents\": true,\n  \"limit\": 20\n}\n```",
+        "operationId": "california_highway_traffic",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.005"
+          },
+          "pricingMode": "fixed",
+          "protocols": [
+            {
+              "x402": {
+                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                "currency": "USDC",
+                "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "payTo": "4tWJRwNyhGr88QTiV2yzMoGsaxZiCSRDepf9JTdBEgyi"
+              }
+            },
+            {
+              "x402": {
+                "network": "eip155:8453",
+                "currency": "USDC",
+                "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                "payTo": "0xe8799C2dedA78ECcEB329D1E8FE9F110bf55E4F8"
+              }
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "region": {
+                    "type": "string",
+                    "enum": [
+                      "NoCal",
+                      "SoCal",
+                      "CenCal"
+                    ],
+                    "default": "NoCal",
+                    "description": "California traffic region."
+                  },
+                  "road": {
+                    "type": "string",
+                    "description": "Optional road/highway filter, such as 101, 580, I-80, or CA-1."
+                  },
+                  "direction": {
+                    "type": "string",
+                    "enum": [
+                      "North",
+                      "South",
+                      "East",
+                      "West"
+                    ],
+                    "description": "Direction filter for California Highway Traffic Speeds. Accepted values: \"North\", \"South\", \"East\", \"West\". Constraints: accepted values: \"North\", \"South\", \"East\", \"West\"."
+                  },
+                  "minMph": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Only return sections whose average speed is at or below this MPH."
+                  },
+                  "includeIncidents": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Set true to enable include incidents behavior for California Highway Traffic Speeds. Constraints: default: true."
+                  },
+                  "includeSensors": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Set true to enable include sensors behavior for California Highway Traffic Speeds. Constraints: default: false."
+                  },
+                  "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 200,
+                    "default": 100,
+                    "description": "Limit numeric value for California Highway Traffic Speeds. Constraints: default: 100; min: 1; max: 200."
+                  },
+                  "proxiesSx": {
+                    "type": [
+                      "boolean",
+                      "object"
+                    ],
+                    "description": "Optional Proxies.sx egress hint for services that need mobile/residential fetches. Pass true for default US mobile egress, or an object with enabled, country, session, and rotation. Credentials and proxy URLs are never accepted from callers.",
+                    "properties": {
+                      "enabled": {
+                        "type": "boolean",
+                        "default": true,
+                        "description": "Set false to force direct Worker egress when service-level Proxies.sx default routing is enabled."
+                      },
+                      "country": {
+                        "type": "string",
+                        "minLength": 2,
+                        "maxLength": 2,
+                        "default": "US",
+                        "description": "Two-letter country code for the Proxies.sx pool, for example US."
+                      },
+                      "session": {
+                        "type": "string",
+                        "maxLength": 64,
+                        "description": "Optional sticky-session key. Use stable, non-secret text when you need repeated calls to keep the same mobile identity."
+                      },
+                      "rotation": {
+                        "type": "string",
+                        "enum": [
+                          "sticky",
+                          "hard",
+                          "auto5",
+                          "auto10",
+                          "auto20",
+                          "auto60",
+                          "ondemand"
+                        ],
+                        "default": "sticky",
+                        "description": "Rotation mode requested from the runner. sticky keeps the same session; hard asks for a fresh mobile IP."
+                      },
+                      "pool": {
+                        "type": "string",
+                        "enum": [
+                          "mobile",
+                          "residential",
+                          "any"
+                        ],
+                        "default": "mobile",
+                        "description": "Optional pool preference. mobile maps to the Proxies.sx mbl pool, residential maps to peer, and any lets the gateway choose."
+                      },
+                      "reason": {
+                        "type": "string",
+                        "maxLength": 160,
+                        "description": "Optional caller note for internal observability, such as blocked-direct-worker-egress."
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              },
+              "example": {
+                "region": "NoCal",
+                "road": "580",
+                "includeIncidents": true,
+                "limit": 20
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Utility result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "tool",
+                    "requested",
+                    "checkedAt"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "tool": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "requested": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "results": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    },
+                    "result": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "egress": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "checkedAt": {
+                      "type": "string",
+                      "format": "date-time"
+                    }
+                  },
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "tags": [
+          "traffic",
+          "california",
+          "highways",
+          "public-data",
+          "transportation"
+        ]
+      }
+    },
+    "/api/public-data/rental-listing-search": {
+      "post": {
+        "summary": "Search rental listings by location and filters",
+        "description": "Purpose: Find public rental listings by market resource id, rental category, price, bedrooms, bathrooms, and result limit; returns normalized rental/building records without collection links.\nBest use: Use this when an agent needs find public rental listings by market resource id, rental category, price, bedrooms, bathrooms, and result limit; returns normalized rental/building records without collection links.\nPrice: $0.005 per successful paid call. Direct Base x402 authorization is verified before execution and settled only after successful fulfillment.\nFulfillment: Managed AgentBodega HTTP+JSON endpoint. Upstream provider details are intentionally not disclosed unless the response explicitly includes managed source metadata.\n\nInput: send a JSON request body.\nRequired fields: resourceId.\nOptional fields: searchSlug, maxPrice, minPrice, bedrooms, bathrooms, orderBy, limit, proxiesSx.\n\nAccepted fields:\n- resourceId (required, string): Market resource slug or id, such as san-francisco-ca, new-york-ny, brooklyn-new-york-ny, or 94110-ca.\n- searchSlug (optional, string): Rental search slug, such as apartments-for-rent, houses-for-rent, condos-for-rent, townhomes-for-rent, or rooms-for-rent. Constraints: default: \"apartments-for-rent\".\n- maxPrice (optional, integer): Max Price numeric value for Rental Listing Search. Constraints: min: 0. Constraints: min: 0.\n- minPrice (optional, integer): Min Price numeric value for Rental Listing Search. Constraints: min: 0. Constraints: min: 0.\n- bedrooms (optional, string): Comma-separated bedroom filter, such as 1,2,3.\n- bathrooms (optional, string): Comma-separated bathroom filter, such as 1,1.5,2.\n- orderBy (optional, string): Order By filter for Rental Listing Search. Accepted values: \"score\", \"recencyTime\", \"price\". Constraints: accepted values: \"score\", \"recencyTime\", \"price\"; default: \"score\". Constraints: accepted values: \"score\", \"recencyTime\", \"price\"; default: \"score\".\n- limit (optional, integer): Limit numeric value for Rental Listing Search. Constraints: default: 25; min: 1; max: 100. Constraints: default: 25; min: 1; max: 100.\n- proxiesSx (optional, boolean | object): Optional Proxies.sx egress hint for services that need mobile/residential fetches. Pass true for default US mobile egress, or an object with enabled, country, session, and rotation. Credentials and proxy URLs are never accepted from callers. Object accepts: enabled, country, session, rotation, pool, reason.\n\nExample request body:\n```json\n{\n  \"resourceId\": \"san-francisco-ca\",\n  \"searchSlug\": \"apartments-for-rent\",\n  \"maxPrice\": 4000,\n  \"bedrooms\": \"1,2\",\n  \"limit\": 10\n}\n```",
+        "operationId": "rental_listing_search",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.005"
+          },
+          "pricingMode": "fixed",
+          "protocols": [
+            {
+              "x402": {
+                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                "currency": "USDC",
+                "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "payTo": "4tWJRwNyhGr88QTiV2yzMoGsaxZiCSRDepf9JTdBEgyi"
+              }
+            },
+            {
+              "x402": {
+                "network": "eip155:8453",
+                "currency": "USDC",
+                "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                "payTo": "0xe8799C2dedA78ECcEB329D1E8FE9F110bf55E4F8"
+              }
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "resourceId"
+                ],
+                "properties": {
+                  "resourceId": {
+                    "type": "string",
+                    "description": "Market resource slug or id, such as san-francisco-ca, new-york-ny, brooklyn-new-york-ny, or 94110-ca."
+                  },
+                  "searchSlug": {
+                    "type": "string",
+                    "default": "apartments-for-rent",
+                    "description": "Rental search slug, such as apartments-for-rent, houses-for-rent, condos-for-rent, townhomes-for-rent, or rooms-for-rent."
+                  },
+                  "maxPrice": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Max Price numeric value for Rental Listing Search. Constraints: min: 0."
+                  },
+                  "minPrice": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Min Price numeric value for Rental Listing Search. Constraints: min: 0."
+                  },
+                  "bedrooms": {
+                    "type": "string",
+                    "description": "Comma-separated bedroom filter, such as 1,2,3."
+                  },
+                  "bathrooms": {
+                    "type": "string",
+                    "description": "Comma-separated bathroom filter, such as 1,1.5,2."
+                  },
+                  "orderBy": {
+                    "type": "string",
+                    "enum": [
+                      "score",
+                      "recencyTime",
+                      "price"
+                    ],
+                    "default": "score",
+                    "description": "Order By filter for Rental Listing Search. Accepted values: \"score\", \"recencyTime\", \"price\". Constraints: accepted values: \"score\", \"recencyTime\", \"price\"; default: \"score\"."
+                  },
+                  "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 100,
+                    "default": 25,
+                    "description": "Limit numeric value for Rental Listing Search. Constraints: default: 25; min: 1; max: 100."
+                  },
+                  "proxiesSx": {
+                    "type": [
+                      "boolean",
+                      "object"
+                    ],
+                    "description": "Optional Proxies.sx egress hint for services that need mobile/residential fetches. Pass true for default US mobile egress, or an object with enabled, country, session, and rotation. Credentials and proxy URLs are never accepted from callers.",
+                    "properties": {
+                      "enabled": {
+                        "type": "boolean",
+                        "default": true,
+                        "description": "Set false to force direct Worker egress when service-level Proxies.sx default routing is enabled."
+                      },
+                      "country": {
+                        "type": "string",
+                        "minLength": 2,
+                        "maxLength": 2,
+                        "default": "US",
+                        "description": "Two-letter country code for the Proxies.sx pool, for example US."
+                      },
+                      "session": {
+                        "type": "string",
+                        "maxLength": 64,
+                        "description": "Optional sticky-session key. Use stable, non-secret text when you need repeated calls to keep the same mobile identity."
+                      },
+                      "rotation": {
+                        "type": "string",
+                        "enum": [
+                          "sticky",
+                          "hard",
+                          "auto5",
+                          "auto10",
+                          "auto20",
+                          "auto60",
+                          "ondemand"
+                        ],
+                        "default": "sticky",
+                        "description": "Rotation mode requested from the runner. sticky keeps the same session; hard asks for a fresh mobile IP."
+                      },
+                      "pool": {
+                        "type": "string",
+                        "enum": [
+                          "mobile",
+                          "residential",
+                          "any"
+                        ],
+                        "default": "mobile",
+                        "description": "Optional pool preference. mobile maps to the Proxies.sx mbl pool, residential maps to peer, and any lets the gateway choose."
+                      },
+                      "reason": {
+                        "type": "string",
+                        "maxLength": 160,
+                        "description": "Optional caller note for internal observability, such as blocked-direct-worker-egress."
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              },
+              "example": {
+                "resourceId": "san-francisco-ca",
+                "searchSlug": "apartments-for-rent",
+                "maxPrice": 4000,
+                "bedrooms": "1,2",
+                "limit": 10
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Utility result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "tool",
+                    "requested",
+                    "checkedAt"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "tool": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "requested": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "results": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    },
+                    "result": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "egress": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "checkedAt": {
+                      "type": "string",
+                      "format": "date-time"
+                    }
+                  },
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "tags": [
+          "rentals",
+          "real-estate-rentals",
+          "apartments",
+          "housing",
+          "public-data"
+        ]
+      }
+    },
+    "/api/public-data/hospital-quality-rating": {
+      "post": {
+        "summary": "Fetch hospital quality ratings by location",
+        "description": "Purpose: Look up public hospital quality metadata by facility id or hospital name/state, including overall star rating and selected measure rows.\nBest use: Use this when an agent needs look up public hospital quality metadata by facility id or hospital name/state, including overall star rating and selected measure rows.\nPrice: $0.005 per successful paid call. Direct Base x402 authorization is verified before execution and settled only after successful fulfillment.\nFulfillment: Managed AgentBodega HTTP+JSON endpoint. Upstream provider details are intentionally not disclosed unless the response explicitly includes managed source metadata.\n\nInput: send a JSON request body.\nRequired fields: none.\nOptional fields: ccn, careCompareUrl, hospitalName, city, state, includeMeasures, compareTo, proxiesSx.\n\nAccepted fields:\n- ccn (optional, string): Six-digit facility id.\n- careCompareUrl (optional, string): Optional hospital detail URL containing the facility id. Prefer ccn or hospitalName/state for whitelabeled calls. Constraints: format: uri.\n- hospitalName (optional, string): Hospital/facility name for lookup.\n- city (optional, string): City value for Hospital Quality Rating.\n- state (optional, string): Two-letter state abbreviation for name lookup.\n- includeMeasures (optional, boolean): Set true to enable include measures behavior for Hospital Quality Rating. Constraints: default: true. Constraints: default: true.\n- compareTo (optional, array): Optional extra CCNs to fetch side by side. Constraints: max items: 3.\n- proxiesSx (optional, boolean | object): Optional Proxies.sx egress hint for services that need mobile/residential fetches. Pass true for default US mobile egress, or an object with enabled, country, session, and rotation. Credentials and proxy URLs are never accepted from callers. Object accepts: enabled, country, session, rotation, pool, reason.\n\nExample request body:\n```json\n{\n  \"ccn\": \"240010\",\n  \"includeMeasures\": true\n}\n```",
+        "operationId": "hospital_quality_rating",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.005"
+          },
+          "pricingMode": "fixed",
+          "protocols": [
+            {
+              "x402": {
+                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                "currency": "USDC",
+                "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "payTo": "4tWJRwNyhGr88QTiV2yzMoGsaxZiCSRDepf9JTdBEgyi"
+              }
+            },
+            {
+              "x402": {
+                "network": "eip155:8453",
+                "currency": "USDC",
+                "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                "payTo": "0xe8799C2dedA78ECcEB329D1E8FE9F110bf55E4F8"
+              }
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "ccn": {
+                    "type": "string",
+                    "description": "Six-digit facility id."
+                  },
+                  "careCompareUrl": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "Optional hospital detail URL containing the facility id. Prefer ccn or hospitalName/state for whitelabeled calls."
+                  },
+                  "hospitalName": {
+                    "type": "string",
+                    "description": "Hospital/facility name for lookup."
+                  },
+                  "city": {
+                    "type": "string",
+                    "description": "City value for Hospital Quality Rating."
+                  },
+                  "state": {
+                    "type": "string",
+                    "description": "Two-letter state abbreviation for name lookup."
+                  },
+                  "includeMeasures": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Set true to enable include measures behavior for Hospital Quality Rating. Constraints: default: true."
+                  },
+                  "compareTo": {
+                    "type": "array",
+                    "maxItems": 3,
+                    "items": {
+                      "type": "string",
+                      "description": "Compare To item value for Hospital Quality Rating."
+                    },
+                    "description": "Optional extra CCNs to fetch side by side."
+                  },
+                  "proxiesSx": {
+                    "type": [
+                      "boolean",
+                      "object"
+                    ],
+                    "description": "Optional Proxies.sx egress hint for services that need mobile/residential fetches. Pass true for default US mobile egress, or an object with enabled, country, session, and rotation. Credentials and proxy URLs are never accepted from callers.",
+                    "properties": {
+                      "enabled": {
+                        "type": "boolean",
+                        "default": true,
+                        "description": "Set false to force direct Worker egress when service-level Proxies.sx default routing is enabled."
+                      },
+                      "country": {
+                        "type": "string",
+                        "minLength": 2,
+                        "maxLength": 2,
+                        "default": "US",
+                        "description": "Two-letter country code for the Proxies.sx pool, for example US."
+                      },
+                      "session": {
+                        "type": "string",
+                        "maxLength": 64,
+                        "description": "Optional sticky-session key. Use stable, non-secret text when you need repeated calls to keep the same mobile identity."
+                      },
+                      "rotation": {
+                        "type": "string",
+                        "enum": [
+                          "sticky",
+                          "hard",
+                          "auto5",
+                          "auto10",
+                          "auto20",
+                          "auto60",
+                          "ondemand"
+                        ],
+                        "default": "sticky",
+                        "description": "Rotation mode requested from the runner. sticky keeps the same session; hard asks for a fresh mobile IP."
+                      },
+                      "pool": {
+                        "type": "string",
+                        "enum": [
+                          "mobile",
+                          "residential",
+                          "any"
+                        ],
+                        "default": "mobile",
+                        "description": "Optional pool preference. mobile maps to the Proxies.sx mbl pool, residential maps to peer, and any lets the gateway choose."
+                      },
+                      "reason": {
+                        "type": "string",
+                        "maxLength": 160,
+                        "description": "Optional caller note for internal observability, such as blocked-direct-worker-egress."
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              },
+              "example": {
+                "ccn": "240010",
+                "includeMeasures": true
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Utility result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "tool",
+                    "requested",
+                    "checkedAt"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "tool": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "requested": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "results": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    },
+                    "result": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "egress": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "checkedAt": {
+                      "type": "string",
+                      "format": "date-time"
+                    }
+                  },
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "tags": [
+          "hospital",
+          "healthcare",
+          "ratings",
+          "public-records",
+          "quality",
+          "public-data"
+        ]
+      }
+    },
+    "/api/public-data/school-quality-rating": {
+      "post": {
+        "summary": "Fetch school quality ratings by location",
+        "description": "Purpose: Look up public school rating data by school name/city/state, returning rating, grades, enrollment, district, address, and ids.\nBest use: Use this when an agent needs look up public school rating data by school name/city/state, returning rating, grades, enrollment, district, address, and ids.\nPrice: $0.005 per successful paid call. Direct Base x402 authorization is verified before execution and settled only after successful fulfillment.\nFulfillment: Managed AgentBodega HTTP+JSON endpoint. Upstream provider details are intentionally not disclosed unless the response explicitly includes managed source metadata.\n\nInput: send a JSON request body.\nRequired fields: none.\nOptional fields: schoolUrl, schoolName, city, state, includeCatchment, proxiesSx.\n\nAccepted fields:\n- schoolUrl (optional, string): Optional school detail URL. Prefer schoolName/city/state for whitelabeled calls. Constraints: format: uri.\n- schoolName (optional, string): School name to resolve.\n- city (optional, string): City value for School Quality Rating Lookup.\n- state (optional, string): State value for School Quality Rating Lookup.\n- includeCatchment (optional, boolean): Include catchment GeoJSON when present. Large polygons are omitted by default. Constraints: default: false.\n- proxiesSx (optional, boolean | object): Optional Proxies.sx egress hint for services that need mobile/residential fetches. Pass true for default US mobile egress, or an object with enabled, country, session, and rotation. Credentials and proxy URLs are never accepted from callers. Object accepts: enabled, country, session, rotation, pool, reason.\n\nExample request body:\n```json\n{\n  \"schoolName\": \"Sylvia Mendez Elementary\",\n  \"city\": \"Berkeley\",\n  \"state\": \"CA\"\n}\n```",
+        "operationId": "school_quality_rating",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.005"
+          },
+          "pricingMode": "fixed",
+          "protocols": [
+            {
+              "x402": {
+                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                "currency": "USDC",
+                "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "payTo": "4tWJRwNyhGr88QTiV2yzMoGsaxZiCSRDepf9JTdBEgyi"
+              }
+            },
+            {
+              "x402": {
+                "network": "eip155:8453",
+                "currency": "USDC",
+                "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                "payTo": "0xe8799C2dedA78ECcEB329D1E8FE9F110bf55E4F8"
+              }
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "schoolUrl": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "Optional school detail URL. Prefer schoolName/city/state for whitelabeled calls."
+                  },
+                  "schoolName": {
+                    "type": "string",
+                    "description": "School name to resolve."
+                  },
+                  "city": {
+                    "type": "string",
+                    "description": "City value for School Quality Rating Lookup."
+                  },
+                  "state": {
+                    "type": "string",
+                    "description": "State value for School Quality Rating Lookup."
+                  },
+                  "includeCatchment": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Include catchment GeoJSON when present. Large polygons are omitted by default."
+                  },
+                  "proxiesSx": {
+                    "type": [
+                      "boolean",
+                      "object"
+                    ],
+                    "description": "Optional Proxies.sx egress hint for services that need mobile/residential fetches. Pass true for default US mobile egress, or an object with enabled, country, session, and rotation. Credentials and proxy URLs are never accepted from callers.",
+                    "properties": {
+                      "enabled": {
+                        "type": "boolean",
+                        "default": true,
+                        "description": "Set false to force direct Worker egress when service-level Proxies.sx default routing is enabled."
+                      },
+                      "country": {
+                        "type": "string",
+                        "minLength": 2,
+                        "maxLength": 2,
+                        "default": "US",
+                        "description": "Two-letter country code for the Proxies.sx pool, for example US."
+                      },
+                      "session": {
+                        "type": "string",
+                        "maxLength": 64,
+                        "description": "Optional sticky-session key. Use stable, non-secret text when you need repeated calls to keep the same mobile identity."
+                      },
+                      "rotation": {
+                        "type": "string",
+                        "enum": [
+                          "sticky",
+                          "hard",
+                          "auto5",
+                          "auto10",
+                          "auto20",
+                          "auto60",
+                          "ondemand"
+                        ],
+                        "default": "sticky",
+                        "description": "Rotation mode requested from the runner. sticky keeps the same session; hard asks for a fresh mobile IP."
+                      },
+                      "pool": {
+                        "type": "string",
+                        "enum": [
+                          "mobile",
+                          "residential",
+                          "any"
+                        ],
+                        "default": "mobile",
+                        "description": "Optional pool preference. mobile maps to the Proxies.sx mbl pool, residential maps to peer, and any lets the gateway choose."
+                      },
+                      "reason": {
+                        "type": "string",
+                        "maxLength": 160,
+                        "description": "Optional caller note for internal observability, such as blocked-direct-worker-egress."
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              },
+              "example": {
+                "schoolName": "Sylvia Mendez Elementary",
+                "city": "Berkeley",
+                "state": "CA"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Utility result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "tool",
+                    "requested",
+                    "checkedAt"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "tool": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "requested": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "results": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    },
+                    "result": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "egress": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "checkedAt": {
+                      "type": "string",
+                      "format": "date-time"
+                    }
+                  },
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "tags": [
+          "schools",
+          "ratings",
+          "real-estate",
+          "education",
+          "public-data"
+        ]
+      }
+    },
+    "/api/public-data/home-comparable-sales": {
+      "post": {
+        "summary": "Fetch comparable home sales by location",
+        "description": "Purpose: Return best-effort recent sold comparable sales for a region or lat/lon search, with normalized property attributes and no source links.\nBest use: Use this when an agent needs return best-effort recent sold comparable sales for a region or lat/lon search, with normalized property attributes and no source links.\nPrice: $0.03 per successful paid call. Direct Base x402 authorization is verified before execution and settled only after successful fulfillment.\nFulfillment: Managed AgentBodega HTTP+JSON endpoint. Upstream provider details are intentionally not disclosed unless the response explicitly includes managed source metadata.\n\nInput: send a JSON request body.\nRequired fields: none.\nOptional fields: regionId, regionType, market, lat, lon, radiusMiles, soldWithinDays, minPrice, maxPrice, minBeds, maxBeds, minBaths, maxBaths, limit, proxiesSx.\n\nAccepted fields:\n- regionId (optional, string): Market region id, such as city id or ZIP region id.\n- regionType (optional, integer): Market region type. Common values: 2 for ZIP, 6 for city. Constraints: default: 6.\n- market (optional, string): Market slug, such as sanfrancisco, losangeles, seattle, chicago, newyork, or boston.\n- lat (optional, number): Subject latitude for a bounded-radius polygon search.\n- lon (optional, number): Subject longitude for a bounded-radius polygon search.\n- radiusMiles (optional, number): Radius Miles numeric value for Home Comparable Sales. Constraints: default: 1; min: 0.1; max: 25. Constraints: default: 1; min: 0.1; max: 25.\n- soldWithinDays (optional, integer): Sold Within Days filter for Home Comparable Sales. Accepted values: 30, 90, 180, 365, 730, 1095. Constraints: accepted values: 30, 90, 180, 365, 730, 1095; default: 180. Constraints: accepted values: 30, 90, 180, 365, 730, 1095; default: 180.\n- minPrice (optional, integer): Min Price numeric value for Home Comparable Sales. Constraints: min: 0. Constraints: min: 0.\n- maxPrice (optional, integer): Max Price numeric value for Home Comparable Sales. Constraints: min: 0. Constraints: min: 0.\n- minBeds (optional, integer): Min Beds numeric value for Home Comparable Sales. Constraints: min: 0. Constraints: min: 0.\n- maxBeds (optional, integer): Max Beds numeric value for Home Comparable Sales. Constraints: min: 0. Constraints: min: 0.\n- minBaths (optional, number): Min Baths numeric value for Home Comparable Sales. Constraints: min: 0. Constraints: min: 0.\n- maxBaths (optional, number): Max Baths numeric value for Home Comparable Sales. Constraints: min: 0. Constraints: min: 0.\n- limit (optional, integer): Limit numeric value for Home Comparable Sales. Constraints: default: 10; min: 1; max: 50. Constraints: default: 10; min: 1; max: 50.\n- proxiesSx (optional, boolean | object): Optional Proxies.sx egress hint for services that need mobile/residential fetches. Pass true for default US mobile egress, or an object with enabled, country, session, and rotation. Credentials and proxy URLs are never accepted from callers. Object accepts: enabled, country, session, rotation, pool, reason.\n\nExample request body:\n```json\n{\n  \"regionId\": \"17151\",\n  \"regionType\": 6,\n  \"market\": \"sanfrancisco\",\n  \"soldWithinDays\": 180,\n  \"minBeds\": 2,\n  \"limit\": 10\n}\n```",
+        "operationId": "home_comparable_sales",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.03"
+          },
+          "pricingMode": "fixed",
+          "protocols": [
+            {
+              "x402": {
+                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                "currency": "USDC",
+                "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "payTo": "4tWJRwNyhGr88QTiV2yzMoGsaxZiCSRDepf9JTdBEgyi"
+              }
+            },
+            {
+              "x402": {
+                "network": "eip155:8453",
+                "currency": "USDC",
+                "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                "payTo": "0xe8799C2dedA78ECcEB329D1E8FE9F110bf55E4F8"
+              }
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "regionId": {
+                    "type": "string",
+                    "description": "Market region id, such as city id or ZIP region id."
+                  },
+                  "regionType": {
+                    "type": "integer",
+                    "default": 6,
+                    "description": "Market region type. Common values: 2 for ZIP, 6 for city."
+                  },
+                  "market": {
+                    "type": "string",
+                    "description": "Market slug, such as sanfrancisco, losangeles, seattle, chicago, newyork, or boston."
+                  },
+                  "lat": {
+                    "type": "number",
+                    "description": "Subject latitude for a bounded-radius polygon search."
+                  },
+                  "lon": {
+                    "type": "number",
+                    "description": "Subject longitude for a bounded-radius polygon search."
+                  },
+                  "radiusMiles": {
+                    "type": "number",
+                    "minimum": 0.1,
+                    "maximum": 25,
+                    "default": 1,
+                    "description": "Radius Miles numeric value for Home Comparable Sales. Constraints: default: 1; min: 0.1; max: 25."
+                  },
+                  "soldWithinDays": {
+                    "type": "integer",
+                    "enum": [
+                      30,
+                      90,
+                      180,
+                      365,
+                      730,
+                      1095
+                    ],
+                    "default": 180,
+                    "description": "Sold Within Days filter for Home Comparable Sales. Accepted values: 30, 90, 180, 365, 730, 1095. Constraints: accepted values: 30, 90, 180, 365, 730, 1095; default: 180."
+                  },
+                  "minPrice": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Min Price numeric value for Home Comparable Sales. Constraints: min: 0."
+                  },
+                  "maxPrice": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Max Price numeric value for Home Comparable Sales. Constraints: min: 0."
+                  },
+                  "minBeds": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Min Beds numeric value for Home Comparable Sales. Constraints: min: 0."
+                  },
+                  "maxBeds": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Max Beds numeric value for Home Comparable Sales. Constraints: min: 0."
+                  },
+                  "minBaths": {
+                    "type": "number",
+                    "minimum": 0,
+                    "description": "Min Baths numeric value for Home Comparable Sales. Constraints: min: 0."
+                  },
+                  "maxBaths": {
+                    "type": "number",
+                    "minimum": 0,
+                    "description": "Max Baths numeric value for Home Comparable Sales. Constraints: min: 0."
+                  },
+                  "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 50,
+                    "default": 10,
+                    "description": "Limit numeric value for Home Comparable Sales. Constraints: default: 10; min: 1; max: 50."
+                  },
+                  "proxiesSx": {
+                    "type": [
+                      "boolean",
+                      "object"
+                    ],
+                    "description": "Optional Proxies.sx egress hint for services that need mobile/residential fetches. Pass true for default US mobile egress, or an object with enabled, country, session, and rotation. Credentials and proxy URLs are never accepted from callers.",
+                    "properties": {
+                      "enabled": {
+                        "type": "boolean",
+                        "default": true,
+                        "description": "Set false to force direct Worker egress when service-level Proxies.sx default routing is enabled."
+                      },
+                      "country": {
+                        "type": "string",
+                        "minLength": 2,
+                        "maxLength": 2,
+                        "default": "US",
+                        "description": "Two-letter country code for the Proxies.sx pool, for example US."
+                      },
+                      "session": {
+                        "type": "string",
+                        "maxLength": 64,
+                        "description": "Optional sticky-session key. Use stable, non-secret text when you need repeated calls to keep the same mobile identity."
+                      },
+                      "rotation": {
+                        "type": "string",
+                        "enum": [
+                          "sticky",
+                          "hard",
+                          "auto5",
+                          "auto10",
+                          "auto20",
+                          "auto60",
+                          "ondemand"
+                        ],
+                        "default": "sticky",
+                        "description": "Rotation mode requested from the runner. sticky keeps the same session; hard asks for a fresh mobile IP."
+                      },
+                      "pool": {
+                        "type": "string",
+                        "enum": [
+                          "mobile",
+                          "residential",
+                          "any"
+                        ],
+                        "default": "mobile",
+                        "description": "Optional pool preference. mobile maps to the Proxies.sx mbl pool, residential maps to peer, and any lets the gateway choose."
+                      },
+                      "reason": {
+                        "type": "string",
+                        "maxLength": 160,
+                        "description": "Optional caller note for internal observability, such as blocked-direct-worker-egress."
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              },
+              "example": {
+                "regionId": "17151",
+                "regionType": 6,
+                "market": "sanfrancisco",
+                "soldWithinDays": 180,
+                "minBeds": 2,
+                "limit": 10
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Utility result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "tool",
+                    "requested",
+                    "checkedAt"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "tool": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "requested": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "results": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    },
+                    "result": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "egress": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "checkedAt": {
+                      "type": "string",
+                      "format": "date-time"
+                    }
+                  },
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "tags": [
+          "comparable-sales",
+          "real-estate",
+          "sold-comps",
+          "valuation",
+          "public-data",
+          "redfin",
+          "redfin-comps"
+        ]
+      }
+    },
+    "/api/public-data/volunteer-opportunity-search": {
+      "post": {
+        "summary": "Search volunteer opportunities by filters",
+        "description": "Purpose: Search public volunteer opportunities by query, cause, remote/local mode, lat/lon, radius, page, and result limit.\nBest use: Use this when an agent needs search public volunteer opportunities by query, cause, remote/local mode, lat/lon, radius, page, and result limit.\nPrice: $0.005 per successful paid call. Direct Base x402 authorization is verified before execution and settled only after successful fulfillment.\nFulfillment: Managed AgentBodega HTTP+JSON endpoint. Upstream provider details are intentionally not disclosed unless the response explicitly includes managed source metadata.\n\nInput: send a JSON request body.\nRequired fields: none.\nOptional fields: query, opportunityUrl, lat, lon, radiusMiles, remote, categories, page, limit, proxiesSx.\n\nAccepted fields:\n- query (optional, string): Search text.\n- opportunityUrl (optional, string): Optional direct opportunity URL. Prefer query/location filters for whitelabeled calls. Constraints: format: uri.\n- lat (optional, number): Lat numeric value for Volunteer Opportunity Search.\n- lon (optional, number): Lon numeric value for Volunteer Opportunity Search.\n- radiusMiles (optional, number): Radius Miles numeric value for Volunteer Opportunity Search. Constraints: default: 25; min: 1; max: 250. Constraints: default: 25; min: 1; max: 250.\n- remote (optional, boolean): Filter for remote/virtual opportunities.\n- categories (optional, array): Cause/category values, such as ANIMALS, EDUCATION, HEALTH_MEDICINE, or ENVIRONMENT. Constraints: max items: 8.\n- page (optional, integer): Page numeric value for Volunteer Opportunity Search. Constraints: default: 0; min: 0; max: 100. Constraints: default: 0; min: 0; max: 100.\n- limit (optional, integer): Limit numeric value for Volunteer Opportunity Search. Constraints: default: 20; min: 1; max: 100. Constraints: default: 20; min: 1; max: 100.\n- proxiesSx (optional, boolean | object): Optional Proxies.sx egress hint for services that need mobile/residential fetches. Pass true for default US mobile egress, or an object with enabled, country, session, and rotation. Credentials and proxy URLs are never accepted from callers. Object accepts: enabled, country, session, rotation, pool, reason.\n\nExample request body:\n```json\n{\n  \"query\": \"food bank\",\n  \"lat\": 40.7128,\n  \"lon\": -74.006,\n  \"radiusMiles\": 25,\n  \"categories\": [\n    \"HUNGER_FOOD_SECURITY\"\n  ],\n  \"limit\": 10\n}\n```",
+        "operationId": "volunteer_opportunity_search",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.005"
+          },
+          "pricingMode": "fixed",
+          "protocols": [
+            {
+              "x402": {
+                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                "currency": "USDC",
+                "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "payTo": "4tWJRwNyhGr88QTiV2yzMoGsaxZiCSRDepf9JTdBEgyi"
+              }
+            },
+            {
+              "x402": {
+                "network": "eip155:8453",
+                "currency": "USDC",
+                "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                "payTo": "0xe8799C2dedA78ECcEB329D1E8FE9F110bf55E4F8"
+              }
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "query": {
+                    "type": "string",
+                    "description": "Search text."
+                  },
+                  "opportunityUrl": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "Optional direct opportunity URL. Prefer query/location filters for whitelabeled calls."
+                  },
+                  "lat": {
+                    "type": "number",
+                    "description": "Lat numeric value for Volunteer Opportunity Search."
+                  },
+                  "lon": {
+                    "type": "number",
+                    "description": "Lon numeric value for Volunteer Opportunity Search."
+                  },
+                  "radiusMiles": {
+                    "type": "number",
+                    "minimum": 1,
+                    "maximum": 250,
+                    "default": 25,
+                    "description": "Radius Miles numeric value for Volunteer Opportunity Search. Constraints: default: 25; min: 1; max: 250."
+                  },
+                  "remote": {
+                    "type": "boolean",
+                    "description": "Filter for remote/virtual opportunities."
+                  },
+                  "categories": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "Categories item value for Volunteer Opportunity Search."
+                    },
+                    "maxItems": 8,
+                    "description": "Cause/category values, such as ANIMALS, EDUCATION, HEALTH_MEDICINE, or ENVIRONMENT."
+                  },
+                  "page": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 100,
+                    "default": 0,
+                    "description": "Page numeric value for Volunteer Opportunity Search. Constraints: default: 0; min: 0; max: 100."
+                  },
+                  "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 100,
+                    "default": 20,
+                    "description": "Limit numeric value for Volunteer Opportunity Search. Constraints: default: 20; min: 1; max: 100."
+                  },
+                  "proxiesSx": {
+                    "type": [
+                      "boolean",
+                      "object"
+                    ],
+                    "description": "Optional Proxies.sx egress hint for services that need mobile/residential fetches. Pass true for default US mobile egress, or an object with enabled, country, session, and rotation. Credentials and proxy URLs are never accepted from callers.",
+                    "properties": {
+                      "enabled": {
+                        "type": "boolean",
+                        "default": true,
+                        "description": "Set false to force direct Worker egress when service-level Proxies.sx default routing is enabled."
+                      },
+                      "country": {
+                        "type": "string",
+                        "minLength": 2,
+                        "maxLength": 2,
+                        "default": "US",
+                        "description": "Two-letter country code for the Proxies.sx pool, for example US."
+                      },
+                      "session": {
+                        "type": "string",
+                        "maxLength": 64,
+                        "description": "Optional sticky-session key. Use stable, non-secret text when you need repeated calls to keep the same mobile identity."
+                      },
+                      "rotation": {
+                        "type": "string",
+                        "enum": [
+                          "sticky",
+                          "hard",
+                          "auto5",
+                          "auto10",
+                          "auto20",
+                          "auto60",
+                          "ondemand"
+                        ],
+                        "default": "sticky",
+                        "description": "Rotation mode requested from the runner. sticky keeps the same session; hard asks for a fresh mobile IP."
+                      },
+                      "pool": {
+                        "type": "string",
+                        "enum": [
+                          "mobile",
+                          "residential",
+                          "any"
+                        ],
+                        "default": "mobile",
+                        "description": "Optional pool preference. mobile maps to the Proxies.sx mbl pool, residential maps to peer, and any lets the gateway choose."
+                      },
+                      "reason": {
+                        "type": "string",
+                        "maxLength": 160,
+                        "description": "Optional caller note for internal observability, such as blocked-direct-worker-egress."
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              },
+              "example": {
+                "query": "food bank",
+                "lat": 40.7128,
+                "lon": -74.006,
+                "radiusMiles": 25,
+                "categories": [
+                  "HUNGER_FOOD_SECURITY"
+                ],
+                "limit": 10
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Utility result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "tool",
+                    "requested",
+                    "checkedAt"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "tool": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "requested": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "results": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    },
+                    "result": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "egress": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "checkedAt": {
+                      "type": "string",
+                      "format": "date-time"
+                    }
+                  },
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "tags": [
+          "volunteering",
+          "opportunities",
+          "civic",
+          "nonprofit",
+          "public-data"
+        ]
+      }
+    },
+    "/api/public-data/us-weather-forecast": {
+      "post": {
+        "summary": "Fetch a US weather forecast by location",
+        "description": "Purpose: Return a US weather forecast for a point by latitude/longitude, ZIP code, or city/state, including current observation, hourly forecast, multi-day periods, alerts, and grid metadata.\nBest use: Use this when an agent needs return a US weather forecast for a point by latitude/longitude, ZIP code, or city/state, including current observation, hourly forecast, multi-day periods, alerts, and grid metadata.\nPrice: $0.005 per successful paid call. Direct Base x402 authorization is verified before execution and settled only after successful fulfillment.\nFulfillment: Managed AgentBodega HTTP+JSON endpoint. Upstream provider details are intentionally not disclosed unless the response explicitly includes managed source metadata.\n\nInput: send a JSON request body.\nRequired fields: none.\nOptional fields: lat, lon, zip, city, state, location, includeCurrent, includeHourly, includeAlerts, includeOffice, hourlyLimit, dailyLimit, proxiesSx.\n\nAccepted fields:\n- lat (optional, number): Latitude for a US point. Must be paired with lon. Constraints: min: -90; max: 90.\n- lon (optional, number): Longitude for a US point. Must be paired with lat. Constraints: min: -180; max: 180.\n- zip (optional, string): US ZIP code to geocode before forecast lookup.\n- city (optional, string): US city name. Pair with state for best geocoding.\n- state (optional, string): US state name or two-letter abbreviation for city lookup.\n- location (optional, string): Free-form US place query when lat/lon, zip, or city/state are not supplied.\n- includeCurrent (optional, boolean): Fetch the nearest station's latest observation. Constraints: default: true.\n- includeHourly (optional, boolean): Fetch the hourly forecast. Constraints: default: true.\n- includeAlerts (optional, boolean): Fetch active watches, warnings, and advisories for the point. Constraints: default: true.\n- includeOffice (optional, boolean): Fetch forecast-center metadata such as name, phone, and email when available. Constraints: default: false.\n- hourlyLimit (optional, integer): Maximum hourly periods to return. Constraints: default: 24; min: 1; max: 72.\n- dailyLimit (optional, integer): Maximum multi-day forecast periods to return. Constraints: default: 14; min: 1; max: 14.\n- proxiesSx (optional, boolean | object): Optional Proxies.sx egress hint for services that need mobile/residential fetches. Pass true for default US mobile egress, or an object with enabled, country, session, and rotation. Credentials and proxy URLs are never accepted from callers. Object accepts: enabled, country, session, rotation, pool, reason.\n\nExample request body:\n```json\n{\n  \"city\": \"Boulder\",\n  \"state\": \"CO\",\n  \"hourlyLimit\": 24,\n  \"includeAlerts\": true\n}\n```",
+        "operationId": "us_weather_forecast",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.005"
+          },
+          "pricingMode": "fixed",
+          "protocols": [
+            {
+              "x402": {
+                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                "currency": "USDC",
+                "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "payTo": "4tWJRwNyhGr88QTiV2yzMoGsaxZiCSRDepf9JTdBEgyi"
+              }
+            },
+            {
+              "x402": {
+                "network": "eip155:8453",
+                "currency": "USDC",
+                "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                "payTo": "0xe8799C2dedA78ECcEB329D1E8FE9F110bf55E4F8"
+              }
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "lat": {
+                    "type": "number",
+                    "minimum": -90,
+                    "maximum": 90,
+                    "description": "Latitude for a US point. Must be paired with lon."
+                  },
+                  "lon": {
+                    "type": "number",
+                    "minimum": -180,
+                    "maximum": 180,
+                    "description": "Longitude for a US point. Must be paired with lat."
+                  },
+                  "zip": {
+                    "type": "string",
+                    "description": "US ZIP code to geocode before forecast lookup."
+                  },
+                  "city": {
+                    "type": "string",
+                    "description": "US city name. Pair with state for best geocoding."
+                  },
+                  "state": {
+                    "type": "string",
+                    "description": "US state name or two-letter abbreviation for city lookup."
+                  },
+                  "location": {
+                    "type": "string",
+                    "description": "Free-form US place query when lat/lon, zip, or city/state are not supplied."
+                  },
+                  "includeCurrent": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Fetch the nearest station's latest observation."
+                  },
+                  "includeHourly": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Fetch the hourly forecast."
+                  },
+                  "includeAlerts": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Fetch active watches, warnings, and advisories for the point."
+                  },
+                  "includeOffice": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Fetch forecast-center metadata such as name, phone, and email when available."
+                  },
+                  "hourlyLimit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 72,
+                    "default": 24,
+                    "description": "Maximum hourly periods to return."
+                  },
+                  "dailyLimit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 14,
+                    "default": 14,
+                    "description": "Maximum multi-day forecast periods to return."
+                  },
+                  "proxiesSx": {
+                    "type": [
+                      "boolean",
+                      "object"
+                    ],
+                    "description": "Optional Proxies.sx egress hint for services that need mobile/residential fetches. Pass true for default US mobile egress, or an object with enabled, country, session, and rotation. Credentials and proxy URLs are never accepted from callers.",
+                    "properties": {
+                      "enabled": {
+                        "type": "boolean",
+                        "default": true,
+                        "description": "Set false to force direct Worker egress when service-level Proxies.sx default routing is enabled."
+                      },
+                      "country": {
+                        "type": "string",
+                        "minLength": 2,
+                        "maxLength": 2,
+                        "default": "US",
+                        "description": "Two-letter country code for the Proxies.sx pool, for example US."
+                      },
+                      "session": {
+                        "type": "string",
+                        "maxLength": 64,
+                        "description": "Optional sticky-session key. Use stable, non-secret text when you need repeated calls to keep the same mobile identity."
+                      },
+                      "rotation": {
+                        "type": "string",
+                        "enum": [
+                          "sticky",
+                          "hard",
+                          "auto5",
+                          "auto10",
+                          "auto20",
+                          "auto60",
+                          "ondemand"
+                        ],
+                        "default": "sticky",
+                        "description": "Rotation mode requested from the runner. sticky keeps the same session; hard asks for a fresh mobile IP."
+                      },
+                      "pool": {
+                        "type": "string",
+                        "enum": [
+                          "mobile",
+                          "residential",
+                          "any"
+                        ],
+                        "default": "mobile",
+                        "description": "Optional pool preference. mobile maps to the Proxies.sx mbl pool, residential maps to peer, and any lets the gateway choose."
+                      },
+                      "reason": {
+                        "type": "string",
+                        "maxLength": 160,
+                        "description": "Optional caller note for internal observability, such as blocked-direct-worker-egress."
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              },
+              "example": {
+                "city": "Boulder",
+                "state": "CO",
+                "hourlyLimit": 24,
+                "includeAlerts": true
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Utility result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "tool",
+                    "requested",
+                    "checkedAt"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "tool": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "requested": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "results": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    },
+                    "result": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "egress": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "checkedAt": {
+                      "type": "string",
+                      "format": "date-time"
+                    }
+                  },
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "tags": [
+          "weather",
+          "forecast",
+          "alerts",
+          "public-data"
+        ]
       }
     },
     "/api/status/check": {
       "post": {
         "summary": "Check one official status source",
+        "description": "Purpose: Check one official status page or status API for GitHub, GitLab, deploy platforms, package registries, databases, auth, and AI APIs.\nBest use: Use this when an agent needs check one official status page or status API for GitHub, GitLab, deploy platforms, package registries, databases, auth, and AI APIs.\nPrice: $0.005 per successful paid call. Direct Base x402 authorization is verified before execution and settled only after successful fulfillment.\nFulfillment: Managed AgentBodega HTTP+JSON endpoint. Upstream provider details are intentionally not disclosed unless the response explicitly includes managed source metadata.\n\nInput: send a JSON request body.\nRequired fields: service.\nOptional fields: includeComponents, includeIncidentDetails, incidentLimit, component, components.\n\nAccepted fields:\n- service (required, string): Service id from /api/status/catalog, for example github or gitlab.\n- includeComponents (optional, boolean): Set true to enable include components behavior for Official Service Status Check. Constraints: default: true. Constraints: default: true.\n- includeIncidentDetails (optional, boolean): Optional deep incident history/timeline fetch. For Status.io providers this parses the public history page; for Statuspage providers it uses /api/v2/incidents.json. Constraints: default: false.\n- incidentLimit (optional, integer): Maximum recent incidents to return when includeIncidentDetails is true. Constraints: default: 5; min: 1; max: 20.\n- component (optional, string): Optional component selector, alias, id, or name.\n- components (optional, array): Optional component selectors when the caller wants a scoped provider status. Constraints: max items: 12.\n\nExample request body:\n```json\n{\n  \"service\": \"github\",\n  \"includeComponents\": true\n}\n```",
         "operationId": "official_status_check",
         "security": [
           {
@@ -265,11 +9669,25 @@
           "price": {
             "mode": "fixed",
             "currency": "USD",
-            "amount": "0.001"
+            "amount": "0.005"
           },
+          "pricingMode": "fixed",
           "protocols": [
             {
-              "x402": {}
+              "x402": {
+                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                "currency": "USDC",
+                "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "payTo": "4tWJRwNyhGr88QTiV2yzMoGsaxZiCSRDepf9JTdBEgyi"
+              }
+            },
+            {
+              "x402": {
+                "network": "eip155:8453",
+                "currency": "USDC",
+                "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                "payTo": "0xe8799C2dedA78ECcEB329D1E8FE9F110bf55E4F8"
+              }
             }
           ]
         },
@@ -289,7 +9707,8 @@
                   },
                   "includeComponents": {
                     "type": "boolean",
-                    "default": true
+                    "default": true,
+                    "description": "Set true to enable include components behavior for Official Service Status Check. Constraints: default: true."
                   },
                   "includeIncidentDetails": {
                     "type": "boolean",
@@ -310,7 +9729,8 @@
                   "components": {
                     "type": "array",
                     "items": {
-                      "type": "string"
+                      "type": "string",
+                      "description": "Components item value for Official Service Status Check."
                     },
                     "maxItems": 12,
                     "description": "Optional component selectors when the caller wants a scoped provider status."
@@ -340,12 +9760,21 @@
           "402": {
             "description": "Payment Required"
           }
-        }
+        },
+        "tags": [
+          "status",
+          "github",
+          "gitlab",
+          "deploy-readiness",
+          "incident-response",
+          "agent-tools"
+        ]
       }
     },
     "/api/cloud/status/check": {
       "post": {
         "summary": "Check one cloud provider service",
+        "description": "Purpose: Check one public AWS, Google Cloud, Azure, DigitalOcean, or Linode service/location status source and return a terse agent-ready verdict.\nBest use: Use this when an agent needs check one public AWS, Google Cloud, Azure, DigitalOcean, or Linode service/location status source and return a terse agent-ready verdict.\nPrice: $0.005 per successful paid call. Direct Base x402 authorization is verified before execution and settled only after successful fulfillment.\nFulfillment: Managed AgentBodega HTTP+JSON endpoint. Upstream provider details are intentionally not disclosed unless the response explicitly includes managed source metadata.\n\nInput: send a JSON request body.\nRequired fields: provider.\nOptional fields: service, product, region, location, includeHistory, includeHealthy, incidentLimit.\n\nAccepted fields:\n- provider (required, string): Cloud provider id. Constraints: accepted values: \"aws\", \"gcp\", \"azure\", \"digitalocean\", \"linode\".\n- service (optional, string): Provider service name or id, for example ec2, lambda, app-service, spaces, droplets, object-storage, or lke.\n- product (optional, string): GCP product name, id, or alias, for example cloud-run, vertex-ai, cloud-sql, or compute-engine.\n- region (optional, string): Provider region/location such as us-east-1, us-central1, eastus, nyc3, us-east-newark, or global.\n- location (optional, string): Provider location alias. Treated the same as region.\n- includeHistory (optional, boolean): Return recent/resolved historical incidents when the provider source exposes them. Constraints: default: false.\n- includeHealthy (optional, boolean): Include healthy/noisy rows. Default responses focus on degraded or relevant incidents. Constraints: default: false.\n- incidentLimit (optional, integer): Incident Limit numeric value for Cloud Provider Status Check. Constraints: default: 5; min: 1; max: 20. Constraints: default: 5; min: 1; max: 20.\n\nExample request body:\n```json\n{\n  \"provider\": \"aws\",\n  \"service\": \"lambda\",\n  \"region\": \"us-east-1\",\n  \"includeHistory\": false\n}\n```",
         "operationId": "cloud_status_check",
         "security": [
           {
@@ -356,11 +9785,25 @@
           "price": {
             "mode": "fixed",
             "currency": "USD",
-            "amount": "0.001"
+            "amount": "0.005"
           },
+          "pricingMode": "fixed",
           "protocols": [
             {
-              "x402": {}
+              "x402": {
+                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                "currency": "USDC",
+                "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "payTo": "4tWJRwNyhGr88QTiV2yzMoGsaxZiCSRDepf9JTdBEgyi"
+              }
+            },
+            {
+              "x402": {
+                "network": "eip155:8453",
+                "currency": "USDC",
+                "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                "payTo": "0xe8799C2dedA78ECcEB329D1E8FE9F110bf55E4F8"
+              }
             }
           ]
         },
@@ -415,7 +9858,8 @@
                     "type": "integer",
                     "minimum": 1,
                     "maximum": 20,
-                    "default": 5
+                    "default": 5,
+                    "description": "Incident Limit numeric value for Cloud Provider Status Check. Constraints: default: 5; min: 1; max: 20."
                   }
                 },
                 "additionalProperties": false
@@ -444,12 +9888,23 @@
           "402": {
             "description": "Payment Required"
           }
-        }
+        },
+        "tags": [
+          "status",
+          "cloud",
+          "aws",
+          "gcp",
+          "azure",
+          "digitalocean",
+          "linode",
+          "incident-response"
+        ]
       }
     },
     "/api/cloud/status/summary": {
       "post": {
         "summary": "Summarize cloud provider incidents",
+        "description": "Purpose: Summarize public broad-impact incidents for AWS, Google Cloud, Azure, DigitalOcean, Linode, or all providers before an agent retries cloud work.\nBest use: Use this when an agent needs summarize public broad-impact incidents for AWS, Google Cloud, Azure, DigitalOcean, Linode, or all providers before an agent retries cloud work.\nPrice: $0.01 per successful paid call. Direct Base x402 authorization is verified before execution and settled only after successful fulfillment.\nFulfillment: Managed AgentBodega HTTP+JSON endpoint. Upstream provider details are intentionally not disclosed unless the response explicitly includes managed source metadata.\n\nInput: send a JSON request body.\nRequired fields: none.\nOptional fields: provider, includeHistory, includeHealthy, incidentLimit.\n\nAccepted fields:\n- provider (optional, string): Provider filter for Cloud Provider Status Summary. Accepted values: \"aws\", \"gcp\", \"azure\", \"digitalocean\", \"linode\", \"all\". Constraints: accepted values: \"aws\", \"gcp\", \"azure\", \"digitalocean\", \"linode\", \"all\"; default: \"all\". Constraints: accepted values: \"aws\", \"gcp\", \"azure\", \"digitalocean\", \"linode\", \"all\"; default: \"all\".\n- includeHistory (optional, boolean): Set true to enable include history behavior for Cloud Provider Status Summary. Constraints: default: false. Constraints: default: false.\n- includeHealthy (optional, boolean): Set true to enable include healthy behavior for Cloud Provider Status Summary. Constraints: default: false. Constraints: default: false.\n- incidentLimit (optional, integer): Incident Limit numeric value for Cloud Provider Status Summary. Constraints: default: 5; min: 1; max: 20. Constraints: default: 5; min: 1; max: 20.\n\nExample request body:\n```json\n{\n  \"provider\": \"all\",\n  \"includeHistory\": false\n}\n```",
         "operationId": "cloud_status_summary",
         "security": [
           {
@@ -460,11 +9915,25 @@
           "price": {
             "mode": "fixed",
             "currency": "USD",
-            "amount": "0.002"
+            "amount": "0.01"
           },
+          "pricingMode": "fixed",
           "protocols": [
             {
-              "x402": {}
+              "x402": {
+                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                "currency": "USDC",
+                "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "payTo": "4tWJRwNyhGr88QTiV2yzMoGsaxZiCSRDepf9JTdBEgyi"
+              }
+            },
+            {
+              "x402": {
+                "network": "eip155:8453",
+                "currency": "USDC",
+                "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                "payTo": "0xe8799C2dedA78ECcEB329D1E8FE9F110bf55E4F8"
+              }
             }
           ]
         },
@@ -485,21 +9954,25 @@
                       "linode",
                       "all"
                     ],
-                    "default": "all"
+                    "default": "all",
+                    "description": "Provider filter for Cloud Provider Status Summary. Accepted values: \"aws\", \"gcp\", \"azure\", \"digitalocean\", \"linode\", \"all\". Constraints: accepted values: \"aws\", \"gcp\", \"azure\", \"digitalocean\", \"linode\", \"all\"; default: \"all\"."
                   },
                   "includeHistory": {
                     "type": "boolean",
-                    "default": false
+                    "default": false,
+                    "description": "Set true to enable include history behavior for Cloud Provider Status Summary. Constraints: default: false."
                   },
                   "includeHealthy": {
                     "type": "boolean",
-                    "default": false
+                    "default": false,
+                    "description": "Set true to enable include healthy behavior for Cloud Provider Status Summary. Constraints: default: false."
                   },
                   "incidentLimit": {
                     "type": "integer",
                     "minimum": 1,
                     "maximum": 20,
-                    "default": 5
+                    "default": 5,
+                    "description": "Incident Limit numeric value for Cloud Provider Status Summary. Constraints: default: 5; min: 1; max: 20."
                   }
                 },
                 "additionalProperties": false
@@ -526,12 +9999,24 @@
           "402": {
             "description": "Payment Required"
           }
-        }
+        },
+        "tags": [
+          "status",
+          "cloud",
+          "summary",
+          "aws",
+          "gcp",
+          "azure",
+          "digitalocean",
+          "linode",
+          "incident-response"
+        ]
       }
     },
     "/api/cloud/status/bundle": {
       "post": {
         "summary": "Check a small cloud status bundle",
+        "description": "Purpose: Check up to five cloud service/location units, or a curated cloud-provider bundle, without dumping every healthy cloud service.\nBest use: Use this when an agent needs check up to five cloud service/location units, or a curated cloud-provider bundle, without dumping every healthy cloud service.\nPrice: $0.01 per successful paid call. Direct Base x402 authorization is verified before execution and settled only after successful fulfillment.\nFulfillment: Managed AgentBodega HTTP+JSON endpoint. Upstream provider details are intentionally not disclosed unless the response explicitly includes managed source metadata.\n\nInput: send a JSON request body.\nRequired fields: none.\nOptional fields: bundle, targets, includeHistory, includeHealthy.\n\nAccepted fields:\n- bundle (optional, string): Bundle filter for Cloud Status Small Bundle. Accepted values: \"cloud-core\", \"aws-webapp\", \"gcp-ai-app\", \"azure-saas\", \"do-core\", \"linode-core\". Constraints: accepted values: \"cloud-core\", \"aws-webapp\", \"gcp-ai-app\", \"azure-saas\", \"do-core\", \"linode-core\"; default: \"cloud-core\". Constraints: accepted values: \"cloud-core\", \"aws-webapp\", \"gcp-ai-app\", \"azure-saas\", \"do-core\", \"linode-core\"; default: \"cloud-core\".\n- targets (optional, array): Optional explicit cloud checks. Bundle price covers up to five normalized units. Constraints: min items: 1; max items: 5. Array items accept: provider, service, product, region, location.\n- includeHistory (optional, boolean): Set true to enable include history behavior for Cloud Status Small Bundle. Constraints: default: false. Constraints: default: false.\n- includeHealthy (optional, boolean): Set true to enable include healthy behavior for Cloud Status Small Bundle. Constraints: default: false. Constraints: default: false.\n\nExample request body:\n```json\n{\n  \"bundle\": \"cloud-core\",\n  \"includeHistory\": false\n}\n```",
         "operationId": "cloud_status_bundle",
         "security": [
           {
@@ -542,11 +10027,25 @@
           "price": {
             "mode": "fixed",
             "currency": "USD",
-            "amount": "0.005"
+            "amount": "0.01"
           },
+          "pricingMode": "fixed",
           "protocols": [
             {
-              "x402": {}
+              "x402": {
+                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                "currency": "USDC",
+                "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "payTo": "4tWJRwNyhGr88QTiV2yzMoGsaxZiCSRDepf9JTdBEgyi"
+              }
+            },
+            {
+              "x402": {
+                "network": "eip155:8453",
+                "currency": "USDC",
+                "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                "payTo": "0xe8799C2dedA78ECcEB329D1E8FE9F110bf55E4F8"
+              }
             }
           ]
         },
@@ -567,7 +10066,8 @@
                       "do-core",
                       "linode-core"
                     ],
-                    "default": "cloud-core"
+                    "default": "cloud-core",
+                    "description": "Bundle filter for Cloud Status Small Bundle. Accepted values: \"cloud-core\", \"aws-webapp\", \"gcp-ai-app\", \"azure-saas\", \"do-core\", \"linode-core\". Constraints: accepted values: \"cloud-core\", \"aws-webapp\", \"gcp-ai-app\", \"azure-saas\", \"do-core\", \"linode-core\"; default: \"cloud-core\"."
                   },
                   "targets": {
                     "type": "array",
@@ -605,7 +10105,8 @@
                           "description": "Provider location alias. Treated the same as region."
                         }
                       },
-                      "additionalProperties": false
+                      "additionalProperties": false,
+                      "description": "Targets item object for configuring Cloud Status Small Bundle."
                     },
                     "minItems": 1,
                     "maxItems": 5,
@@ -613,11 +10114,13 @@
                   },
                   "includeHistory": {
                     "type": "boolean",
-                    "default": false
+                    "default": false,
+                    "description": "Set true to enable include history behavior for Cloud Status Small Bundle. Constraints: default: false."
                   },
                   "includeHealthy": {
                     "type": "boolean",
-                    "default": false
+                    "default": false,
+                    "description": "Set true to enable include healthy behavior for Cloud Status Small Bundle. Constraints: default: false."
                   }
                 },
                 "additionalProperties": false
@@ -644,12 +10147,24 @@
           "402": {
             "description": "Payment Required"
           }
-        }
+        },
+        "tags": [
+          "status",
+          "cloud",
+          "bundle",
+          "aws",
+          "gcp",
+          "azure",
+          "digitalocean",
+          "linode",
+          "incident-response"
+        ]
       }
     },
     "/api/cloud/status/stack": {
       "post": {
         "summary": "Check a cloud service stack",
+        "description": "Purpose: Check up to twelve caller-selected cloud service/location units for a stack-wide public status verdict.\nBest use: Use this when an agent needs check up to twelve caller-selected cloud service/location units for a stack-wide public status verdict.\nPrice: $0.01 per successful paid call. Direct Base x402 authorization is verified before execution and settled only after successful fulfillment.\nFulfillment: Managed AgentBodega HTTP+JSON endpoint. Upstream provider details are intentionally not disclosed unless the response explicitly includes managed source metadata.\n\nInput: send a JSON request body.\nRequired fields: targets.\nOptional fields: includeHistory, includeHealthy.\n\nAccepted fields:\n- targets (required, array): Caller-selected cloud checks. Stack price covers up to twelve normalized units. Constraints: min items: 3; max items: 12. Array items accept: provider, service, product, region, location.\n- includeHistory (optional, boolean): Set true to enable include history behavior for Cloud Stack Status Bundle. Constraints: default: false. Constraints: default: false.\n- includeHealthy (optional, boolean): Set true to enable include healthy behavior for Cloud Stack Status Bundle. Constraints: default: false. Constraints: default: false.\n\nExample request body:\n```json\n{\n  \"targets\": [\n    {\n      \"provider\": \"aws\",\n      \"service\": \"lambda\",\n      \"region\": \"us-east-1\"\n    },\n    {\n      \"provider\": \"aws\",\n      \"service\": \"s3\",\n      \"region\": \"us-east-1\"\n    },\n    {\n      \"provider\": \"gcp\",\n      \"product\": \"cloud-run\",\n      \"location\": \"us-central1\"\n    },\n    {\n      \"provider\": \"azure\",\n      \"service\": \"app-service\",\n      \"region\": \"eastus\"\n    }\n  ],\n  \"includeHistory\": false\n}\n```",
         "operationId": "cloud_status_stack",
         "security": [
           {
@@ -662,9 +10177,23 @@
             "currency": "USD",
             "amount": "0.01"
           },
+          "pricingMode": "fixed",
           "protocols": [
             {
-              "x402": {}
+              "x402": {
+                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                "currency": "USDC",
+                "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "payTo": "4tWJRwNyhGr88QTiV2yzMoGsaxZiCSRDepf9JTdBEgyi"
+              }
+            },
+            {
+              "x402": {
+                "network": "eip155:8453",
+                "currency": "USDC",
+                "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                "payTo": "0xe8799C2dedA78ECcEB329D1E8FE9F110bf55E4F8"
+              }
             }
           ]
         },
@@ -714,7 +10243,8 @@
                           "description": "Provider location alias. Treated the same as region."
                         }
                       },
-                      "additionalProperties": false
+                      "additionalProperties": false,
+                      "description": "Targets item object for configuring Cloud Stack Status Bundle."
                     },
                     "minItems": 3,
                     "maxItems": 12,
@@ -722,11 +10252,13 @@
                   },
                   "includeHistory": {
                     "type": "boolean",
-                    "default": false
+                    "default": false,
+                    "description": "Set true to enable include history behavior for Cloud Stack Status Bundle. Constraints: default: false."
                   },
                   "includeHealthy": {
                     "type": "boolean",
-                    "default": false
+                    "default": false,
+                    "description": "Set true to enable include healthy behavior for Cloud Stack Status Bundle. Constraints: default: false."
                   }
                 },
                 "additionalProperties": false
@@ -774,12 +10306,24 @@
           "402": {
             "description": "Payment Required"
           }
-        }
+        },
+        "tags": [
+          "status",
+          "cloud",
+          "custom-stack",
+          "aws",
+          "gcp",
+          "azure",
+          "digitalocean",
+          "linode",
+          "incident-response"
+        ]
       }
     },
     "/api/status/bundle": {
       "post": {
         "summary": "Check deploy readiness services",
+        "description": "Purpose: Check a bundle of official status sources so an agent can decide whether to deploy, retry, or wait before blaming its own code.\nBest use: Use this when an agent needs check a bundle of official status sources so an agent can decide whether to deploy, retry, or wait before blaming its own code.\nPrice: $0.01 per successful paid call. Direct Base x402 authorization is verified before execution and settled only after successful fulfillment.\nFulfillment: Managed AgentBodega HTTP+JSON endpoint. Upstream provider details are intentionally not disclosed unless the response explicitly includes managed source metadata.\n\nInput: send a JSON request body.\nRequired fields: none.\nOptional fields: bundle, services, includeComponents.\n\nAccepted fields:\n- bundle (optional, string): Bundle filter for Vibe Deploy Readiness Bundle. Accepted values: \"vibe-deploy-readiness\", \"ai-app-stack\", \"source-and-ci\", \"deploy-platforms\", \"all\". Constraints: accepted values: \"vibe-deploy-readiness\", \"ai-app-stack\", \"source-and-ci\", \"deploy-platforms\", \"all\"; default: \"vibe-deploy-readiness\". Constraints: accepted values: \"vibe-deploy-readiness\", \"ai-app-stack\", \"source-and-ci\", \"deploy-platforms\", \"all\"; default: \"vibe-deploy-readiness\".\n- services (optional, array): Optional explicit service ids from /api/status/catalog. Constraints: min items: 1; max items: 20.\n- includeComponents (optional, boolean): Set true to enable include components behavior for Vibe Deploy Readiness Bundle. Constraints: default: false. Constraints: default: false.\n\nExample request body:\n```json\n{\n  \"bundle\": \"vibe-deploy-readiness\",\n  \"includeComponents\": false\n}\n```",
         "operationId": "status_bundle_check",
         "security": [
           {
@@ -790,11 +10334,25 @@
           "price": {
             "mode": "fixed",
             "currency": "USD",
-            "amount": "0.005"
+            "amount": "0.01"
           },
+          "pricingMode": "fixed",
           "protocols": [
             {
-              "x402": {}
+              "x402": {
+                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                "currency": "USDC",
+                "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "payTo": "4tWJRwNyhGr88QTiV2yzMoGsaxZiCSRDepf9JTdBEgyi"
+              }
+            },
+            {
+              "x402": {
+                "network": "eip155:8453",
+                "currency": "USDC",
+                "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                "payTo": "0xe8799C2dedA78ECcEB329D1E8FE9F110bf55E4F8"
+              }
             }
           ]
         },
@@ -814,12 +10372,14 @@
                       "deploy-platforms",
                       "all"
                     ],
-                    "default": "vibe-deploy-readiness"
+                    "default": "vibe-deploy-readiness",
+                    "description": "Bundle filter for Vibe Deploy Readiness Bundle. Accepted values: \"vibe-deploy-readiness\", \"ai-app-stack\", \"source-and-ci\", \"deploy-platforms\", \"all\". Constraints: accepted values: \"vibe-deploy-readiness\", \"ai-app-stack\", \"source-and-ci\", \"deploy-platforms\", \"all\"; default: \"vibe-deploy-readiness\"."
                   },
                   "services": {
                     "type": "array",
                     "items": {
-                      "type": "string"
+                      "type": "string",
+                      "description": "Services item value for Vibe Deploy Readiness Bundle."
                     },
                     "minItems": 1,
                     "maxItems": 20,
@@ -827,7 +10387,8 @@
                   },
                   "includeComponents": {
                     "type": "boolean",
-                    "default": false
+                    "default": false,
+                    "description": "Set true to enable include components behavior for Vibe Deploy Readiness Bundle. Constraints: default: false."
                   }
                 },
                 "additionalProperties": false
@@ -854,12 +10415,22 @@
           "402": {
             "description": "Payment Required"
           }
-        }
+        },
+        "tags": [
+          "status",
+          "deploy-readiness",
+          "github",
+          "gitlab",
+          "vercel",
+          "supabase",
+          "openai"
+        ]
       }
     },
     "/api/status/stack": {
       "post": {
         "summary": "Check a custom service stack",
+        "description": "Purpose: Check a caller-selected stack of official status sources at the stack-bundle price. Repeated stack layers are rejected before payment.\nBest use: Use this when an agent needs check a caller-selected stack of official status sources at the stack-bundle price. Repeated stack layers are rejected before payment.\nPrice: $0.01 per successful paid call. Direct Base x402 authorization is verified before execution and settled only after successful fulfillment.\nFulfillment: Managed AgentBodega HTTP+JSON endpoint. Upstream provider details are intentionally not disclosed unless the response explicitly includes managed source metadata.\n\nInput: send a JSON request body.\nRequired fields: services.\nOptional fields: includeComponents.\n\nAccepted fields:\n- services (required, array): Service ids from /api/status/catalog. Stack pricing requires at least three stack roles and no repeated capped layer, for example one data layer and one deploy host. Constraints: min items: 3; max items: 20.\n- includeComponents (optional, boolean): Set true to enable include components behavior for Custom Stack Status Bundle. Constraints: default: false. Constraints: default: false.\n\nExample request body:\n```json\n{\n  \"services\": [\n    \"github\",\n    \"npm\",\n    \"vercel\",\n    \"supabase\",\n    \"openai\"\n  ],\n  \"includeComponents\": false\n}\n```",
         "operationId": "status_stack_bundle",
         "security": [
           {
@@ -870,11 +10441,25 @@
           "price": {
             "mode": "fixed",
             "currency": "USD",
-            "amount": "0.005"
+            "amount": "0.01"
           },
+          "pricingMode": "fixed",
           "protocols": [
             {
-              "x402": {}
+              "x402": {
+                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                "currency": "USDC",
+                "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "payTo": "4tWJRwNyhGr88QTiV2yzMoGsaxZiCSRDepf9JTdBEgyi"
+              }
+            },
+            {
+              "x402": {
+                "network": "eip155:8453",
+                "currency": "USDC",
+                "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                "payTo": "0xe8799C2dedA78ECcEB329D1E8FE9F110bf55E4F8"
+              }
             }
           ]
         },
@@ -891,7 +10476,8 @@
                   "services": {
                     "type": "array",
                     "items": {
-                      "type": "string"
+                      "type": "string",
+                      "description": "Services item value for Custom Stack Status Bundle."
                     },
                     "minItems": 3,
                     "maxItems": 20,
@@ -899,7 +10485,8 @@
                   },
                   "includeComponents": {
                     "type": "boolean",
-                    "default": false
+                    "default": false,
+                    "description": "Set true to enable include components behavior for Custom Stack Status Bundle. Constraints: default: false."
                   }
                 },
                 "additionalProperties": false
@@ -932,12 +10519,22 @@
           "402": {
             "description": "Payment Required"
           }
-        }
+        },
+        "tags": [
+          "status",
+          "custom-stack",
+          "deploy-readiness",
+          "github",
+          "vercel",
+          "supabase",
+          "openai"
+        ]
       }
     },
     "/api/status/github": {
       "post": {
         "summary": "Check GitHub status before retrying",
+        "description": "Purpose: Check GitHub's official status source for current incidents, component health, and scheduled maintenance before an agent retries, deploys, or escalates.\nBest use: Use this when an agent needs check GitHub's official status source for current incidents, component health, and scheduled maintenance before an agent retries, deploys, or escalates.\nPrice: $0.005 per successful paid call. Direct Base x402 authorization is verified before execution and settled only after successful fulfillment.\nFulfillment: Managed AgentBodega HTTP+JSON endpoint. Upstream provider details are intentionally not disclosed unless the response explicitly includes managed source metadata.\n\nInput: send a JSON request body.\nRequired fields: none.\nOptional fields: includeComponents, includeIncidentDetails, incidentLimit, component, components.\n\nAccepted fields:\n- includeComponents (optional, boolean): Set true to enable include components behavior for GitHub Status Check. Constraints: default: true. Constraints: default: true.\n- includeIncidentDetails (optional, boolean): Optional deep incident history/timeline fetch. For Status.io providers this parses the public history page; for Statuspage providers it uses /api/v2/incidents.json. Constraints: default: false.\n- incidentLimit (optional, integer): Maximum recent incidents to return when includeIncidentDetails is true. Constraints: default: 5; min: 1; max: 20.\n- component (optional, string): Optional component selector, alias, id, or name.\n- components (optional, array): Optional component selectors when the caller wants a scoped provider status. Constraints: max items: 12.\n\nExample request body:\n```json\n{\n  \"includeComponents\": true\n}\n```",
         "operationId": "official_status_github",
         "security": [
           {
@@ -948,11 +10545,25 @@
           "price": {
             "mode": "fixed",
             "currency": "USD",
-            "amount": "0.001"
+            "amount": "0.005"
           },
+          "pricingMode": "fixed",
           "protocols": [
             {
-              "x402": {}
+              "x402": {
+                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                "currency": "USDC",
+                "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "payTo": "4tWJRwNyhGr88QTiV2yzMoGsaxZiCSRDepf9JTdBEgyi"
+              }
+            },
+            {
+              "x402": {
+                "network": "eip155:8453",
+                "currency": "USDC",
+                "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                "payTo": "0xe8799C2dedA78ECcEB329D1E8FE9F110bf55E4F8"
+              }
             }
           ]
         },
@@ -965,7 +10576,8 @@
                 "properties": {
                   "includeComponents": {
                     "type": "boolean",
-                    "default": true
+                    "default": true,
+                    "description": "Set true to enable include components behavior for GitHub Status Check. Constraints: default: true."
                   },
                   "includeIncidentDetails": {
                     "type": "boolean",
@@ -986,7 +10598,8 @@
                   "components": {
                     "type": "array",
                     "items": {
-                      "type": "string"
+                      "type": "string",
+                      "description": "Components item value for GitHub Status Check."
                     },
                     "maxItems": 12,
                     "description": "Optional component selectors when the caller wants a scoped provider status."
@@ -1015,12 +10628,21 @@
           "402": {
             "description": "Payment Required"
           }
-        }
+        },
+        "tags": [
+          "status",
+          "github",
+          "git",
+          "ci",
+          "packages",
+          "incident-response"
+        ]
       }
     },
     "/api/status/gitlab": {
       "post": {
         "summary": "Check GitLab.com status before retrying",
+        "description": "Purpose: Check GitLab.com's official status source for current incidents, component health, and scheduled maintenance before an agent retries, deploys, or escalates.\nBest use: Use this when an agent needs check GitLab.com's official status source for current incidents, component health, and scheduled maintenance before an agent retries, deploys, or escalates.\nPrice: $0.005 per successful paid call. Direct Base x402 authorization is verified before execution and settled only after successful fulfillment.\nFulfillment: Managed AgentBodega HTTP+JSON endpoint. Upstream provider details are intentionally not disclosed unless the response explicitly includes managed source metadata.\n\nInput: send a JSON request body.\nRequired fields: none.\nOptional fields: includeComponents, includeIncidentDetails, incidentLimit, component, components.\n\nAccepted fields:\n- includeComponents (optional, boolean): Set true to enable include components behavior for GitLab Status Check. Constraints: default: true. Constraints: default: true.\n- includeIncidentDetails (optional, boolean): Optional deep incident history/timeline fetch. For Status.io providers this parses the public history page; for Statuspage providers it uses /api/v2/incidents.json. Constraints: default: false.\n- incidentLimit (optional, integer): Maximum recent incidents to return when includeIncidentDetails is true. Constraints: default: 5; min: 1; max: 20.\n- component (optional, string): Optional component selector, alias, id, or name.\n- components (optional, array): Optional component selectors when the caller wants a scoped provider status. Constraints: max items: 12.\n\nExample request body:\n```json\n{\n  \"includeComponents\": true\n}\n```",
         "operationId": "official_status_gitlab",
         "security": [
           {
@@ -1031,11 +10653,25 @@
           "price": {
             "mode": "fixed",
             "currency": "USD",
-            "amount": "0.001"
+            "amount": "0.005"
           },
+          "pricingMode": "fixed",
           "protocols": [
             {
-              "x402": {}
+              "x402": {
+                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                "currency": "USDC",
+                "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "payTo": "4tWJRwNyhGr88QTiV2yzMoGsaxZiCSRDepf9JTdBEgyi"
+              }
+            },
+            {
+              "x402": {
+                "network": "eip155:8453",
+                "currency": "USDC",
+                "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                "payTo": "0xe8799C2dedA78ECcEB329D1E8FE9F110bf55E4F8"
+              }
             }
           ]
         },
@@ -1048,7 +10684,8 @@
                 "properties": {
                   "includeComponents": {
                     "type": "boolean",
-                    "default": true
+                    "default": true,
+                    "description": "Set true to enable include components behavior for GitLab Status Check. Constraints: default: true."
                   },
                   "includeIncidentDetails": {
                     "type": "boolean",
@@ -1069,7 +10706,8 @@
                   "components": {
                     "type": "array",
                     "items": {
-                      "type": "string"
+                      "type": "string",
+                      "description": "Components item value for GitLab Status Check."
                     },
                     "maxItems": 12,
                     "description": "Optional component selectors when the caller wants a scoped provider status."
@@ -1098,12 +10736,21 @@
           "402": {
             "description": "Payment Required"
           }
-        }
+        },
+        "tags": [
+          "status",
+          "gitlab",
+          "git",
+          "ci",
+          "packages",
+          "incident-response"
+        ]
       }
     },
     "/api/status/bitbucket": {
       "post": {
         "summary": "Check Bitbucket status before retrying",
+        "description": "Purpose: Check Bitbucket's official status source for current incidents, component health, and scheduled maintenance before an agent retries, deploys, or escalates.\nBest use: Use this when an agent needs check Bitbucket's official status source for current incidents, component health, and scheduled maintenance before an agent retries, deploys, or escalates.\nPrice: $0.005 per successful paid call. Direct Base x402 authorization is verified before execution and settled only after successful fulfillment.\nFulfillment: Managed AgentBodega HTTP+JSON endpoint. Upstream provider details are intentionally not disclosed unless the response explicitly includes managed source metadata.\n\nInput: send a JSON request body.\nRequired fields: none.\nOptional fields: includeComponents, includeIncidentDetails, incidentLimit, component, components.\n\nAccepted fields:\n- includeComponents (optional, boolean): Set true to enable include components behavior for Bitbucket Status Check. Constraints: default: true. Constraints: default: true.\n- includeIncidentDetails (optional, boolean): Optional deep incident history/timeline fetch. For Status.io providers this parses the public history page; for Statuspage providers it uses /api/v2/incidents.json. Constraints: default: false.\n- incidentLimit (optional, integer): Maximum recent incidents to return when includeIncidentDetails is true. Constraints: default: 5; min: 1; max: 20.\n- component (optional, string): Optional component selector, alias, id, or name.\n- components (optional, array): Optional component selectors when the caller wants a scoped provider status. Constraints: max items: 12.\n\nExample request body:\n```json\n{\n  \"includeComponents\": true\n}\n```",
         "operationId": "official_status_bitbucket",
         "security": [
           {
@@ -1114,11 +10761,25 @@
           "price": {
             "mode": "fixed",
             "currency": "USD",
-            "amount": "0.001"
+            "amount": "0.005"
           },
+          "pricingMode": "fixed",
           "protocols": [
             {
-              "x402": {}
+              "x402": {
+                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                "currency": "USDC",
+                "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "payTo": "4tWJRwNyhGr88QTiV2yzMoGsaxZiCSRDepf9JTdBEgyi"
+              }
+            },
+            {
+              "x402": {
+                "network": "eip155:8453",
+                "currency": "USDC",
+                "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                "payTo": "0xe8799C2dedA78ECcEB329D1E8FE9F110bf55E4F8"
+              }
             }
           ]
         },
@@ -1131,7 +10792,8 @@
                 "properties": {
                   "includeComponents": {
                     "type": "boolean",
-                    "default": true
+                    "default": true,
+                    "description": "Set true to enable include components behavior for Bitbucket Status Check. Constraints: default: true."
                   },
                   "includeIncidentDetails": {
                     "type": "boolean",
@@ -1152,7 +10814,8 @@
                   "components": {
                     "type": "array",
                     "items": {
-                      "type": "string"
+                      "type": "string",
+                      "description": "Components item value for Bitbucket Status Check."
                     },
                     "maxItems": 12,
                     "description": "Optional component selectors when the caller wants a scoped provider status."
@@ -1181,12 +10844,20 @@
           "402": {
             "description": "Payment Required"
           }
-        }
+        },
+        "tags": [
+          "status",
+          "bitbucket",
+          "git",
+          "ci",
+          "incident-response"
+        ]
       }
     },
     "/api/status/npm": {
       "post": {
         "summary": "Check npm status before retrying",
+        "description": "Purpose: Check npm's official status source for current incidents, component health, and scheduled maintenance before an agent retries, deploys, or escalates.\nBest use: Use this when an agent needs check npm's official status source for current incidents, component health, and scheduled maintenance before an agent retries, deploys, or escalates.\nPrice: $0.005 per successful paid call. Direct Base x402 authorization is verified before execution and settled only after successful fulfillment.\nFulfillment: Managed AgentBodega HTTP+JSON endpoint. Upstream provider details are intentionally not disclosed unless the response explicitly includes managed source metadata.\n\nInput: send a JSON request body.\nRequired fields: none.\nOptional fields: includeComponents, includeIncidentDetails, incidentLimit, component, components.\n\nAccepted fields:\n- includeComponents (optional, boolean): Set true to enable include components behavior for npm Status Check. Constraints: default: true. Constraints: default: true.\n- includeIncidentDetails (optional, boolean): Optional deep incident history/timeline fetch. For Status.io providers this parses the public history page; for Statuspage providers it uses /api/v2/incidents.json. Constraints: default: false.\n- incidentLimit (optional, integer): Maximum recent incidents to return when includeIncidentDetails is true. Constraints: default: 5; min: 1; max: 20.\n- component (optional, string): Optional component selector, alias, id, or name.\n- components (optional, array): Optional component selectors when the caller wants a scoped provider status. Constraints: max items: 12.\n\nExample request body:\n```json\n{\n  \"includeComponents\": true\n}\n```",
         "operationId": "official_status_npm",
         "security": [
           {
@@ -1197,11 +10868,25 @@
           "price": {
             "mode": "fixed",
             "currency": "USD",
-            "amount": "0.001"
+            "amount": "0.005"
           },
+          "pricingMode": "fixed",
           "protocols": [
             {
-              "x402": {}
+              "x402": {
+                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                "currency": "USDC",
+                "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "payTo": "4tWJRwNyhGr88QTiV2yzMoGsaxZiCSRDepf9JTdBEgyi"
+              }
+            },
+            {
+              "x402": {
+                "network": "eip155:8453",
+                "currency": "USDC",
+                "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                "payTo": "0xe8799C2dedA78ECcEB329D1E8FE9F110bf55E4F8"
+              }
             }
           ]
         },
@@ -1214,7 +10899,8 @@
                 "properties": {
                   "includeComponents": {
                     "type": "boolean",
-                    "default": true
+                    "default": true,
+                    "description": "Set true to enable include components behavior for npm Status Check. Constraints: default: true."
                   },
                   "includeIncidentDetails": {
                     "type": "boolean",
@@ -1235,7 +10921,8 @@
                   "components": {
                     "type": "array",
                     "items": {
-                      "type": "string"
+                      "type": "string",
+                      "description": "Components item value for npm Status Check."
                     },
                     "maxItems": 12,
                     "description": "Optional component selectors when the caller wants a scoped provider status."
@@ -1264,12 +10951,21 @@
           "402": {
             "description": "Payment Required"
           }
-        }
+        },
+        "tags": [
+          "status",
+          "npm",
+          "node",
+          "packages",
+          "registry",
+          "incident-response"
+        ]
       }
     },
     "/api/status/vercel": {
       "post": {
         "summary": "Check Vercel status before retrying",
+        "description": "Purpose: Check Vercel's official status source for current incidents, component health, and scheduled maintenance before an agent retries, deploys, or escalates.\nBest use: Use this when an agent needs check Vercel's official status source for current incidents, component health, and scheduled maintenance before an agent retries, deploys, or escalates.\nPrice: $0.005 per successful paid call. Direct Base x402 authorization is verified before execution and settled only after successful fulfillment.\nFulfillment: Managed AgentBodega HTTP+JSON endpoint. Upstream provider details are intentionally not disclosed unless the response explicitly includes managed source metadata.\n\nInput: send a JSON request body.\nRequired fields: none.\nOptional fields: includeComponents, includeIncidentDetails, incidentLimit, component, components.\n\nAccepted fields:\n- includeComponents (optional, boolean): Set true to enable include components behavior for Vercel Status Check. Constraints: default: true. Constraints: default: true.\n- includeIncidentDetails (optional, boolean): Optional deep incident history/timeline fetch. For Status.io providers this parses the public history page; for Statuspage providers it uses /api/v2/incidents.json. Constraints: default: false.\n- incidentLimit (optional, integer): Maximum recent incidents to return when includeIncidentDetails is true. Constraints: default: 5; min: 1; max: 20.\n- component (optional, string): Optional component selector, alias, id, or name.\n- components (optional, array): Optional component selectors when the caller wants a scoped provider status. Constraints: max items: 12.\n\nExample request body:\n```json\n{\n  \"includeComponents\": true\n}\n```",
         "operationId": "official_status_vercel",
         "security": [
           {
@@ -1280,11 +10976,25 @@
           "price": {
             "mode": "fixed",
             "currency": "USD",
-            "amount": "0.001"
+            "amount": "0.005"
           },
+          "pricingMode": "fixed",
           "protocols": [
             {
-              "x402": {}
+              "x402": {
+                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                "currency": "USDC",
+                "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "payTo": "4tWJRwNyhGr88QTiV2yzMoGsaxZiCSRDepf9JTdBEgyi"
+              }
+            },
+            {
+              "x402": {
+                "network": "eip155:8453",
+                "currency": "USDC",
+                "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                "payTo": "0xe8799C2dedA78ECcEB329D1E8FE9F110bf55E4F8"
+              }
             }
           ]
         },
@@ -1297,7 +11007,8 @@
                 "properties": {
                   "includeComponents": {
                     "type": "boolean",
-                    "default": true
+                    "default": true,
+                    "description": "Set true to enable include components behavior for Vercel Status Check. Constraints: default: true."
                   },
                   "includeIncidentDetails": {
                     "type": "boolean",
@@ -1318,7 +11029,8 @@
                   "components": {
                     "type": "array",
                     "items": {
-                      "type": "string"
+                      "type": "string",
+                      "description": "Components item value for Vercel Status Check."
                     },
                     "maxItems": 12,
                     "description": "Optional component selectors when the caller wants a scoped provider status."
@@ -1347,12 +11059,21 @@
           "402": {
             "description": "Payment Required"
           }
-        }
+        },
+        "tags": [
+          "status",
+          "vercel",
+          "deploy",
+          "hosting",
+          "nextjs",
+          "incident-response"
+        ]
       }
     },
     "/api/status/netlify": {
       "post": {
         "summary": "Check Netlify status before retrying",
+        "description": "Purpose: Check Netlify's official status source for current incidents, component health, and scheduled maintenance before an agent retries, deploys, or escalates.\nBest use: Use this when an agent needs check Netlify's official status source for current incidents, component health, and scheduled maintenance before an agent retries, deploys, or escalates.\nPrice: $0.005 per successful paid call. Direct Base x402 authorization is verified before execution and settled only after successful fulfillment.\nFulfillment: Managed AgentBodega HTTP+JSON endpoint. Upstream provider details are intentionally not disclosed unless the response explicitly includes managed source metadata.\n\nInput: send a JSON request body.\nRequired fields: none.\nOptional fields: includeComponents, includeIncidentDetails, incidentLimit, component, components.\n\nAccepted fields:\n- includeComponents (optional, boolean): Set true to enable include components behavior for Netlify Status Check. Constraints: default: true. Constraints: default: true.\n- includeIncidentDetails (optional, boolean): Optional deep incident history/timeline fetch. For Status.io providers this parses the public history page; for Statuspage providers it uses /api/v2/incidents.json. Constraints: default: false.\n- incidentLimit (optional, integer): Maximum recent incidents to return when includeIncidentDetails is true. Constraints: default: 5; min: 1; max: 20.\n- component (optional, string): Optional component selector, alias, id, or name.\n- components (optional, array): Optional component selectors when the caller wants a scoped provider status. Constraints: max items: 12.\n\nExample request body:\n```json\n{\n  \"includeComponents\": true\n}\n```",
         "operationId": "official_status_netlify",
         "security": [
           {
@@ -1363,11 +11084,25 @@
           "price": {
             "mode": "fixed",
             "currency": "USD",
-            "amount": "0.001"
+            "amount": "0.005"
           },
+          "pricingMode": "fixed",
           "protocols": [
             {
-              "x402": {}
+              "x402": {
+                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                "currency": "USDC",
+                "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "payTo": "4tWJRwNyhGr88QTiV2yzMoGsaxZiCSRDepf9JTdBEgyi"
+              }
+            },
+            {
+              "x402": {
+                "network": "eip155:8453",
+                "currency": "USDC",
+                "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                "payTo": "0xe8799C2dedA78ECcEB329D1E8FE9F110bf55E4F8"
+              }
             }
           ]
         },
@@ -1380,7 +11115,8 @@
                 "properties": {
                   "includeComponents": {
                     "type": "boolean",
-                    "default": true
+                    "default": true,
+                    "description": "Set true to enable include components behavior for Netlify Status Check. Constraints: default: true."
                   },
                   "includeIncidentDetails": {
                     "type": "boolean",
@@ -1401,7 +11137,8 @@
                   "components": {
                     "type": "array",
                     "items": {
-                      "type": "string"
+                      "type": "string",
+                      "description": "Components item value for Netlify Status Check."
                     },
                     "maxItems": 12,
                     "description": "Optional component selectors when the caller wants a scoped provider status."
@@ -1430,12 +11167,21 @@
           "402": {
             "description": "Payment Required"
           }
-        }
+        },
+        "tags": [
+          "status",
+          "netlify",
+          "deploy",
+          "hosting",
+          "functions",
+          "incident-response"
+        ]
       }
     },
     "/api/status/render": {
       "post": {
         "summary": "Check Render status before retrying",
+        "description": "Purpose: Check Render's official status source for current incidents, component health, and scheduled maintenance before an agent retries, deploys, or escalates.\nBest use: Use this when an agent needs check Render's official status source for current incidents, component health, and scheduled maintenance before an agent retries, deploys, or escalates.\nPrice: $0.005 per successful paid call. Direct Base x402 authorization is verified before execution and settled only after successful fulfillment.\nFulfillment: Managed AgentBodega HTTP+JSON endpoint. Upstream provider details are intentionally not disclosed unless the response explicitly includes managed source metadata.\n\nInput: send a JSON request body.\nRequired fields: none.\nOptional fields: includeComponents, includeIncidentDetails, incidentLimit, component, components.\n\nAccepted fields:\n- includeComponents (optional, boolean): Set true to enable include components behavior for Render Status Check. Constraints: default: true. Constraints: default: true.\n- includeIncidentDetails (optional, boolean): Optional deep incident history/timeline fetch. For Status.io providers this parses the public history page; for Statuspage providers it uses /api/v2/incidents.json. Constraints: default: false.\n- incidentLimit (optional, integer): Maximum recent incidents to return when includeIncidentDetails is true. Constraints: default: 5; min: 1; max: 20.\n- component (optional, string): Optional component selector, alias, id, or name.\n- components (optional, array): Optional component selectors when the caller wants a scoped provider status. Constraints: max items: 12.\n\nExample request body:\n```json\n{\n  \"includeComponents\": true\n}\n```",
         "operationId": "official_status_render",
         "security": [
           {
@@ -1446,11 +11192,25 @@
           "price": {
             "mode": "fixed",
             "currency": "USD",
-            "amount": "0.001"
+            "amount": "0.005"
           },
+          "pricingMode": "fixed",
           "protocols": [
             {
-              "x402": {}
+              "x402": {
+                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                "currency": "USDC",
+                "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "payTo": "4tWJRwNyhGr88QTiV2yzMoGsaxZiCSRDepf9JTdBEgyi"
+              }
+            },
+            {
+              "x402": {
+                "network": "eip155:8453",
+                "currency": "USDC",
+                "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                "payTo": "0xe8799C2dedA78ECcEB329D1E8FE9F110bf55E4F8"
+              }
             }
           ]
         },
@@ -1463,7 +11223,8 @@
                 "properties": {
                   "includeComponents": {
                     "type": "boolean",
-                    "default": true
+                    "default": true,
+                    "description": "Set true to enable include components behavior for Render Status Check. Constraints: default: true."
                   },
                   "includeIncidentDetails": {
                     "type": "boolean",
@@ -1484,7 +11245,8 @@
                   "components": {
                     "type": "array",
                     "items": {
-                      "type": "string"
+                      "type": "string",
+                      "description": "Components item value for Render Status Check."
                     },
                     "maxItems": 12,
                     "description": "Optional component selectors when the caller wants a scoped provider status."
@@ -1513,12 +11275,21 @@
           "402": {
             "description": "Payment Required"
           }
-        }
+        },
+        "tags": [
+          "status",
+          "render",
+          "deploy",
+          "hosting",
+          "postgres",
+          "incident-response"
+        ]
       }
     },
     "/api/status/fly": {
       "post": {
         "summary": "Check Fly.io status before retrying",
+        "description": "Purpose: Check Fly.io's official status source for current incidents, component health, and scheduled maintenance before an agent retries, deploys, or escalates.\nBest use: Use this when an agent needs check Fly.io's official status source for current incidents, component health, and scheduled maintenance before an agent retries, deploys, or escalates.\nPrice: $0.005 per successful paid call. Direct Base x402 authorization is verified before execution and settled only after successful fulfillment.\nFulfillment: Managed AgentBodega HTTP+JSON endpoint. Upstream provider details are intentionally not disclosed unless the response explicitly includes managed source metadata.\n\nInput: send a JSON request body.\nRequired fields: none.\nOptional fields: includeComponents, includeIncidentDetails, incidentLimit, component, components.\n\nAccepted fields:\n- includeComponents (optional, boolean): Set true to enable include components behavior for Fly.io Status Check. Constraints: default: true. Constraints: default: true.\n- includeIncidentDetails (optional, boolean): Optional deep incident history/timeline fetch. For Status.io providers this parses the public history page; for Statuspage providers it uses /api/v2/incidents.json. Constraints: default: false.\n- incidentLimit (optional, integer): Maximum recent incidents to return when includeIncidentDetails is true. Constraints: default: 5; min: 1; max: 20.\n- component (optional, string): Optional component selector, alias, id, or name.\n- components (optional, array): Optional component selectors when the caller wants a scoped provider status. Constraints: max items: 12.\n\nExample request body:\n```json\n{\n  \"includeComponents\": true\n}\n```",
         "operationId": "official_status_fly",
         "security": [
           {
@@ -1529,11 +11300,25 @@
           "price": {
             "mode": "fixed",
             "currency": "USD",
-            "amount": "0.001"
+            "amount": "0.005"
           },
+          "pricingMode": "fixed",
           "protocols": [
             {
-              "x402": {}
+              "x402": {
+                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                "currency": "USDC",
+                "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "payTo": "4tWJRwNyhGr88QTiV2yzMoGsaxZiCSRDepf9JTdBEgyi"
+              }
+            },
+            {
+              "x402": {
+                "network": "eip155:8453",
+                "currency": "USDC",
+                "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                "payTo": "0xe8799C2dedA78ECcEB329D1E8FE9F110bf55E4F8"
+              }
             }
           ]
         },
@@ -1546,7 +11331,8 @@
                 "properties": {
                   "includeComponents": {
                     "type": "boolean",
-                    "default": true
+                    "default": true,
+                    "description": "Set true to enable include components behavior for Fly.io Status Check. Constraints: default: true."
                   },
                   "includeIncidentDetails": {
                     "type": "boolean",
@@ -1567,7 +11353,8 @@
                   "components": {
                     "type": "array",
                     "items": {
-                      "type": "string"
+                      "type": "string",
+                      "description": "Components item value for Fly.io Status Check."
                     },
                     "maxItems": 12,
                     "description": "Optional component selectors when the caller wants a scoped provider status."
@@ -1596,12 +11383,130 @@
           "402": {
             "description": "Payment Required"
           }
-        }
+        },
+        "tags": [
+          "status",
+          "fly",
+          "flyio",
+          "deploy",
+          "hosting",
+          "edge",
+          "incident-response"
+        ]
+      }
+    },
+    "/api/status/railway": {
+      "post": {
+        "summary": "Check Railway status before retrying",
+        "description": "Purpose: Check Railway's official status source for current incidents, component health, and scheduled maintenance before an agent retries, deploys, or escalates.\nBest use: Use this when an agent needs check Railway's official status source for current incidents, component health, and scheduled maintenance before an agent retries, deploys, or escalates.\nPrice: $0.005 per successful paid call. Direct Base x402 authorization is verified before execution and settled only after successful fulfillment.\nFulfillment: Managed AgentBodega HTTP+JSON endpoint. Upstream provider details are intentionally not disclosed unless the response explicitly includes managed source metadata.\n\nInput: send a JSON request body.\nRequired fields: none.\nOptional fields: includeComponents, includeIncidentDetails, incidentLimit, component, components.\n\nAccepted fields:\n- includeComponents (optional, boolean): Set true to enable include components behavior for Railway Status Check. Constraints: default: true. Constraints: default: true.\n- includeIncidentDetails (optional, boolean): Optional deep incident history/timeline fetch. For Status.io providers this parses the public history page; for Statuspage providers it uses /api/v2/incidents.json. Constraints: default: false.\n- incidentLimit (optional, integer): Maximum recent incidents to return when includeIncidentDetails is true. Constraints: default: 5; min: 1; max: 20.\n- component (optional, string): Optional component selector, alias, id, or name.\n- components (optional, array): Optional component selectors when the caller wants a scoped provider status. Constraints: max items: 12.\n\nExample request body:\n```json\n{\n  \"includeComponents\": true\n}\n```",
+        "operationId": "official_status_railway",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.005"
+          },
+          "pricingMode": "fixed",
+          "protocols": [
+            {
+              "x402": {
+                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                "currency": "USDC",
+                "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "payTo": "4tWJRwNyhGr88QTiV2yzMoGsaxZiCSRDepf9JTdBEgyi"
+              }
+            },
+            {
+              "x402": {
+                "network": "eip155:8453",
+                "currency": "USDC",
+                "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                "payTo": "0xe8799C2dedA78ECcEB329D1E8FE9F110bf55E4F8"
+              }
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "includeComponents": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Set true to enable include components behavior for Railway Status Check. Constraints: default: true."
+                  },
+                  "includeIncidentDetails": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Optional deep incident history/timeline fetch. For Status.io providers this parses the public history page; for Statuspage providers it uses /api/v2/incidents.json."
+                  },
+                  "incidentLimit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 20,
+                    "default": 5,
+                    "description": "Maximum recent incidents to return when includeIncidentDetails is true."
+                  },
+                  "component": {
+                    "type": "string",
+                    "description": "Optional component selector, alias, id, or name. For Anthropic examples: api, code, console, claude-ai, cowork, government."
+                  },
+                  "components": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "Components item value for Railway Status Check."
+                    },
+                    "maxItems": 12,
+                    "description": "Optional component selectors when the caller wants a scoped provider status."
+                  }
+                },
+                "additionalProperties": false
+              },
+              "example": {
+                "includeComponents": true
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Utility result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "tags": [
+          "status",
+          "railway",
+          "deploy",
+          "hosting",
+          "builds",
+          "incident-response"
+        ]
       }
     },
     "/api/status/coinbase": {
       "post": {
         "summary": "Check Coinbase status before retrying",
+        "description": "Purpose: Check Coinbase's official status source for current incidents, component health, and scheduled maintenance before an agent retries, deploys, or escalates.\nBest use: Use this when an agent needs check Coinbase's official status source for current incidents, component health, and scheduled maintenance before an agent retries, deploys, or escalates.\nPrice: $0.005 per successful paid call. Direct Base x402 authorization is verified before execution and settled only after successful fulfillment.\nFulfillment: Managed AgentBodega HTTP+JSON endpoint. Upstream provider details are intentionally not disclosed unless the response explicitly includes managed source metadata.\n\nInput: send a JSON request body.\nRequired fields: none.\nOptional fields: includeComponents, includeIncidentDetails, incidentLimit, component, components.\n\nAccepted fields:\n- includeComponents (optional, boolean): Set true to enable include components behavior for Coinbase Status Check. Constraints: default: true. Constraints: default: true.\n- includeIncidentDetails (optional, boolean): Optional deep incident history/timeline fetch. For Status.io providers this parses the public history page; for Statuspage providers it uses /api/v2/incidents.json. Constraints: default: false.\n- incidentLimit (optional, integer): Maximum recent incidents to return when includeIncidentDetails is true. Constraints: default: 5; min: 1; max: 20.\n- component (optional, string): Optional component selector, alias, id, or name.\n- components (optional, array): Optional component selectors when the caller wants a scoped provider status. Constraints: max items: 12.\n\nExample request body:\n```json\n{\n  \"includeComponents\": true\n}\n```",
         "operationId": "official_status_coinbase",
         "security": [
           {
@@ -1612,11 +11517,25 @@
           "price": {
             "mode": "fixed",
             "currency": "USD",
-            "amount": "0.001"
+            "amount": "0.005"
           },
+          "pricingMode": "fixed",
           "protocols": [
             {
-              "x402": {}
+              "x402": {
+                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                "currency": "USDC",
+                "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "payTo": "4tWJRwNyhGr88QTiV2yzMoGsaxZiCSRDepf9JTdBEgyi"
+              }
+            },
+            {
+              "x402": {
+                "network": "eip155:8453",
+                "currency": "USDC",
+                "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                "payTo": "0xe8799C2dedA78ECcEB329D1E8FE9F110bf55E4F8"
+              }
             }
           ]
         },
@@ -1629,7 +11548,8 @@
                 "properties": {
                   "includeComponents": {
                     "type": "boolean",
-                    "default": true
+                    "default": true,
+                    "description": "Set true to enable include components behavior for Coinbase Status Check. Constraints: default: true."
                   },
                   "includeIncidentDetails": {
                     "type": "boolean",
@@ -1650,7 +11570,8 @@
                   "components": {
                     "type": "array",
                     "items": {
-                      "type": "string"
+                      "type": "string",
+                      "description": "Components item value for Coinbase Status Check."
                     },
                     "maxItems": 12,
                     "description": "Optional component selectors when the caller wants a scoped provider status."
@@ -1679,12 +11600,22 @@
           "402": {
             "description": "Payment Required"
           }
-        }
+        },
+        "tags": [
+          "status",
+          "coinbase",
+          "crypto",
+          "payments",
+          "wallet",
+          "api",
+          "incident-response"
+        ]
       }
     },
     "/api/status/cursor": {
       "post": {
         "summary": "Check Cursor status before retrying",
+        "description": "Purpose: Check Cursor's official status source for current incidents, component health, and scheduled maintenance before an agent retries, deploys, or escalates.\nBest use: Use this when an agent needs check Cursor's official status source for current incidents, component health, and scheduled maintenance before an agent retries, deploys, or escalates.\nPrice: $0.005 per successful paid call. Direct Base x402 authorization is verified before execution and settled only after successful fulfillment.\nFulfillment: Managed AgentBodega HTTP+JSON endpoint. Upstream provider details are intentionally not disclosed unless the response explicitly includes managed source metadata.\n\nInput: send a JSON request body.\nRequired fields: none.\nOptional fields: includeComponents, includeIncidentDetails, incidentLimit, component, components.\n\nAccepted fields:\n- includeComponents (optional, boolean): Set true to enable include components behavior for Cursor Status Check. Constraints: default: true. Constraints: default: true.\n- includeIncidentDetails (optional, boolean): Optional deep incident history/timeline fetch. For Status.io providers this parses the public history page; for Statuspage providers it uses /api/v2/incidents.json. Constraints: default: false.\n- incidentLimit (optional, integer): Maximum recent incidents to return when includeIncidentDetails is true. Constraints: default: 5; min: 1; max: 20.\n- component (optional, string): Optional component selector, alias, id, or name.\n- components (optional, array): Optional component selectors when the caller wants a scoped provider status. Constraints: max items: 12.\n\nExample request body:\n```json\n{\n  \"includeComponents\": true\n}\n```",
         "operationId": "official_status_cursor",
         "security": [
           {
@@ -1695,11 +11626,25 @@
           "price": {
             "mode": "fixed",
             "currency": "USD",
-            "amount": "0.001"
+            "amount": "0.005"
           },
+          "pricingMode": "fixed",
           "protocols": [
             {
-              "x402": {}
+              "x402": {
+                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                "currency": "USDC",
+                "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "payTo": "4tWJRwNyhGr88QTiV2yzMoGsaxZiCSRDepf9JTdBEgyi"
+              }
+            },
+            {
+              "x402": {
+                "network": "eip155:8453",
+                "currency": "USDC",
+                "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                "payTo": "0xe8799C2dedA78ECcEB329D1E8FE9F110bf55E4F8"
+              }
             }
           ]
         },
@@ -1712,7 +11657,8 @@
                 "properties": {
                   "includeComponents": {
                     "type": "boolean",
-                    "default": true
+                    "default": true,
+                    "description": "Set true to enable include components behavior for Cursor Status Check. Constraints: default: true."
                   },
                   "includeIncidentDetails": {
                     "type": "boolean",
@@ -1733,7 +11679,8 @@
                   "components": {
                     "type": "array",
                     "items": {
-                      "type": "string"
+                      "type": "string",
+                      "description": "Components item value for Cursor Status Check."
                     },
                     "maxItems": 12,
                     "description": "Optional component selectors when the caller wants a scoped provider status."
@@ -1762,12 +11709,22 @@
           "402": {
             "description": "Payment Required"
           }
-        }
+        },
+        "tags": [
+          "status",
+          "cursor",
+          "ai",
+          "editor",
+          "ide",
+          "developer-tools",
+          "incident-response"
+        ]
       }
     },
     "/api/status/bambulab": {
       "post": {
         "summary": "Check Bambu Lab status before retrying",
+        "description": "Purpose: Check Bambu Lab's official status source for current incidents, component health, and scheduled maintenance before an agent retries, deploys, or escalates.\nBest use: Use this when an agent needs check Bambu Lab's official status source for current incidents, component health, and scheduled maintenance before an agent retries, deploys, or escalates.\nPrice: $0.005 per successful paid call. Direct Base x402 authorization is verified before execution and settled only after successful fulfillment.\nFulfillment: Managed AgentBodega HTTP+JSON endpoint. Upstream provider details are intentionally not disclosed unless the response explicitly includes managed source metadata.\n\nInput: send a JSON request body.\nRequired fields: none.\nOptional fields: includeComponents, includeIncidentDetails, incidentLimit, component, components.\n\nAccepted fields:\n- includeComponents (optional, boolean): Set true to enable include components behavior for Bambu Lab Status Check. Constraints: default: true. Constraints: default: true.\n- includeIncidentDetails (optional, boolean): Optional deep incident history/timeline fetch. For Status.io providers this parses the public history page; for Statuspage providers it uses /api/v2/incidents.json. Constraints: default: false.\n- incidentLimit (optional, integer): Maximum recent incidents to return when includeIncidentDetails is true. Constraints: default: 5; min: 1; max: 20.\n- component (optional, string): Optional component selector, alias, id, or name.\n- components (optional, array): Optional component selectors when the caller wants a scoped provider status. Constraints: max items: 12.\n\nExample request body:\n```json\n{\n  \"includeComponents\": true\n}\n```",
         "operationId": "official_status_bambulab",
         "security": [
           {
@@ -1778,11 +11735,25 @@
           "price": {
             "mode": "fixed",
             "currency": "USD",
-            "amount": "0.001"
+            "amount": "0.005"
           },
+          "pricingMode": "fixed",
           "protocols": [
             {
-              "x402": {}
+              "x402": {
+                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                "currency": "USDC",
+                "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "payTo": "4tWJRwNyhGr88QTiV2yzMoGsaxZiCSRDepf9JTdBEgyi"
+              }
+            },
+            {
+              "x402": {
+                "network": "eip155:8453",
+                "currency": "USDC",
+                "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                "payTo": "0xe8799C2dedA78ECcEB329D1E8FE9F110bf55E4F8"
+              }
             }
           ]
         },
@@ -1795,7 +11766,8 @@
                 "properties": {
                   "includeComponents": {
                     "type": "boolean",
-                    "default": true
+                    "default": true,
+                    "description": "Set true to enable include components behavior for Bambu Lab Status Check. Constraints: default: true."
                   },
                   "includeIncidentDetails": {
                     "type": "boolean",
@@ -1816,7 +11788,8 @@
                   "components": {
                     "type": "array",
                     "items": {
-                      "type": "string"
+                      "type": "string",
+                      "description": "Components item value for Bambu Lab Status Check."
                     },
                     "maxItems": 12,
                     "description": "Optional component selectors when the caller wants a scoped provider status."
@@ -1845,12 +11818,21 @@
           "402": {
             "description": "Payment Required"
           }
-        }
+        },
+        "tags": [
+          "status",
+          "bambu-lab",
+          "3d-printing",
+          "hardware",
+          "iot",
+          "incident-response"
+        ]
       }
     },
     "/api/status/ring": {
       "post": {
         "summary": "Check Ring status before retrying",
+        "description": "Purpose: Check Ring's official status source for current incidents, component health, and scheduled maintenance before an agent retries, deploys, or escalates.\nBest use: Use this when an agent needs check Ring's official status source for current incidents, component health, and scheduled maintenance before an agent retries, deploys, or escalates.\nPrice: $0.005 per successful paid call. Direct Base x402 authorization is verified before execution and settled only after successful fulfillment.\nFulfillment: Managed AgentBodega HTTP+JSON endpoint. Upstream provider details are intentionally not disclosed unless the response explicitly includes managed source metadata.\n\nInput: send a JSON request body.\nRequired fields: none.\nOptional fields: includeComponents, includeIncidentDetails, incidentLimit, component, components.\n\nAccepted fields:\n- includeComponents (optional, boolean): Set true to enable include components behavior for Ring Status Check. Constraints: default: true. Constraints: default: true.\n- includeIncidentDetails (optional, boolean): Optional deep incident history/timeline fetch. For Status.io providers this parses the public history page; for Statuspage providers it uses /api/v2/incidents.json. Constraints: default: false.\n- incidentLimit (optional, integer): Maximum recent incidents to return when includeIncidentDetails is true. Constraints: default: 5; min: 1; max: 20.\n- component (optional, string): Optional component selector, alias, id, or name.\n- components (optional, array): Optional component selectors when the caller wants a scoped provider status. Constraints: max items: 12.\n\nExample request body:\n```json\n{\n  \"includeComponents\": true\n}\n```",
         "operationId": "official_status_ring",
         "security": [
           {
@@ -1861,11 +11843,25 @@
           "price": {
             "mode": "fixed",
             "currency": "USD",
-            "amount": "0.001"
+            "amount": "0.005"
           },
+          "pricingMode": "fixed",
           "protocols": [
             {
-              "x402": {}
+              "x402": {
+                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                "currency": "USDC",
+                "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "payTo": "4tWJRwNyhGr88QTiV2yzMoGsaxZiCSRDepf9JTdBEgyi"
+              }
+            },
+            {
+              "x402": {
+                "network": "eip155:8453",
+                "currency": "USDC",
+                "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                "payTo": "0xe8799C2dedA78ECcEB329D1E8FE9F110bf55E4F8"
+              }
             }
           ]
         },
@@ -1878,7 +11874,8 @@
                 "properties": {
                   "includeComponents": {
                     "type": "boolean",
-                    "default": true
+                    "default": true,
+                    "description": "Set true to enable include components behavior for Ring Status Check. Constraints: default: true."
                   },
                   "includeIncidentDetails": {
                     "type": "boolean",
@@ -1899,7 +11896,8 @@
                   "components": {
                     "type": "array",
                     "items": {
-                      "type": "string"
+                      "type": "string",
+                      "description": "Components item value for Ring Status Check."
                     },
                     "maxItems": 12,
                     "description": "Optional component selectors when the caller wants a scoped provider status."
@@ -1928,12 +11926,22 @@
           "402": {
             "description": "Payment Required"
           }
-        }
+        },
+        "tags": [
+          "status",
+          "ring",
+          "iot",
+          "security",
+          "camera",
+          "smart-home",
+          "incident-response"
+        ]
       }
     },
     "/api/status/cloudflare": {
       "post": {
         "summary": "Check Cloudflare status before retrying",
+        "description": "Purpose: Check Cloudflare's official status source for current incidents, component health, and scheduled maintenance before an agent retries, deploys, or escalates.\nBest use: Use this when an agent needs check Cloudflare's official status source for current incidents, component health, and scheduled maintenance before an agent retries, deploys, or escalates.\nPrice: $0.005 per successful paid call. Direct Base x402 authorization is verified before execution and settled only after successful fulfillment.\nFulfillment: Managed AgentBodega HTTP+JSON endpoint. Upstream provider details are intentionally not disclosed unless the response explicitly includes managed source metadata.\n\nInput: send a JSON request body.\nRequired fields: none.\nOptional fields: includeComponents, includeIncidentDetails, incidentLimit, component, components.\n\nAccepted fields:\n- includeComponents (optional, boolean): Set true to enable include components behavior for Cloudflare Status Check. Constraints: default: true. Constraints: default: true.\n- includeIncidentDetails (optional, boolean): Optional deep incident history/timeline fetch. For Status.io providers this parses the public history page; for Statuspage providers it uses /api/v2/incidents.json. Constraints: default: false.\n- incidentLimit (optional, integer): Maximum recent incidents to return when includeIncidentDetails is true. Constraints: default: 5; min: 1; max: 20.\n- component (optional, string): Optional component selector, alias, id, or name.\n- components (optional, array): Optional component selectors when the caller wants a scoped provider status. Constraints: max items: 12.\n\nExample request body:\n```json\n{\n  \"includeComponents\": true\n}\n```",
         "operationId": "official_status_cloudflare",
         "security": [
           {
@@ -1944,11 +11952,25 @@
           "price": {
             "mode": "fixed",
             "currency": "USD",
-            "amount": "0.001"
+            "amount": "0.005"
           },
+          "pricingMode": "fixed",
           "protocols": [
             {
-              "x402": {}
+              "x402": {
+                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                "currency": "USDC",
+                "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "payTo": "4tWJRwNyhGr88QTiV2yzMoGsaxZiCSRDepf9JTdBEgyi"
+              }
+            },
+            {
+              "x402": {
+                "network": "eip155:8453",
+                "currency": "USDC",
+                "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                "payTo": "0xe8799C2dedA78ECcEB329D1E8FE9F110bf55E4F8"
+              }
             }
           ]
         },
@@ -1961,7 +11983,8 @@
                 "properties": {
                   "includeComponents": {
                     "type": "boolean",
-                    "default": true
+                    "default": true,
+                    "description": "Set true to enable include components behavior for Cloudflare Status Check. Constraints: default: true."
                   },
                   "includeIncidentDetails": {
                     "type": "boolean",
@@ -1982,7 +12005,8 @@
                   "components": {
                     "type": "array",
                     "items": {
-                      "type": "string"
+                      "type": "string",
+                      "description": "Components item value for Cloudflare Status Check."
                     },
                     "maxItems": 12,
                     "description": "Optional component selectors when the caller wants a scoped provider status."
@@ -2011,12 +12035,22 @@
           "402": {
             "description": "Payment Required"
           }
-        }
+        },
+        "tags": [
+          "status",
+          "cloudflare",
+          "dns",
+          "cdn",
+          "workers",
+          "edge",
+          "incident-response"
+        ]
       }
     },
     "/api/status/supabase": {
       "post": {
         "summary": "Check Supabase status before retrying",
+        "description": "Purpose: Check Supabase's official status source for current incidents, component health, and scheduled maintenance before an agent retries, deploys, or escalates.\nBest use: Use this when an agent needs check Supabase's official status source for current incidents, component health, and scheduled maintenance before an agent retries, deploys, or escalates.\nPrice: $0.005 per successful paid call. Direct Base x402 authorization is verified before execution and settled only after successful fulfillment.\nFulfillment: Managed AgentBodega HTTP+JSON endpoint. Upstream provider details are intentionally not disclosed unless the response explicitly includes managed source metadata.\n\nInput: send a JSON request body.\nRequired fields: none.\nOptional fields: includeComponents, includeIncidentDetails, incidentLimit, component, components.\n\nAccepted fields:\n- includeComponents (optional, boolean): Set true to enable include components behavior for Supabase Status Check. Constraints: default: true. Constraints: default: true.\n- includeIncidentDetails (optional, boolean): Optional deep incident history/timeline fetch. For Status.io providers this parses the public history page; for Statuspage providers it uses /api/v2/incidents.json. Constraints: default: false.\n- incidentLimit (optional, integer): Maximum recent incidents to return when includeIncidentDetails is true. Constraints: default: 5; min: 1; max: 20.\n- component (optional, string): Optional component selector, alias, id, or name.\n- components (optional, array): Optional component selectors when the caller wants a scoped provider status. Constraints: max items: 12.\n\nExample request body:\n```json\n{\n  \"includeComponents\": true\n}\n```",
         "operationId": "official_status_supabase",
         "security": [
           {
@@ -2027,11 +12061,25 @@
           "price": {
             "mode": "fixed",
             "currency": "USD",
-            "amount": "0.001"
+            "amount": "0.005"
           },
+          "pricingMode": "fixed",
           "protocols": [
             {
-              "x402": {}
+              "x402": {
+                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                "currency": "USDC",
+                "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "payTo": "4tWJRwNyhGr88QTiV2yzMoGsaxZiCSRDepf9JTdBEgyi"
+              }
+            },
+            {
+              "x402": {
+                "network": "eip155:8453",
+                "currency": "USDC",
+                "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                "payTo": "0xe8799C2dedA78ECcEB329D1E8FE9F110bf55E4F8"
+              }
             }
           ]
         },
@@ -2044,7 +12092,8 @@
                 "properties": {
                   "includeComponents": {
                     "type": "boolean",
-                    "default": true
+                    "default": true,
+                    "description": "Set true to enable include components behavior for Supabase Status Check. Constraints: default: true."
                   },
                   "includeIncidentDetails": {
                     "type": "boolean",
@@ -2065,7 +12114,8 @@
                   "components": {
                     "type": "array",
                     "items": {
-                      "type": "string"
+                      "type": "string",
+                      "description": "Components item value for Supabase Status Check."
                     },
                     "maxItems": 12,
                     "description": "Optional component selectors when the caller wants a scoped provider status."
@@ -2094,12 +12144,21 @@
           "402": {
             "description": "Payment Required"
           }
-        }
+        },
+        "tags": [
+          "status",
+          "supabase",
+          "postgres",
+          "auth",
+          "storage",
+          "incident-response"
+        ]
       }
     },
     "/api/status/convex": {
       "post": {
         "summary": "Check Convex status before retrying",
+        "description": "Purpose: Check Convex's official status source for current incidents, component health, and scheduled maintenance before an agent retries, deploys, or escalates.\nBest use: Use this when an agent needs check Convex's official status source for current incidents, component health, and scheduled maintenance before an agent retries, deploys, or escalates.\nPrice: $0.005 per successful paid call. Direct Base x402 authorization is verified before execution and settled only after successful fulfillment.\nFulfillment: Managed AgentBodega HTTP+JSON endpoint. Upstream provider details are intentionally not disclosed unless the response explicitly includes managed source metadata.\n\nInput: send a JSON request body.\nRequired fields: none.\nOptional fields: includeComponents, includeIncidentDetails, incidentLimit, component, components.\n\nAccepted fields:\n- includeComponents (optional, boolean): Set true to enable include components behavior for Convex Status Check. Constraints: default: true. Constraints: default: true.\n- includeIncidentDetails (optional, boolean): Optional deep incident history/timeline fetch. For Status.io providers this parses the public history page; for Statuspage providers it uses /api/v2/incidents.json. Constraints: default: false.\n- incidentLimit (optional, integer): Maximum recent incidents to return when includeIncidentDetails is true. Constraints: default: 5; min: 1; max: 20.\n- component (optional, string): Optional component selector, alias, id, or name.\n- components (optional, array): Optional component selectors when the caller wants a scoped provider status. Constraints: max items: 12.\n\nExample request body:\n```json\n{\n  \"includeComponents\": true\n}\n```",
         "operationId": "official_status_convex",
         "security": [
           {
@@ -2110,11 +12169,25 @@
           "price": {
             "mode": "fixed",
             "currency": "USD",
-            "amount": "0.001"
+            "amount": "0.005"
           },
+          "pricingMode": "fixed",
           "protocols": [
             {
-              "x402": {}
+              "x402": {
+                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                "currency": "USDC",
+                "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "payTo": "4tWJRwNyhGr88QTiV2yzMoGsaxZiCSRDepf9JTdBEgyi"
+              }
+            },
+            {
+              "x402": {
+                "network": "eip155:8453",
+                "currency": "USDC",
+                "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                "payTo": "0xe8799C2dedA78ECcEB329D1E8FE9F110bf55E4F8"
+              }
             }
           ]
         },
@@ -2127,7 +12200,8 @@
                 "properties": {
                   "includeComponents": {
                     "type": "boolean",
-                    "default": true
+                    "default": true,
+                    "description": "Set true to enable include components behavior for Convex Status Check. Constraints: default: true."
                   },
                   "includeIncidentDetails": {
                     "type": "boolean",
@@ -2148,7 +12222,8 @@
                   "components": {
                     "type": "array",
                     "items": {
-                      "type": "string"
+                      "type": "string",
+                      "description": "Components item value for Convex Status Check."
                     },
                     "maxItems": 12,
                     "description": "Optional component selectors when the caller wants a scoped provider status."
@@ -2177,12 +12252,21 @@
           "402": {
             "description": "Payment Required"
           }
-        }
+        },
+        "tags": [
+          "status",
+          "convex",
+          "backend",
+          "database",
+          "realtime",
+          "incident-response"
+        ]
       }
     },
     "/api/status/clerk": {
       "post": {
         "summary": "Check Clerk status before retrying",
+        "description": "Purpose: Check Clerk's official status source for current incidents, component health, and scheduled maintenance before an agent retries, deploys, or escalates.\nBest use: Use this when an agent needs check Clerk's official status source for current incidents, component health, and scheduled maintenance before an agent retries, deploys, or escalates.\nPrice: $0.005 per successful paid call. Direct Base x402 authorization is verified before execution and settled only after successful fulfillment.\nFulfillment: Managed AgentBodega HTTP+JSON endpoint. Upstream provider details are intentionally not disclosed unless the response explicitly includes managed source metadata.\n\nInput: send a JSON request body.\nRequired fields: none.\nOptional fields: includeComponents, includeIncidentDetails, incidentLimit, component, components.\n\nAccepted fields:\n- includeComponents (optional, boolean): Set true to enable include components behavior for Clerk Status Check. Constraints: default: true. Constraints: default: true.\n- includeIncidentDetails (optional, boolean): Optional deep incident history/timeline fetch. For Status.io providers this parses the public history page; for Statuspage providers it uses /api/v2/incidents.json. Constraints: default: false.\n- incidentLimit (optional, integer): Maximum recent incidents to return when includeIncidentDetails is true. Constraints: default: 5; min: 1; max: 20.\n- component (optional, string): Optional component selector, alias, id, or name.\n- components (optional, array): Optional component selectors when the caller wants a scoped provider status. Constraints: max items: 12.\n\nExample request body:\n```json\n{\n  \"includeComponents\": true\n}\n```",
         "operationId": "official_status_clerk",
         "security": [
           {
@@ -2193,11 +12277,25 @@
           "price": {
             "mode": "fixed",
             "currency": "USD",
-            "amount": "0.001"
+            "amount": "0.005"
           },
+          "pricingMode": "fixed",
           "protocols": [
             {
-              "x402": {}
+              "x402": {
+                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                "currency": "USDC",
+                "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "payTo": "4tWJRwNyhGr88QTiV2yzMoGsaxZiCSRDepf9JTdBEgyi"
+              }
+            },
+            {
+              "x402": {
+                "network": "eip155:8453",
+                "currency": "USDC",
+                "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                "payTo": "0xe8799C2dedA78ECcEB329D1E8FE9F110bf55E4F8"
+              }
             }
           ]
         },
@@ -2210,7 +12308,8 @@
                 "properties": {
                   "includeComponents": {
                     "type": "boolean",
-                    "default": true
+                    "default": true,
+                    "description": "Set true to enable include components behavior for Clerk Status Check. Constraints: default: true."
                   },
                   "includeIncidentDetails": {
                     "type": "boolean",
@@ -2231,7 +12330,8 @@
                   "components": {
                     "type": "array",
                     "items": {
-                      "type": "string"
+                      "type": "string",
+                      "description": "Components item value for Clerk Status Check."
                     },
                     "maxItems": 12,
                     "description": "Optional component selectors when the caller wants a scoped provider status."
@@ -2260,12 +12360,21 @@
           "402": {
             "description": "Payment Required"
           }
-        }
+        },
+        "tags": [
+          "status",
+          "clerk",
+          "auth",
+          "identity",
+          "sessions",
+          "incident-response"
+        ]
       }
     },
     "/api/status/openai": {
       "post": {
         "summary": "Check OpenAI status before retrying",
+        "description": "Purpose: Check OpenAI's official status source for current incidents, component health, and scheduled maintenance before an agent retries, deploys, or escalates.\nBest use: Use this when an agent needs check OpenAI's official status source for current incidents, component health, and scheduled maintenance before an agent retries, deploys, or escalates.\nPrice: $0.005 per successful paid call. Direct Base x402 authorization is verified before execution and settled only after successful fulfillment.\nFulfillment: Managed AgentBodega HTTP+JSON endpoint. Upstream provider details are intentionally not disclosed unless the response explicitly includes managed source metadata.\n\nInput: send a JSON request body.\nRequired fields: none.\nOptional fields: includeComponents, includeIncidentDetails, incidentLimit, component, components.\n\nAccepted fields:\n- includeComponents (optional, boolean): Set true to enable include components behavior for OpenAI Status Check. Constraints: default: true. Constraints: default: true.\n- includeIncidentDetails (optional, boolean): Optional deep incident history/timeline fetch. For Status.io providers this parses the public history page; for Statuspage providers it uses /api/v2/incidents.json. Constraints: default: false.\n- incidentLimit (optional, integer): Maximum recent incidents to return when includeIncidentDetails is true. Constraints: default: 5; min: 1; max: 20.\n- component (optional, string): Optional component selector, alias, id, or name.\n- components (optional, array): Optional component selectors when the caller wants a scoped provider status. Constraints: max items: 12.\n\nExample request body:\n```json\n{\n  \"includeComponents\": true\n}\n```",
         "operationId": "official_status_openai",
         "security": [
           {
@@ -2276,11 +12385,25 @@
           "price": {
             "mode": "fixed",
             "currency": "USD",
-            "amount": "0.001"
+            "amount": "0.005"
           },
+          "pricingMode": "fixed",
           "protocols": [
             {
-              "x402": {}
+              "x402": {
+                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                "currency": "USDC",
+                "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "payTo": "4tWJRwNyhGr88QTiV2yzMoGsaxZiCSRDepf9JTdBEgyi"
+              }
+            },
+            {
+              "x402": {
+                "network": "eip155:8453",
+                "currency": "USDC",
+                "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                "payTo": "0xe8799C2dedA78ECcEB329D1E8FE9F110bf55E4F8"
+              }
             }
           ]
         },
@@ -2293,7 +12416,8 @@
                 "properties": {
                   "includeComponents": {
                     "type": "boolean",
-                    "default": true
+                    "default": true,
+                    "description": "Set true to enable include components behavior for OpenAI Status Check. Constraints: default: true."
                   },
                   "includeIncidentDetails": {
                     "type": "boolean",
@@ -2314,7 +12438,8 @@
                   "components": {
                     "type": "array",
                     "items": {
-                      "type": "string"
+                      "type": "string",
+                      "description": "Components item value for OpenAI Status Check."
                     },
                     "maxItems": 12,
                     "description": "Optional component selectors when the caller wants a scoped provider status."
@@ -2343,12 +12468,21 @@
           "402": {
             "description": "Payment Required"
           }
-        }
+        },
+        "tags": [
+          "status",
+          "openai",
+          "ai",
+          "llm",
+          "api",
+          "incident-response"
+        ]
       }
     },
     "/api/status/anthropic": {
       "post": {
         "summary": "Check Anthropic Claude status before retrying",
+        "description": "Purpose: Check Anthropic Claude's official status source for current incidents, component health, and scheduled maintenance before an agent retries, deploys, or escalates.\nBest use: Use this when an agent needs check Anthropic Claude's official status source for current incidents, component health, and scheduled maintenance before an agent retries, deploys, or escalates.\nPrice: $0.005 per successful paid call. Direct Base x402 authorization is verified before execution and settled only after successful fulfillment.\nFulfillment: Managed AgentBodega HTTP+JSON endpoint. Upstream provider details are intentionally not disclosed unless the response explicitly includes managed source metadata.\n\nInput: send a JSON request body.\nRequired fields: none.\nOptional fields: includeComponents, includeIncidentDetails, incidentLimit, component, components.\n\nAccepted fields:\n- includeComponents (optional, boolean): Set true to enable include components behavior for Anthropic Claude Status Check. Constraints: default: true. Constraints: default: true.\n- includeIncidentDetails (optional, boolean): Optional deep incident history/timeline fetch. For Status.io providers this parses the public history page; for Statuspage providers it uses /api/v2/incidents.json. Constraints: default: false.\n- incidentLimit (optional, integer): Maximum recent incidents to return when includeIncidentDetails is true. Constraints: default: 5; min: 1; max: 20.\n- component (optional, string): Optional component selector, alias, id, or name. For Anthropic examples: api, code, console, claude-ai, cowork, government.\n- components (optional, array): Optional component selectors when the caller wants a scoped provider status. Constraints: max items: 12.\n\nExample request body:\n```json\n{\n  \"includeComponents\": true\n}\n```",
         "operationId": "official_status_anthropic",
         "security": [
           {
@@ -2359,11 +12493,25 @@
           "price": {
             "mode": "fixed",
             "currency": "USD",
-            "amount": "0.001"
+            "amount": "0.005"
           },
+          "pricingMode": "fixed",
           "protocols": [
             {
-              "x402": {}
+              "x402": {
+                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                "currency": "USDC",
+                "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "payTo": "4tWJRwNyhGr88QTiV2yzMoGsaxZiCSRDepf9JTdBEgyi"
+              }
+            },
+            {
+              "x402": {
+                "network": "eip155:8453",
+                "currency": "USDC",
+                "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                "payTo": "0xe8799C2dedA78ECcEB329D1E8FE9F110bf55E4F8"
+              }
             }
           ]
         },
@@ -2376,7 +12524,8 @@
                 "properties": {
                   "includeComponents": {
                     "type": "boolean",
-                    "default": true
+                    "default": true,
+                    "description": "Set true to enable include components behavior for Anthropic Claude Status Check. Constraints: default: true."
                   },
                   "includeIncidentDetails": {
                     "type": "boolean",
@@ -2397,7 +12546,8 @@
                   "components": {
                     "type": "array",
                     "items": {
-                      "type": "string"
+                      "type": "string",
+                      "description": "Components item value for Anthropic Claude Status Check."
                     },
                     "maxItems": 12,
                     "description": "Optional component selectors when the caller wants a scoped provider status."
@@ -2426,12 +12576,22 @@
           "402": {
             "description": "Payment Required"
           }
-        }
+        },
+        "tags": [
+          "status",
+          "anthropic",
+          "claude",
+          "ai",
+          "llm",
+          "api",
+          "incident-response"
+        ]
       }
     },
     "/api/check/domain": {
       "post": {
         "summary": "Check DNS and email launch basics",
+        "description": "Purpose: Check a domain's launch basics: DNS resolution, HTTPS reachability, MX, SPF, DMARC, CAA, and optional DKIM selectors.\nBest use: Use this when an agent needs check a domain's launch basics: DNS resolution, HTTPS reachability, MX, SPF, DMARC, CAA, and optional DKIM selectors.\nPrice: $0.02 per successful paid call. Direct Base x402 authorization is verified before execution and settled only after successful fulfillment.\nFulfillment: Managed AgentBodega HTTP+JSON endpoint. Upstream provider details are intentionally not disclosed unless the response explicitly includes managed source metadata.\n\nInput: send a JSON request body.\nRequired fields: domain.\nOptional fields: dkimSelectors.\n\nAccepted fields:\n- domain (required, string): Domain name to inspect, without a URL scheme. Constraints: min length: 1.\n- dkimSelectors (optional, array): Optional DKIM selectors to check, such as google or selector1. Constraints: max items: 10.\n\nExample request body:\n```json\n{\n  \"domain\": \"example.com\",\n  \"dkimSelectors\": [\n    \"google\",\n    \"selector1\"\n  ]\n}\n```",
         "operationId": "domain_launch_check",
         "security": [
           {
@@ -2444,9 +12604,23 @@
             "currency": "USD",
             "amount": "0.02"
           },
+          "pricingMode": "fixed",
           "protocols": [
             {
-              "x402": {}
+              "x402": {
+                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                "currency": "USDC",
+                "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "payTo": "4tWJRwNyhGr88QTiV2yzMoGsaxZiCSRDepf9JTdBEgyi"
+              }
+            },
+            {
+              "x402": {
+                "network": "eip155:8453",
+                "currency": "USDC",
+                "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                "payTo": "0xe8799C2dedA78ECcEB329D1E8FE9F110bf55E4F8"
+              }
             }
           ]
         },
@@ -2468,7 +12642,8 @@
                   "dkimSelectors": {
                     "type": "array",
                     "items": {
-                      "type": "string"
+                      "type": "string",
+                      "description": "Dkim Selectors item value for DNS SSL Email Launch Check."
                     },
                     "maxItems": 10,
                     "description": "Optional DKIM selectors to check, such as google or selector1."
@@ -2501,12 +12676,336 @@
           "402": {
             "description": "Payment Required"
           }
-        }
+        },
+        "tags": [
+          "dns",
+          "ssl",
+          "email",
+          "deliverability",
+          "launch-check"
+        ]
+      }
+    },
+    "/api/name/check": {
+      "post": {
+        "summary": "Check name, domain, and GitHub availability",
+        "description": "Purpose: Check one launch-name slug against selected public domain TLDs and GitHub handles, returning available, taken, invalid, or unknown with evidence and confidence instead of guessing.\nBest use: Use this when an agent needs check one launch-name slug against selected public domain TLDs and GitHub handles, returning available, taken, invalid, or unknown with evidence and confidence instead of guessing.\nPrice: $0.005 per successful paid call. Direct Base x402 authorization is verified before execution and settled only after successful fulfillment.\nFulfillment: Managed AgentBodega HTTP+JSON endpoint. Upstream provider details are intentionally not disclosed unless the response explicitly includes managed source metadata.\n\nInput: send a JSON request body.\nRequired fields: candidate.\nOptional fields: tlds, handles, includeWarnings.\n\nAccepted fields:\n- candidate (required, string): Required launch-name slug to check. Use lowercase letters, numbers, and hyphens only; no spaces, underscores, URL schemes, or leading @. Constraints: min length: 1; max length: 80.\n- tlds (optional, array): Domain TLDs to check. This endpoint only accepts delegated TLDs with reliable public RDAP coverage, and rejects unsupported TLDs instead of guessing. Constraints: default: \"com\", \"ai\", \"dev\", \"app\", \"io\", \"co\", \"net\", \"org\", \"xyz\", \"store\"; max items: 10.\n- handles (optional, array): Developer handle platforms to check. MVP coverage is GitHub only; browser-heavy social handle checks are separate future routes and are not advertised here. Constraints: default: \"github\"; max items: 1.\n- includeWarnings (optional, boolean): Include actionability and legal/ownership warnings in the response. Constraints: default: true.\n\nExample request body:\n```json\n{\n  \"candidate\": \"agentbodega\",\n  \"tlds\": [\n    \"com\",\n    \"dev\"\n  ],\n  \"handles\": [\n    \"github\"\n  ],\n  \"includeWarnings\": true\n}\n```",
+        "operationId": "name_availability_check",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.005"
+          },
+          "pricingMode": "fixed",
+          "protocols": [
+            {
+              "x402": {
+                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                "currency": "USDC",
+                "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "payTo": "4tWJRwNyhGr88QTiV2yzMoGsaxZiCSRDepf9JTdBEgyi"
+              }
+            },
+            {
+              "x402": {
+                "network": "eip155:8453",
+                "currency": "USDC",
+                "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                "payTo": "0xe8799C2dedA78ECcEB329D1E8FE9F110bf55E4F8"
+              }
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "candidate"
+                ],
+                "properties": {
+                  "candidate": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 80,
+                    "description": "Required launch-name slug to check. Use lowercase letters, numbers, and hyphens only; no spaces, underscores, URL schemes, or leading @."
+                  },
+                  "tlds": {
+                    "type": "array",
+                    "maxItems": 10,
+                    "default": [
+                      "com",
+                      "ai",
+                      "dev",
+                      "app",
+                      "io",
+                      "co",
+                      "net",
+                      "org",
+                      "xyz",
+                      "store"
+                    ],
+                    "items": {
+                      "type": "string",
+                      "enum": [
+                        "com",
+                        "ai",
+                        "dev",
+                        "app",
+                        "io",
+                        "co",
+                        "net",
+                        "org",
+                        "xyz",
+                        "store"
+                      ],
+                      "description": "Tlds item filter for Name Availability Check. Accepted values: \"com\", \"ai\", \"dev\", \"app\", \"io\", \"co\", \"net\", \"org\", \"xyz\", \"store\". Constraints: accepted values: \"com\", \"ai\", \"dev\", \"app\", \"io\", \"co\", \"net\", \"org\", \"xyz\", \"store\"."
+                    },
+                    "description": "Domain TLDs to check. This endpoint only accepts delegated TLDs with reliable public RDAP coverage, and rejects unsupported TLDs instead of guessing."
+                  },
+                  "handles": {
+                    "type": "array",
+                    "maxItems": 1,
+                    "default": [
+                      "github"
+                    ],
+                    "items": {
+                      "type": "string",
+                      "enum": [
+                        "github"
+                      ],
+                      "description": "Handles item filter for Name Availability Check. Accepted values: \"github\". Constraints: accepted values: \"github\"."
+                    },
+                    "description": "Developer handle platforms to check. MVP coverage is GitHub only; browser-heavy social handle checks are separate future routes and are not advertised here."
+                  },
+                  "includeWarnings": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Include actionability and legal/ownership warnings in the response."
+                  }
+                },
+                "additionalProperties": false
+              },
+              "example": {
+                "candidate": "agentbodega",
+                "tlds": [
+                  "com",
+                  "dev"
+                ],
+                "handles": [
+                  "github"
+                ],
+                "includeWarnings": true
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Utility result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "tool",
+                    "candidate",
+                    "checkedAt",
+                    "summary",
+                    "domains",
+                    "handles"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "tool": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "candidate": {
+                      "type": "string"
+                    },
+                    "checkedAt": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "summary": {
+                      "type": "object",
+                      "required": [
+                        "recommendation",
+                        "domainCounts",
+                        "handleCounts"
+                      ],
+                      "properties": {
+                        "recommendation": {
+                          "type": "string",
+                          "enum": [
+                            "shortlist",
+                            "review",
+                            "avoid"
+                          ]
+                        },
+                        "domainCounts": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "integer"
+                          }
+                        },
+                        "handleCounts": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "integer"
+                          }
+                        },
+                        "highConfidenceOnly": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "domains": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "required": [
+                          "domain",
+                          "tld",
+                          "status",
+                          "confidence",
+                          "source",
+                          "checkedAt"
+                        ],
+                        "properties": {
+                          "domain": {
+                            "type": "string"
+                          },
+                          "tld": {
+                            "type": "string"
+                          },
+                          "status": {
+                            "type": "string",
+                            "enum": [
+                              "available",
+                              "taken",
+                              "unknown"
+                            ]
+                          },
+                          "confidence": {
+                            "type": "string",
+                            "enum": [
+                              "high",
+                              "low"
+                            ]
+                          },
+                          "source": {
+                            "type": "string"
+                          },
+                          "checkedAt": {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "evidence": {
+                            "type": "object",
+                            "additionalProperties": true
+                          }
+                        },
+                        "additionalProperties": true
+                      }
+                    },
+                    "handles": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "required": [
+                          "platform",
+                          "handle",
+                          "status",
+                          "confidence",
+                          "source",
+                          "checkedAt"
+                        ],
+                        "properties": {
+                          "platform": {
+                            "type": "string",
+                            "enum": [
+                              "github"
+                            ]
+                          },
+                          "handle": {
+                            "type": "string"
+                          },
+                          "status": {
+                            "type": "string",
+                            "enum": [
+                              "available",
+                              "taken",
+                              "unknown",
+                              "invalid"
+                            ]
+                          },
+                          "confidence": {
+                            "type": "string",
+                            "enum": [
+                              "high",
+                              "low"
+                            ]
+                          },
+                          "source": {
+                            "type": "string"
+                          },
+                          "checkedAt": {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "evidence": {
+                            "type": "object",
+                            "additionalProperties": true
+                          }
+                        },
+                        "additionalProperties": true
+                      }
+                    },
+                    "warnings": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "tags": [
+          "name-availability",
+          "domain-availability",
+          "github",
+          "brand-check",
+          "launch-check",
+          "agent-tools",
+          "x402"
+        ]
       }
     },
     "/api/artifacts": {
       "post": {
         "summary": "Create a temporary hosted artifact",
+        "description": "Purpose: Create a short-lived signed hosted artifact for agents: text, JSON, SVG badge, or redirect URL. No database required for small artifacts.\nBest use: Use this when an agent needs create a short-lived signed hosted artifact for agents: text, JSON, SVG badge, or redirect URL. No database required for small artifacts.\nPrice: $0.01 per successful paid call. Direct Base x402 authorization is verified before execution and settled only after successful fulfillment.\nFulfillment: Managed AgentBodega HTTP+JSON endpoint. Upstream provider details are intentionally not disclosed unless the response explicitly includes managed source metadata.\n\nInput: send a JSON request body.\nRequired fields: kind, content.\nOptional fields: contentType, ttlSeconds, filename.\n\nAccepted fields:\n- kind (required, string): Kind filter for Temporary Hosted Artifact. Accepted values: \"text\", \"json\", \"svg\", \"redirect\". Constraints: accepted values: \"text\", \"json\", \"svg\", \"redirect\". Constraints: accepted values: \"text\", \"json\", \"svg\", \"redirect\".\n- content (required, any): Artifact body. Use a string for text, SVG, and redirects, or any JSON value when kind is json.\n- contentType (optional, string): Optional MIME type override.\n- ttlSeconds (optional, integer): Artifact lifetime in seconds. Constraints: default: 86400; min: 60; max: 604800.\n- filename (optional, string): Optional display filename. Constraints: max length: 120.\n\nExample request body:\n```json\n{\n  \"kind\": \"json\",\n  \"content\": {\n    \"ok\": true,\n    \"message\": \"hello agent\"\n  },\n  \"ttlSeconds\": 3600\n}\n```",
         "operationId": "hosted_artifact",
         "security": [
           {
@@ -2519,9 +13018,23 @@
             "currency": "USD",
             "amount": "0.01"
           },
+          "pricingMode": "fixed",
           "protocols": [
             {
-              "x402": {}
+              "x402": {
+                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                "currency": "USDC",
+                "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "payTo": "4tWJRwNyhGr88QTiV2yzMoGsaxZiCSRDepf9JTdBEgyi"
+              }
+            },
+            {
+              "x402": {
+                "network": "eip155:8453",
+                "currency": "USDC",
+                "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                "payTo": "0xe8799C2dedA78ECcEB329D1E8FE9F110bf55E4F8"
+              }
             }
           ]
         },
@@ -2543,7 +13056,8 @@
                       "json",
                       "svg",
                       "redirect"
-                    ]
+                    ],
+                    "description": "Kind filter for Temporary Hosted Artifact. Accepted values: \"text\", \"json\", \"svg\", \"redirect\". Constraints: accepted values: \"text\", \"json\", \"svg\", \"redirect\"."
                   },
                   "content": {
                     "description": "Artifact body. Use a string for text, SVG, and redirects, or any JSON value when kind is json."
@@ -2606,12 +13120,19 @@
           "402": {
             "description": "Payment Required"
           }
-        }
+        },
+        "tags": [
+          "artifact-hosting",
+          "webhook-bin",
+          "signed-url",
+          "agent-tools"
+        ]
       }
     },
     "/api/audit/agent-launch": {
       "post": {
         "summary": "Check agent launch readiness",
+        "description": "Purpose: Audit whether a site or API is ready for AI agents: discoverability, markdown access, OpenAPI, MCP, Agent Skills, x402 commerce, and concrete fix instructions.\nBest use: Use this when an agent needs audit whether a site or API is ready for AI agents: discoverability, markdown access, OpenAPI, MCP, Agent Skills, x402 commerce, and concrete fix instructions.\nPrice: $0.03 per successful paid call. Direct Base x402 authorization is verified before execution and settled only after successful fulfillment.\nFulfillment: Managed AgentBodega HTTP+JSON endpoint. Upstream provider details are intentionally not disclosed unless the response explicitly includes managed source metadata.\n\nInput: send a JSON request body.\nRequired fields: url.\nOptional fields: siteType, includeEvidence.\n\nAccepted fields:\n- url (required, string): Url value for Agent Launch Audit. Constraints: format: uri. Constraints: format: uri.\n- siteType (optional, string): Site Type filter for Agent Launch Audit. Accepted values: \"all\", \"content\", \"api\". Constraints: accepted values: \"all\", \"content\", \"api\"; default: \"all\". Constraints: accepted values: \"all\", \"content\", \"api\"; default: \"all\".\n- includeEvidence (optional, boolean): Set true to enable include evidence behavior for Agent Launch Audit. Constraints: default: true. Constraints: default: true.\n\nExample request body:\n```json\n{\n  \"url\": \"https://example.com\",\n  \"siteType\": \"all\",\n  \"includeEvidence\": true\n}\n```",
         "operationId": "agent_launch_audit",
         "security": [
           {
@@ -2624,9 +13145,23 @@
             "currency": "USD",
             "amount": "0.03"
           },
+          "pricingMode": "fixed",
           "protocols": [
             {
-              "x402": {}
+              "x402": {
+                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                "currency": "USDC",
+                "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "payTo": "4tWJRwNyhGr88QTiV2yzMoGsaxZiCSRDepf9JTdBEgyi"
+              }
+            },
+            {
+              "x402": {
+                "network": "eip155:8453",
+                "currency": "USDC",
+                "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                "payTo": "0xe8799C2dedA78ECcEB329D1E8FE9F110bf55E4F8"
+              }
             }
           ]
         },
@@ -2642,7 +13177,8 @@
                 "properties": {
                   "url": {
                     "type": "string",
-                    "format": "uri"
+                    "format": "uri",
+                    "description": "Url value for Agent Launch Audit. Constraints: format: uri."
                   },
                   "siteType": {
                     "type": "string",
@@ -2651,11 +13187,13 @@
                       "content",
                       "api"
                     ],
-                    "default": "all"
+                    "default": "all",
+                    "description": "Site Type filter for Agent Launch Audit. Accepted values: \"all\", \"content\", \"api\". Constraints: accepted values: \"all\", \"content\", \"api\"; default: \"all\"."
                   },
                   "includeEvidence": {
                     "type": "boolean",
-                    "default": true
+                    "default": true,
+                    "description": "Set true to enable include evidence behavior for Agent Launch Audit. Constraints: default: true."
                   }
                 },
                 "additionalProperties": false
@@ -2683,12 +13221,21 @@
           "402": {
             "description": "Payment Required"
           }
-        }
+        },
+        "tags": [
+          "agent-readiness",
+          "launch-audit",
+          "mcp",
+          "agent-skills",
+          "x402",
+          "seo"
+        ]
       }
     },
     "/api/check/agent-discoverability": {
       "post": {
         "summary": "Check agent discoverability signals",
+        "description": "Purpose: Check robots.txt, sitemap, Link headers, markdown access, llms.txt, and AI content-signal hints for agent-facing discoverability.\nBest use: Use this when an agent needs check robots.txt, sitemap, Link headers, markdown access, llms.txt, and AI content-signal hints for agent-facing discoverability.\nPrice: $0.01 per successful paid call. Direct Base x402 authorization is verified before execution and settled only after successful fulfillment.\nFulfillment: Managed AgentBodega HTTP+JSON endpoint. Upstream provider details are intentionally not disclosed unless the response explicitly includes managed source metadata.\n\nInput: send a JSON request body.\nRequired fields: url.\nOptional fields: includeEvidence.\n\nAccepted fields:\n- url (required, string): Url value for Agent Discoverability Check. Constraints: format: uri. Constraints: format: uri.\n- includeEvidence (optional, boolean): Set true to enable include evidence behavior for Agent Discoverability Check. Constraints: default: true. Constraints: default: true.\n\nExample request body:\n```json\n{\n  \"url\": \"https://example.com\",\n  \"includeEvidence\": true\n}\n```",
         "operationId": "agent_discoverability_check",
         "security": [
           {
@@ -2701,9 +13248,23 @@
             "currency": "USD",
             "amount": "0.01"
           },
+          "pricingMode": "fixed",
           "protocols": [
             {
-              "x402": {}
+              "x402": {
+                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                "currency": "USDC",
+                "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "payTo": "4tWJRwNyhGr88QTiV2yzMoGsaxZiCSRDepf9JTdBEgyi"
+              }
+            },
+            {
+              "x402": {
+                "network": "eip155:8453",
+                "currency": "USDC",
+                "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                "payTo": "0xe8799C2dedA78ECcEB329D1E8FE9F110bf55E4F8"
+              }
             }
           ]
         },
@@ -2719,11 +13280,13 @@
                 "properties": {
                   "url": {
                     "type": "string",
-                    "format": "uri"
+                    "format": "uri",
+                    "description": "Url value for Agent Discoverability Check. Constraints: format: uri."
                   },
                   "includeEvidence": {
                     "type": "boolean",
-                    "default": true
+                    "default": true,
+                    "description": "Set true to enable include evidence behavior for Agent Discoverability Check. Constraints: default: true."
                   }
                 },
                 "additionalProperties": false
@@ -2750,12 +13313,21 @@
           "402": {
             "description": "Payment Required"
           }
-        }
+        },
+        "tags": [
+          "agent-readiness",
+          "robots",
+          "sitemap",
+          "llms",
+          "markdown",
+          "link-headers"
+        ]
       }
     },
     "/api/check/agent-protocols": {
       "post": {
         "summary": "Check agent protocol metadata",
+        "description": "Purpose: Check OpenAPI, API catalog, MCP server cards, Agent Skills, auth.md, OAuth discovery, OAuth protected-resource metadata, A2A cards, and WebMCP hints.\nBest use: Use this when an agent needs check OpenAPI, API catalog, MCP server cards, Agent Skills, auth.md, OAuth discovery, OAuth protected-resource metadata, A2A cards, and WebMCP hints.\nPrice: $0.02 per successful paid call. Direct Base x402 authorization is verified before execution and settled only after successful fulfillment.\nFulfillment: Managed AgentBodega HTTP+JSON endpoint. Upstream provider details are intentionally not disclosed unless the response explicitly includes managed source metadata.\n\nInput: send a JSON request body.\nRequired fields: url.\nOptional fields: includeEvidence.\n\nAccepted fields:\n- url (required, string): Url value for Agent Protocol Discovery Check. Constraints: format: uri. Constraints: format: uri.\n- includeEvidence (optional, boolean): Set true to enable include evidence behavior for Agent Protocol Discovery Check. Constraints: default: true. Constraints: default: true.\n\nExample request body:\n```json\n{\n  \"url\": \"https://example.com\",\n  \"includeEvidence\": true\n}\n```",
         "operationId": "agent_protocol_check",
         "security": [
           {
@@ -2768,9 +13340,23 @@
             "currency": "USD",
             "amount": "0.02"
           },
+          "pricingMode": "fixed",
           "protocols": [
             {
-              "x402": {}
+              "x402": {
+                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                "currency": "USDC",
+                "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "payTo": "4tWJRwNyhGr88QTiV2yzMoGsaxZiCSRDepf9JTdBEgyi"
+              }
+            },
+            {
+              "x402": {
+                "network": "eip155:8453",
+                "currency": "USDC",
+                "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                "payTo": "0xe8799C2dedA78ECcEB329D1E8FE9F110bf55E4F8"
+              }
             }
           ]
         },
@@ -2786,11 +13372,13 @@
                 "properties": {
                   "url": {
                     "type": "string",
-                    "format": "uri"
+                    "format": "uri",
+                    "description": "Url value for Agent Protocol Discovery Check. Constraints: format: uri."
                   },
                   "includeEvidence": {
                     "type": "boolean",
-                    "default": true
+                    "default": true,
+                    "description": "Set true to enable include evidence behavior for Agent Protocol Discovery Check. Constraints: default: true."
                   }
                 },
                 "additionalProperties": false
@@ -2817,12 +13405,22 @@
           "402": {
             "description": "Payment Required"
           }
-        }
+        },
+        "tags": [
+          "agent-readiness",
+          "openapi",
+          "mcp",
+          "agent-skills",
+          "oauth",
+          "a2a",
+          "webmcp"
+        ]
       }
     },
     "/api/check/agent-commerce": {
       "post": {
         "summary": "Check agent commerce metadata",
+        "description": "Purpose: Check whether a site exposes machine-payable commerce metadata for x402, MPP-style OpenAPI payment hints, UCP, or ACP.\nBest use: Use this when an agent needs check whether a site exposes machine-payable commerce metadata for x402, MPP-style OpenAPI payment hints, UCP, or ACP.\nPrice: $0.01 per successful paid call. Direct Base x402 authorization is verified before execution and settled only after successful fulfillment.\nFulfillment: Managed AgentBodega HTTP+JSON endpoint. Upstream provider details are intentionally not disclosed unless the response explicitly includes managed source metadata.\n\nInput: send a JSON request body.\nRequired fields: url.\nOptional fields: includeEvidence.\n\nAccepted fields:\n- url (required, string): Url value for Agent Commerce Check. Constraints: format: uri. Constraints: format: uri.\n- includeEvidence (optional, boolean): Set true to enable include evidence behavior for Agent Commerce Check. Constraints: default: true. Constraints: default: true.\n\nExample request body:\n```json\n{\n  \"url\": \"https://example.com\",\n  \"includeEvidence\": true\n}\n```",
         "operationId": "agent_commerce_check",
         "security": [
           {
@@ -2835,9 +13433,23 @@
             "currency": "USD",
             "amount": "0.01"
           },
+          "pricingMode": "fixed",
           "protocols": [
             {
-              "x402": {}
+              "x402": {
+                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                "currency": "USDC",
+                "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "payTo": "4tWJRwNyhGr88QTiV2yzMoGsaxZiCSRDepf9JTdBEgyi"
+              }
+            },
+            {
+              "x402": {
+                "network": "eip155:8453",
+                "currency": "USDC",
+                "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                "payTo": "0xe8799C2dedA78ECcEB329D1E8FE9F110bf55E4F8"
+              }
             }
           ]
         },
@@ -2853,11 +13465,13 @@
                 "properties": {
                   "url": {
                     "type": "string",
-                    "format": "uri"
+                    "format": "uri",
+                    "description": "Url value for Agent Commerce Check. Constraints: format: uri."
                   },
                   "includeEvidence": {
                     "type": "boolean",
-                    "default": true
+                    "default": true,
+                    "description": "Set true to enable include evidence behavior for Agent Commerce Check. Constraints: default: true."
                   }
                 },
                 "additionalProperties": false
@@ -2884,12 +13498,21 @@
           "402": {
             "description": "Payment Required"
           }
-        }
+        },
+        "tags": [
+          "agent-readiness",
+          "x402",
+          "mpp",
+          "ucp",
+          "acp",
+          "commerce"
+        ]
       }
     },
     "/api/audit/agent-batch": {
       "post": {
         "summary": "Check agent readiness for URLs",
+        "description": "Purpose: Run agent-readiness checks across up to five URLs in one paid call and return comparable scores, failures, and concrete next steps.\nBest use: Use this when an agent needs run agent-readiness checks across up to five URLs in one paid call and return comparable scores, failures, and concrete next steps.\nPrice: $0.05 per successful paid call. Direct Base x402 authorization is verified before execution and settled only after successful fulfillment.\nFulfillment: Managed AgentBodega HTTP+JSON endpoint. Upstream provider details are intentionally not disclosed unless the response explicitly includes managed source metadata.\n\nInput: send a JSON request body.\nRequired fields: urls.\nOptional fields: scope, includeEvidence.\n\nAccepted fields:\n- urls (required, array): List of urls values for Agent Readiness Batch Audit. Constraints: min items: 1; max items: 5. Constraints: min items: 1; max items: 5.\n- scope (optional, string): Scope filter for Agent Readiness Batch Audit. Accepted values: \"all\", \"discoverability\", \"protocols\", \"commerce\". Constraints: accepted values: \"all\", \"discoverability\", \"protocols\", \"commerce\"; default: \"all\". Constraints: accepted values: \"all\", \"discoverability\", \"protocols\", \"commerce\"; default: \"all\".\n- includeEvidence (optional, boolean): Set true to enable include evidence behavior for Agent Readiness Batch Audit. Constraints: default: false. Constraints: default: false.\n\nExample request body:\n```json\n{\n  \"urls\": [\n    \"https://example.com\",\n    \"https://example.org\"\n  ],\n  \"scope\": \"all\",\n  \"includeEvidence\": false\n}\n```",
         "operationId": "agent_readiness_batch",
         "security": [
           {
@@ -2902,9 +13525,23 @@
             "currency": "USD",
             "amount": "0.05"
           },
+          "pricingMode": "fixed",
           "protocols": [
             {
-              "x402": {}
+              "x402": {
+                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                "currency": "USDC",
+                "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "payTo": "4tWJRwNyhGr88QTiV2yzMoGsaxZiCSRDepf9JTdBEgyi"
+              }
+            },
+            {
+              "x402": {
+                "network": "eip155:8453",
+                "currency": "USDC",
+                "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                "payTo": "0xe8799C2dedA78ECcEB329D1E8FE9F110bf55E4F8"
+              }
             }
           ]
         },
@@ -2922,10 +13559,12 @@
                     "type": "array",
                     "items": {
                       "type": "string",
-                      "format": "uri"
+                      "format": "uri",
+                      "description": "Urls item value for Agent Readiness Batch Audit. Constraints: format: uri."
                     },
                     "minItems": 1,
-                    "maxItems": 5
+                    "maxItems": 5,
+                    "description": "List of urls values for Agent Readiness Batch Audit. Constraints: min items: 1; max items: 5."
                   },
                   "scope": {
                     "type": "string",
@@ -2935,11 +13574,13 @@
                       "protocols",
                       "commerce"
                     ],
-                    "default": "all"
+                    "default": "all",
+                    "description": "Scope filter for Agent Readiness Batch Audit. Accepted values: \"all\", \"discoverability\", \"protocols\", \"commerce\". Constraints: accepted values: \"all\", \"discoverability\", \"protocols\", \"commerce\"; default: \"all\"."
                   },
                   "includeEvidence": {
                     "type": "boolean",
-                    "default": false
+                    "default": false,
+                    "description": "Set true to enable include evidence behavior for Agent Readiness Batch Audit. Constraints: default: false."
                   }
                 },
                 "additionalProperties": false
@@ -2970,12 +13611,20 @@
           "402": {
             "description": "Payment Required"
           }
-        }
+        },
+        "tags": [
+          "agent-readiness",
+          "batch-audit",
+          "launch-audit",
+          "seo",
+          "x402"
+        ]
       }
     },
     "/api/badge/agent-ready": {
       "post": {
         "summary": "Generate an agent-ready badge",
+        "description": "Purpose: Generate an agent-readiness score and SVG badge for a URL using the same checks as the launch audit.\nBest use: Use this when an agent needs generate an agent-readiness score and SVG badge for a URL using the same checks as the launch audit.\nPrice: $0.01 per successful paid call. Direct Base x402 authorization is verified before execution and settled only after successful fulfillment.\nFulfillment: Managed AgentBodega HTTP+JSON endpoint. Upstream provider details are intentionally not disclosed unless the response explicitly includes managed source metadata.\n\nInput: send a JSON request body.\nRequired fields: url.\nOptional fields: scope, includeEvidence.\n\nAccepted fields:\n- url (required, string): Url value for Agent Ready Badge. Constraints: format: uri. Constraints: format: uri.\n- scope (optional, string): Scope filter for Agent Ready Badge. Accepted values: \"all\", \"discoverability\", \"protocols\", \"commerce\". Constraints: accepted values: \"all\", \"discoverability\", \"protocols\", \"commerce\"; default: \"all\". Constraints: accepted values: \"all\", \"discoverability\", \"protocols\", \"commerce\"; default: \"all\".\n- includeEvidence (optional, boolean): Set true to enable include evidence behavior for Agent Ready Badge. Constraints: default: false. Constraints: default: false.\n\nExample request body:\n```json\n{\n  \"url\": \"https://example.com\",\n  \"scope\": \"all\",\n  \"includeEvidence\": false\n}\n```",
         "operationId": "agent_ready_badge",
         "security": [
           {
@@ -2988,9 +13637,23 @@
             "currency": "USD",
             "amount": "0.01"
           },
+          "pricingMode": "fixed",
           "protocols": [
             {
-              "x402": {}
+              "x402": {
+                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                "currency": "USDC",
+                "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "payTo": "4tWJRwNyhGr88QTiV2yzMoGsaxZiCSRDepf9JTdBEgyi"
+              }
+            },
+            {
+              "x402": {
+                "network": "eip155:8453",
+                "currency": "USDC",
+                "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                "payTo": "0xe8799C2dedA78ECcEB329D1E8FE9F110bf55E4F8"
+              }
             }
           ]
         },
@@ -3006,7 +13669,8 @@
                 "properties": {
                   "url": {
                     "type": "string",
-                    "format": "uri"
+                    "format": "uri",
+                    "description": "Url value for Agent Ready Badge. Constraints: format: uri."
                   },
                   "scope": {
                     "type": "string",
@@ -3016,11 +13680,13 @@
                       "protocols",
                       "commerce"
                     ],
-                    "default": "all"
+                    "default": "all",
+                    "description": "Scope filter for Agent Ready Badge. Accepted values: \"all\", \"discoverability\", \"protocols\", \"commerce\". Constraints: accepted values: \"all\", \"discoverability\", \"protocols\", \"commerce\"; default: \"all\"."
                   },
                   "includeEvidence": {
                     "type": "boolean",
-                    "default": false
+                    "default": false,
+                    "description": "Set true to enable include evidence behavior for Agent Ready Badge. Constraints: default: false."
                   }
                 },
                 "additionalProperties": false
@@ -3048,12 +13714,19 @@
           "402": {
             "description": "Payment Required"
           }
-        }
+        },
+        "tags": [
+          "agent-readiness",
+          "badge",
+          "svg",
+          "launch-audit"
+        ]
       }
     },
     "/api/package/x402-directory": {
       "post": {
         "summary": "Create x402 directory listing data",
+        "description": "Purpose: Build a compact listing payload for x402 directories: service name, discovery links, payment metadata, endpoint counts, tags, and readiness warnings.\nBest use: Use this when an agent needs build a compact listing payload for x402 directories: service name, discovery links, payment metadata, endpoint counts, tags, and readiness warnings.\nPrice: $0.01 per successful paid call. Direct Base x402 authorization is verified before execution and settled only after successful fulfillment.\nFulfillment: Managed AgentBodega HTTP+JSON endpoint. Upstream provider details are intentionally not disclosed unless the response explicitly includes managed source metadata.\n\nInput: send a JSON request body.\nRequired fields: url.\nOptional fields: name, tags.\n\nAccepted fields:\n- url (required, string): Url value for x402 Directory Listing Pack. Constraints: format: uri. Constraints: format: uri.\n- name (optional, string): Name value for x402 Directory Listing Pack. Constraints: max length: 80. Constraints: max length: 80.\n- tags (optional, array): List of tags values for x402 Directory Listing Pack. Constraints: max items: 12. Constraints: max items: 12.\n\nExample request body:\n```json\n{\n  \"url\": \"https://example.com\",\n  \"name\": \"Example x402 API\",\n  \"tags\": [\n    \"x402\",\n    \"agents\"\n  ]\n}\n```",
         "operationId": "x402_directory_pack",
         "security": [
           {
@@ -3066,9 +13739,23 @@
             "currency": "USD",
             "amount": "0.01"
           },
+          "pricingMode": "fixed",
           "protocols": [
             {
-              "x402": {}
+              "x402": {
+                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                "currency": "USDC",
+                "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "payTo": "4tWJRwNyhGr88QTiV2yzMoGsaxZiCSRDepf9JTdBEgyi"
+              }
+            },
+            {
+              "x402": {
+                "network": "eip155:8453",
+                "currency": "USDC",
+                "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                "payTo": "0xe8799C2dedA78ECcEB329D1E8FE9F110bf55E4F8"
+              }
             }
           ]
         },
@@ -3084,18 +13771,22 @@
                 "properties": {
                   "url": {
                     "type": "string",
-                    "format": "uri"
+                    "format": "uri",
+                    "description": "Url value for x402 Directory Listing Pack. Constraints: format: uri."
                   },
                   "name": {
                     "type": "string",
-                    "maxLength": 80
+                    "maxLength": 80,
+                    "description": "Name value for x402 Directory Listing Pack. Constraints: max length: 80."
                   },
                   "tags": {
                     "type": "array",
                     "items": {
-                      "type": "string"
+                      "type": "string",
+                      "description": "Tags item value for x402 Directory Listing Pack."
                     },
-                    "maxItems": 12
+                    "maxItems": 12,
+                    "description": "List of tags values for x402 Directory Listing Pack. Constraints: max items: 12."
                   }
                 },
                 "additionalProperties": false
@@ -3126,7 +13817,14 @@
           "402": {
             "description": "Payment Required"
           }
-        }
+        },
+        "tags": [
+          "x402",
+          "directory-listing",
+          "marketplace",
+          "bazaar",
+          "discovery"
+        ]
       }
     }
   },
@@ -3137,6 +13835,17 @@
         "in": "header",
         "name": "X-PAYMENT",
         "description": "Base64url-encoded x402 payment payload."
+      },
+      "l402Auth": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "Authorization",
+        "description": "L402 credential in the form Authorization: L402 <macaroon>:<preimage>. See /.well-known/l402-services for the current handoff status."
+      },
+      "mppAuth": {
+        "type": "http",
+        "scheme": "Payment",
+        "description": "MPP credential in the form Authorization: Payment <credential>. The 402 response advertises challenges in WWW-Authenticate and fulfilled responses return Payment-Receipt."
       }
     }
   }

--- a/providers/agentbodegastore/agentbodega/openapi.json
+++ b/providers/agentbodegastore/agentbodega/openapi.json
@@ -379,13 +379,15 @@
                     "enum": [
                       "aws",
                       "gcp",
-                      "azure"
+                      "azure",
+                      "digitalocean",
+                      "linode"
                     ],
                     "description": "Cloud provider id."
                   },
                   "service": {
                     "type": "string",
-                    "description": "AWS/Azure service name or id, for example ec2, lambda, apigateway, cloudfront, or compute."
+                    "description": "Provider service name or id, for example ec2, lambda, app-service, spaces, droplets, object-storage, or lke."
                   },
                   "product": {
                     "type": "string",
@@ -393,7 +395,7 @@
                   },
                   "region": {
                     "type": "string",
-                    "description": "Provider region/location such as us-east-1, us-central1, eastus, or global."
+                    "description": "Provider region/location such as us-east-1, us-central1, eastus, nyc3, us-east-newark, or global."
                   },
                   "location": {
                     "type": "string",
@@ -479,6 +481,8 @@
                       "aws",
                       "gcp",
                       "azure",
+                      "digitalocean",
+                      "linode",
                       "all"
                     ],
                     "default": "all"
@@ -559,7 +563,9 @@
                       "cloud-core",
                       "aws-webapp",
                       "gcp-ai-app",
-                      "azure-saas"
+                      "azure-saas",
+                      "do-core",
+                      "linode-core"
                     ],
                     "default": "cloud-core"
                   },
@@ -576,13 +582,15 @@
                           "enum": [
                             "aws",
                             "gcp",
-                            "azure"
+                            "azure",
+                            "digitalocean",
+                            "linode"
                           ],
                           "description": "Cloud provider id."
                         },
                         "service": {
                           "type": "string",
-                          "description": "AWS/Azure service name or id, for example ec2, lambda, apigateway, cloudfront, or compute."
+                          "description": "Provider service name or id, for example ec2, lambda, app-service, spaces, droplets, object-storage, or lke."
                         },
                         "product": {
                           "type": "string",
@@ -590,7 +598,7 @@
                         },
                         "region": {
                           "type": "string",
-                          "description": "Provider region/location such as us-east-1, us-central1, eastus, or global."
+                          "description": "Provider region/location such as us-east-1, us-central1, eastus, nyc3, us-east-newark, or global."
                         },
                         "location": {
                           "type": "string",
@@ -683,13 +691,15 @@
                           "enum": [
                             "aws",
                             "gcp",
-                            "azure"
+                            "azure",
+                            "digitalocean",
+                            "linode"
                           ],
                           "description": "Cloud provider id."
                         },
                         "service": {
                           "type": "string",
-                          "description": "AWS/Azure service name or id, for example ec2, lambda, apigateway, cloudfront, or compute."
+                          "description": "Provider service name or id, for example ec2, lambda, app-service, spaces, droplets, object-storage, or lke."
                         },
                         "product": {
                           "type": "string",
@@ -697,7 +707,7 @@
                         },
                         "region": {
                           "type": "string",
-                          "description": "Provider region/location such as us-east-1, us-central1, eastus, or global."
+                          "description": "Provider region/location such as us-east-1, us-central1, eastus, nyc3, us-east-newark, or global."
                         },
                         "location": {
                           "type": "string",

--- a/providers/agentbodegastore/agentbodega/openapi.json
+++ b/providers/agentbodegastore/agentbodega/openapi.json
@@ -19,16 +19,12 @@
   "x-discovery": {
     "tags": [
       "x402",
-      "mpp",
-      "payment-auth",
-      "l402",
-      "lightning",
       "agent-tools",
       "mcp-tools",
       "paid-utilities"
     ],
     "endpointCount": 71,
-    "totalEndpointCount": 71,
+    "totalEndpointCount": 81,
     "surface": {
       "label": "Full Catalog",
       "mode": "full",
@@ -62,9 +58,7 @@
       "note": "AgentBodega is the single store root. Each offering carries stable department, aisle, optional shelf, and offering IDs; shelves are optional and only appear when they add useful grouping."
     },
     "payments": {
-      "x402": "https://agentbodega.store/.well-known/x402",
-      "mpp": "https://agentbodega.store/openapi.json",
-      "l402": "https://agentbodega.store/.well-known/l402-services"
+      "x402": "https://agentbodega.store/.well-known/x402"
     },
     "directory": "https://agentbodega.store/api/directory",
     "taxonomy": "https://agentbodega.store/api/taxonomy",
@@ -77,7 +71,8 @@
       "fullX402": "https://agentbodega.store/.well-known/x402",
       "summaryX402": "https://agentbodega.store/.well-known/x402.summary.json",
       "registry": "https://agentbodega.store/registry/index.json"
-    }
+    },
+    "paidEndpointCount": 71
   },
   "paths": {
     "/api/directory": {
@@ -13835,17 +13830,6 @@
         "in": "header",
         "name": "X-PAYMENT",
         "description": "Base64url-encoded x402 payment payload."
-      },
-      "l402Auth": {
-        "type": "apiKey",
-        "in": "header",
-        "name": "Authorization",
-        "description": "L402 credential in the form Authorization: L402 <macaroon>:<preimage>. See /.well-known/l402-services for the current handoff status."
-      },
-      "mppAuth": {
-        "type": "http",
-        "scheme": "Payment",
-        "description": "MPP credential in the form Authorization: Payment <credential>. The 402 response advertises challenges in WWW-Authenticate and fulfilled responses return Payment-Receipt."
       }
     }
   }

--- a/providers/agentbodegastore/agentbodega/openapi.json
+++ b/providers/agentbodegastore/agentbodega/openapi.json
@@ -23,7 +23,7 @@
       "mcp-tools",
       "paid-utilities"
     ],
-    "endpointCount": 31
+    "endpointCount": 35
   },
   "paths": {
     "/api/directory": {
@@ -321,6 +321,430 @@
               "example": {
                 "service": "github",
                 "includeComponents": true
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Utility result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        }
+      }
+    },
+    "/api/cloud/status/check": {
+      "post": {
+        "summary": "Check one cloud provider service",
+        "operationId": "cloud_status_check",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "provider"
+                ],
+                "properties": {
+                  "provider": {
+                    "type": "string",
+                    "enum": [
+                      "aws",
+                      "gcp",
+                      "azure"
+                    ],
+                    "description": "Cloud provider id."
+                  },
+                  "service": {
+                    "type": "string",
+                    "description": "AWS/Azure service name or id, for example ec2, lambda, apigateway, cloudfront, or compute."
+                  },
+                  "product": {
+                    "type": "string",
+                    "description": "GCP product name, id, or alias, for example cloud-run, vertex-ai, cloud-sql, or compute-engine."
+                  },
+                  "region": {
+                    "type": "string",
+                    "description": "Provider region/location such as us-east-1, us-central1, eastus, or global."
+                  },
+                  "location": {
+                    "type": "string",
+                    "description": "Provider location alias. Treated the same as region."
+                  },
+                  "includeHistory": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Return recent/resolved historical incidents when the provider source exposes them."
+                  },
+                  "includeHealthy": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Include healthy/noisy rows. Default responses focus on degraded or relevant incidents."
+                  },
+                  "incidentLimit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 20,
+                    "default": 5
+                  }
+                },
+                "additionalProperties": false
+              },
+              "example": {
+                "provider": "aws",
+                "service": "lambda",
+                "region": "us-east-1",
+                "includeHistory": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Utility result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        }
+      }
+    },
+    "/api/cloud/status/summary": {
+      "post": {
+        "summary": "Summarize cloud provider incidents",
+        "operationId": "cloud_status_summary",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.002"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "provider": {
+                    "type": "string",
+                    "enum": [
+                      "aws",
+                      "gcp",
+                      "azure",
+                      "all"
+                    ],
+                    "default": "all"
+                  },
+                  "includeHistory": {
+                    "type": "boolean",
+                    "default": false
+                  },
+                  "includeHealthy": {
+                    "type": "boolean",
+                    "default": false
+                  },
+                  "incidentLimit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 20,
+                    "default": 5
+                  }
+                },
+                "additionalProperties": false
+              },
+              "example": {
+                "provider": "all",
+                "includeHistory": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Utility result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        }
+      }
+    },
+    "/api/cloud/status/bundle": {
+      "post": {
+        "summary": "Check a small cloud status bundle",
+        "operationId": "cloud_status_bundle",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.005"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "bundle": {
+                    "type": "string",
+                    "enum": [
+                      "cloud-core",
+                      "aws-webapp",
+                      "gcp-ai-app",
+                      "azure-saas"
+                    ],
+                    "default": "cloud-core"
+                  },
+                  "targets": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "required": [
+                        "provider"
+                      ],
+                      "properties": {
+                        "provider": {
+                          "type": "string",
+                          "enum": [
+                            "aws",
+                            "gcp",
+                            "azure"
+                          ],
+                          "description": "Cloud provider id."
+                        },
+                        "service": {
+                          "type": "string",
+                          "description": "AWS/Azure service name or id, for example ec2, lambda, apigateway, cloudfront, or compute."
+                        },
+                        "product": {
+                          "type": "string",
+                          "description": "GCP product name, id, or alias, for example cloud-run, vertex-ai, cloud-sql, or compute-engine."
+                        },
+                        "region": {
+                          "type": "string",
+                          "description": "Provider region/location such as us-east-1, us-central1, eastus, or global."
+                        },
+                        "location": {
+                          "type": "string",
+                          "description": "Provider location alias. Treated the same as region."
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "minItems": 1,
+                    "maxItems": 5,
+                    "description": "Optional explicit cloud checks. Bundle price covers up to five normalized units."
+                  },
+                  "includeHistory": {
+                    "type": "boolean",
+                    "default": false
+                  },
+                  "includeHealthy": {
+                    "type": "boolean",
+                    "default": false
+                  }
+                },
+                "additionalProperties": false
+              },
+              "example": {
+                "bundle": "cloud-core",
+                "includeHistory": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Utility result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        }
+      }
+    },
+    "/api/cloud/status/stack": {
+      "post": {
+        "summary": "Check a cloud service stack",
+        "operationId": "cloud_status_stack",
+        "security": [
+          {
+            "x402": []
+          }
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.01"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "targets"
+                ],
+                "properties": {
+                  "targets": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "required": [
+                        "provider"
+                      ],
+                      "properties": {
+                        "provider": {
+                          "type": "string",
+                          "enum": [
+                            "aws",
+                            "gcp",
+                            "azure"
+                          ],
+                          "description": "Cloud provider id."
+                        },
+                        "service": {
+                          "type": "string",
+                          "description": "AWS/Azure service name or id, for example ec2, lambda, apigateway, cloudfront, or compute."
+                        },
+                        "product": {
+                          "type": "string",
+                          "description": "GCP product name, id, or alias, for example cloud-run, vertex-ai, cloud-sql, or compute-engine."
+                        },
+                        "region": {
+                          "type": "string",
+                          "description": "Provider region/location such as us-east-1, us-central1, eastus, or global."
+                        },
+                        "location": {
+                          "type": "string",
+                          "description": "Provider location alias. Treated the same as region."
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "minItems": 3,
+                    "maxItems": 12,
+                    "description": "Caller-selected cloud checks. Stack price covers up to twelve normalized units."
+                  },
+                  "includeHistory": {
+                    "type": "boolean",
+                    "default": false
+                  },
+                  "includeHealthy": {
+                    "type": "boolean",
+                    "default": false
+                  }
+                },
+                "additionalProperties": false
+              },
+              "example": {
+                "targets": [
+                  {
+                    "provider": "aws",
+                    "service": "lambda",
+                    "region": "us-east-1"
+                  },
+                  {
+                    "provider": "aws",
+                    "service": "s3",
+                    "region": "us-east-1"
+                  },
+                  {
+                    "provider": "gcp",
+                    "product": "cloud-run",
+                    "location": "us-central1"
+                  },
+                  {
+                    "provider": "azure",
+                    "service": "app-service",
+                    "region": "eastus"
+                  }
+                ],
+                "includeHistory": false
               }
             }
           }


### PR DESCRIPTION
Adds AgentBodega as a Pay.sh discoverable provider.

Validation run:

```bash
npx --yes @solana/pay catalog check providers/agentbodegastore/agentbodega/PAY.md
```

Result: `PAY.md check successful`; 37 endpoints tested; 35/35 gates compatible with Solana.

Notes:
- Service URL: https://agentbodega.store
- Paid endpoints advertise Solana mainnet USDC x402 requirements.
- Includes scoped AWS, Google Cloud, and Azure public status checks alongside app status, launch audits, x402 inspection, domain checks, signed artifacts, directory packaging, and receipts.
- The provider path is `providers/agentbodegastore/agentbodega` and the commit author is the `agentbodegastore` GitHub identity.
