### PR TITLE
Add myvideogift/gifts provider (personalized gift videos, USDC)

### DIFF
--- a/providers/myvideogift/gifts/PAY.md
+++ b/providers/myvideogift/gifts/PAY.md
@@ -1,0 +1,40 @@
+---
+name: gifts
+title: "My Video Gift — Agent API"
+description: "Photos (and optional video clips) in, a finished personalized gift film with an original song out — one flat USDC price per delivered film."
+use_case: "Create + deliver a personalized gift VIDEO from someone's photos (and optional clips) set to an original occasion song — birthdays, anniversaries, weddings, graduations, memorials, and more. Choose over a static card or plain slideshow."
+category: media
+service_url: https://myvideogift-pay-gateway.fly.dev
+openapi:
+  path: openapi.json
+---
+
+Photos (and optional video clips) in, a finished personalized gift film with an
+original song out — one flat USDC price per delivered film. Discovery and the
+build steps are free; only the final render is paid.
+
+## Flow
+
+1. `GET /occasions` — pick a valid occasion slug (free).
+2. `GET /samples` — preview the quality per occasion (free, optional).
+3. `POST /gifts` — create + reserve a gift with the recipient, relationship,
+   occasion, a short memory/story, and a few feeling words (free). Keep the
+   returned `gift_id`.
+4. `POST /gifts/{gift_id}/photos` — add the recipient's photos by URL or base64,
+   up to 30 (free). Optional short video clips are supported too.
+5. `POST /gifts/{gift_id}/render` — **the one paid call.** Requires `consent:true`
+   (you attest rights to the photos and the recipient's depiction). Settled in USDC.
+6. `GET /gifts/{gift_id}` — poll until `status` is `delivered-paid`, then read
+   `film_url` (16x9 + 9x16) and the hosted `gift_url` (free).
+
+## Spend-aware usage
+
+- Everything except `render` is FREE. Only `POST /gifts/{gift_id}/render` costs
+  USDC (one flat price per delivered film) — reserve it for when the gift is ready.
+- Create the gift ONCE and reuse its `gift_id` for photos, render, and status.
+  Don't create duplicate gifts, and don't re-render a gift that already delivered
+  (read the URLs from `GET /gifts/{gift_id}` instead).
+- Confirm the recipient, occasion, and photos with the user BEFORE the paid render.
+- A render takes a few minutes — poll `GET /gifts/{gift_id}`; do NOT re-POST render
+  to "retry". A held or failed render is auto-made-good with a free re-render, so
+  never pay twice for the same gift.

--- a/providers/myvideogift/gifts/PAY.md
+++ b/providers/myvideogift/gifts/PAY.md
@@ -20,21 +20,24 @@ build steps are free; only the final render is paid.
 3. `POST /gifts` — create + reserve a gift with the recipient, relationship,
    occasion, a short memory/story, and a few feeling words (free). Keep the
    returned `gift_id`.
-4. `POST /gifts/{gift_id}/photos` — add the recipient's photos by URL or base64,
-   up to 30 (free). Optional short video clips are supported too.
-5. `POST /gifts/{gift_id}/render` — **the one paid call.** Requires `consent:true`
+4. `POST /gifts/{giftId}/photos` — add the recipient's photos by URL or base64,
+   up to 30 (free). Optionally `POST /gifts/{giftId}/clips` adds 1-3 short video
+   clips (up to 4MB each) — photos alone are enough.
+5. `POST /gifts/{giftId}/render` — **the one paid call.** Requires `consent:true`
    (you attest rights to the photos and the recipient's depiction). Settled in USDC.
-6. `GET /gifts/{gift_id}` — poll until `status` is `delivered-paid`, then read
+6. `GET /gifts/{giftId}` — poll until `status` is `delivered-paid`, then read
    `film_url` (16x9 + 9x16) and the hosted `gift_url` (free).
 
 ## Spend-aware usage
 
-- Everything except `render` is FREE. Only `POST /gifts/{gift_id}/render` costs
+- Everything except `render` is FREE. Only `POST /gifts/{giftId}/render` costs
   USDC (one flat price per delivered film) — reserve it for when the gift is ready.
 - Create the gift ONCE and reuse its `gift_id` for photos, render, and status.
   Don't create duplicate gifts, and don't re-render a gift that already delivered
-  (read the URLs from `GET /gifts/{gift_id}` instead).
+  (read the URLs from `GET /gifts/{giftId}` instead).
+- Every render delivers the **signature** tier at the single listed USDC price —
+  there is no cheaper tier on this channel, so `tier` needs no tuning.
 - Confirm the recipient, occasion, and photos with the user BEFORE the paid render.
-- A render takes a few minutes — poll `GET /gifts/{gift_id}`; do NOT re-POST render
+- A render takes a few minutes — poll `GET /gifts/{giftId}`; do NOT re-POST render
   to "retry". A held or failed render is auto-made-good with a free re-render, so
   never pay twice for the same gift.

--- a/providers/myvideogift/gifts/openapi.json
+++ b/providers/myvideogift/gifts/openapi.json
@@ -1,0 +1,150 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "My Video Gift — Agent API",
+    "version": "2026-07-09",
+    "description": "Photos (and optional video clips) in, a finished personalized gift film with an original song out — one flat USDC price per delivered film. Discovery + build steps are free; only the final render is paid.",
+    "contact": { "name": "My Video Gift", "url": "https://myvideogift.com", "email": "hello@myvideogift.com" }
+  },
+  "servers": [{ "url": "https://myvideogift-pay-gateway.fly.dev", "description": "pay.sh gateway (USDC on Solana)" }],
+  "paths": {
+    "/occasions": {
+      "get": {
+        "operationId": "listOccasions",
+        "summary": "List supported gift occasions",
+        "description": "Free. Returns the occasions you can create a gift for (slug, name, tone, photo ideas). Call this first to pick a valid `occasion` slug.",
+        "responses": { "200": { "description": "Occasions", "content": { "application/json": { "schema": { "type": "object", "properties": { "occasions": { "type": "array", "items": { "type": "object" } } } } } } } }
+      }
+    },
+    "/samples": {
+      "get": {
+        "operationId": "listSamples",
+        "summary": "List pre-rendered sample films",
+        "description": "Free. The 'what you get' quality gallery — finished sample films per occasion.",
+        "responses": { "200": { "description": "Samples", "content": { "application/json": { "schema": { "type": "object" } } } } }
+      }
+    },
+    "/gifts": {
+      "post": {
+        "operationId": "createGift",
+        "summary": "Create and reserve a gift",
+        "description": "Free. Reserves a gift and fixes its brief (occasion, recipient, story, feelings). Supports an Idempotency-Key header for safe retries. Returns a gift_id + share_slug.",
+        "requestBody": {
+          "required": true,
+          "content": { "application/json": { "schema": { "$ref": "#/components/schemas/CreateGift" } } }
+        },
+        "responses": {
+          "201": { "description": "Gift reserved", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/GiftCreated" } } } },
+          "400": { "description": "Invalid request" }
+        }
+      }
+    },
+    "/gifts/{giftId}/photos": {
+      "post": {
+        "operationId": "addPhotos",
+        "summary": "Add recipient photos (URL or base64)",
+        "description": "Free. Add 1–10 photos per call by public URL (SSRF-guarded fetch) or inline base64. Up to 30 photos per gift.",
+        "parameters": [{ "name": "giftId", "in": "path", "required": true, "description": "The gift_id returned by POST /gifts.", "schema": { "type": "string" } }],
+        "requestBody": {
+          "required": true,
+          "content": { "application/json": { "schema": { "$ref": "#/components/schemas/AddPhotos" } } }
+        },
+        "responses": {
+          "200": { "description": "Photos accepted", "content": { "application/json": { "schema": { "type": "object", "properties": { "photo_count": { "type": "integer" }, "photo_ids": { "type": "array", "items": { "type": "string" } } } } } } },
+          "400": { "description": "Invalid photo URL/data or photo limit reached" }
+        }
+      }
+    },
+    "/gifts/{giftId}": {
+      "get": {
+        "operationId": "getGift",
+        "summary": "Poll gift status (and delivery URLs once ready)",
+        "description": "Free. Poll after rendering; once status is 'delivered-paid' the response includes film_url (16x9 + 9x16) and the hosted gift_url. A held/failed render auto-refunds and can be re-rendered.",
+        "parameters": [{ "name": "giftId", "in": "path", "required": true, "description": "The gift_id returned by POST /gifts.", "schema": { "type": "string" } }],
+        "responses": {
+          "200": { "description": "Gift status", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/GiftStatus" } } } },
+          "404": { "description": "Not found" }
+        }
+      }
+    },
+    "/gifts/{giftId}/render": {
+      "post": {
+        "operationId": "renderGift",
+        "summary": "Render and deliver the film (PAID, USDC)",
+        "description": "The one paid action. Requires consent:true (you attest rights to the photos and the recipient's depiction). Payment is settled in USDC by the pay.sh gateway; the film renders and delivers (poll GET /gifts/{giftId} for the film URL). A failed/held render is made good with a free re-render.",
+        "parameters": [{ "name": "giftId", "in": "path", "required": true, "description": "The gift_id returned by POST /gifts.", "schema": { "type": "string" } }],
+        "requestBody": {
+          "required": true,
+          "content": { "application/json": { "schema": { "type": "object", "required": ["consent"], "properties": { "consent": { "type": "boolean", "enum": [true], "description": "Attests you hold the rights to these photos and to the recipient's depiction." } } } } }
+        },
+        "responses": {
+          "202": { "description": "Rendering started", "content": { "application/json": { "schema": { "type": "object", "properties": { "status": { "type": "string" }, "tier": { "type": "string" }, "poll_after_sec": { "type": "integer" } } } } } },
+          "402": { "description": "Payment required (x402 / USDC on Solana)" },
+          "409": { "description": "Not ready (needs a reservation + at least one photo)" }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "CreateGift": {
+        "type": "object",
+        "required": ["occasion", "recipient_name", "relationship"],
+        "properties": {
+          "occasion": { "type": "string", "description": "A slug from GET /occasions (e.g. 'anniversary-video')." },
+          "recipient_name": { "type": "string", "minLength": 1, "maxLength": 80, "description": "The gift recipient's name." },
+          "relationship": { "type": "string", "minLength": 1, "maxLength": 80, "description": "e.g. 'my wife', 'grandpa'." },
+          "memory": { "type": "string", "maxLength": 500 },
+          "story_note": { "type": "string", "maxLength": 500 },
+          "feeling_words": { "type": "array", "items": { "type": "string", "maxLength": 30 }, "maxItems": 6 },
+          "length_sec": { "type": "integer", "minimum": 30, "maximum": 180 },
+          "tier": { "type": "string", "enum": ["standard", "signature"], "default": "signature" }
+        }
+      },
+      "GiftCreated": {
+        "type": "object",
+        "properties": {
+          "gift_id": { "type": "string" },
+          "status": { "type": "string", "example": "reserved" },
+          "tier": { "type": "string" },
+          "occasion": { "type": "string" },
+          "share_slug": { "type": "string" },
+          "photo_limit": { "type": "integer" }
+        }
+      },
+      "AddPhotos": {
+        "type": "object",
+        "required": ["photos"],
+        "properties": {
+          "photos": {
+            "type": "array", "minItems": 1, "maxItems": 10, "description": "1-10 photos, each as {url} (public image URL) or {data,mime} (base64 bytes).",
+            "items": {
+              "oneOf": [
+                { "type": "object", "required": ["url"], "properties": { "url": { "type": "string", "format": "uri" } } },
+                { "type": "object", "required": ["data", "mime"], "properties": { "data": { "type": "string", "description": "base64" }, "mime": { "type": "string", "enum": ["image/jpeg", "image/png", "image/webp"] } } }
+              ]
+            }
+          },
+          "subject_photo_index": { "type": "integer", "minimum": 0, "description": "Which photo is the main subject." }
+        }
+      },
+      "GiftStatus": {
+        "type": "object",
+        "properties": {
+          "gift_id": { "type": "string" },
+          "status": { "type": "string", "description": "reserved | needs-content | delivered-paid | …" },
+          "tier": { "type": "string" },
+          "occasion": { "type": "string" },
+          "recipient_name": { "type": "string" },
+          "share_slug": { "type": "string" },
+          "photo_count": { "type": "integer" },
+          "clip_count": { "type": "integer" },
+          "created_at": { "type": "string", "format": "date-time" },
+          "fulfillment": { "type": "object", "nullable": true },
+          "film_url": { "type": "object", "properties": { "16x9": { "type": "string" }, "9x16": { "type": "string" } } },
+          "gift_url": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/providers/myvideogift/gifts/openapi.json
+++ b/providers/myvideogift/gifts/openapi.json
@@ -55,6 +55,23 @@
         }
       }
     },
+    "/gifts/{giftId}/clips": {
+      "post": {
+        "operationId": "addClips",
+        "summary": "Add short video clips (URL or base64)",
+        "description": "Free, optional. Add 1-3 short video clips per gift, each up to 4MB, by public URL (SSRF-guarded fetch) or inline base64. Larger clips (up to 500MB) use a separate two-step client-upload token flow. Photos alone are enough; clips are additive.",
+        "parameters": [{ "name": "giftId", "in": "path", "required": true, "description": "The gift_id returned by POST /gifts.", "schema": { "type": "string" } }],
+        "requestBody": {
+          "required": true,
+          "content": { "application/json": { "schema": { "$ref": "#/components/schemas/AddClips" } } }
+        },
+        "responses": {
+          "200": { "description": "Clips accepted", "content": { "application/json": { "schema": { "type": "object", "properties": { "clip_count": { "type": "integer" }, "clip_ids": { "type": "array", "items": { "type": "string" } } } } } } },
+          "400": { "description": "Invalid clip URL/data or clip limit reached" },
+          "404": { "description": "Gift not found" }
+        }
+      }
+    },
     "/gifts/{giftId}": {
       "get": {
         "operationId": "getGift",
@@ -80,6 +97,7 @@
         "responses": {
           "202": { "description": "Rendering started", "content": { "application/json": { "schema": { "type": "object", "properties": { "status": { "type": "string" }, "tier": { "type": "string" }, "poll_after_sec": { "type": "integer" } } } } } },
           "402": { "description": "Payment required (x402 / USDC on Solana)" },
+          "404": { "description": "Gift not found" },
           "409": { "description": "Not ready (needs a reservation + at least one photo)" }
         }
       }
@@ -126,6 +144,21 @@
             }
           },
           "subject_photo_index": { "type": "integer", "minimum": 0, "description": "Which photo is the main subject." }
+        }
+      },
+      "AddClips": {
+        "type": "object",
+        "required": ["clips"],
+        "properties": {
+          "clips": {
+            "type": "array", "minItems": 1, "maxItems": 3, "description": "1-3 short video clips, each up to 4MB, as {url} (public video URL) or {data,mime} (base64 bytes).",
+            "items": {
+              "oneOf": [
+                { "type": "object", "required": ["url"], "properties": { "url": { "type": "string", "format": "uri", "description": "Public URL to an mp4/mov/webm clip (up to 4MB)." }, "duration_sec": { "type": "number", "description": "Optional clip duration hint in seconds." } } },
+                { "type": "object", "required": ["data", "mime"], "properties": { "data": { "type": "string", "description": "base64-encoded clip bytes (up to 4MB)." }, "mime": { "type": "string", "enum": ["video/mp4", "video/quicktime", "video/webm"] }, "duration_sec": { "type": "number", "description": "Optional clip duration hint in seconds." } } }
+              ]
+            }
+          }
         }
       },
       "GiftStatus": {


### PR DESCRIPTION
Adds the **myvideogift/gifts** provider — personalized gift **videos** paid in USDC on Solana.

**What it is:** photos (and optional short video clips) in, a finished personalized gift film with an original song out. One flat USDC price per delivered film; all discovery + build steps (occasions, samples, create, photos, status) are **free** — only `POST /gifts/{giftId}/render` is paid.

**Gateway:** https://myvideogift-pay-gateway.fly.dev — live on Solana mainnet (`pay server start` fronting our API, settles USDC to our wallet, proxies the paid request upstream).

**This PR** (`providers/myvideogift/gifts/`):
- `PAY.md` (category `media`) + committed `openapi.json` sidecar (`openapi: { path: openapi.json }`)
- `pay catalog check` passes locally: 6 endpoints probed, **1/1 gates Solana-compatible**, parameterized 404s tolerated
- Two-level native layout; `name: gifts` matches the directory