### PR TITLE
Add Xona media provider

### DIFF
--- a/providers/xona/media/PAY.md
+++ b/providers/xona/media/PAY.md
@@ -1,0 +1,30 @@
+---
+name: media
+title: "Xona Media Generation"
+description: "AI media generation APIs: image generation and editing (FLUX.2, Nano Banana, GPT Image, Grok Imagine, Qwen, Seedream), 10-second video clips, music generation, text-to-speech voices, and audio transcription. Returns CDN URLs and metadata."
+use_case: "Use for generating images from text prompts, editing images with reference photos, creating short video clips, composing AI music tracks, converting text to speech, and transcribing audio files to text."
+category: media
+service_url: https://api.xona-agent.com
+openapi:
+  path: openapi.json
+---
+
+Pay-per-call AI media generation for agents. Every endpoint is x402-gated:
+an unpaid request returns an HTTP 402 challenge priced in USDC on Solana
+mainnet; pay and retry with the `payment-signature` header. Generated assets
+are returned as CDN URLs.
+
+## Spend-aware usage
+
+- Image models range from $0.04 (`/image/grok-imagine`) to $0.15
+  (`/image/nano-banana-pro`). Start with a cheaper model and only escalate if
+  the result quality is insufficient for the task.
+- `/image/creative-director` ($0.03) researches live X/Google trends to refine
+  a prompt. Call it once per concept and reuse the refined direction across
+  multiple generations rather than re-running it per image.
+- `/image/nano-banana-2` prices by resolution (1k $0.06 / 2k $0.10 / 4k $0.15)
+  — request the lowest resolution that satisfies the use case.
+- `/audio/elevenlabs-music` is priced by duration ($1 per 120 seconds, max 3
+  minutes). Request the shortest `music_length_ms` that fits.
+- `/video/short-generation` ($0.50) always produces a 10-second clip. Get the
+  prompt right in one call instead of iterating.

