### PR TITLE
feat: add The Stall — 292-cap x402 data API on Base + Solana

### DIFF
--- a/providers/intuitek/the-stall/PAY.md
+++ b/providers/intuitek/the-stall/PAY.md
@@ -1,0 +1,42 @@
+---
+name: the-stall
+title: "The Stall by IntuiTek¹"
+description: "299 pay-per-call AI capabilities on Base mainnet via x402 USDC — stock prices, earnings, DeFi analytics, macro indicators, prediction markets, research synthesis, company intelligence, crypto, options, OSINT, and more. No API keys or accounts."
+use_case: "Use for equity research (stock prices, earnings, fundamentals, analyst ratings, insider trades), DeFi analytics (yields, TVL, token security, wallet screening), macro intelligence (Fed data, economic indicators, sector rotation), prediction markets (Polymarket), research synthesis, company due diligence, patent search, NPI lookup, and OSINT. Pay USDC on Base per call — no subscriptions."
+category: finance
+service_url: https://the-stall.intuitek.ai
+openapi:
+  url: https://the-stall.intuitek.ai/openapi.json
+---
+
+The Stall is a domain-agnostic x402 capability chassis serving 299 AI-callable data tools over USDC on Base mainnet. No API keys, no accounts, no subscriptions — pay per call with exact USDC micropayments.
+
+## What you get
+
+**Equity & Earnings:** stock prices (single + multi-ticker batch), earnings calendar, earnings estimates, earnings surprises, earnings quality, analyst ratings, analyst upgrades, insider trades, institutional ownership, form 144, SEC filings, income statements, balance sheets, cash flow, equity fundamentals, equity technicals, equity brief, equity sentiment, dividend intel, options chain, options flow, equity watchlist.
+
+**DeFi & Crypto:** token security scores, wallet screening, DeFi yields, DEX pools, DeFi TVL, chain pulse, crypto brief, crypto fear/greed, crypto top movers, crypto momentum, stablecoin watch, meme radar, defillama protocol, address intel, wallet balance, ERC-20 snapshot, whale radar.
+
+**Macro & Economic:** FRED query, economic calendar, economic momentum, inflation intel, labor market, treasury yields, FOMC tracker, sector rotation, market breadth, market regime intel, market intelligence, global equity indices, COT positioning.
+
+**Research & Intelligence:** research synthesis ($2.50 — moat cap), fact-check, company research bundle, company due diligence, company intel, merger/acquisition intel, activist investor intel, hedge fund holdings, peer benchmarking, patent intel, PubMed intel, arXiv intel, clinical trials, SEC full-text search.
+
+**Prediction & Social:** Polymarket intel, Polymarket sentiment shift, Polymarket whale entries, Polymarket accuracy score, Reddit intel, social momentum, Twitter/X intel, news sentiment, social intel.
+
+**Identity & Compliance:** NPI lookup (healthcare providers), FDIC bank intel, FEC donor intel, government contract intel, nonprofit intel, entity clearance, sanctions screening, wallet credit score.
+
+## Pricing highlights
+
+- `us-stock-price`: $0.295/call (168+ confirmed calls, 46+ payers)
+- `research-synthesis`: $2.50/call (moat — unique multi-source synthesis)
+- `energy-brief`: $0.990/call (sector + commodity + weather brief)
+- `fact-check`: $0.470/call
+- Most data caps: $0.021–$0.099/call
+
+## Spend-aware usage
+
+- For multi-ticker price lookups, use `stock-price-multi` (batches 5 tickers at $0.295 = $0.059/ticker) instead of calling `us-stock-price` 5× ($1.475 total).
+- For complete earnings context, `earnings-intel-bundle` covers calendar + estimates + surprises + quality in one call.
+- For company-level research, `company-research-bundle` and `company-due-diligence` cover more ground than piecing together individual caps.
+- `research-synthesis` ($2.50) returns multi-source analysis — use it when depth matters; use raw data caps when you need a single clean number.
+- MCP interface at `/mcp` supports Streamable HTTP for streaming-capable clients.

--- a/providers/intuitek/the-stall/openapi.json
+++ b/providers/intuitek/the-stall/openapi.json
@@ -1,0 +1,9082 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "The Stall \u2014 292-cap pay-per-call data API",
+    "description": "292 pay-per-call AI data tools on Base and Solana mainnet. Equity, options, on-chain analytics, insider filings, DeFi yields, macro indicators, OSINT, and research synthesis. No API keys or accounts required. Pay USDC per call via x402 protocol.",
+    "version": "4.94.0",
+    "contact": {
+      "name": "IntuiTek",
+      "url": "https://the-stall.intuitek.ai"
+    }
+  },
+  "servers": [
+    {
+      "url": "https://the-stall.intuitek.ai",
+      "description": "Production (Base + Solana rails)"
+    }
+  ],
+  "components": {
+    "securitySchemes": {
+      "x402Payment": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-Payment",
+        "description": "x402 payment \u2014 EIP-3009 signed authorization (Base) or signed USDC transfer (Solana mainnet-beta) in the X-Payment header. See /.well-known/x402 for the full challenge schema."
+      }
+    }
+  },
+  "paths": {
+    "/cap/action-receipt": {
+      "get": {
+        "operationId": "action-receipt",
+        "summary": "Issue a self-verifying action receipt: sha256-chained record binding actor, action, subject, and result hash to a timestamp and nonce. Returns the receipt plus the exact recompute recipe so any third party can verify it offline. Durable proof for agent actions, dispute defense, and audit trails.",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.05,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/activist-investor-intel": {
+      "get": {
+        "operationId": "activist-investor-intel",
+        "summary": "SEC EDGAR Schedule 13D/13G beneficial ownership disclosures for US equities. Mode 1 (ticker): returns all 5%+ shareholders for a company \u2014 activist funds (13D) vs passive holders (13G), with ownership %, share count, and EDGAR filing URL. Mode 2 (recent): returns market-wide Schedule 13D disclosures",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.02,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/address-intel": {
+      "get": {
+        "operationId": "address-intel",
+        "summary": "On-chain intelligence for any Base network wallet. Classifies EOA vs contract, profiles USDC transfer activity over a configurable block window, scores payer diversity (distinct counterparties / total transfers, 0\u2013100), detects sybil vanity-lookalike address clusters (same first-4 + last-4 hex chars",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.05,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/address-security": {
+      "get": {
+        "operationId": "address-security",
+        "summary": "Wallet/address security and reputation check. Detects phishing, sanctions, cybercrime, money laundering, dark-web activity, and blacklisted wallets using GoPlus Labs + SlowMist + BlockSec data. Returns risk score (0-100) and per-flag breakdown. Supports Ethereum, Base, BSC, Polygon, Arbitrum, Optimi",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.136,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/agent-access-check": {
+      "get": {
+        "operationId": "agent-access-check",
+        "summary": "Checks whether a website is accessible and agent-friendly. Fetches robots.txt, .well-known/ai.txt, and sitemap.xml; inspects HTTP headers (CORS, CSP, rate-limit); and returns a readiness verdict. Useful for agents that need to decide whether to scrape, crawl, or interact with a domain before committ",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.034,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/agent-kya-score": {
+      "get": {
+        "operationId": "agent-kya-score",
+        "summary": "Know Your Agent (KYA) trust score for any EVM wallet. Returns a 0\u2013100 score, tier (trusted/verified/unknown), sanctions screening result, per-dimension score breakdown (wallet age, activity, sanctions, ERC-8004 identity, KYB, tx history, trust bond, endpoint quality), on-chain attestations (Coinbase",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.136,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/agriculture-brief": {
+      "get": {
+        "operationId": "agriculture-brief",
+        "summary": "AI-synthesized US agricultural commodities market intelligence brief. Assembles 9 real-time signals from Yahoo Finance: corn futures (ZC=F), wheat (ZW=F), soybeans (ZS=F), live cattle (LE=F), lean hogs (HE=F), coffee arabica (KC=F), cotton (CT=F), agribusiness sector ETF (MOO), and Deere & Co (DE, f",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.35,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/ai-image-gen": {
+      "get": {
+        "operationId": "ai-image-gen",
+        "summary": "Generate an AI image from a text prompt using DALL-E 3. Returns a public URL for the image (hosted for 1 hour) plus the model's revised prompt. Supports vivid or natural style, and three aspect ratios: square (1024\u00d71024), portrait (1024\u00d71792), or landscape (1792\u00d71024). $0.080/image \u2014 20% below close",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.289,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/ai-pipeline-brief": {
+      "get": {
+        "operationId": "ai-pipeline-brief",
+        "summary": "AI pipeline architecture brief: finds the best HuggingFace models for your ML task, validates or generates your cron schedule, and synthesizes a deployment guide \u2014 all in one call. Serves AI developers and agent builders who need model selection + scheduling together. Input: task description (e.g. '",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 1.75,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/air-quality": {
+      "get": {
+        "operationId": "air-quality",
+        "summary": "Real-time US AQI and pollutant readings for any lat/lon. Returns current AQI with category label (Good/Moderate/Unhealthy/Hazardous), PM2.5, PM10, nitrogen dioxide, ozone, carbon monoxide, dust levels, and UV index. Data from CAMS (Copernicus Atmosphere Monitoring Service), updated hourly. Use for h",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.059,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/analyst-ratings": {
+      "get": {
+        "operationId": "analyst-ratings",
+        "summary": "Wall Street analyst consensus and price targets for any US equity. Returns buy/hold/sell breakdown, mean recommendation score (1=Strong Buy, 5=Strong Sell), analyst count, and price target range (low/mean/median/high) with upside-to-target. Free Yahoo Finance data, no API key. Complements us-stock-p",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.078,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/analyst-upgrades": {
+      "get": {
+        "operationId": "analyst-upgrades",
+        "summary": "Analyst rating change history (upgrades, downgrades, initiations) for any US equity. Returns each firm, action, from/to grade, and date \u2014 up to 365 days back. Computes net sentiment (upgrades minus downgrades): positive = bullish momentum building. Pairs with analyst-ratings (current consensus) and ",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.025,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/app-store-intel": {
+      "get": {
+        "operationId": "app-store-intel",
+        "summary": "iOS App Store competitive intelligence: search apps by keyword, look up a specific app's profile (ratings, freshness, install tier, release notes), or fetch top-charts for a category (finance, productivity, games, etc.). Free iTunes API, no auth required. Covers the App Store gap in the developer-ec",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.01,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/arxiv-intel": {
+      "get": {
+        "operationId": "arxiv-intel",
+        "summary": "Search arXiv preprints by query, filtered by field (title/abstract/author/all) and category. Returns title, authors (up to 6), abstract (first 600 chars), arXiv ID, PDF link, publish date, and subject categories. arXiv is the canonical source for AI/ML, CS, physics, math, and quantitative biology pr",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.034,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/audio-transcribe": {
+      "get": {
+        "operationId": "audio-transcribe",
+        "summary": "Transcribe audio from any publicly accessible URL using OpenAI Whisper. Supports mp3, mp4, m4a, wav, webm, ogg, flac, and wma up to 24 MB. Returns the full transcript text, detected language, and estimated duration in seconds. Optionally accepts an ISO 639-1 language hint to improve accuracy. Useful",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.213,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/aviation-weather": {
+      "get": {
+        "operationId": "aviation-weather",
+        "summary": "Aviation weather (METAR + TAF) for any airport. Returns current conditions (temp, wind, visibility, ceiling, flight category VFR/MVFR/IFR/LIFR) plus 24\u201330 hour TAF forecast periods. Accepts IATA (JFK) or ICAO (KJFK) codes. Source: NOAA Aviation Weather Center \u2014 official, real-time, no API key.",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.059,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/balance-sheet": {
+      "get": {
+        "operationId": "balance-sheet",
+        "summary": "Quarterly or annual balance sheet history for any US public stock. Returns cash & equivalents, short-term investments, total assets, total debt, net debt, total liabilities, stockholders' equity, book value, retained earnings, goodwill & intangibles, tangible book value, working capital, and shares ",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.015,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/base-season": {
+      "get": {
+        "operationId": "base-season",
+        "summary": "Base chain season snapshot: total chain TVL, top 10 protocols by Base-native TVL, category breakdown, 7d trend, and top Base ecosystem tokens by market cap. No input required \u2014 agents use this for pre-trade orientation before DeFi, lending, or liquidity calls on Base.",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.034,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/block-intel": {
+      "get": {
+        "operationId": "block-intel",
+        "summary": "Returns block header data (number, hash, timestamp, gas used/limit, base fee, tx count, validator address) for any block on Base, Ethereum, or Arbitrum. Accepts block tag (latest/safe/finalized) or number. Free-RPC alternative to skills.onesource.io at 33% lower price \u2014 $0.002 vs $0.003.",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.034,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/bonds-brief": {
+      "get": {
+        "operationId": "bonds-brief",
+        "summary": "AI-synthesized fixed-income market brief. Assembles 9 signals: Treasury yield curve (3M/5Y/10Y/30Y from Yahoo Finance CBOE indices), 2Y yield + 10Y TIPS real yield + 10Y breakeven inflation (FRED), and HY/IG credit spreads (FRED ICE BofA). Returns 2Y-10Y inversion signal, real rate environment, cred",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.4,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/breadcrumb-extractor": {
+      "get": {
+        "operationId": "breadcrumb-extractor",
+        "summary": "Extracts structured breadcrumb navigation from a URL. Returns domain, ordered path segments with human-readable labels, query parameters as key-value pairs, and a formatted breadcrumb trail string. Identifies numeric IDs vs. named path segments. Pure URL parsing \u2014 zero external calls. Useful for age",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.034,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/btc-game-theory": {
+      "get": {
+        "operationId": "btc-game-theory",
+        "summary": "Bitcoin mining game theory and systems dynamics in one call. Returns: selfish-mining profitability threshold (Eyal-Sirer), 51%-attack electricity cost estimate, fee-vs-subsidy revenue split, difficulty epoch trajectory (expansion / contraction / neutral), Nash-equilibrium state for honest mining, an",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.136,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/btc-miner-econ": {
+      "get": {
+        "operationId": "btc-miner-econ",
+        "summary": "Bitcoin mining economics and fee-market game theory via mempool.space. Returns current fee rates and pressure tier, miner revenue split (subsidy vs fees), next difficulty adjustment (direction, magnitude, blocks remaining), mining pool concentration (top-3 hashrate share), and mempool backlog size. ",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.059,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/btc-systems-theory": {
+      "get": {
+        "operationId": "btc-systems-theory",
+        "summary": "Seven-lens systems theory analysis of the Bitcoin network. Returns: (1) difficulty feedback loop state + regulator lag, (2) mempool stock-flow ratio and queue depth, (3) confirmation delay at economy/priority fee tiers, (4) fee nonlinearity index and hash-rate growth curvature, (5) Nakamoto coeffici",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.059,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/capital-allocation-score": {
+      "get": {
+        "operationId": "capital-allocation-score",
+        "summary": "Capital allocation quality assessment for any US public company. Returns ROIC (Return on Invested Capital), FCF yield, total shareholder yield (dividends + buybacks), CapEx intensity, and reinvestment rate. Synthesizes these into a letter grade (A\u2013F) that answers: is management good at deploying the",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.025,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/cash-flow-statement": {
+      "get": {
+        "operationId": "cash-flow-statement",
+        "summary": "Full cash flow statement history for any US public stock \u2014 operating, investing, and financing sections. Returns: D&A, stock-based comp, working capital changes, operating CF, capex, acquisitions, investing CF, debt issuance/repayment, share buybacks, dividends paid, financing CF, free cash flow, be",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.015,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/cdp-market-depth": {
+      "get": {
+        "operationId": "cdp-market-depth",
+        "summary": "Real-time Coinbase order book depth and market microstructure for any crypto trading pair (BTC-USD, ETH-USD, SOL-USD, etc.). Returns best bid/ask spread, 24h price stats (high, low, volume, % change), top-N bids and asks with cumulative notional, order pressure ratio (bid vs ask volume), and the las",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.059,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/chain-pulse": {
+      "get": {
+        "operationId": "chain-pulse",
+        "summary": "Returns an Ethereum block header + current stablecoin depeg status in one call. Collapses the eth-block \u2192 stablecoin-watch 2-hop chain. Block fields: number, hash, miner, timestamp, gas_used, tx_count. Stablecoin fields: symbol, price, peg_deviation, depeg_status, composite alert level. Supports Eth",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.059,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/changelog-generate": {
+      "get": {
+        "operationId": "changelog-generate",
+        "summary": "Converts commit messages to a keep-a-changelog release block. Groups feat/fix/perf/docs/security commits into Added/Fixed/Changed/Security sections. Returns versioned markdown or structured JSON. No API key \u2014 pure transform.",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.023,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/chromatic-dispersion": {
+      "get": {
+        "operationId": "chromatic-dispersion",
+        "summary": "Fiber optic chromatic dispersion calculator. Computes dispersion coefficient D(\u03bb) in ps/(nm\u00b7km), accumulated dispersion (ps/nm) over a fiber span, and dispersion slope for SMF-28, NZDSF, DSF, LEAF, DCF, and ULLSF fiber types. Optionally sweeps a wavelength range (C-band, L-band, or custom). Pure mat",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.034,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/city-lookup": {
+      "get": {
+        "operationId": "city-lookup",
+        "summary": "Search airports and cities by keyword, IATA code, or city name. Returns IATA/ICAO codes, coordinates, country, and timezone for each match \u2014 useful for travel planning, routing, and geographic enrichment.",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.034,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/classic-novels": {
+      "get": {
+        "operationId": "classic-novels",
+        "summary": "Looks up classic and contemporary books by title, author, or ISBN via Open Library (748M+ editions). Returns publication year, subjects/genres, page count, cover images, and links to read online via Project Gutenberg or Internet Archive. Useful for research agents, reading recommendation workflows, ",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.034,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/clinical-trials": {
+      "get": {
+        "operationId": "clinical-trials",
+        "summary": "Search ClinicalTrials.gov for clinical studies by condition, intervention, or keyword. Returns phase, status, enrollment, sponsor, and dates. NIH primary source \u2014 no markup. $0.005/call.",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.034,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/code-api-surface": {
+      "get": {
+        "operationId": "code-api-surface",
+        "summary": "Analyzes a code snippet and returns its API surface: HTTP routes (method + path), exported symbols, and middleware. Supports Express, FastAPI, Flask, Django, Spring Boot, ASP.NET, Rails, Gin. Pure static analysis \u2014 no code execution. Returns JSON with routes[], exports[], middleware[], lang, framewo",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.045,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/code-test-detector": {
+      "get": {
+        "operationId": "code-test-detector",
+        "summary": "Detects testing frameworks and test coverage presence in a code snippet or GitHub repository. For code snippets: identifies test functions, assertions, mocks, fixtures, and frameworks (Jest, pytest, go test, JUnit, RSpec, etc.). For GitHub repos: counts test files vs source files, surfaces config fi",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.034,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/commodity-futures": {
+      "get": {
+        "operationId": "commodity-futures",
+        "summary": "Returns live price and intraday metrics for major commodity futures: crude oil, natural gas, gold, silver, copper, platinum, wheat, corn, soybeans, and coffee. Includes price, day high/low, 52-week range, previous close, exchange, and contract name. Filter by commodity name or category (energy/metal",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.059,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/company-due-diligence": {
+      "get": {
+        "operationId": "company-due-diligence",
+        "summary": "AI-agent due diligence on any company. Queries SEC EDGAR for public company data (CIK, ticker, SIC, address, filing history) and optionally analyzes the company website for contact details, social profiles, and legitimacy signals. Returns a structured report with risk flags. Accepts company name plu",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.358,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/company-intel": {
+      "get": {
+        "operationId": "company-intel",
+        "summary": "Returns SEC EDGAR due diligence data for any US public company by ticker symbol: legal name, CIK, SIC industry code and description, state of incorporation, fiscal year end, SEC filer category, primary business location, and 2-year filing history (10-K/10-Q/8-K counts and most-recent dates). Use bef",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.059,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/concentration-risk-score": {
+      "get": {
+        "operationId": "concentration-risk-score",
+        "summary": "Returns a concentration-risk score for an x402 pay_to wallet: HHI, unique payer count, top-payer share, persistence across scans, and a risk tier (LOW / MEDIUM / HIGH / CRITICAL). An agent uses this to assess whether an endpoint is a single-agent dependency before building a workflow that depends on",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.213,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/congressional-trades": {
+      "get": {
+        "operationId": "congressional-trades",
+        "summary": "US Congressional stock trades (STOCK Act disclosures). Two modes: supply a ticker to get all congress member trades in that stock (with excess-return-vs-SPY performance), or omit ticker for recent market-wide congressional activity. Returns representative, party, chamber, transaction type, dollar ra",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.117,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/consumer-brief": {
+      "get": {
+        "operationId": "consumer-brief",
+        "summary": "AI-synthesized US consumer health briefing. Fetches 8 FRED signals (Michigan sentiment, retail sales MoM, real PCE, real disposable income, savings rate, total/revolving consumer credit) and uses GPT-4o-mini to produce consumer posture, spending regime, confidence level, savings stress, credit depen",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.37,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/content-analyze": {
+      "get": {
+        "operationId": "content-analyze",
+        "summary": "AI-powered URL content analysis. Fetches a URL, extracts the readable article text, and returns structured intelligence: 2\u20133 sentence summary, key points, named entities with types, sentiment score, topic tags, content type classification, and credibility signals (has author/date/sources). Use for c",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.165,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/content-moderation": {
+      "get": {
+        "operationId": "content-moderation",
+        "summary": "Classify text (and optional image URLs) for harmful content \u2014 hate speech, harassment, self-harm, sexual content, violence, and illicit instructions. Returns flagged status, risk level (NONE/LOW/MEDIUM/HIGH), flagged categories, per-category confidence scores, and an optional AI-generated safe rewri",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.136,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/cot-positioning": {
+      "get": {
+        "operationId": "cot-positioning",
+        "summary": "CFTC Commitment of Traders weekly positioning: large speculator (hedge fund) vs commercial hedger net long/short, week-over-week change, % of OI, 4-week trend, and a SPEC_LONG/SPEC_SHORT/NEUTRAL signal. Free CFTC source, updated Fridays.",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.018,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/country-info": {
+      "get": {
+        "operationId": "country-info",
+        "summary": "Country information lookup by name, ISO code (alpha-2 or alpha-3), or capital city. Returns: official name, ISO codes, capital, population, area (km\u00b2), region, languages, currencies (code + symbol), borders, calling code, timezones, and flag image URL. Useful for international business agents, geogr",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.034,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/credit-spreads": {
+      "get": {
+        "operationId": "credit-spreads",
+        "summary": "Returns current US corporate credit spreads from ICE BofA indices via FRED (free, no API key): High Yield OAS, Investment Grade OAS, and BBB (lowest IG tier) OAS. Includes HY-IG differential and risk regime classification. Pairs with treasury-yields for complete fixed-income discount rate constructi",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.034,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/cron-parser": {
+      "get": {
+        "operationId": "cron-parser",
+        "summary": "Parse and explain any Unix cron expression in plain English. Returns human-readable schedule description, field breakdown, and the next N run times (UTC). Supports @yearly/@monthly/@weekly/@daily/@hourly shortcuts. Zero external calls.",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.034,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/cross-chain-bridge-status": {
+      "get": {
+        "operationId": "cross-chain-bridge-status",
+        "summary": "Live cross-chain bridge availability and route discovery. Given a from/to chain pair, returns all active bridges (Stargate, Across, CCTP, Relay, Squid, etc.), chain metadata, and bridge coverage breadth. Use before any cross-chain transfer or arbitrage to identify available routes. Free \u2014 powered by",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.025,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/crypto-brief": {
+      "get": {
+        "operationId": "crypto-brief",
+        "summary": "AI-synthesized cryptocurrency market intelligence brief. Assembles 12 real-time signals from CoinGecko (BTC, ETH, SOL, BNB, XRP, DOGE, ADA, AVAX, LINK, UNI, MATIC, ATOM \u2014 price, 24h change, market cap, volume) plus the Alternative.me Fear & Greed Index. Returns crypto regime classification and a 200",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.35,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/crypto-equity-brief": {
+      "get": {
+        "operationId": "crypto-equity-brief",
+        "summary": "AI-synthesized cross-market brief combining top crypto movers and equity performance \u2014 identifies how crypto and stock markets are moving together or diverging. Returns top crypto gainers/losers, equity prices, global crypto market stats, and a synthesized cross-market intelligence brief: market reg",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 2.0,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/crypto-fear-greed": {
+      "get": {
+        "operationId": "crypto-fear-greed",
+        "summary": "Crypto Fear & Greed Index \u2014 current score (0=extreme fear, 100=extreme greed), 7-day trend, 30-day min/max/avg, and trading regime signal. Free alternative.me data updated daily. $0.005/call.",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.059,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/crypto-fiat-price": {
+      "get": {
+        "operationId": "crypto-fiat-price",
+        "summary": "Cryptocurrency price in any fiat currency \u2014 JPY, EUR, CNY, GBP, KRW, INR, AUD, BRL, or 80+ more. Input a coin name or CoinGecko ID (bitcoin, ethereum, solana, btc, eth, sol, etc.) and one or more currency codes. Returns current price, 24h percent change per currency, and last updated timestamp. Free",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.059,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/crypto-momentum-pack": {
+      "get": {
+        "operationId": "crypto-momentum-pack",
+        "summary": "Korean exchange volume leaders + global 24h movers + optional DeFi yield cross-reference in one call. Collapses the printmoneylab/market-movers \u2192 ottoai/yield-farming-active agent chain at 53% of the chain cost. Returns top gaining/losing/volume-leading tokens on Upbit (Korea's #1 exchange), global ",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.059,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/crypto-news-equity-brief": {
+      "get": {
+        "operationId": "crypto-news-equity-brief",
+        "summary": "AI brief connecting today's crypto news narrative to equity watchlist performance in one call \u2014 replaces separate crypto-news-impact + stock-price-multi lookups. Fetches CoinDesk headlines, pairs with live equity prices via Yahoo Finance, and GPT-4o-mini synthesizes the dominant news story and its p",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 1.75,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/crypto-news-impact": {
+      "get": {
+        "operationId": "crypto-news-impact",
+        "summary": "Latest cryptocurrency news headlines from CoinDesk with live price correlation for mentioned assets. Returns up to 10 recent articles \u2014 each with title, URL, published timestamp, primary category, and a keyword-derived sentiment signal (bullish/bearish/neutral). For each article, identified crypto a",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.059,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/crypto-pulse": {
+      "get": {
+        "operationId": "crypto-pulse",
+        "summary": "Crypto market pulse \u2014 latest Ethereum (or Base) block context plus top crypto gainers and losers by 24h change, in a single call. Returns: block_number, timestamp, gas info (base_fee_gwei, gas_used/limit, tx_count), and top movers (symbol, name, price_usd, change_24h, volume_24h, market_cap). Use fo",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.059,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/crypto-stock-pulse": {
+      "get": {
+        "operationId": "crypto-stock-pulse",
+        "summary": "Focused cross-asset analysis: top crypto movers + single equity deep dive synthesized in one call. Answers 'how does the current crypto regime affect this specific stock?' Returns top crypto gainers/losers, global market stats, individual stock data (price, change, volume, 52-week range), and GPT-4o",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 1.25,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/crypto-top-movers": {
+      "get": {
+        "operationId": "crypto-top-movers",
+        "summary": "Real-time cryptocurrency market snapshot: top 5 gainers and top 5 losers by 24-hour percentage change (among the top 100 coins by market cap), plus the 10 largest coins by market cap with current prices and 24h change. Also returns global market statistics: total market cap (USD), BTC dominance perc",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.059,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/currency-format": {
+      "get": {
+        "operationId": "currency-format",
+        "summary": "Locale-aware currency formatting and symbol lookup for any ISO 4217 currency. Formats numbers as currency strings (e.g. 1234.56 USD \u2192 '$1,234.56', EUR in German locale \u2192 '1.234,56 \u20ac'), returns currency symbol, decimal separator, grouping separator, and currency name. Pure computation \u2014 no API key, n",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.034,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/cve-intel": {
+      "get": {
+        "operationId": "cve-intel",
+        "summary": "CVE vulnerability lookup via NVD NIST. Query by CVE ID, keyword, or severity. Returns CVSS score, attack vector, CWEs, and references. Covers 260K+ vulnerabilities.",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.136,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/db-perf-intel": {
+      "get": {
+        "operationId": "db-perf-intel",
+        "summary": "Database performance intelligence: current versions, EOL status, and benchmark-grounded performance profiles for PostgreSQL, MySQL, MariaDB, MongoDB, Redis, Elasticsearch, SQLite, Cassandra, CockroachDB, and SQL Server. Useful mid-task for infrastructure audits, database selection, and upgrade urgen",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.034,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/dcf-scenario": {
+      "get": {
+        "operationId": "dcf-scenario",
+        "summary": "Three-scenario DCF model (bear / base / bull) for any US public company plus a sensitivity grid. Runs five-year FCF projections and Gordon Growth terminal value for each growth assumption in parallel, returns margin of safety and upside % per scenario, a probability-weighted composite intrinsic valu",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.045,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/dcf-valuation": {
+      "get": {
+        "operationId": "dcf-valuation",
+        "summary": "5-year Discounted Cash Flow model for any US public company. Fetches free cash flow history, consensus EPS growth, and WACC (CAPM), then projects 5 years of FCF, adds a Gordon Growth terminal value, subtracts net debt, and divides by diluted shares to produce intrinsic value per share vs current pri",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.025,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/defi-market-pulse": {
+      "get": {
+        "operationId": "defi-market-pulse",
+        "summary": "Combined DeFi yield intelligence and market momentum in one call \u2014 33% cheaper than separate yield-farming-active + market-movers calls ($0.009). Returns top yield pools from DeFiLlama, crypto and equity market movers, and a cross-signal layer that flags 'boosted' pools (high APY + rising token) vs ",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.059,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/defi-portfolio": {
+      "get": {
+        "operationId": "defi-portfolio",
+        "summary": "Multi-chain DeFi portfolio scanner. Returns token holdings and USD values for any EVM wallet across Ethereum, Base, Polygon, and Arbitrum mainnet. Covers ETH, major stablecoins (USDC, USDT, DAI), WBTC, ARB, cbETH, and chain-native assets. Collapses the defi.hugen.tokyo/defi/address seam \u2014 41 payers.",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.059,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/defi-state-pack": {
+      "get": {
+        "operationId": "defi-state-pack",
+        "summary": "Returns Ethereum block header + stablecoin depeg status + top DeFi yield farming pools in one call. Collapses the 3-hop eth-block \u2192 stablecoin-watch \u2192 yield-farming chain into a single call. All three upstreams fetched in parallel. Supports Ethereum, Base, Polygon, Arbitrum. Filter yield pools by ch",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.059,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/defi-yield-strategies": {
+      "get": {
+        "operationId": "defi-yield-strategies",
+        "summary": "DeFi yield strategy planner. Given a portfolio size and risk tolerance, returns an optimized allocation across top DeFi yield opportunities. Risk tiers: low (stablecoins only, APY < 30%, TVL \u2265 $50M), medium (TVL \u2265 $10M, APY < 80%), high (TVL \u2265 $1M, all assets). Output includes per-position allocatio",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.039,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/defi-yields": {
+      "get": {
+        "operationId": "defi-yields",
+        "summary": "Returns top DeFi yield pools ranked by APY from DeFiLlama. Covers 16,000+ pools across 400+ protocols and 50+ chains (Ethereum, Base, Solana, Arbitrum, Polygon, etc.). Filter by chain, minimum APY, minimum TVL, or stablecoin-only. Each pool includes APY breakdown (base + reward), TVL, 7-day APY chan",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.059,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/defillama-coin-price": {
+      "get": {
+        "operationId": "defillama-coin-price",
+        "summary": "Returns on-chain aggregated token prices via DefiLlama coins API. Accepts coingecko IDs, contract addresses, or shorthand (eth, btc, sol). Up to 10 tokens per call. Undercuts blockrun.ai's $0.021/call by 24%.",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.059,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/defillama-pack": {
+      "get": {
+        "operationId": "defillama-pack",
+        "summary": "DeFi research pack: returns TVL, chain breakdown, fees, and native token price for 1\u20133 protocols in one call. Collapses the defillama-protocol + defillama-coin-price 2-call chain at 70% of combined cost ($0.034\u2192$0.024). Same DefiLlama upstreams, zero auth.",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.059,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/defillama-protocol": {
+      "get": {
+        "operationId": "defillama-protocol",
+        "summary": "Returns current TVL, chain breakdown, 24h/7d TVL change, fees, and metadata for any DeFi protocol slug (aave, uniswap-v3, lido, etc.) via DefiLlama. Undercuts blockrun.ai's $0.022/call by 18%.",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.059,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/dex-pair-search": {
+      "get": {
+        "operationId": "dex-pair-search",
+        "summary": "Search DEX trading pairs for any token (by symbol, name, or contract address) across 50+ chains including Ethereum, Solana, Base, BSC, Arbitrum, Polygon, and Avalanche. Returns top pairs by liquidity with real-time price, 24h volume, buy/sell transaction counts, price change %, and buy pressure metr",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.059,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/dex-swap-quote": {
+      "get": {
+        "operationId": "dex-swap-quote",
+        "summary": "Best-route DEX swap quote across 20+ chains via Li.Fi aggregator. Returns expected output, exchange rate, gas cost, price impact, and route (DEX/bridge names). Works for same-chain and cross-chain swaps. Use ETH/USDC/WBTC symbols or ERC-20 addresses. Chains: ethereum, base, polygon, arbitrum, optimi",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.059,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/dex-trending-pools": {
+      "get": {
+        "operationId": "dex-trending-pools",
+        "summary": "Trending DEX liquidity pools with buy/sell pressure data across multiple timeframes (5m, 1h, 6h, 24h). Sourced from GeckoTerminal (free, no key). Supports 100+ networks: eth, base, bsc, arbitrum, polygon_pos, solana, etc. Returns pool name, price, price change %, volume, buy vs sell transaction coun",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.059,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/dictionary-intel": {
+      "get": {
+        "operationId": "dictionary-intel",
+        "summary": "English word lookup: definitions (up to 4 per part of speech), phonetic transcription, audio pronunciation URL, synonyms, antonyms, and example sentences. Supports multiple parts of speech per word (noun, verb, adjective, etc.). Useful for writing agents, NLP preprocessing, vocabulary enrichment, co",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.034,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/dividend-calendar": {
+      "get": {
+        "operationId": "dividend-calendar",
+        "summary": "Upcoming dividend ex-dates from NASDAQ \u2014 all stocks going ex-dividend on a given date (default: today) or in the next 1\u20137 days. Returns symbol, company name, ex-date, record date, payment date, dividend amount, and annual indicated dividend. $0.008/call.",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.059,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/dividend-intel": {
+      "get": {
+        "operationId": "dividend-intel",
+        "summary": "Full dividend intelligence for any US equity: trailing 12-month yield, forward annual rate, payout frequency (monthly/quarterly/semi-annual/annual), 5-year dividend CAGR, consecutive years paid, consecutive years of growth, and complete 5-year dividend history with dates and amounts. Single call \u2014 n",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.059,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/dns-lookup": {
+      "get": {
+        "operationId": "dns-lookup",
+        "summary": "DNS record lookup for any domain via Cloudflare DoH. Supports A, AAAA, MX, TXT, CNAME, NS, SOA, CAA, or ALL record types. TXT lookups include SPF/DMARC/DKIM email security signal extraction. Useful for domain audits, email configuration verification, CDN setup checks, and infrastructure reconnaissan",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.023,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/document-qa-prep": {
+      "get": {
+        "operationId": "document-qa-prep",
+        "summary": "Prepares a document for question-answering and RAG pipelines. Chunks the input text at paragraph/sentence boundaries, assigns deterministic chunk IDs, estimates token counts, and extracts document metadata (word count, type, headings). Returns ready-to-embed chunks with overlap support. No LLM or ex",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.194,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/domain-availability": {
+      "get": {
+        "operationId": "domain-availability",
+        "summary": "Check domain name availability across multiple TLDs (com, net, org, io, ai, co, app, dev by default). Returns per-TLD availability status, registrar, and expiry for registered domains. Uses RDAP \u2014 authoritative registry data, no API key. Ideal for brand research, startup naming, and domain portfolio",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.034,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/domain-whois": {
+      "get": {
+        "operationId": "domain-whois",
+        "summary": "Domain WHOIS/RDAP lookup. Returns registration date, expiration date, last updated, registrar, nameservers, status flags, and registrant/admin contact info (where available). Uses RDAP \u2014 the structured JSON replacement for WHOIS. Useful for domain due diligence, expiry monitoring, and identifying re",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.034,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/drug-intel": {
+      "get": {
+        "operationId": "drug-intel",
+        "summary": "FDA drug intelligence: labeling (warnings, dosage, drug interactions, contraindications, indications), adverse event report summary (top reactions + total count), and recent recall history. Accepts brand or generic name. Data from openFDA \u2014 no API key. Useful for pharmaceutical research, clinical AI",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.034,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/earnings-brief": {
+      "get": {
+        "operationId": "earnings-brief",
+        "summary": "AI-synthesized earnings catalyst brief for the next 7 days (configurable 1\u201314). Fetches the Alpha Vantage earnings calendar, identifies S&P 500 bellwether events, and uses gpt-4o-mini to produce a 150-200 word forward-looking assessment: most important event, sector concentration, and agent decision",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.35,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/earnings-calendar": {
+      "get": {
+        "operationId": "earnings-calendar",
+        "summary": "Upcoming US stock earnings \u2014 report date, EPS estimate, pre/post-market timing. Filter by ticker or look N days ahead (1\u201390). Data: Alpha Vantage 3-month calendar, cached 2 hr.",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.059,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/earnings-estimates": {
+      "get": {
+        "operationId": "earnings-estimates",
+        "summary": "Forward analyst consensus EPS and revenue estimates for any US equity. Returns current-quarter, next-quarter, current-year, and next-year forecasts \u2014 avg/low/high EPS and revenue, YoY growth, analyst count, estimate revision momentum (revisions up vs down last 7/30 days), and EPS trend drift (curren",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.012,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/earnings-intel-bundle": {
+      "get": {
+        "operationId": "earnings-intel-bundle",
+        "summary": "Full earnings intelligence for a US stock in one call: next earnings date + EPS estimates, historical EPS beat/miss data, fundamental valuations (P/E, EV/EBITDA, margins), and current FOMC rate context. Replaces 4 separate cap calls at ~37% discount.",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.08,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/earnings-quality": {
+      "get": {
+        "operationId": "earnings-quality",
+        "summary": "Earnings quality and manipulation-risk screen for any US public company. Returns Beneish M-Score (8-component manipulation detector: M > -1.78 = manipulation risk), Sloan Accrual Ratio, cash conversion ratio, and AR vs revenue quality signal. Designed to chain after income-statements and equity-fund",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.025,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/earnings-reaction": {
+      "get": {
+        "operationId": "earnings-reaction",
+        "summary": "Stock price reaction to past earnings events for any US equity. Returns report-day and next-day price move % for each recent quarterly earnings date, paired with the EPS beat/miss magnitude and reaction class (beat_and_up, beat_selloff, miss_and_down, miss_rally, neutral). Identifies contrarian sign",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.025,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/earnings-surprises": {
+      "get": {
+        "operationId": "earnings-surprises",
+        "summary": "Historical EPS beat/miss data for any US equity: actual EPS, consensus estimate, surprise %, beat rate, estimate revisions (30-day EPS drift), and next earnings date. Free Yahoo Finance data, no API key. Pairs with analyst-ratings and equity-fundamentals for a complete earnings intelligence stack.",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.059,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/earthquake-intel": {
+      "get": {
+        "operationId": "earthquake-intel",
+        "summary": "Real-time earthquake intelligence from USGS. Fetch recent global significant quakes (M5.0+ last 7 days) or quakes near a lat/lon (M3.0+ within 500 km). Returns magnitude, depth, location, tsunami flag, and shake intensity. Free USGS FDSN API \u2014 no key required.",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.059,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/economic-calendar": {
+      "get": {
+        "operationId": "economic-calendar",
+        "summary": "Upcoming US macro data release schedule: CPI, NFP, FOMC, GDP, PCE, PPI, JOLTS, Retail Sales, Housing Starts, and 20+ more releases with exact dates, times (ET), and market-impact priority. BLS live calendar + Fed/BEA/Census static 2026 schedule. Essential for agents timing trades or building macro-r",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.034,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/economic-momentum": {
+      "get": {
+        "operationId": "economic-momentum",
+        "summary": "Tracks 6 key US economic indicators (unemployment, nonfarm payrolls, CPI, core CPI, retail sales, industrial production) from FRED and classifies each as accelerating/stable/decelerating. Returns a composite momentum signal (HOT/WARM/GOLDILOCKS/COOLING/COLD) for sector rotation and rate-path modelin",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.018,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/email-verify": {
+      "get": {
+        "operationId": "email-verify",
+        "summary": "Email address validation and quality scoring. Checks RFC-5322 syntax, detects disposable/throwaway domains (via Kickbox free API), and verifies DNS MX record presence (via Cloudflare DoH). Returns a quality score (0-100) and verdict: DELIVERABLE | RISKY | UNDELIVERABLE | INVALID. Useful for lead qua",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.034,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/energy-brief": {
+      "get": {
+        "operationId": "energy-brief",
+        "summary": "AI-synthesized US energy market intelligence brief. Assembles 9 real-time signals from Yahoo Finance: WTI crude futures, Brent crude (with spread), natural gas (Henry Hub proxy), energy sector ETF (XLE), oil services ETF (OIH), ExxonMobil, Chevron, Marathon Petroleum, and Baker Hughes. Returns 52-we",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.67,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/ens-lookup": {
+      "get": {
+        "operationId": "ens-lookup",
+        "summary": "ENS name \u2194 Ethereum address resolution. Forward: pass a .eth name to get the address, avatar, and social profile records. Reverse: pass a 0x address to get its primary ENS name and profile. Returns address, ens_primary, avatar_url, description, twitter, github, discord, telegram, url, and content_ha",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.059,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/entity-clearance": {
+      "get": {
+        "operationId": "entity-clearance",
+        "summary": "Clearance check on a business/entity before an agent acts on it: live-site probe, domain/contact consistency, name corroboration, graded evidence (E0-E2), risk flags, recommended_action, and a self-verifying sha256 receipt. Turns 'found' into 'safe enough to proceed'.",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.25,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/equity-brief": {
+      "get": {
+        "operationId": "equity-brief",
+        "summary": "AI-synthesized equity situation brief for any US stock. Gathers five signal layers in parallel \u2014 current price/52w range, RSI-14 + SMA20/50/200 trend regime, insider buy/sell activity (SEC EDGAR Form 4, last 60 days), options IV30 + put/call ratio (CBOE), and next earnings date + EPS estimate (Yahoo",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.37,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/equity-fundamentals": {
+      "get": {
+        "operationId": "equity-fundamentals",
+        "summary": "Fundamental valuation metrics for any US public company \u2014 P/E TTM, forward P/E, PEG, P/B, EV/EBITDA, margins, ROE, ROA, revenue TTM, earnings/revenue growth, free cash flow, market cap, beta. Raw data for valuation screening and DCF inputs. No API key.",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.059,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/equity-quality-screen": {
+      "get": {
+        "operationId": "equity-quality-screen",
+        "summary": "Piotroski F-Score (0\u20139 quality composite: profitability+leverage+efficiency trends) and Altman Z-Score (distress predictor) for any US public company. One call replaces manual assembly of 3 years of annual statements. $0.025/call.",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.025,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/equity-sentiment": {
+      "get": {
+        "operationId": "equity-sentiment",
+        "summary": "Equity market Fear & Greed composite. Four signals: VIX vs 90-day percentile, SPY vs 200-day moving average, US high-yield credit spread vs 90-day range (FRED BAMLH0A0HYM2), SPY RSI-14. Returns composite score 0\u2013100 (0=extreme greed, 100=extreme fear) with regime label and per-signal breakdown. Dist",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.035,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/equity-technicals": {
+      "get": {
+        "operationId": "equity-technicals",
+        "summary": "Returns a complete technical analysis package for any US stock: RSI(14) with oversold/overbought signal, MACD(12/26/9) with histogram, Bollinger Bands(20,2\u03c3) with price position, SMA 20/50/200 with crossover state, 20-day volume ratio, and a consensus signal (BULLISH/BEARISH/NEUTRAL) based on indica",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.07,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/equity-watchlist-brief": {
+      "get": {
+        "operationId": "equity-watchlist-brief",
+        "summary": "Portfolio watchlist snapshot with technical analysis and AI brief. Accepts up to 8 US equity tickers, returns price, change %, RSI(14), 52-week positioning, volume vs 20-day average, and trend regime (above/below SMA50) for each. AI synthesizes a portfolio mood assessment, focus analysis on the bigg",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 1.25,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/erc20-snapshot": {
+      "get": {
+        "operationId": "erc20-snapshot",
+        "summary": "Complete ERC20 token state in one call: name, symbol, decimals, total supply (raw + formatted), wallet balance, and allowance. Collapses four separate chain calls (total-supply + erc20-balance + allowance + contract) into one payment. Supports Ethereum (default), Base, Polygon, Arbitrum. No API key ",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.034,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/etf-holdings": {
+      "get": {
+        "operationId": "etf-holdings",
+        "summary": "Top holdings, sector weights, and asset allocation for any US ETF (SPY, VOO, QQQ, AGG, XLK, etc.). Returns up to 25 positions with weights, sector breakdown, and equity/bond/cash split. No API key. $0.018/call.",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.059,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/eth-block": {
+      "get": {
+        "operationId": "eth-block",
+        "summary": "Returns an Ethereum block header and transaction hashes by block number, hex string, or tag (latest/pending/earliest/safe/finalized). Fields: block_number, hash, parent_hash, miner, timestamp_iso, gas_used, gas_limit, base_fee_gwei (EIP-1559), tx_count, transaction_hashes. Supports Ethereum (default",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.059,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/evm-log-events": {
+      "get": {
+        "operationId": "evm-log-events",
+        "summary": "Query EVM contract event logs via eth_getLogs. Filter by contract address, event topic (signature hash), and block range. Returns up to 50 decoded log entries with topics, data, tx hash, block number. Supports Ethereum/Base/Polygon/Arbitrum via free DRPC. $0.004/call \u2014 20% below comparable market ra",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.059,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/evm-nonce": {
+      "get": {
+        "operationId": "evm-nonce",
+        "summary": "Returns the current nonce (confirmed transaction count) and pending nonce for any EVM wallet address. Supports Ethereum, Base, Polygon, Arbitrum, and Optimism. Use the pending nonce when building new transactions. $0.002/call \u2014 33% below comparable market rate.",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.059,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/evm-token-security": {
+      "get": {
+        "operationId": "evm-token-security",
+        "summary": "Honeypot, rug-pull, and scam detection for any EVM token. Returns a 0\u2013100 risk score with labeled flags: honeypot status, hidden ownership, mint authority, self-destruct, buy/sell tax rates, creator wallet concentration, and open-source status. Covers 40+ chains (Ethereum, Base, BSC, Arbitrum, Polyg",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.136,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/fact-check": {
+      "get": {
+        "operationId": "fact-check",
+        "summary": "Factual claim verification using Wikipedia evidence + AI synthesis. Extracts search terms from the claim, queries Wikipedia for relevant articles, and returns a structured verdict (LIKELY_TRUE / LIKELY_FALSE / MIXED / UNVERIFIABLE) with confidence score, explanation, and source citations.",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.1,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/fda-recall-watch": {
+      "get": {
+        "operationId": "fda-recall-watch",
+        "summary": "FDA recall and enforcement search across drugs, food/cosmetics, and medical devices (85,000+ actions). Returns classification (Class I/II/III), recall reason, product description, status, and distribution pattern. Seam cap: fills the product-safety layer missing from drug-intel + company-due-diligen",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.034,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/fdic-bank-intel": {
+      "get": {
+        "operationId": "fdic-bank-intel",
+        "summary": "FDIC BankFind Suite: US bank financial health, regulatory capital ratios, and historical bank failure data. search mode: find institutions by name with asset size and state. profile mode: quarterly Call Report data \u2014 ROA, ROE, risk-based capital ratio, net income, loans, deposits (input: bank name o",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.015,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/fec-donor-intel": {
+      "get": {
+        "operationId": "fec-donor-intel",
+        "summary": "FEC campaign finance lookup \u2014 search all US federal political donations by individual or organization name. Returns recent contributions (sorted newest-first) with committee names, donation amounts, election cycles, employer/occupation, and aggregate totals (total donated, number of contributions, c",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.034,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/federal-contract-intel": {
+      "get": {
+        "operationId": "federal-contract-intel",
+        "summary": "US federal contract and grant intelligence for any company via USASpending.gov. Returns total obligated amount, award count, top awards (award ID, amount, agency, description, start date), and agency breakdown \u2014 covering $10T+ in federal spending. Useful for procurement research, competitive intelli",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.034,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/federal-register-search": {
+      "get": {
+        "operationId": "federal-register-search",
+        "summary": "Search the Federal Register for Rules, Proposed Rules, and Notices matching a keyword \u2014 returns title, abstract, document type, agencies, significance, effective date, and links. No API key. $0.002/call.",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.034,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/flight-tracker": {
+      "get": {
+        "operationId": "flight-tracker",
+        "summary": "Real-time global flight positions via OpenSky Network ADS-B. icao24 mode: locate any aircraft by its 6-hex transponder code \u2014 returns altitude (ft), speed (kts), heading, vertical rate, squawk. callsign mode: find a flight by ICAO callsign (e.g. 'AAL123', 'UAL456') across CONUS or globally. area mod",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.03,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/fomc-tracker": {
+      "get": {
+        "operationId": "fomc-tracker",
+        "summary": "US Federal Funds Rate, next FOMC meeting date + countdown, rate trend (hiking/holding/cutting), and full 2026 schedule. FRED public CSV + static calendar. Pairs with treasury-yields and credit-spreads.",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.034,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/forex-historical": {
+      "get": {
+        "operationId": "forex-historical",
+        "summary": "Historical ECB exchange rates \u2014 single date lookup or time-series range. Returns rates for up to 30 major currencies (EUR, GBP, JPY, CAD, CHF, CNY, AUD, KRW, etc.) from 1999-01-04 to present. Free, no key, sourced from Frankfurter/ECB. Use for: tax-date FX rates, historical expense reconciliation, m",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.059,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/forex-rates": {
+      "get": {
+        "operationId": "forex-rates",
+        "summary": "Real-time fiat foreign exchange rates. Base currency defaults to USD; returns rates for all 166 supported currencies, or a filtered subset. Sourced from open.er-api.com (free, no key, daily updates ~00:00 UTC). Supports any ISO 4217 base: EUR, GBP, JPY, KRW, CNY, AUD, etc. Use for: USD\u2192KRW conversio",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.059,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/form-144-intel": {
+      "get": {
+        "operationId": "form-144-intel",
+        "summary": "Retrieves SEC Form 144 planned insider sale filings for a US public company \u2014 earlier signal than Form 4 (post-trade). Returns seller name, role, shares planned for sale, market value, approximate sale date, and acquisition type (RSU, open market, etc.).",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.097,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/fred-query": {
+      "get": {
+        "operationId": "fred-query",
+        "summary": "Pull any FRED (St. Louis Fed) economic series by ID. Returns recent observations, trend, and summary stats. Covers 800,000+ series: M2, Fed balance sheet, truck tonnage, payrolls, yields, CPI, consumer credit, and more. Free public data, no API key.",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.008,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/funding-rates": {
+      "get": {
+        "operationId": "funding-rates",
+        "summary": "Returns current perpetual funding rates for 200+ assets on Hyperliquid DEX, sorted by absolute funding magnitude. Includes 8-hour and annualized rates, open interest, mark price, and directional signal (longs-pay or shorts-pay). Use before entering a perpetual position to factor funding cost/income ",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.059,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/gas-estimate": {
+      "get": {
+        "operationId": "gas-estimate",
+        "summary": "Multi-chain gas price oracle: fast/standard/slow Gwei + USD cost for a transfer. Chains: ethereum, base, polygon, arbitrum, bsc. Seam: x402node/myceliasignal gas feeds.",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.059,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/gas-prices": {
+      "get": {
+        "operationId": "gas-prices",
+        "summary": "Current gas prices and EIP-1559 fee recommendations across 6 major EVM chains: Ethereum, Base, Arbitrum, Optimism, Polygon, BNB Chain. Returns base fee, priority fee percentiles (slow/standard/fast), and estimated ETH/MATIC/BNB cost for a standard 21k-gas transfer. All sourced from free public RPC e",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.059,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/geocode": {
+      "get": {
+        "operationId": "geocode",
+        "summary": "Forward and reverse geocoding via OpenStreetMap Nominatim. Forward: convert an address or place name to latitude/longitude, bounding box, and OSM metadata. Reverse: convert lat/lon to a structured street address. Supports any location worldwide. Useful for location enrichment, address validation, co",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.014,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/geopolitical-brief": {
+      "get": {
+        "operationId": "geopolitical-brief",
+        "summary": "AI-synthesized geopolitical risk intelligence brief via market-implied signals. No news API required. Assembles 10 market signals from Yahoo Finance: VIX fear gauge, gold ETF (GLD), 20Y Treasury ETF (TLT), USD index ETF (UUP), emerging markets (EEM), China ETF (FXI), Japan ETF (EWJ), WTI crude futur",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.35,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/github-intel": {
+      "get": {
+        "operationId": "github-intel",
+        "summary": "GitHub repository intelligence: stars, forks, contributors, releases, open issues, and weekly commit activity. Compare up to 4 repos side-by-side or search GitHub for repos by keyword, language, and topic. Use to evaluate library health before adopting a dependency, find the top maintainers of a pro",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.015,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/github-org-intel": {
+      "get": {
+        "operationId": "github-org-intel",
+        "summary": "Comprehensive GitHub organization intelligence. Returns org profile (members, followers, website, location), top public repositories by stars with activity and language data, tech stack distribution, and recent activity signals. Covers up to 25 top repos per call. Useful for due diligence, competiti",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.035,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/github-repo-intel": {
+      "get": {
+        "operationId": "github-repo-intel",
+        "summary": "GitHub repository intelligence: stars, forks, open issues, language, license, last push date, latest release version and date, topics, and whether the repo is actively maintained. Input any GitHub repo as 'owner/repo' or a full GitHub URL. Use before wiring a new library as a dependency, when evalua",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.034,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/github-trending": {
+      "get": {
+        "operationId": "github-trending",
+        "summary": "Top trending GitHub repositories by star velocity \u2014 new repos gaining the most stars today, this week, or this month. Filter by programming language and/or topic tag.",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.006,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/global-equity-indices": {
+      "get": {
+        "operationId": "global-equity-indices",
+        "summary": "Global equity snapshot: 9 major indices (Nikkei 225, Hang Seng, ASX 200, Nifty 50, Shanghai, FTSE 100, DAX, CAC 40, Euro Stoxx 50) plus DXY. Returns current level, daily % change, 52-week range context, and region posture (bullish/mixed/bearish). Free Yahoo Finance data. No API key. Overnight contex",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.059,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/gov-votes": {
+      "get": {
+        "operationId": "gov-votes",
+        "summary": "US Congressional vote records from official government XML sources (senate.gov + clerk.house.gov). Search by chamber (house/senate), category (passage, amendment, cloture, nomination, procedural, etc.), or limit. Returns vote question, result (Passed/Failed), yea/nay totals, bill number, and descrip",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.034,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/government-contract-intel": {
+      "get": {
+        "operationId": "government-contract-intel",
+        "summary": "Federal government contract award tracker via USASpending.gov (no API key). The U.S. government awards $700B+ annually \u2014 this cap surfaces who wins the money, how much, and for what. Mode 'company' (company_name): all federal contracts awarded to a named company \u2014 which agencies, what amounts, optio",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.015,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/guidance-quality": {
+      "get": {
+        "operationId": "guidance-quality",
+        "summary": "Earnings guidance quality and predictability scoring for any US equity. Converts the historical EPS beat/miss record into a label (SUPER_BEATER / RELIABLE_BEATER / INCONSISTENT / GUIDANCE_RISK), a predictability score (0\u2013100), trend signal (IMPROVING / STABLE / DETERIORATING), and a DCF implication.",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.025,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/healthcare-brief": {
+      "get": {
+        "operationId": "healthcare-brief",
+        "summary": "AI-synthesized US healthcare and biotech sector intelligence brief. Assembles 10 real-time signals from Yahoo Finance: healthcare sector ETF (XLV), large-cap biotech (IBB), small-cap biotech (XBI), Eli Lilly, UnitedHealth, J&J, AbbVie, Moderna, Pfizer, and Medtronic. Returns biotech risk-appetite si",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.35,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/hedge-fund-holdings": {
+      "get": {
+        "operationId": "hedge-fund-holdings",
+        "summary": "Returns top stock holdings from any institution's latest SEC 13F filing. Input: institution name (e.g. 'Renaissance Technologies', 'Bridgewater Associates'). Output: top 25 positions by market value with shares, value, and portfolio weight. No API key. SEC EDGAR source. $0.025 vs $25-50/mo Quiver Qu",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.117,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/hf-model-search": {
+      "get": {
+        "operationId": "hf-model-search",
+        "summary": "Search HuggingFace Hub for ML models. Specify a keyword (e.g. 'bert', 'llama', 'stable diffusion') and optional task filter (e.g. 'text-classification', 'text-generation', 'image-classification'). Returns top results sorted by downloads or likes, including model ID, author, pipeline task, framework ",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.059,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/hn-search": {
+      "get": {
+        "operationId": "hn-search",
+        "summary": "Hacker News story and comment search via Algolia. Returns titles, scores, comment counts, authors, and URLs for posts matching the query. Filter by type (story/comment) and date range (day/week/month/year/all). Sorted by relevance by default; use sort=date for newest-first. Useful for tech news, com",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.04,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/housing-brief": {
+      "get": {
+        "operationId": "housing-brief",
+        "summary": "AI-synthesized US housing market briefing. Fetches 8 FRED signals (starts, permits, existing/new sales, months supply, 30Y mortgage rate, Case-Shiller HPI, median price) and uses gpt-4o-mini to produce market phase, direction, supply posture, affordability regime, 150-word narrative, dominant risk, ",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.37,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/http-headers": {
+      "get": {
+        "operationId": "http-headers",
+        "summary": "HTTP response headers inspector and security grader. Fetches headers from any public URL and evaluates OWASP-recommended security headers: HSTS, CSP, X-Frame-Options, X-Content-Type-Options, Referrer-Policy, Permissions-Policy. Returns raw headers, per-header security findings, overall grade (A\u2013F), ",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.023,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/huggingface-intel": {
+      "get": {
+        "operationId": "huggingface-intel",
+        "summary": "HuggingFace Hub intelligence: search AI models and datasets, get detailed model metadata, and find trending models by task. Returns downloads, likes, license, supported languages, pipeline task, and tags. Use to evaluate which open-source model best fits a task, compare model families (Llama vs Qwen",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.01,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/image-detect": {
+      "get": {
+        "operationId": "image-detect",
+        "summary": "Detects the true image format of any URL via magic byte inspection \u2014 works even when the file extension or Content-Type header lies (common with proxied or CDN-hosted images). Returns: format (png/jpeg/gif/webp/avif/bmp/tiff/svg/ico/unknown), detected MIME type, whether Content-Type header matches, ",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.07,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/imf-country-outlook": {
+      "get": {
+        "operationId": "imf-country-outlook",
+        "summary": "IMF World Economic Outlook forecasts \u2014 current year + 3-year horizon for 180+ countries. Returns GDP growth, CPI inflation, unemployment rate, current account balance (% GDP), government gross debt (% GDP), and fiscal balance (% GDP). Sourced from IMF DataMapper API (no key required). Distinct from ",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.034,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/income-statements": {
+      "get": {
+        "operationId": "income-statements",
+        "summary": "Full income statement + cash flow history for any US public stock. Returns quarterly (default, up to 8 periods) or annual (up to 4 years): revenue, COGS, gross profit, R&D, SG&A, operating income, EBITDA, pretax income, tax, net income, EPS (basic/diluted), operating cash flow, capex, free cash flow",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.035,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/inflation-intel": {
+      "get": {
+        "operationId": "inflation-intel",
+        "summary": "US CPI inflation: headline (all-items), core (less food & energy), energy, and food \u2014 MoM and YoY % changes, ACCELERATING/DECELERATING/STABLE trend signal, and Fed policy implication. BLS data via FRED public CSV, no API key needed. Pairs with fomc-tracker, credit-spreads, treasury-yields, sector-ro",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.015,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/insider-trades": {
+      "get": {
+        "operationId": "insider-trades",
+        "summary": "Recent SEC Form 4 insider trading activity for any US public company. Returns who bought or sold (director, officer, 10%+ owner), transaction date, shares, price per share, total value, and position after trade. Sourced from SEC EDGAR public API \u2014 authoritative, free, no API key. Use for investment ",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.117,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/insider-trading-intel": {
+      "get": {
+        "operationId": "insider-trading-intel",
+        "summary": "SEC Form 4 insider transaction intelligence. Mode get_insider_trades: Form 4 filings for a ticker in the last N days \u2014 insider name, role, buy/sell type, shares, price, total value, and net buy/sell sentiment. Mode recent_insider_buys: market-wide open-market purchase events (code P) above a min dol",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.015,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/institutional-ownership-intel": {
+      "get": {
+        "operationId": "institutional-ownership-intel",
+        "summary": "Institutional fund holdings intelligence for US equities. Returns which funds own the stock (Vanguard, Blackrock, Fidelity, etc.), their position sizes, % of shares outstanding, and market value. Breakdown mode shows % institutional vs insider vs public float and top-5 concentration signal (HIGH/MOD",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.015,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/institutional-ownership": {
+      "get": {
+        "operationId": "institutional-ownership",
+        "summary": "Institutional and insider ownership snapshot for any US equity. Returns: (1) major holders breakdown \u2014 % insiders, % institutions, float coverage, total institution count; (2) up to 10 largest institutional holders \u2014 name, pct of shares held, share count, total value (USD), pct change since prior 13",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.015,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/intel-pack": {
+      "get": {
+        "operationId": "intel-pack",
+        "summary": "Three-source intelligence pack in one x402 call: equity market snapshot (SPY/QQQ/IWM/VIX/risk signal) + top DeFi yield pools by APY + top prediction markets by volume. Replaces three separate calls. $0.109 purchased individually; $0.09 as a pack. No inputs required.",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.11,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/intl-stock-price": {
+      "get": {
+        "operationId": "intl-stock-price",
+        "summary": "Returns current price and intraday metrics for international equities (EU, UK, Swiss, Japan, Australia, Canada, Hong Kong, India). Accepts exchange-suffixed tickers (MC.PA for LVMH, SAP.DE for SAP, AZN.L for AstraZeneca) or market shorthand (market=fr, ticker=MC). Sourced from Yahoo Finance \u2014 no API",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.059,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/ip-intel": {
+      "get": {
+        "operationId": "ip-intel",
+        "summary": "Geolocation and network intelligence for IP addresses or domain names. Returns country, region, city, coordinates, ISP, organization, ASN, reverse DNS, and proxy/VPN/mobile/hosting flags. Accepts IPv4, IPv6, or domain names (auto-resolved to IP). Useful for infrastructure audits, fraud detection, bl",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.034,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/ipo-calendar": {
+      "get": {
+        "operationId": "ipo-calendar",
+        "summary": "Returns live IPO calendar from Nasdaq \u2014 upcoming deals with expected pricing dates, recently priced offerings, new S-1 filings, and withdrawn deals. Covers all major US exchanges. Includes company name, ticker, exchange, price range, share count, and total offer amount. Structured extraction WITH su",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.04,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/json-extract": {
+      "get": {
+        "operationId": "json-extract",
+        "summary": "Extracts and parses JSON from mixed-content text. Handles LLM output with JSON embedded in prose, code fences (```json), trailing commas, single-quoted strings, JS-style comments, and bare object keys (JSON5-style). Returns the parsed data, a cleaned JSON string, extraction method used, and any repa",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.034,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/kimchi-premium": {
+      "get": {
+        "operationId": "kimchi-premium",
+        "summary": "Real-time Kimchi Premium for any Upbit-listed token: KRW price on Upbit vs USD price on global exchange (Kraken/OKX), FX-adjusted. Returns premium_percent and premium_direction. Matches printmoneylab endpoint at 1/1 price.",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.034,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/korean-crypto-movers": {
+      "get": {
+        "operationId": "korean-crypto-movers",
+        "summary": "Top movers and volume leaders on Korean exchanges (Upbit, 263 KRW markets). Returns biggest 24h price movers (% change from prev close), highest-volume tokens by KRW trade value, and optional raw snapshot. 20% cheaper than printmoneylab's market-movers endpoint at the same Upbit/Bithumb data layer.",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.059,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/korean-market-movers": {
+      "get": {
+        "operationId": "korean-market-movers",
+        "summary": "Real-time movers and volume-spike leaders across all KRW-denominated markets on Upbit (South Korea's largest crypto exchange). Returns top risers, top fallers, and top volume leaders ranked by 24h change or accumulated trade value. Korean exchange data is a leading indicator frequently observed by i",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.059,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/labor-brief": {
+      "get": {
+        "operationId": "labor-brief",
+        "summary": "AI-synthesized US labor market briefing. Fetches 7 FRED signals (initial claims, continued claims, JOLTS openings, nonfarm payrolls MoM, unemployment rate, wage growth YoY, labor force participation) and uses GPT-4o-mini to produce labor regime, wage pressure, claims trend, Fed posture signal, 150-w",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.37,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/labor-market": {
+      "get": {
+        "operationId": "labor-market",
+        "summary": "Returns US labor market leading indicators from FRED (free, no API key): initial jobless claims (weekly), continued claims, JOLTS job openings, nonfarm payrolls, labor force participation rate, average hourly earnings with YoY wage growth, and the openings-per-unemployed Beveridge curve ratio. Pairs",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.034,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/lbo-model": {
+      "get": {
+        "operationId": "lbo-model",
+        "summary": "Full leveraged buyout model for any US public company: entry valuation, debt structure, 5-year operating model with FCF-driven debt paydown, exit waterfall, IRR and MOIC. Includes sensitivity table across entry/exit EV/EBITDA multiples and AI-synthesized deal brief with verdict, investment thesis, a",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 3.42,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/legal-search": {
+      "get": {
+        "operationId": "legal-search",
+        "summary": "Searches 5M+ US court opinions (SCOTUS, federal circuits, district courts, state courts) via CourtListener. Returns case name, court, date, citation, docket number, and a text snippet. Filter by court level, date range, or judge name. Useful for legal research agents, contract risk analysis, precede",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.034,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/limitless-markets": {
+      "get": {
+        "operationId": "limitless-markets",
+        "summary": "Returns active prediction markets from Limitless Exchange with current Yes/No probabilities. Covers short-duration crypto markets (5-min, 15-min BTC/ETH direction), plus longer-term markets. Returns title, implied yes/no prices, expiration, volume, categories, and slug. $0.006/call \u2014 free upstream, ",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.034,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/llm-proxy": {
+      "get": {
+        "operationId": "llm-proxy",
+        "summary": "LLM inference proxy \u2014 pay USDC, get AI responses without managing API keys. Accepts a prompt and optional system instruction, forwards to OpenAI, returns the completion. Supports gpt-4o-mini (default, fast and cost-efficient) or gpt-4o (more capable). Agents that already hold USDC on Base can call t",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.01,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/macro-brief": {
+      "get": {
+        "operationId": "macro-brief",
+        "summary": "AI-synthesized US macroeconomic situation briefing. Gathers 7 real-time signals \u2014 HY/IG credit spreads, yield curve (10Y-3M), initial jobless claims, JOLTS openings, core PCE, and Fed Funds rate \u2014 from FRED (free, no auth) then uses GPT-4o-mini to synthesize a structured briefing: regime label (expa",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.37,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/macro-indicators": {
+      "get": {
+        "operationId": "macro-indicators",
+        "summary": "Returns current US macroeconomic indicators: Fed Funds Rate, CPI (with year-over-year inflation %), Unemployment Rate, and Real GDP. Sourced from FRED (St. Louis Federal Reserve), updated monthly. One call establishes the policy and economic backdrop for any risk-pricing or multi-asset workflow. Pai",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.034,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/manufacturing-brief": {
+      "get": {
+        "operationId": "manufacturing-brief",
+        "summary": "AI-synthesized US manufacturing & industrial sector briefing. Gathers 7 FRED signals (free, no auth): Industrial Production, Capacity Utilization, Durable Goods Orders, Manufacturing Output, Manufacturing Employment, Inventory/Sales Ratio, and PPI All Commodities. Uses GPT-4o-mini to synthesize: man",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.37,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/market-breadth": {
+      "get": {
+        "operationId": "market-breadth",
+        "summary": "US equity market breadth dashboard via institutional ETF-ratio breadth proxies. Measures participation across equal-weight (RSP/SPY divergence), small-caps (IWM/SPY), risk appetite (SPHB/SPLV), and mid-caps (MDY/SPY). Returns per-pair ratios, 20-day average, divergence%, 5-day momentum, and OUTPERFO",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.01,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/market-gex": {
+      "get": {
+        "operationId": "market-gex",
+        "summary": "Dealer gamma exposure (GEX) analysis for any US equity or ETF \u2014 returns aggregate GEX, gamma flip level, key pinning strikes, and vol regime signal (positive GEX = pinning, negative = acceleration). Free CBOE delayed data, no API key. Standard SpotGamma-style calculation: calls subtract gamma, puts ",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.04,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/market-intelligence": {
+      "get": {
+        "operationId": "market-intelligence",
+        "summary": "Discovers active x402 APIs with verified organic USDC settlements \u2014 shows which endpoints have genuine payer breadth across the ecosystem. Sourced from on-chain settlements, not catalog listings. Filter by category, price range, and minimum unique payers. Useful before wiring a workflow to an extern",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.045,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/market-movers": {
+      "get": {
+        "operationId": "market-movers",
+        "summary": "Today's top market movers \u2014 equity gainers, losers, most-active, and crypto gainers/losers by 24h change. Sourced from Yahoo Finance screener and CoinGecko (free, no API key). Returns symbol, name, price, % change, volume, and market cap. Filter by asset class (equities, crypto, or both) and mover t",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.059,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/market-overview": {
+      "get": {
+        "operationId": "market-overview",
+        "summary": "Single-call market snapshot: SPY, QQQ, IWM, and DIA price + intraday % change, VIX fear gauge, 10-year Treasury yield (^TNX), and a derived risk-posture signal (RISK_ON / NEUTRAL / RISK_OFF / RISK_OFF_ELEVATED). Replaces 5\u20136 individual price calls with one structured payload useful for position-sizi",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.04,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/market-regime-intel": {
+      "get": {
+        "operationId": "market-regime-intel",
+        "summary": "Classify US equity market regime (BULL/CORRECTION/BEAR/SIDEWAYS/RISK_OFF) from 5 signals: SPY SMA50/200 trend, VIX level and trend, HYG/IEF credit spread, 10-yr yield, and QQQ/IWM momentum divergence. Returns regime label, per-signal scores, composite confidence 0-100, and narrative summary.",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.04,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/market-sentiment": {
+      "get": {
+        "operationId": "market-sentiment",
+        "summary": "Combined crypto market sentiment signal: Crypto Fear & Greed Index (alternative.me, 0\u2013100, 30-day trend) plus BTC and ETH Implied Volatility from Deribit options market (annualized %). Free upstream sources, no keys. Returns current FGI value, classification (Extreme Fear to Extreme Greed), 7-day FG",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.035,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/meme-generator": {
+      "get": {
+        "operationId": "meme-generator",
+        "summary": "Generate a meme image URL from text. Provide text_top and text_bottom (the two lines of the meme), and optionally a template name. If no template is given, supply a topic keyword and a fitting template will be chosen automatically. Returns a direct image URL you can embed in messages, posts, or web ",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.039,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/meme-radar": {
+      "get": {
+        "operationId": "meme-radar",
+        "summary": "Solana meme coin quality-volume radar. Returns trending tokens ranked by a quality score that rewards organic buy pressure, liquidity depth, and volume consistency. Filters out low-liquidity rugs. Use for meme coin discovery, social-momentum confirmation, or pump detection. Data: DexScreener free AP",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.039,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/merger-acquisition-intel": {
+      "get": {
+        "operationId": "merger-acquisition-intel",
+        "summary": "SEC EDGAR M&A activity tracker for US public companies. Mode 'company' (ticker): returns all M&A-related EDGAR filings for that company \u2014 incoming tender offers (SC TO-T), going-private transactions (SC 13E-3), merger proxies (DEFM14A/PREM14A), and issuer self-tenders (SC TO-I) \u2014 with EDGAR URLs. Mo",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.02,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/metals-brief": {
+      "get": {
+        "operationId": "metals-brief",
+        "summary": "AI-synthesized precious and industrial metals market brief. Assembles 9 real-time signals from Yahoo Finance: gold futures (GC=F), silver futures with G/S ratio, copper futures (Dr. Copper economic indicator), platinum futures, GLD/SLV ETFs, copper miners ETF (COPX), Newmont Mining (NEM), and Freepo",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.35,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/model-research-brief": {
+      "get": {
+        "operationId": "model-research-brief",
+        "summary": "AI/ML domain intelligence in one call: discover top HuggingFace models for a task or domain plus a synthesized research brief from HN, OpenAlex, Reddit, and arXiv. Returns model rankings, landscape summary, research trends, and a deployment recommendation.",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 2.0,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/news-sentiment": {
+      "get": {
+        "operationId": "news-sentiment",
+        "summary": "Returns global news coverage and sentiment for any company, stock ticker, or topic. Primary source: GDELT Project v2 (250M+ articles, ML tone scoring). Fallback: Google News RSS with keyword heuristic. Returns article count, avg sentiment tone (\u2212100 negative \u2192 +100 positive), top positive/negative h",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.059,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/nft-metadata": {
+      "get": {
+        "operationId": "nft-metadata",
+        "summary": "Fetch NFT metadata, traits, image URL, and collection floor price for any ERC-721 or ERC-1155 token. Returns name, description, all attributes/traits, cached image CDN URL, collection name, OpenSea floor price, token type, and mint block. Supports Ethereum, Polygon, Base, Arbitrum mainnet. Useful fo",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.059,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/nonprofit-intel": {
+      "get": {
+        "operationId": "nonprofit-intel",
+        "summary": "Nonprofit financial intelligence from IRS Form 990 filings via ProPublica Nonprofit Explorer. Mode 'search' (org_name, optional state): find nonprofits by name -- returns EIN, city, state, NTEE category (B=Education, E=Health, T=Philanthropy), revenue, assets, and 501(c) subsection. Mode 'by_ein' (e",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.015,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/npi-lookup": {
+      "get": {
+        "operationId": "npi-lookup",
+        "summary": "US NPI registry lookup \u2014 find any licensed US healthcare provider or organization by NPI number, name, state, or specialty. Returns NPI, entity type, name, credentials, specialty/taxonomy, license states, practice address, and active status. 7M+ records from CMS. Use for provider credentialing, heal",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.005,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/npm-lookup": {
+      "get": {
+        "operationId": "npm-lookup",
+        "summary": "Node.js / JavaScript package metadata from the npm registry. Returns latest version, description, license, keywords, direct dependencies, weekly download count, publish date, GitHub repository, and all recent versions. Also supports looking up a specific version. Use before adding an npm package as ",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.034,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/npm-trends": {
+      "get": {
+        "operationId": "npm-trends",
+        "summary": "Compare npm package download trends for up to 5 packages. Returns total downloads and week-over-week trend for the requested period (last-week, last-month, last-year). Useful for evaluating package adoption before adding a dependency, comparing competing libraries (express vs fastify, react-query vs",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.02,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/open-food-intel": {
+      "get": {
+        "operationId": "open-food-intel",
+        "summary": "Open Food Facts nutritional intelligence \u2014 3M+ consumer food products. Two modes: (1) search: keyword search returning Nutri-Score (A\u2013E), NOVA processing level (1\u20134), macronutrients per 100g, allergens, eco-score, and popularity rank. (2) barcode: exact UPC/EAN lookup with full nutritional profile p",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.015,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/options-chain": {
+      "get": {
+        "operationId": "options-chain",
+        "summary": "CBOE delayed options chain for any US equity or index \u2014 returns stock price, per-contract IV, greeks (delta/gamma/theta/vega), OI, volume, and bid/ask. Filterable by expiration date and call/put. Free CBOE data, no API key.",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.059,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/options-flow-unusual": {
+      "get": {
+        "operationId": "options-flow-unusual",
+        "summary": "Detects unusual options activity via CBOE delayed data \u2014 flags contracts where volume/OI ratio exceeds threshold (institutional sweep signal), ranks top flows by notional value, and returns a BULLISH_SWEEP/BEARISH_SWEEP/NEUTRAL interpretation. No API key required.",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.025,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/options-iv-snapshot": {
+      "get": {
+        "operationId": "options-iv-snapshot",
+        "summary": "Options IV snapshot: CBOE IV30, expected move from ATM straddle (1st + 2nd expiry), P/C ratio. Completes pre-earnings decision workflow.",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.025,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/options-snapshot": {
+      "get": {
+        "operationId": "options-snapshot",
+        "summary": "Options intelligence snapshot for any US equity \u2014 IV30, put/call volume ratio, top calls and puts by trading volume, and unusual-volume flags. Free CBOE delayed data (15-min delay during trading hours), no API key required. Complements us-stock-price and equity-technicals with the options-layer sent",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.035,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/page-intel": {
+      "get": {
+        "operationId": "page-intel",
+        "summary": "Extracts structured content from any public URL: page title, meta description, H1-H3 headings, all links (with text and internal/external flag), and a 500-character text preview. Useful for research agents following link chains from on-chain data, auditing page structure, or seeding downstream text-",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.059,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/page-links": {
+      "get": {
+        "operationId": "page-links",
+        "summary": "Extracts all hyperlinks from a webpage. Fetches the target URL, resolves relative links to absolute URLs, and classifies each as internal (same domain) or external. Filter by all/external/internal, cap results with limit. Returns page title, total link count before filtering, and a structured array ",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.034,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/patent-intel": {
+      "get": {
+        "operationId": "patent-intel",
+        "summary": "USPTO patent intelligence for any company or keyword. Mode 'company' (ticker or company name): recent granted patents assigned to that company \u2014 accepts US stock ticker (resolved via SEC EDGAR) or free-form assignee name. Returns title, abstract excerpt (\u2264400 chars), grant date, filing date, CPC tec",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.015,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/peer-benchmarking": {
+      "get": {
+        "operationId": "peer-benchmarking",
+        "summary": "Comparable-company analysis for any US equity. Returns target vs. 5 sector-peer median on P/E, EV/EBITDA, revenue growth, and profit margin \u2014 with explicit premium/discount %. Replaces manual comps-table research. No API key required.",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.1,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/ping": {
+      "get": {
+        "operationId": "ping",
+        "summary": "Liveness + echo probe. Pays back a timestamp and echoes `msg`. Use to verify the x402 rail and Bazaar listing end to end.",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.021,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/place-details": {
+      "get": {
+        "operationId": "place-details",
+        "summary": "Enriched place and business details by name (OSM Nominatim). Returns website, phone, email, opening hours, operator, brand, cuisine, social media links, full address, and coordinates. Use when you need the business metadata behind a location \u2014 not just where it is, but who runs it and how to reach i",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.045,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/podcast-intel": {
+      "get": {
+        "operationId": "podcast-intel",
+        "summary": "Podcast intelligence: show metadata and recent episodes. Search by name via iTunes or supply a direct RSS feed URL. Returns title, author, description, artwork, categories, and up to 20 recent episodes with titles, dates, durations, and audio URLs.",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.039,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/policy-impact-mapper": {
+      "get": {
+        "operationId": "policy-impact-mapper",
+        "summary": "Analyzes regulatory and policy text to map its impact across industry sectors. Extracts compliance requirements, change types (new mandates, prohibitions, exemptions), effective dates, affected entities, and assigns sector-level impact scores (HIGH/MEDIUM/LOW). Pure pattern analysis \u2014 no LLM, instan",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.034,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/polymarket-accuracy-score": {
+      "get": {
+        "operationId": "polymarket-accuracy-score",
+        "summary": "Historical Polymarket crowd accuracy score: % of markets where the final crowd majority correctly predicted the outcome, plus Brier score (calibration quality). Breakdowns by category \u2014 crypto, politics, sports, macro, equities, ai. Filter by category and lookback days. $0.004/call \u2014 20% below close",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.034,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/polymarket-category-performance": {
+      "get": {
+        "operationId": "polymarket-category-performance",
+        "summary": "Polymarket category activity breakdown: volume, liquidity, market count, and top market per category (crypto, politics, sports, ai, macro, equities). Shows where trading activity is concentrated. Optionally filter to one category. $0.004/call \u2014 20% below closest x402 competitor. Source: Polymarket p",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.034,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/polymarket-crypto-updown": {
+      "get": {
+        "operationId": "polymarket-crypto-updown",
+        "summary": "Crypto price direction prediction markets from Polymarket. Returns binary up/down markets for BTC, ETH, SOL, XRP and other assets \u2014 current market consensus on near-term price direction. Filter by asset symbol or get all active crypto markets. Use for directional sentiment, agent decision context, o",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.059,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/polymarket-intel": {
+      "get": {
+        "operationId": "polymarket-intel",
+        "summary": "Polymarket prediction market data. Search by topic keyword (e.g. 'bitcoin', 'election', 'fed rate') or retrieve top markets by trading volume. Returns Yes/No probabilities, volume, liquidity, price momentum, and resolution date. No API keys. Use for event risk, trading signal context, or agent decis",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.034,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/polymarket-sentiment-shift": {
+      "get": {
+        "operationId": "polymarket-sentiment-shift",
+        "summary": "Returns Polymarket prediction markets with the biggest recent probability shifts \u2014 useful for detecting sudden consensus changes on elections, crypto prices, and macro outcomes. Sorted by absolute 1-week change by default. Each result includes current probability, price change, volume, and resolutio",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.034,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/polymarket-whale-entries": {
+      "get": {
+        "operationId": "polymarket-whale-entries",
+        "summary": "Scans Polymarket for recent large-position trades. Returns whale entries filtered by minimum USDC value (size \u00d7 entry price). Includes trader wallet, YES/NO side, USDC amount, entry price, market name, and on-chain tx hash. Use for smart-money signals, copy-trade detection, or market sentiment confi",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.136,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/portfolio-rebalance": {
+      "get": {
+        "operationId": "portfolio-rebalance",
+        "summary": "Pure-math portfolio rebalancing calculator. Given current holdings (asset names and their current USD values) and target allocations (percentages summing to 100), returns the exact buy/sell dollar amounts needed to reach target weights. Handles partial rebalancing with a drift threshold. No external",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.035,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/portfolio-synthesis": {
+      "get": {
+        "operationId": "portfolio-synthesis",
+        "summary": "AI portfolio intelligence for a basket of US equities \u2014 fetches live prices for up to 5 tickers and synthesizes multi-source market intelligence into a portfolio-level narrative. Returns per-ticker price data (price, change %, volume, 52-week range) plus a portfolio analysis: executive summary, key ",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 2.5,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/pre-earnings-brief": {
+      "get": {
+        "operationId": "pre-earnings-brief",
+        "summary": "Pre-earnings decision brief for any US stock: next earnings date + EPS/revenue consensus, 4-quarter beat/miss track record with average surprise %, analyst buy/hold/sell count and mean price target, short interest ratio, and 52-week technical position. Single call replaces 4+ separate lookups. Use a",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.075,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/prediction-markets": {
+      "get": {
+        "operationId": "prediction-markets",
+        "summary": "Returns top active Polymarket prediction markets sorted by trading volume. Includes crowd-sourced outcome probabilities (0\u20131), USDC volume, liquidity, and resolution date. Filter by keyword. Use this to gauge market consensus on events before making decisions. $0.05/call \u2014 free upstream, no API key.",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.07,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/prediction-stock-pulse": {
+      "get": {
+        "operationId": "prediction-stock-pulse",
+        "summary": "One call returns prediction market sentiment (Limitless Exchange) + live equity price for a specified ticker. Collapses the prediction-market \u2192 stock-price agent chain into a single x402 payment. $0.016 vs $0.024 bought individually. Inputs: ticker (required), query (optional keyword filter for pred",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.059,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/price-target-consensus": {
+      "get": {
+        "operationId": "price-target-consensus",
+        "summary": "Analyst price target consensus for any US public company: current price, 12-month consensus target (mean, median, high, low), buy/hold/sell analyst count, implied upside %, and recommendation trend. Pulled from Yahoo Finance \u2014 no API key required.",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.01,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/protocol-revenue-leaders": {
+      "get": {
+        "operationId": "protocol-revenue-leaders",
+        "summary": "Returns DeFi protocols ranked by daily fees (revenue generated). Covers 1000+ protocols across chains \u2014 DEXes, lending markets, derivatives, stablecoins. Includes 1d/7d/30d trend context, category breakdown, and chain presence. Use to identify which protocols are capturing the most economic activity",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.059,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/pubmed-intel": {
+      "get": {
+        "operationId": "pubmed-intel",
+        "summary": "PubMed biomedical literature search and article retrieval across 36M+ NCBI/MEDLINE citations. search mode: find papers by keyword with optional year range and article type filter (clinical_trial, review, meta_analysis, systematic_review, randomized_trial, case_report) \u2014 returns PMID, title, authors,",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.015,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/pypi-intel": {
+      "get": {
+        "operationId": "pypi-intel",
+        "summary": "Python package intelligence from PyPI and pypistats.org. Returns metadata (author, license, dev status, dependencies, Python version support), download velocity (last day/week/month), version history, and known vulnerabilities. Compare up to 4 packages side-by-side. Use to evaluate library maturity,",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.015,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/pypi-lookup": {
+      "get": {
+        "operationId": "pypi-lookup",
+        "summary": "Python package metadata from PyPI. Returns latest version, summary, author, license, Python version requirement, install dependencies, release date, and download URLs. Also supports fetching a specific version. Use before integrating a Python library: check if it's actively maintained, what license ",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.034,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/readable-content": {
+      "get": {
+        "operationId": "readable-content",
+        "summary": "Fetches any public URL and returns the full readable article text as clean Markdown, stripped of navigation, ads, and boilerplate. Returns title, published date (if available), and the complete body ready for LLM summarization, analysis, or RAG ingestion. A $0.004 alternative to exa.ai/contents ($0.",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.034,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/reddit-intel": {
+      "get": {
+        "operationId": "reddit-intel",
+        "summary": "Searches Reddit posts and/or comments by keyword. Returns top results with score, comment count, author, subreddit, URL, and timestamp. Filter by subreddit, sort by score or date. Supports separate post and comment search. Sourced from PullPush public API \u2014 no auth required. Ideal for competitive se",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.04,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/regex-tester": {
+      "get": {
+        "operationId": "regex-tester",
+        "summary": "Safe regex testing and extraction. Validates a pattern, finds all matches (with capture groups), replaces text, and explains what the pattern matches. Zero external API calls \u2014 instant, deterministic. Useful for agents generating or debugging regex patterns mid-task, validating extracted data, or tr",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.034,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/research-automation-brief": {
+      "get": {
+        "operationId": "research-automation-brief",
+        "summary": "Automated research intelligence: combines deep topic synthesis (Hacker News, OpenAlex academic papers, Reddit, arXiv, DuckDuckGo) with scheduling guidance in a single call. Returns a structured research report \u2014 executive summary, key findings, sentiment, emerging trends, and recommendations \u2014 plus ",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 3.0,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/research-paper-search": {
+      "get": {
+        "operationId": "research-paper-search",
+        "summary": "Academic paper search across 250M+ works via OpenAlex (free, no key). Returns top papers with title, authors, year, DOI, citation count, open-access status, and primary research topic. Covers all disciplines: AI/ML, medicine, physics, economics, law, biology, and more. Supports relevance, citation-c",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.059,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/research-synthesis": {
+      "get": {
+        "operationId": "research-synthesis",
+        "summary": "AI-synthesized intelligence report on any topic \u2014 aggregates Hacker News, OpenAlex academic papers, Reddit, arXiv preprints, and DuckDuckGo in parallel, then distills into a structured report: executive summary, key findings, market sentiment, emerging trends, and recommendations. Works across domai",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 2.5,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/retail-sector-brief": {
+      "get": {
+        "operationId": "retail-sector-brief",
+        "summary": "AI-synthesized US retail sector briefing: XRT/XLY/XLP ETF signals, major retailer stock performance (AMZN/WMT/TGT/COST/HD/LOW), derived risk-appetite and sector-alpha scores, and GPT-4o-mini synthesis into regime classification + narrative. Companion to consumer-brief (macro signals) \u2014 this covers r",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.35,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/revenue-growth-intel": {
+      "get": {
+        "operationId": "revenue-growth-intel",
+        "summary": "Revenue growth quality analysis for any US public company. Computes 1/3/5-year revenue CAGRs, growth consistency (coefficient of variation), acceleration vs long-run trend, gross margin direction, and operating leverage. Returns a composite letter grade (A\u2013F) that anchors DCF growth rate assumptions",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.02,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/rss-reader": {
+      "get": {
+        "operationId": "rss-reader",
+        "summary": "Fetches and parses any public RSS 2.0 or Atom 1.0 feed. Returns feed metadata (title, description, language, last updated) and structured items (title, link, 400-char summary, author, published date, GUID). Useful for monitoring news, blog posts, GitHub release notes, Reddit RSS, arXiv category feed",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.025,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/sanctions-screening": {
+      "get": {
+        "operationId": "sanctions-screening",
+        "summary": "OFAC SDN sanctions screening \u2014 checks whether a person, company, vessel, or aircraft appears on the US Treasury Specially Designated Nationals list. Returns match score, sanctions program(s), and entity type. Covers ~19,000 entries including RUSSIA-EO14024, SDGT, IRAN, DPRK, TCO, and 30+ programs. U",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.165,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/sec-filing-intel": {
+      "get": {
+        "operationId": "sec-filing-intel",
+        "summary": "Real-time SEC EDGAR filing lookup by ticker or CIK. Returns company profile plus recent filings (form type, date, description, EDGAR URL). Supports 8-K (material events), 10-K/10-Q (earnings), Form 4 (insider trades), DEF14A (proxy), and all other EDGAR form types. Authoritative US government data, ",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.035,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/sec-full-text-search": {
+      "get": {
+        "operationId": "sec-full-text-search",
+        "summary": "Full-text search across all SEC EDGAR filings. Finds every public company that mentioned a keyword or phrase in their 10-K, 10-Q, 8-K, or other forms. Returns company names, tickers, filing dates, and relevance scores. Ideal for thematic equity research: 'which companies disclosed tariff risk in Q1 ",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.01,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/sec-insider-trades": {
+      "get": {
+        "operationId": "sec-insider-trades",
+        "summary": "SEC EDGAR Form 4 insider trading data for any US public company \u2014 shows recent insider buys, sells, awards, and exercises with shares, price, and post-transaction ownership. No API key. EDGAR primary source.",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.04,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/sector-rotation": {
+      "get": {
+        "operationId": "sector-rotation",
+        "summary": "S&P 500 sector rotation: relative performance of all 11 GICS sectors (XLK XLF XLE XLV XLI XLY XLP XLB XLRE XLU XLC) vs SPY benchmark. Returns 1D, 5D, 1M, and 3M absolute and relative returns, a rotation signal per sector (LEADING, CATCHING_UP, FALLING_BEHIND, LAGGING), and 1M leadership ranking. Par",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.04,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/short-interest-intel": {
+      "get": {
+        "operationId": "short-interest-intel",
+        "summary": "Outstanding short interest intelligence for US equities: shares sold short, short % of float, days-to-cover (covering pressure), and last FINRA report date. Includes heuristic squeeze risk scoring: EXTREME/HIGH/MODERATE/LOW based on float short % and days-to-cover. Closes the equity ownership trifec",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.012,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/short-volume-intel": {
+      "get": {
+        "operationId": "short-volume-intel",
+        "summary": "Daily FINRA consolidated short-sale volume for any US equity ticker: short volume, total volume, and short ratio (short/total) for the last N trading days. Useful for detecting crowded short positions and short-squeeze setups. Free FINRA CDN upstream, no API key.",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.034,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/social-intel": {
+      "get": {
+        "operationId": "social-intel",
+        "summary": "Returns public profile data for any social platform account. Pass a profile URL (platform auto-detected) or platform + username. Supports GitHub, Reddit, HackerNews, Twitter/X, npm, and Open Graph fallback for any URL. Returns name, bio, follower/karma counts, creation date, and platform-specific me",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.059,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/social-momentum": {
+      "get": {
+        "operationId": "social-momentum",
+        "summary": "Cross-platform social momentum for any topic. Queries Reddit (recent top posts), Hacker News (recent stories), and GitHub (active repos) in parallel and returns a composite momentum score (0\u2013100) plus raw results from each platform. Single call replaces three separate searches. Use before committing",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.059,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/solana-token-risk": {
+      "get": {
+        "operationId": "solana-token-risk",
+        "summary": "Rug-pull and risk scanner for Solana SPL tokens. Input a mint address; returns mint/freeze authority status, top-10 holder concentration, liquidity depth, token age, and a composite safety score (0\u2013100, higher = safer) with risk level (safe/moderate/risky/danger) and green/warning flags. Uses Solana",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.07,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/solana-tx-explainer": {
+      "get": {
+        "operationId": "solana-tx-explainer",
+        "summary": "Given a Solana transaction signature, returns a decoded breakdown: fee payer, programs invoked (Jupiter, Raydium, Pump.fun, SPL Token, etc.), SPL token balance changes with deltas, transaction fee in SOL and USD, block time, and a one-sentence human-readable summary. Uses public Solana mainnet RPC \u2014",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.07,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/solar-intel": {
+      "get": {
+        "operationId": "solar-intel",
+        "summary": "Solar irradiance analysis and 7-day forecast for any location. Returns GHI (global horizontal irradiance), DNI (direct normal), DHI (diffuse), peak sun hours, cloud cover, sunrise/sunset, and panel yield estimate for a 1 kW system. Useful for rooftop solar feasibility, agricultural planning, EV char",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.045,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/sports-prediction": {
+      "get": {
+        "operationId": "sports-prediction",
+        "summary": "Returns today's (or a given date's) sports games with team win-loss records, venue, scheduled time, and live score. Supports MLB, NBA, NFL, NHL, NCAAF, NCAAB. Sourced from ESPN public API \u2014 no key required. $0.005/call. Use before prediction-markets or sports-content tasks to get accurate team conte",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.059,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/sports-scores": {
+      "get": {
+        "operationId": "sports-scores",
+        "summary": "Live and recent sports scores for NBA, NFL, MLB, NHL, MLS, EPL, La Liga, Bundesliga, Serie A, Champions League, and more. Returns game status, current score, venue, period/clock, and broadcast info. Uses ESPN's free public scoreboard API. Optional date filter (YYYYMMDD) for historical or upcoming sc",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.059,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/ssl-cert": {
+      "get": {
+        "operationId": "ssl-cert",
+        "summary": "Inspects the TLS/SSL certificate of any HTTPS host. Returns validity window (not-before, not-after, days remaining), issuer (CA name, organization), subject (CN), Subject Alternative Names, SHA-256 fingerprint, serial number, and an expiry status (HEALTHY/OK/WARNING/CRITICAL/EXPIRED). Useful for mon",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.034,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/stablecoin-watch": {
+      "get": {
+        "operationId": "stablecoin-watch",
+        "summary": "Real-time depeg monitor for top USD stablecoins (USDT, USDC, DAI, USDS, and others ranked by market cap). Returns current price, peg deviation %, depeg status (PARITY / MILD_DEPEG / MODERATE_DEPEG / SEVERE_DEPEG), supply trend, and a composite alert level (GREEN / YELLOW / ORANGE / RED). Sourced fro",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.07,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/stackoverflow-intel": {
+      "get": {
+        "operationId": "stackoverflow-intel",
+        "summary": "Stack Overflow question search. Returns top-scored questions matching the query with answer counts, accepted-answer status, tags, and body excerpts. Filter by tags (comma-separated). Sort by votes, relevance, activity, or creation date. Useful for developer agents debugging errors or researching lib",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.034,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/stock-brief": {
+      "get": {
+        "operationId": "stock-brief",
+        "summary": "US equity snapshot + Limitless prediction market sentiment in one call. Returns current price, intraday change, volume, 52-week range for any NYSE/NASDAQ ticker, plus any active Limitless prediction markets matching the ticker keyword (direction bets, price level markets). Single-call alternative to",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.035,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/stock-compare": {
+      "get": {
+        "operationId": "stock-compare",
+        "summary": "Compare a primary US equity against up to 4 peers in a single call. Returns live price, change %, volume, and day/52-week range for each ticker, plus a performance ranking showing leader (highest gain%), laggard (lowest gain%), and the primary stock's relative rank among the group. Replaces separate",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.139,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/stock-monitor-builder": {
+      "get": {
+        "operationId": "stock-monitor-builder",
+        "summary": "Build a complete stock monitoring job in one call. Validates your cron schedule (returns human description + next run times) AND fetches current prices for the stocks you want to watch. Returns a ready-to-use monitoring config combining both. Replaces separate cron-parser + stock-price-multi calls.",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.089,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/stock-ohlcv": {
+      "get": {
+        "operationId": "stock-ohlcv",
+        "summary": "Returns historical OHLCV (open/high/low/close/volume) candlestick data for a stock, ETF, or index. Supports intervals from 1-minute to monthly and ranges from 1 day to max history. Use for chart analysis, trend detection, and quantitative backtesting. $0.010/call \u2014 free upstream, no API key.",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.059,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/stock-price-multi": {
+      "get": {
+        "operationId": "stock-price-multi",
+        "summary": "Returns current US equity prices for up to 5 tickers in one call \u2014 STRC, AMD, MSTR, SLV, USO, or any NYSE/NASDAQ symbol. Each call returns price, change %, volume, day range, and 52-week range per ticker. Sourced from Yahoo Finance public data, no API key.",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.059,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/stock-screener": {
+      "get": {
+        "operationId": "stock-screener",
+        "summary": "Run a Yahoo Finance predefined equity screen (day_gainers, day_losers, most_actives, undervalued_growth_stocks, undervalued_large_caps, growth_technology_stocks, aggressive_small_caps, small_cap_gainers). Returns up to 50 stocks with price, % change, volume, market cap, P/E (trailing + forward), 52-",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.025,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/strategy-signal": {
+      "get": {
+        "operationId": "strategy-signal",
+        "summary": "Technical analysis signal for any US equity, ETF, or crypto. Returns RSI(14), MACD(12/26/9), Bollinger Bands(20), volume trend, directional posture (STRONG_BUY/BUY/NEUTRAL/SELL/STRONG_SELL), and key price levels. Richer output than comparable services at $0.090. Free upstream: Yahoo Finance (equitie",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.11,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/supply-chain-brief": {
+      "get": {
+        "operationId": "supply-chain-brief",
+        "summary": "AI-synthesized global supply chain intelligence brief. Assembles 10 real-time signals from Yahoo Finance: dry bulk shipping ETF (BDRY/Baltic Dry proxy), FedEx, UPS, XPO Logistics, Old Dominion LTL, C.H. Robinson freight brokerage, Matson trans-Pacific shipping, copper futures, Nucor steel, and Albem",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.35,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/tech-brief": {
+      "get": {
+        "operationId": "tech-brief",
+        "summary": "AI-synthesized US technology sector intelligence brief. Assembles 10 real-time signals from Yahoo Finance: Nasdaq-100 (QQQ), tech sector ETF (XLK), semiconductor ETF (SMH), NVIDIA, Apple, Microsoft, Alphabet, Meta, AMD, and Intel. Returns 52-week context, semiconductor leadership signal, tech-regime",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.35,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/technical-indicators": {
+      "get": {
+        "operationId": "technical-indicators",
+        "summary": "Full technical analysis for any US equity, ETF, or index. Returns RSI(14), MACD(12,26,9), SMA(20/50/200), EMA(20), Bollinger Bands, volume trend, golden/death cross status, and a composite tech_signal (STRONG_BULLISH/BULLISH/NEUTRAL/BEARISH/STRONG_BEARISH). One call replaces raw price history fetch ",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.025,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/timezone": {
+      "get": {
+        "operationId": "timezone",
+        "summary": "Timezone intelligence using the IANA database (418 zones) built into Node.js. Returns current local time, UTC offset, DST status, and the long timezone name for any IANA timezone. Can also convert an ISO timestamp to one or more target timezones. Useful for scheduling agents, global operations, and ",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.034,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/token-top-holders": {
+      "get": {
+        "operationId": "token-top-holders",
+        "summary": "Returns top holders for any Ethereum ERC-20 token (by contract address), with concentration metrics. Includes each holder's share%, human-readable balance (with decimal conversion), and whale analysis. Reports: top-10 concentration, whale count (>1% holders), Herfindahl-Hirschman Index for concentra",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.059,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/treasury-auction-calendar": {
+      "get": {
+        "operationId": "treasury-auction-calendar",
+        "summary": "Returns upcoming US Treasury auction schedule (Bills, Notes, Bonds, TIPS, FRNs) from TreasuryDirect.gov. Filter by security type and look-ahead window. Shows auction date, issue date, term, offering amount, coupon rate, and reopening status. Official government data, no API key.",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.028,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/treasury-yields": {
+      "get": {
+        "operationId": "treasury-yields",
+        "summary": "Returns current US Treasury yield curve at 3M, 5Y, 10Y, and 30Y nodes from CBOE interest-rate indices (free, no API key). Includes 10Y-3M spread and curve shape classification. Essential for DCF discount rates, bond pricing, and recession signal monitoring.",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.059,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/tvmaze-intel": {
+      "get": {
+        "operationId": "tvmaze-intel",
+        "summary": "TV show intelligence via TVMaze: search 90k+ shows by name, get full show profiles with cast/schedule/rating, list episode guides by season, or fetch the broadcast schedule for any country by date. No API key required.",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.01,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/twitter-intel": {
+      "get": {
+        "operationId": "twitter-intel",
+        "summary": "Real-time Twitter/X data without an API key. lookup_user returns full profile (followers, bio, verification) for any @username. search_tweets returns 10 recent tweets matching a keyword or filter query. x402-settled upstream.",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.035,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/tx-explainer": {
+      "get": {
+        "operationId": "tx-explainer",
+        "summary": "Given a transaction hash and chain, returns a decoded breakdown: sender, recipient, ETH value transferred, gas used, transaction fee, decoded method name (transfer/approve/swap/deposit/etc.), ERC-20 token transfer details if applicable, block number, block timestamp, and a one-sentence agent-readabl",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.034,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/tx-intel": {
+      "get": {
+        "operationId": "tx-intel",
+        "summary": "Decode and explain any EVM transaction \u2014 in one x402 payment. Returns: transaction status, type (ETH transfer / ERC20 transfer / swap / approval / contract call), human-readable summary, token transfers parsed from logs, gas cost, block context, and explorer URL. Collapses the observed tx-explainer ",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.014,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/unit-converter": {
+      "get": {
+        "operationId": "unit-converter",
+        "summary": "Converts between 100+ units across 12 categories: length, weight, temperature, volume, speed, area, energy, pressure, data, time, angle, frequency. Handles mixed-case inputs (km, KM, Km all work). Returns the converted value plus all common units in the same category. Zero external calls \u2014 pure math",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.034,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/us-stock-history": {
+      "get": {
+        "operationId": "us-stock-history",
+        "summary": "Historical OHLCV bars for any US stock, ETF, or index. TradingView-compatible resolution (D, W, M, 60, 15, 5, 1). Pass Unix timestamps for from/to. $0.005/call \u2014 no API key required. Use us-stock-price for live quotes; equity-technicals for indicators.",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.059,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/us-stock-price": {
+      "get": {
+        "operationId": "us-stock-price",
+        "summary": "Returns current US equity price and intraday metrics (change %, volume, day high/low, 52-week range) for any NYSE/NASDAQ ticker. Sourced from Yahoo Finance public data \u2014 no API key, live during market hours.",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.059,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/usgs-earthquake": {
+      "get": {
+        "operationId": "usgs-earthquake",
+        "summary": "Real-time global earthquake events from USGS. Filter by magnitude, depth, location radius, or time window. Returns location, magnitude, depth, PAGER alert, and USGS event URL. Free primary source \u2014 no API key.",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.059,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/vc-funding-intel": {
+      "get": {
+        "operationId": "vc-funding-intel",
+        "summary": "Private fundraising round tracker via SEC Form D EDGAR filings. Regulation D offerings (Rule 506(b)/506(c)/504) must be reported within 15 days of first sale \u2014 a near-real-time window into VC rounds, PE buyouts, startup raises, hedge fund raises, and real estate syndicates. Mode 'company' (company_n",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.015,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/vision-analyze": {
+      "get": {
+        "operationId": "vision-analyze",
+        "summary": "Analyze any image URL using GPT-4o-mini vision. Returns structured analysis based on the mode: describe (full description), ocr (text extraction), chart (data/trend extraction), ui (interface analysis), identify (object/subject ID), or qa (answer a specific question about the image). Input must be a",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.261,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/volatility-brief": {
+      "get": {
+        "operationId": "volatility-brief",
+        "summary": "US equity volatility regime brief \u2014 VIX (30-day), VXMT (93-day), VVIX (vol-of-vol), and SKEW index assembled into a single vol dashboard. Outputs term structure (CONTANGO/FLAT/BACKWARDATION), VIX percentile rank, vol regime (CALM/MODERATE/ELEVATED/CRISIS), and composite signal (RISK_OFF/CAUTION/NEUT",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.059,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/wacc-calculator": {
+      "get": {
+        "operationId": "wacc-calculator",
+        "summary": "Computes WACC (Weighted Average Cost of Capital) for any US public company using CAPM cost of equity (live 10Y Treasury + beta \u00d7 ERP), after-tax cost of debt (interest expense / total debt), and market-value capital structure weights. The discount rate needed to run a DCF model.",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.025,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/wallet-balance": {
+      "get": {
+        "operationId": "wallet-balance",
+        "summary": "Returns the native token balance (ETH, POL, BNB) for any EVM wallet address. Supports Ethereum, Base, Polygon, Arbitrum, Optimism, and BSC. Includes optional USD value. $0.010/call. Free upstreams: DRPC + CoinGecko, no API key required.",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.059,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/wallet-credit-score": {
+      "get": {
+        "operationId": "wallet-credit-score",
+        "summary": "Composite credit score (0\u2013100) for any EVM wallet. Aggregates Ethereum and Base transaction count, account balance, USDC holdings, and multi-chain footprint into a single trustworthiness score with tier label (PRIME / ESTABLISHED / ACTIVE / SPARSE / DORMANT). Use before sending payments, routing age",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.059,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/wallet-screener": {
+      "get": {
+        "operationId": "wallet-screener",
+        "summary": "Risk screening for EVM wallet addresses. Returns a 0\u2013100 risk score and individual flags: sanctions (OFAC/other), phishing activity, cybercrime, money laundering, darkweb transactions, mixer usage, stolen funds, fake KYC, and 12 more categories. Sourced from GoPlusLabs (free, no key, chain_id option",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.136,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/wayback-intel": {
+      "get": {
+        "operationId": "wayback-intel",
+        "summary": "Queries the Internet Archive Wayback Machine for historical snapshots of any public URL. Returns the closest archived snapshot URL, capture timestamp (ISO 8601), and HTTP status code at the time of capture. Optionally lists up to 10 recent snapshots to trace how a site evolved over time. Covers 800B",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.034,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/weather-alerts": {
+      "get": {
+        "operationId": "weather-alerts",
+        "summary": "Active NOAA weather alerts for any US state \u2014 tornado warnings, flash flood watches, hurricane warnings, blizzard advisories, heat alerts, and 80+ other NWS event types. Real-time data from api.weather.gov; no API key. Filterable by state, event type, or severity. Returns event, severity, certainty,",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.059,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/weather-equity-brief": {
+      "get": {
+        "operationId": "weather-equity-brief",
+        "summary": "Recent weather patterns for a region + live equity prices + AI synthesis of weather-market correlations. One call replaces weather-history + stock-price-multi + research-synthesis. Ideal for weather-sensitive sectors: energy (XLE), utilities (XLU), agriculture (MOO/ADM), airlines (DAL). Returns 14-d",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 2.0,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/weather-history": {
+      "get": {
+        "operationId": "weather-history",
+        "summary": "Historical daily weather (temperature, precipitation, wind, sunshine) for any location from 1940 to ~5 days ago. Uses ERA5 reanalysis data. Accepts city name or lat,lng. Returns per-day values plus period summary stats. Useful for seasonal analysis, anomaly detection, and climate-context enrichment.",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.059,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/weather-research-brief": {
+      "get": {
+        "operationId": "weather-research-brief",
+        "summary": "Weather-contextualized research intelligence \u2014 pulls historical weather for any location (ERA5 reanalysis via Open-Meteo) and multi-source research on any topic (Hacker News, OpenAlex academic papers, Reddit, arXiv, DuckDuckGo), then synthesizes them into a unified brief showing how weather conditio",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 2.5,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/weather": {
+      "get": {
+        "operationId": "weather",
+        "summary": "Current weather conditions and 7-day daily forecast for any location worldwide. Input a city name, coordinates, or address. Returns temperature (\u00b0C), humidity, wind speed, precipitation, weather code, and a forecast with high/low temps and precipitation totals. Free upstream: Open-Meteo (no API key,",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.039,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/web-change-monitor": {
+      "get": {
+        "operationId": "web-change-monitor",
+        "summary": "Returns content-change signals for any public URL: ETag, Last-Modified, Content-Length, and Content-Type via HTTP HEAD. Falls back to GET + SHA-256 of the first 32 KB when the server returns no cache markers. Store the snapshot and re-call periodically to detect changes. Useful for monitoring compet",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.059,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/web-company-intel": {
+      "get": {
+        "operationId": "web-company-intel",
+        "summary": "Extract structured company intelligence from any public website. Returns company name, description, logo, emails, phones, address, founded date, social links (Twitter/LinkedIn/GitHub/etc.), and raw OpenGraph + schema.org/Organization data. Pure HTML extraction \u2014 no external APIs. $0.003 hedge agains",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.059,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/web-scrape-links": {
+      "get": {
+        "operationId": "web-scrape-links",
+        "summary": "Extracts all hyperlinks from any public webpage. Returns href URLs normalized to absolute URLs with visible link text. Filters out javascript:, mailto:, data: schemes. Optionally restrict to same-domain links, deduplicate, or include #anchor links. Useful for crawlers, sitemap builders, link graph a",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.059,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/whale-radar": {
+      "get": {
+        "operationId": "whale-radar",
+        "summary": "Polymarket whale intelligence for a given proxy wallet address. Returns recent prediction-market trades (market title, outcome, side, size in USDC, price, timestamp) and current open positions (title, size, avg price, current value, unrealized PnL). Infers whale tier (whale/shark/dolphin/minnow) fro",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.117,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/wikipedia-intel": {
+      "get": {
+        "operationId": "wikipedia-intel",
+        "summary": "Wikipedia article lookup and search. Given a search query, returns the top matching Wikipedia articles with title, plain-text extract (~800 chars), description, thumbnail URL, page URL, and last-modified date. Use for rapid factual lookup, entity enrichment, concept explanation, or pre-flight resear",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.034,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/world-bank-data": {
+      "get": {
+        "operationId": "world-bank-data",
+        "summary": "World Bank open data \u2014 1600+ development indicators for 200+ countries. Returns most-recent values and 5-year trend for any indicator by country. Covers GDP, population, inflation, unemployment, FDI, debt, exports, CO\u2082, life expectancy, Gini, internet penetration, ease of doing business, and more. A",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.034,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/x402-endpoint-intel": {
+      "get": {
+        "operationId": "x402-endpoint-intel",
+        "summary": "Market intelligence for any x402 endpoint or operator wallet. Returns settlement volume, unique payer count, price range, reputation tier, activity window, and endpoint description \u2014 drawn from 4.1M+ Base mainnet settlements in the Stall's proprietary on-chain dataset. Use before routing agent spend",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.04,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/yield-farming-active": {
+      "get": {
+        "operationId": "yield-farming-active",
+        "summary": "Returns active DeFi yield farming pools sorted by 30-day average APY. Sourced from DeFiLlama (free, no key). Each pool includes protocol, chain, symbol, TVL, current APY, 30-day mean APY, impermanent-loss risk, and stablecoin flag. Filter by chain, protocol, minimum TVL, minimum APY, or stablecoin-o",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.059,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/youtube-channel-analytics": {
+      "get": {
+        "operationId": "youtube-channel-analytics",
+        "summary": "YouTube channel video performance analytics: recent N uploads with view counts, upload cadence, ACCELERATING/STABLE/DECLINING momentum, and top/bottom performers. Accepts @handle, channel URL, or UC... channel ID. Replaces 20+ sequential youtube-intel calls for channel-level research.",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.035,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/youtube-channel-intel": {
+      "get": {
+        "operationId": "youtube-channel-intel",
+        "summary": "YouTube channel metadata: subscriber count, channel name, handle, description (1000-char cap), and tags. Accepts @handle, channel URL, or UC channel ID. Uses yt-dlp (no API key required). $0.039/call.",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.039,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/youtube-comments": {
+      "get": {
+        "operationId": "youtube-comments",
+        "summary": "Top comments for any YouTube video, sorted by like count. Returns comment text, author, like count, timestamp, and pinned/favorited flags. Useful for audience sentiment analysis, identifying notable reactions, and understanding community response. Accepts any YouTube URL format or bare 11-character ",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.039,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/youtube-intel": {
+      "get": {
+        "operationId": "youtube-intel",
+        "summary": "YouTube video intelligence: title, author, channel stats (subscriber count, channel ID), description, view/like/comment counts, duration, upload date, thumbnail, tags, categories, structured chapters (timestamps), replay heatmap (top-20 most-replayed segments), live status, and availability. Accepts",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.059,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/youtube-keyword-research": {
+      "get": {
+        "operationId": "youtube-keyword-research",
+        "summary": "YouTube keyword research using Google's autocomplete API. For a seed topic, returns suggested search phrases plus intent clusters: questions people ask, tutorial/learning queries, comparison queries, and year-tagged trending terms. No API key. Upstream of youtube-niche-intel (competition scoring) an",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.059,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/youtube-niche-intel": {
+      "get": {
+        "operationId": "youtube-niche-intel",
+        "summary": "YouTube competitive intelligence for a keyword or niche: channel concentration, view velocity, saturation signal (SATURATED/MODERATE/OPEN), opportunity grade (A\u2013F), and dominant channels by view share.",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.025,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/youtube-playlist": {
+      "get": {
+        "operationId": "youtube-playlist",
+        "summary": "Fetch up to 50 videos from a YouTube playlist. Returns title, channel, duration, view count, and video URL for each entry. No API key required. Pair with youtube-intel to analyze individual videos from the list.",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.015,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/youtube-revenue-estimate": {
+      "get": {
+        "operationId": "youtube-revenue-estimate",
+        "summary": "Estimates a YouTube channel's monthly ad revenue using public view data + industry CPM benchmarks. Returns a low/mid/high monthly revenue range, detected content category, estimated monthly views, RPM tier, and confidence level. Accepts @handle, channel URL, or UCxxxxxxxx channel ID. No API key requ",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.025,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/youtube-search": {
+      "get": {
+        "operationId": "youtube-search",
+        "summary": "Search YouTube for videos matching a query. Returns up to 10 results with title, channel, view count, duration, and video URL. No API key required. Pair with youtube-intel for full metadata on selected videos.",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.015,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/youtube-transcript": {
+      "get": {
+        "operationId": "youtube-transcript",
+        "summary": "Full transcript extraction for any YouTube video. Downloads auto-generated English subtitles via yt-dlp (no auth), parses VTT into timestamped segments with deduplication, and returns both segment array and plain-text transcript. Format 'text' returns only the text string. Accepts any YouTube URL fo",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.039,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    },
+    "/cap/youtube-video-analytics": {
+      "get": {
+        "operationId": "youtube-video-analytics",
+        "summary": "Heuristic performance analysis for a single YouTube video: view velocity (views/day), engagement rate (likes+comments/views), view-to-sub ratio, and tier: VIRAL / HIGH_PERFORMING / AVERAGE / UNDERPERFORMING. Extends youtube-intel (raw metadata) by adding the scored interpretation layer that content ",
+        "tags": [
+          "capabilities"
+        ],
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "x-pricing": {
+          "currency": "USDC",
+          "rails": [
+            "base",
+            "solana"
+          ],
+          "price_usd": 0.015,
+          "scheme": "x402-exact"
+        },
+        "responses": {
+          "200": {
+            "description": "Structured JSON response \u2014 format varies by capability; see /catalog for per-cap output schemas."
+          },
+          "402": {
+            "description": "Payment Required \u2014 x402 challenge with accepted rails and price."
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Provider: The Stall by IntuiTek

292 pay-per-call AI data tools on Base and Solana mainnet. Finance, crypto, DeFi, equity, options, macro, OSINT, and research synthesis — no API keys or accounts required.

**New in this PR**: Solana mainnet-beta x402 rail (USDC) live alongside the existing Base EVM rail. Both rails declared in the `/.well-known/x402` manifest.

### Verification

- Live at: https://the-stall.intuitek.ai
- x402 manifest (both rails): https://the-stall.intuitek.ai/.well-known/x402
- Full catalog (292 caps): https://the-stall.intuitek.ai/catalog
- Health: https://the-stall.intuitek.ai/health

### Payment

| Rail | Address |
|------|---------|
| Solana mainnet-beta | `EairXDfN79D5cw8tYuqmSfFKjYr4jmpPezXCxmd9nztF` |
| Base mainnet (EVM) | `0x03d773c52B67993e60Ecb3134b17436fE03B584c` |

The 402 response body lists both accepted rails with per-cap pricing. Agents can pay on either rail.

### Provider: IntuiTek / William Kyle Million