--- a/providers/xona/media/openapi.json
+++ b/providers/xona/media/openapi.json
@@ -1,0 +1,1612 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Xona Media Generation",
+    "version": "1.0.0",
+    "description": "AI media generation gated by x402 micropayments (USDC on Solana). Image generation and editing, short video generation, music generation, text-to-speech, and speech transcription. Results are returned as CDN URLs.\n\nx402 flow: call any endpoint without payment to receive an HTTP 402 challenge, pay in USDC on Solana mainnet, then retry the request with the payment-signature header."
+  },
+  "servers": [
+    {
+      "url": "https://api.xona-agent.com",
+      "description": "Production"
+    }
+  ],
+  "paths": {
+    "/image/creative-director": {
+      "post": {
+        "operationId": "image_creative_director",
+        "summary": "Generate a refined image prompt from live trend research",
+        "description": "AI-powered creative research and prompt refinement using X and Google. Analyzes trends, and transforms your idea into an optimized generation plan.\n\nPrice: $0.03 USDC per call.",
+        "responses": {
+          "200": {
+            "description": "Successful response (after x402 payment)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "intent": {
+                      "type": "object",
+                      "description": "Analyzed user intent from the prompt"
+                    },
+                    "research": {
+                      "type": "array",
+                      "description": "Research results from X and Google",
+                      "items": {
+                        "type": "object"
+                      }
+                    },
+                    "direction": {
+                      "type": "array",
+                      "description": "Generation plan with refined prompt",
+                      "items": {
+                        "type": "object"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required — x402 challenge (USDC on Solana mainnet). Pay the challenge, then retry with the payment-signature header.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "x402Version": {
+                      "type": "integer"
+                    },
+                    "accepts": {
+                      "type": "array",
+                      "items": {
+                        "type": "object"
+                      }
+                    },
+                    "resource": {
+                      "type": "object"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "idea": {
+                    "type": "string",
+                    "description": "User's prompt/idea for image generation"
+                  },
+                  "reference_images": {
+                    "type": "array",
+                    "description": "Array of existing image URLs to use as references",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": [
+                  "idea"
+                ]
+              },
+              "example": {
+                "idea": "A poster celebrating open-source AI agents"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/image/designer": {
+      "post": {
+        "operationId": "image_designer",
+        "summary": "Generate an image with style keyword blending",
+        "description": "AI image generation with intelligent style blending. Takes your prompt and style keywords, refines them together, and generates a high-quality image.\n\nPrice: $0.06 USDC per call.",
+        "responses": {
+          "200": {
+            "description": "Successful response (after x402 payment)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "image_url": {
+                      "type": "string",
+                      "description": "The generated image URL (CDN)"
+                    },
+                    "image_description": {
+                      "type": "string",
+                      "description": "The refined prompt used for generation"
+                    },
+                    "metadata": {
+                      "type": "object",
+                      "description": "Generation metadata including model info, parameters, etc."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required — x402 challenge (USDC on Solana mainnet). Pay the challenge, then retry with the payment-signature header.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "x402Version": {
+                      "type": "integer"
+                    },
+                    "accepts": {
+                      "type": "array",
+                      "items": {
+                        "type": "object"
+                      }
+                    },
+                    "resource": {
+                      "type": "object"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "prompt": {
+                    "type": "string",
+                    "description": "The detailed prompt description for image generation"
+                  },
+                  "style": {
+                    "type": "array",
+                    "description": "Style keywords to blend into the prompt",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "aspect_ratio": {
+                    "type": "string",
+                    "description": "Aspect ratio for the generated image (default: 1:1)"
+                  },
+                  "referenceImage": {
+                    "type": "array",
+                    "description": "Array of reference image URLs for style guidance",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": [
+                  "prompt"
+                ]
+              },
+              "example": {
+                "prompt": "A serene mountain landscape at golden hour, digital art"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/image/nano-banana-pro": {
+      "post": {
+        "operationId": "image_nano_banana_pro",
+        "summary": "Generate a high-quality image with Nano Banana Pro",
+        "description": "AI image generation using nano-banana-pro model. Takes your prompt and generates a high-quality image directly without style blending.\n\nPrice: $0.15 USDC per call.",
+        "responses": {
+          "200": {
+            "description": "Successful response (after x402 payment)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "image_url": {
+                      "type": "string",
+                      "description": "The generated image URL (CDN)"
+                    },
+                    "image_description": {
+                      "type": "string",
+                      "description": "The prompt used for generation"
+                    },
+                    "metadata": {
+                      "type": "object",
+                      "description": "Generation metadata including model info, parameters, etc."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required — x402 challenge (USDC on Solana mainnet). Pay the challenge, then retry with the payment-signature header.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "x402Version": {
+                      "type": "integer"
+                    },
+                    "accepts": {
+                      "type": "array",
+                      "items": {
+                        "type": "object"
+                      }
+                    },
+                    "resource": {
+                      "type": "object"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "prompt": {
+                    "type": "string",
+                    "description": "The detailed prompt description for image generation"
+                  },
+                  "aspect_ratio": {
+                    "type": "string",
+                    "description": "Aspect ratio for the generated image (default: 1:1)"
+                  },
+                  "referenceImage": {
+                    "type": "array",
+                    "description": "Array of reference image URLs for style guidance",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": [
+                  "prompt"
+                ]
+              },
+              "example": {
+                "prompt": "A serene mountain landscape at golden hour, digital art"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/image/nano-banana": {
+      "post": {
+        "operationId": "image_nano_banana",
+        "summary": "Generate an image quickly with Nano Banana",
+        "description": "AI image generation using nano-banana model. Takes your prompt and generates a high-quality image directly without style blending.\n\nPrice: $0.05 USDC per call.",
+        "responses": {
+          "200": {
+            "description": "Successful response (after x402 payment)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "image_url": {
+                      "type": "string",
+                      "description": "The generated image URL (CDN)"
+                    },
+                    "image_description": {
+                      "type": "string",
+                      "description": "The prompt used for generation"
+                    },
+                    "metadata": {
+                      "type": "object",
+                      "description": "Generation metadata including model info, parameters, etc."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required — x402 challenge (USDC on Solana mainnet). Pay the challenge, then retry with the payment-signature header.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "x402Version": {
+                      "type": "integer"
+                    },
+                    "accepts": {
+                      "type": "array",
+                      "items": {
+                        "type": "object"
+                      }
+                    },
+                    "resource": {
+                      "type": "object"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "prompt": {
+                    "type": "string",
+                    "description": "The detailed prompt description for image generation"
+                  },
+                  "aspect_ratio": {
+                    "type": "string",
+                    "description": "Aspect ratio for the generated image (default: 1:1)"
+                  },
+                  "referenceImage": {
+                    "type": "array",
+                    "description": "Array of reference image URLs for style guidance",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": [
+                  "prompt"
+                ]
+              },
+              "example": {
+                "prompt": "A serene mountain landscape at golden hour, digital art"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/image/gpt-image-2": {
+      "post": {
+        "operationId": "image_gpt_image_2",
+        "summary": "Generate a photorealistic image with GPT Image 2",
+        "description": "AI image generation using GPT Image 2 (OpenAI via Replicate). High-quality photorealism, sharp text rendering, and strong instruction following. Quality: medium.\n\nPrice: $0.12 USDC per call.",
+        "responses": {
+          "200": {
+            "description": "Successful response (after x402 payment)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "image_url": {
+                      "type": "string",
+                      "description": "URL to generated image on CDN"
+                    },
+                    "image_description": {
+                      "type": "string",
+                      "description": "The prompt used for generation"
+                    },
+                    "metadata": {
+                      "type": "object",
+                      "description": "Generation metadata including model, quality, aspectRatio"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required — x402 challenge (USDC on Solana mainnet). Pay the challenge, then retry with the payment-signature header.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "x402Version": {
+                      "type": "integer"
+                    },
+                    "accepts": {
+                      "type": "array",
+                      "items": {
+                        "type": "object"
+                      }
+                    },
+                    "resource": {
+                      "type": "object"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "prompt": {
+                    "type": "string",
+                    "description": "Detailed prompt describing the desired image"
+                  },
+                  "aspect_ratio": {
+                    "type": "string",
+                    "description": "Aspect ratio: 1:1 (square), 3:2 (landscape), or 2:3 (portrait). Default: 1:1"
+                  }
+                },
+                "required": [
+                  "prompt"
+                ]
+              },
+              "example": {
+                "prompt": "A serene mountain landscape at golden hour, digital art"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/image/nano-banana-2": {
+      "post": {
+        "operationId": "image_nano_banana_2",
+        "summary": "Generate an image with resolution-based pricing",
+        "description": "AI image generation using nano-banana-2 model with resolution-based pricing. Dynamic pricing: 1K=$0.06, 2K=$0.10, 4K=$0.15.\n\nPrice: $0.15 USDC per call.",
+        "responses": {
+          "200": {
+            "description": "Successful response (after x402 payment)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "image_url": {
+                      "type": "string",
+                      "description": "The generated image URL (CDN)"
+                    },
+                    "image_description": {
+                      "type": "string",
+                      "description": "The prompt used for generation"
+                    },
+                    "metadata": {
+                      "type": "object",
+                      "description": "Generation metadata including model info, resolution, parameters, etc."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required — x402 challenge (USDC on Solana mainnet). Pay the challenge, then retry with the payment-signature header.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "x402Version": {
+                      "type": "integer"
+                    },
+                    "accepts": {
+                      "type": "array",
+                      "items": {
+                        "type": "object"
+                      }
+                    },
+                    "resource": {
+                      "type": "object"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "prompt": {
+                    "type": "string",
+                    "description": "The detailed prompt description for image generation"
+                  },
+                  "resolution": {
+                    "type": "string",
+                    "description": "Output resolution. Options: 1k (1024px, $0.06), 2k (2048px, $0.10), 4k (4096px, $0.15). Default: 1k"
+                  },
+                  "aspect_ratio": {
+                    "type": "string",
+                    "description": "Aspect ratio for the generated image (default: 1:1)"
+                  },
+                  "referenceImage": {
+                    "type": "array",
+                    "description": "Array of reference image URLs for style guidance",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": [
+                  "prompt"
+                ]
+              },
+              "example": {
+                "prompt": "A serene mountain landscape at golden hour, digital art"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/image/grok-imagine": {
+      "post": {
+        "operationId": "image_grok_imagine",
+        "summary": "Generate an image with xAI Grok Imagine",
+        "description": "AI image generation using Grok Imagine model. Takes your prompt and generates a high-quality image using xAI's Grok Imagine API.\n\nPrice: $0.04 USDC per call.",
+        "responses": {
+          "200": {
+            "description": "Successful response (after x402 payment)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "image_url": {
+                      "type": "string",
+                      "description": "The generated image URL (CDN)"
+                    },
+                    "image_description": {
+                      "type": "string",
+                      "description": "The prompt used for generation"
+                    },
+                    "metadata": {
+                      "type": "object",
+                      "description": "Generation metadata including model info, parameters, etc."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required — x402 challenge (USDC on Solana mainnet). Pay the challenge, then retry with the payment-signature header.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "x402Version": {
+                      "type": "integer"
+                    },
+                    "accepts": {
+                      "type": "array",
+                      "items": {
+                        "type": "object"
+                      }
+                    },
+                    "resource": {
+                      "type": "object"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "prompt": {
+                    "type": "string",
+                    "description": "The detailed prompt description for image generation"
+                  },
+                  "referenceImage": {
+                    "type": "string",
+                    "description": "Single reference image URL for style guidance (Grok only supports one image)"
+                  }
+                },
+                "required": [
+                  "prompt"
+                ]
+              },
+              "example": {
+                "prompt": "A serene mountain landscape at golden hour, digital art"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/video/short-generation": {
+      "post": {
+        "operationId": "video_short_generation",
+        "summary": "Generate a 10-second video with Grok Imagine",
+        "description": "AI short video generation using Grok Imagine Video model. Takes your prompt and generates a 10-second high-quality video using xAI's Grok Video API.\n\nPrice: $0.5 USDC per call.",
+        "responses": {
+          "200": {
+            "description": "Successful response (after x402 payment)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "video_url": {
+                      "type": "string",
+                      "description": "The generated video URL"
+                    },
+                    "duration": {
+                      "type": "number",
+                      "description": "Video duration in seconds (always 10)"
+                    },
+                    "model": {
+                      "type": "string",
+                      "description": "Model used for generation"
+                    },
+                    "metadata": {
+                      "type": "object",
+                      "description": "Generation metadata including request_id, aspect_ratio, etc."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required — x402 challenge (USDC on Solana mainnet). Pay the challenge, then retry with the payment-signature header.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "x402Version": {
+                      "type": "integer"
+                    },
+                    "accepts": {
+                      "type": "array",
+                      "items": {
+                        "type": "object"
+                      }
+                    },
+                    "resource": {
+                      "type": "object"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "prompt": {
+                    "type": "string",
+                    "description": "Prompt for video generation"
+                  },
+                  "aspect_ratio": {
+                    "type": "string",
+                    "description": "Video aspect ratio"
+                  },
+                  "image_url": {
+                    "type": "string",
+                    "description": "Optional input image URL for image-to-video generation"
+                  }
+                },
+                "required": [
+                  "prompt"
+                ]
+              },
+              "example": {
+                "prompt": "A serene mountain landscape at golden hour, digital art"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/audio/elevenlabs-music": {
+      "post": {
+        "operationId": "audio_elevenlabs_music",
+        "summary": "Generate music from a text prompt",
+        "description": "AI music generation using ElevenLabs Music (Replicate). Dynamic pricing: $1 per 120 seconds, max 3 minutes ($1.50).\n\nPrice: $1.5 USDC per call.",
+        "responses": {
+          "200": {
+            "description": "Successful response (after x402 payment)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "music_url": {
+                      "type": "string",
+                      "description": "The generated audio URL (CDN)"
+                    },
+                    "duration_seconds": {
+                      "type": "number",
+                      "description": "Duration in seconds"
+                    },
+                    "metadata": {
+                      "type": "object",
+                      "description": "Generation metadata"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required — x402 challenge (USDC on Solana mainnet). Pay the challenge, then retry with the payment-signature header.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "x402Version": {
+                      "type": "integer"
+                    },
+                    "accepts": {
+                      "type": "array",
+                      "items": {
+                        "type": "object"
+                      }
+                    },
+                    "resource": {
+                      "type": "object"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "prompt": {
+                    "type": "string",
+                    "description": "Description of the music to generate"
+                  },
+                  "output_format": {
+                    "type": "string",
+                    "description": "Output format (e.g. mp3_standard)"
+                  },
+                  "music_length_ms": {
+                    "type": "number",
+                    "description": "Duration in milliseconds (min 1000, max 180000). Price = music_length_ms/120000 USD."
+                  },
+                  "force_instrumental": {
+                    "type": "boolean",
+                    "description": "Force instrumental output"
+                  }
+                },
+                "required": [
+                  "prompt"
+                ]
+              },
+              "example": {
+                "prompt": "A serene mountain landscape at golden hour, digital art"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/audio/x-text-to-speech": {
+      "post": {
+        "operationId": "audio_x_text_to_speech",
+        "summary": "Convert text to speech with xAI voices",
+        "description": "X.AI text-to-speech: convert text to speech (MP3).\n\nPrice: $0.01 USDC per call.",
+        "responses": {
+          "200": {
+            "description": "Successful response (after x402 payment)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "audio_url": {
+                      "type": "string",
+                      "description": "Generated audio URL (CDN)"
+                    },
+                    "duration_seconds": {
+                      "type": "number",
+                      "description": "Duration in seconds (optional)"
+                    },
+                    "metadata": {
+                      "type": "object",
+                      "description": "Generation metadata"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required — x402 challenge (USDC on Solana mainnet). Pay the challenge, then retry with the payment-signature header.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "x402Version": {
+                      "type": "integer"
+                    },
+                    "accepts": {
+                      "type": "array",
+                      "items": {
+                        "type": "object"
+                      }
+                    },
+                    "resource": {
+                      "type": "object"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "text": {
+                    "type": "string",
+                    "description": "Text to convert to speech"
+                  },
+                  "voice_id": {
+                    "type": "string",
+                    "description": "Voice: Eve, Ara, Leo, Rex, or Sal"
+                  },
+                  "output_format": {
+                    "type": "object",
+                    "description": "Optional: codec, sample_rate, bit_rate"
+                  }
+                },
+                "required": [
+                  "text"
+                ]
+              },
+              "example": {
+                "text": "Hello from Xona, pay-per-call AI for autonomous agents."
+              }
+            }
+          }
+        }
+      }
+    },
+    "/audio/speech-to-text": {
+      "post": {
+        "operationId": "audio_speech_to_text",
+        "summary": "Transcribe audio from a URL to text",
+        "description": "Speech-to-text: transcribe audio from a URL using OpenAI GPT-4o Transcribe (Replicate).\n\nPrice: $0.02 USDC per call.",
+        "responses": {
+          "200": {
+            "description": "Successful response (after x402 payment)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "text": {
+                      "type": "string",
+                      "description": "Transcribed text"
+                    },
+                    "metadata": {
+                      "type": "object",
+                      "description": "Model and language metadata"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required — x402 challenge (USDC on Solana mainnet). Pay the challenge, then retry with the payment-signature header.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "x402Version": {
+                      "type": "integer"
+                    },
+                    "accepts": {
+                      "type": "array",
+                      "items": {
+                        "type": "object"
+                      }
+                    },
+                    "resource": {
+                      "type": "object"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "audio_file": {
+                    "type": "string",
+                    "description": "HTTPS URL of the audio file to transcribe (e.g. MP3)"
+                  },
+                  "language": {
+                    "type": "string",
+                    "description": "Language code (default: en)"
+                  }
+                },
+                "required": [
+                  "audio_file"
+                ]
+              },
+              "example": {
+                "audio_file": "https://download.samplelib.com/mp3/sample-3s.mp3"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/image-model/qwen-image": {
+      "post": {
+        "operationId": "image_model_qwen_image",
+        "summary": "Generate an image with Qwen Image",
+        "description": "AI image generation using qwen/qwen-image model. Generate high-quality images with advanced AI capabilities using Dexter x402 v2 middleware.\n\nPrice: $0.05 USDC per call.",
+        "responses": {
+          "200": {
+            "description": "Successful response (after x402 payment)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "image_url": {
+                      "type": "string",
+                      "description": "The generated image URL (CDN)"
+                    },
+                    "image_description": {
+                      "type": "string",
+                      "description": "The prompt used for generation"
+                    },
+                    "metadata": {
+                      "type": "object",
+                      "description": "Generation metadata including model info, parameters, etc.",
+                      "properties": {
+                        "model": {
+                          "type": "string",
+                          "description": "Model name used for generation"
+                        },
+                        "aspectRatio": {
+                          "type": "string",
+                          "description": "Aspect ratio used for generation"
+                        },
+                        "reference_images": {
+                          "type": "array",
+                          "description": "Reference images used",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required — x402 challenge (USDC on Solana mainnet). Pay the challenge, then retry with the payment-signature header.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "x402Version": {
+                      "type": "integer"
+                    },
+                    "accepts": {
+                      "type": "array",
+                      "items": {
+                        "type": "object"
+                      }
+                    },
+                    "resource": {
+                      "type": "object"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "prompt": {
+                    "type": "string",
+                    "description": "The detailed prompt description for image generation"
+                  },
+                  "aspect_ratio": {
+                    "type": "string",
+                    "description": "Aspect ratio for the generated image (default: 1:1)"
+                  },
+                  "referenceImage": {
+                    "type": "array",
+                    "description": "Array of reference image URLs (uses first image for qwen/qwen-image)",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": [
+                  "prompt"
+                ]
+              },
+              "example": {
+                "prompt": "A serene mountain landscape at golden hour, digital art"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/image-model/seedream-4.5": {
+      "post": {
+        "operationId": "image_model_seedream_4_5",
+        "summary": "Generate an image with ByteDance Seedream 4.5",
+        "description": "AI image generation using ByteDance Seedream-4.5 model. Generate high-quality images with advanced AI capabilities using Dexter x402 v2 middleware.\n\nPrice: $0.08 USDC per call.",
+        "responses": {
+          "200": {
+            "description": "Successful response (after x402 payment)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "image_url": {
+                      "type": "string",
+                      "description": "The generated image URL (CDN)"
+                    },
+                    "image_description": {
+                      "type": "string",
+                      "description": "The prompt used for generation"
+                    },
+                    "metadata": {
+                      "type": "object",
+                      "description": "Generation metadata including model info, parameters, etc.",
+                      "properties": {
+                        "model": {
+                          "type": "string",
+                          "description": "Model name used for generation"
+                        },
+                        "aspectRatio": {
+                          "type": "string",
+                          "description": "Aspect ratio used for generation"
+                        },
+                        "reference_images": {
+                          "type": "array",
+                          "description": "Reference images used",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required — x402 challenge (USDC on Solana mainnet). Pay the challenge, then retry with the payment-signature header.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "x402Version": {
+                      "type": "integer"
+                    },
+                    "accepts": {
+                      "type": "array",
+                      "items": {
+                        "type": "object"
+                      }
+                    },
+                    "resource": {
+                      "type": "object"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "prompt": {
+                    "type": "string",
+                    "description": "The detailed prompt description for image generation"
+                  },
+                  "aspect_ratio": {
+                    "type": "string",
+                    "description": "Aspect ratio for the generated image (default: 1:1)"
+                  },
+                  "referenceImage": {
+                    "type": "array",
+                    "description": "Array of reference image URLs for style guidance",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": [
+                  "prompt"
+                ]
+              },
+              "example": {
+                "prompt": "A serene mountain landscape at golden hour, digital art"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/image/flux-2-pro": {
+      "post": {
+        "operationId": "image_flux_2_pro",
+        "summary": "Generate or edit an image with FLUX.2 Pro",
+        "description": "High-quality image generation and editing with support for eight reference images\n\nPrice: $0.06 USDC per call.",
+        "responses": {
+          "200": {
+            "description": "Successful response (after x402 payment)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "image_url": {
+                      "type": "string",
+                      "description": "Generated image URL (CDN)"
+                    },
+                    "image_description": {
+                      "type": "string",
+                      "description": "Prompt used"
+                    },
+                    "metadata": {
+                      "type": "object",
+                      "description": "Model, parameters, CDN key, upstream image URL",
+                      "properties": {
+                        "model": {
+                          "type": "string"
+                        },
+                        "resolution": {
+                          "type": "string"
+                        },
+                        "aspect_ratio": {
+                          "type": "string"
+                        },
+                        "output_format": {
+                          "type": "string"
+                        },
+                        "replicate_url": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required — x402 challenge (USDC on Solana mainnet). Pay the challenge, then retry with the payment-signature header.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "x402Version": {
+                      "type": "integer"
+                    },
+                    "accepts": {
+                      "type": "array",
+                      "items": {
+                        "type": "object"
+                      }
+                    },
+                    "resource": {
+                      "type": "object"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "prompt": {
+                    "type": "string",
+                    "description": "Text prompt for image generation"
+                  },
+                  "resolution": {
+                    "type": "string",
+                    "description": "Output resolution label, e.g. \"1 MP\""
+                  },
+                  "aspect_ratio": {
+                    "type": "string",
+                    "description": "Aspect ratio, e.g. \"1:1\"; use \"custom\" with width and height"
+                  },
+                  "input_images": {
+                    "type": "array",
+                    "description": "HTTPS URLs of reference images (limits vary by model)",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "output_format": {
+                    "type": "string",
+                    "description": "webp, png, or jpg"
+                  },
+                  "output_quality": {
+                    "type": "number",
+                    "description": "Encoder quality 0–100"
+                  },
+                  "safety_tolerance": {
+                    "type": "number",
+                    "description": "Safety tolerance 1 (strict) to 5 (permissive); default 2"
+                  },
+                  "seed": {
+                    "type": "number",
+                    "description": "Optional seed for reproducible generation"
+                  },
+                  "width": {
+                    "type": "number",
+                    "description": "Width when aspect_ratio is custom (multiple of 16)"
+                  },
+                  "height": {
+                    "type": "number",
+                    "description": "Height when aspect_ratio is custom (multiple of 16)"
+                  }
+                },
+                "required": [
+                  "prompt"
+                ]
+              },
+              "example": {
+                "prompt": "A serene mountain landscape at golden hour, digital art"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/image/flux-2-max": {
+      "post": {
+        "operationId": "image_flux_2_max",
+        "summary": "Generate a highest-fidelity image with FLUX.2 Max",
+        "description": "The highest fidelity image model from Black Forest Labs\n\nPrice: $0.1 USDC per call.",
+        "responses": {
+          "200": {
+            "description": "Successful response (after x402 payment)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "image_url": {
+                      "type": "string",
+                      "description": "Generated image URL (CDN)"
+                    },
+                    "image_description": {
+                      "type": "string",
+                      "description": "Prompt used"
+                    },
+                    "metadata": {
+                      "type": "object",
+                      "description": "Model, parameters, CDN key, upstream image URL",
+                      "properties": {
+                        "model": {
+                          "type": "string"
+                        },
+                        "resolution": {
+                          "type": "string"
+                        },
+                        "aspect_ratio": {
+                          "type": "string"
+                        },
+                        "output_format": {
+                          "type": "string"
+                        },
+                        "replicate_url": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required — x402 challenge (USDC on Solana mainnet). Pay the challenge, then retry with the payment-signature header.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "x402Version": {
+                      "type": "integer"
+                    },
+                    "accepts": {
+                      "type": "array",
+                      "items": {
+                        "type": "object"
+                      }
+                    },
+                    "resource": {
+                      "type": "object"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "prompt": {
+                    "type": "string",
+                    "description": "Text prompt for image generation"
+                  },
+                  "resolution": {
+                    "type": "string",
+                    "description": "Output resolution label, e.g. \"1 MP\""
+                  },
+                  "aspect_ratio": {
+                    "type": "string",
+                    "description": "Aspect ratio, e.g. \"1:1\"; use \"custom\" with width and height"
+                  },
+                  "input_images": {
+                    "type": "array",
+                    "description": "HTTPS URLs of reference images (limits vary by model)",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "output_format": {
+                    "type": "string",
+                    "description": "webp, png, or jpg"
+                  },
+                  "output_quality": {
+                    "type": "number",
+                    "description": "Encoder quality 0–100"
+                  },
+                  "safety_tolerance": {
+                    "type": "number",
+                    "description": "Safety tolerance 1 (strict) to 5 (permissive); default 2"
+                  },
+                  "seed": {
+                    "type": "number",
+                    "description": "Optional seed for reproducible generation"
+                  },
+                  "width": {
+                    "type": "number",
+                    "description": "Width when aspect_ratio is custom (multiple of 16)"
+                  },
+                  "height": {
+                    "type": "number",
+                    "description": "Height when aspect_ratio is custom (multiple of 16)"
+                  }
+                },
+                "required": [
+                  "prompt"
+                ]
+              },
+              "example": {
+                "prompt": "A serene mountain landscape at golden hour, digital art"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/image/flux-2-flex": {
+      "post": {
+        "operationId": "image_flux_2_flex",
+        "summary": "Generate or edit an image with FLUX.2 Flex",
+        "description": "Max-quality image generation and editing with support for ten reference images\n\nPrice: $0.05 USDC per call.",
+        "responses": {
+          "200": {
+            "description": "Successful response (after x402 payment)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "image_url": {
+                      "type": "string",
+                      "description": "Generated image URL (CDN)"
+                    },
+                    "image_description": {
+                      "type": "string",
+                      "description": "Prompt used"
+                    },
+                    "metadata": {
+                      "type": "object",
+                      "description": "Model, parameters, CDN key, upstream image URL",
+                      "properties": {
+                        "model": {
+                          "type": "string"
+                        },
+                        "resolution": {
+                          "type": "string"
+                        },
+                        "aspect_ratio": {
+                          "type": "string"
+                        },
+                        "output_format": {
+                          "type": "string"
+                        },
+                        "replicate_url": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required — x402 challenge (USDC on Solana mainnet). Pay the challenge, then retry with the payment-signature header.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "x402Version": {
+                      "type": "integer"
+                    },
+                    "accepts": {
+                      "type": "array",
+                      "items": {
+                        "type": "object"
+                      }
+                    },
+                    "resource": {
+                      "type": "object"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "prompt": {
+                    "type": "string",
+                    "description": "Text prompt for image generation"
+                  },
+                  "resolution": {
+                    "type": "string",
+                    "description": "Output resolution label, e.g. \"1 MP\""
+                  },
+                  "aspect_ratio": {
+                    "type": "string",
+                    "description": "Aspect ratio, e.g. \"1:1\"; use \"custom\" with width and height"
+                  },
+                  "input_images": {
+                    "type": "array",
+                    "description": "HTTPS URLs of reference images (limits vary by model)",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "output_format": {
+                    "type": "string",
+                    "description": "webp, png, or jpg"
+                  },
+                  "output_quality": {
+                    "type": "number",
+                    "description": "Encoder quality 0–100"
+                  },
+                  "safety_tolerance": {
+                    "type": "number",
+                    "description": "Safety tolerance 1 (strict) to 5 (permissive); default 2"
+                  },
+                  "seed": {
+                    "type": "number",
+                    "description": "Optional seed for reproducible generation"
+                  },
+                  "width": {
+                    "type": "number",
+                    "description": "Width when aspect_ratio is custom (multiple of 16)"
+                  },
+                  "height": {
+                    "type": "number",
+                    "description": "Height when aspect_ratio is custom (multiple of 16)"
+                  }
+                },
+                "required": [
+                  "prompt"
+                ]
+              },
+              "example": {
+                "prompt": "A serene mountain landscape at golden hour, digital art"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/providers/xona/media/openapi.json
+++ b/providers/xona/media/openapi.json
@@ -468,7 +468,7 @@
       "post": {
         "operationId": "image_nano_banana_2",
         "summary": "Generate an image with resolution-based pricing",
-        "description": "AI image generation using nano-banana-2 model with resolution-based pricing. Dynamic pricing: 1K=$0.06, 2K=$0.10, 4K=$0.15.\n\nPrice: $0.15 USDC per call.",
+        "description": "AI image generation using nano-banana-2 model with resolution-based pricing. Dynamic pricing: 1K=$0.06, 2K=$0.10, 4K=$0.15.\n\nPrice: resolution-based — $0.06 (1k), $0.10 (2k), or $0.15 (4k) USDC per call. The 402 challenge carries the exact amount.",
         "responses": {
           "200": {
             "description": "Successful response (after x402 payment)",
@@ -736,7 +736,7 @@
       "post": {
         "operationId": "audio_elevenlabs_music",
         "summary": "Generate music from a text prompt",
-        "description": "AI music generation using ElevenLabs Music (Replicate). Dynamic pricing: $1 per 120 seconds, max 3 minutes ($1.50).\n\nPrice: $1.5 USDC per call.",
+        "description": "AI music generation using ElevenLabs Music (Replicate). Dynamic pricing: $1 per 120 seconds, max 3 minutes ($1.50).\n\nPrice: duration-based — $1 USDC per 120 seconds of requested music_length_ms, max 3 minutes ($1.50 covers the full 3 minutes). The 402 challenge carries the exact amount.",
         "responses": {
           "200": {
             "description": "Successful response (after x402 payment)",
@@ -895,7 +895,21 @@
                   },
                   "output_format": {
                     "type": "object",
-                    "description": "Optional: codec, sample_rate, bit_rate"
+                    "description": "Optional: codec, sample_rate, bit_rate",
+                    "properties": {
+                      "codec": {
+                        "type": "string",
+                        "description": "Audio codec (e.g. mp3)"
+                      },
+                      "sample_rate": {
+                        "type": "number",
+                        "description": "Sample rate in Hz (e.g. 44100)"
+                      },
+                      "bit_rate": {
+                        "type": "number",
+                        "description": "Bit rate in bps (e.g. 192000)"
+                      }
+                    }
                   }
                 },
                 "required": [


### PR DESCRIPTION
## Provider

- **FQN:** `xona/media`
- **Service URL:** https://api.xona-agent.com

## Summary

Adds Xona Media Generation — pay-per-call AI media generation for agents, gated by x402 (USDC on Solana mainnet). Generated assets are returned as CDN URLs.

**Image (12 endpoints)**
- `POST /image/creative-director` — trend-researched prompt refinement ($0.03)
- `POST /image/designer` — generation with style keyword blending ($0.06)
- `POST /image/nano-banana`, `/nano-banana-pro`, `/nano-banana-2` — fast / high-quality / resolution-priced generation ($0.05 / $0.15 / $0.06–$0.15)
- `POST /image/grok-imagine`, `/gpt-image-2` — xAI Grok and OpenAI GPT Image 2 ($0.04 / $0.12)
- `POST /image/flux-2-pro`, `/flux-2-max`, `/flux-2-flex` — Black Forest Labs FLUX.2 ($0.05–$0.10)
- `POST /image-model/qwen-image`, `/seedream-4.5` — Qwen and ByteDance Seedream ($0.05 / $0.08)

**Video (1 endpoint)**
- `POST /video/short-generation` — 10-second clips via Grok Imagine ($0.50)

**Audio (3 endpoints)**
- `POST /audio/elevenlabs-music` — music generation, duration-priced ($1 per 120s, max 3 min)
- `POST /audio/x-text-to-speech` — xAI TTS with named voices ($0.01)
- `POST /audio/speech-to-text` — transcription from audio URL ($0.02)

The OpenAPI sidecar is a committed snapshot generated from the service's live `/x402-resources` discovery document. Spend-aware usage notes cover model price laddering and duration/resolution pricing.

## Validation

```bash
pay catalog check providers/xona/media/PAY.md   # 16/16 gates compatible with Solana
pay catalog check . --changed-from origin/main  # mirrors PR CI — pass
pay catalog check . --no-probe                  # registry-wide static check — pass
```

## Checklist

- [x] OpenAPI spec committed as sidecar (`openapi: { path: openapi.json }`)
- [x] `name:` matches parent directory
- [x] `description` 64–255 chars
- [x] `use_case` 32–255 chars
- [x] No TODO placeholders
- [x] `service_url` is production HTTPS
- [x] Free endpoints omit pricing (n/a — all listed endpoints are paid)
- [x] Paid endpoints return HTTP 402 with x402 Solana/USDC challenge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
