### PR TITLE
Add SuVerse Pay crypto verdicts + Solana swap provider

### DIFF
--- a/providers/suverse/data/PAY.md
+++ b/providers/suverse/data/PAY.md
@@ -1,0 +1,76 @@
+---
+name: data
+title: "SuVerse Pay"
+description: "Pay-per-call crypto decision APIs: Polymarket smart-money sheet, Solana token entry verdicts, market regime calls, Base token contract forensics, x402 endpoint liveness grading, and Jupiter-routed USDC swap quotes on Solana."
+use_case: "Use for pre-trade Solana token safety checks, Polymarket smart-money positioning, crypto market regime detection, Base token due diligence, probing x402 payment endpoints, and quoting USDC token swaps on Solana."
+category: finance
+service_url: https://proxy.suverse.io
+version: v1
+openapi:
+  path: openapi.json
+---
+
+SuVerse Pay is an x402 payment gateway. This entry lists its curated
+first-party products: five verdict endpoints that compress multi-source
+crypto research into a single machine-readable call, plus a Jupiter-routed
+Solana swap. Every endpoint answers with a verdict-first JSON object — the
+decision comes first, the evidence and a `data_quality` disclosure follow —
+so an agent can act on the top-level field and only dig into the raw layer
+when the task demands it.
+
+All endpoints are POST with JSON bodies. An unpaid request returns an
+HTTP 402 challenge that includes a machine-readable `input_schema`, so an
+agent can discover the exact request shape for free before paying. Payment
+is accepted on Solana mainnet in USDC. Critical upstream sources are proven
+before payment settles (fail-closed); enrichment sources degrade gracefully
+and the degradation is disclosed in `data_quality`. Post-settle failures are
+automatically refunded.
+
+## Endpoints
+
+- `POST /v1/data/polymarket-smart-sheet` ($0.75) — ranked sheet of every
+  active Polymarket market where tracked smart money currently has an edge:
+  direction, conviction-based confidence, whale flow, entrant skill, holder
+  concentration, and a single strongest pick.
+- `POST /v1/data/token-entry-verdict` ($0.50) — ENTER / CAUTION / AVOID
+  verdict for a Solana token mint, combining token safety checks, fresh
+  24h/7d smart-money netflow, and wallet-label context.
+- `POST /v1/data/market-regime-verdict` ($0.50) — risk_on / risk_off / chop
+  call for the crypto market, combining market pulse, Binance funding, and
+  stablecoin supply trends.
+- `POST /v1/data/base-token-forensics` ($0.35) — CLEAN / WATCH / RED_FLAG
+  verdict for a Base (eip155:8453) token contract from contract metadata,
+  holder distribution, and transaction decoding.
+- `POST /v1/data/x402-liveness-check` ($0.25) — ALIVE / DEGRADED / DEAD
+  grade for any third-party x402 endpoint: probes it unpaid and grades the
+  402 challenge it returns. Private-network targets are rejected before
+  payment settles.
+- `POST /v1/swap/solana/quote` ($0.001) — firm Jupiter-routed quote for a
+  USDC↔token swap on Solana mainnet. The response carries a `quote_id` and
+  an `x402_pay_url` pointing at `POST /v1/swap/solana/execute/{quote_id}`,
+  which executes the swap at a dynamic per-quote price (quoted USDC value
+  plus a 1% service fee). The execute step is not listed in the OpenAPI
+  document because its price is set per quote, not fixed.
+
+The full gateway catalog (400+ additional pay-per-call endpoints) is
+published at `https://proxy.suverse.io/openapi.json`. The same endpoints are
+also reachable as MCP tools via the `@suverselabs/mcp-server` npm package.
+
+## Spend-aware usage
+
+- Send an unpaid request first when unsure of the input shape — the 402
+  challenge includes the endpoint's `input_schema` for free.
+- Start with `x402-liveness-check` ($0.25) only when you actually need to
+  grade a third-party paid endpoint; do not use it to probe this gateway's
+  own endpoints — their 402 challenges are already free to read.
+- For token decisions, call `token-entry-verdict` (Solana) or
+  `base-token-forensics` (Base) once per token and act on the top-level
+  verdict; the evidence layers rarely change the answer within a session.
+- `market-regime-verdict` describes the whole market, not one asset — cache
+  it for the session instead of re-buying per token. Pass
+  `{"detail": "summary"}` to skip the raw payload you will not read.
+- For swaps, buy one $0.001 quote, inspect `expected_output` and
+  `price_impact`, and only then pay the execute URL. Quotes expire — do not
+  stockpile them; re-quote right before executing.
+- `polymarket-smart-sheet` returns up to 50 rows; keep `limit` at the
+  default 20 or lower unless the task genuinely needs the long tail.

--- a/providers/suverse/data/openapi.json
+++ b/providers/suverse/data/openapi.json
@@ -1,0 +1,351 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "SuVerse Pay - crypto verdict APIs and Solana swap",
+    "version": "1.0.0",
+    "description": "Paid (x402) decision endpoints on proxy.suverse.io. Every path below returns HTTP 402 with a Solana mainnet USDC accept until paid. The full 400+ endpoint catalog is at https://proxy.suverse.io/openapi.json; this document lists the curated first-party products."
+  },
+  "servers": [
+    {
+      "url": "https://proxy.suverse.io"
+    }
+  ],
+  "paths": {
+    "/v1/data/polymarket-smart-sheet": {
+      "post": {
+        "operationId": "polymarket_smart_sheet",
+        "summary": "Polymarket Smart-Money Sheet",
+        "description": "Joins the four Polymarket Smart Money endpoints (smart-bias, whale-entries, trader-skill, position-holders) into a single ranked sheet of every active market where tracked smart money currently has an edge. Each row carries direction, conviction-based confidence, whale flow, entrant skill and holder concentration, topped by a verdict with the single strongest pick. The critical bias source is proven before payment settles; enrichment sources degrade gracefully and are disclosed in data_quality. Post-settle failures are auto-refunded.",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.750000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [],
+                "properties": {
+                  "limit": {
+                    "type": "integer",
+                    "description": "Rows in the returned sheet, 1-50 (default 20). Out-of-range values are clamped, never rejected."
+                  },
+                  "category": {
+                    "type": "string",
+                    "description": "Optional market category filter (default all).",
+                    "pattern": "^(politics|crypto|sports|macro|other|all)$"
+                  },
+                  "time_window": {
+                    "type": "string",
+                    "description": "Smart-bias aggregation window (default 24h).",
+                    "pattern": "^(1h|24h|7d|30d)$"
+                  }
+                }
+              },
+              "example": {
+                "limit": 20,
+                "category": "all",
+                "time_window": "24h"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Verdict payload (JSON object): verdict block first, evidence and data_quality layers after."
+          },
+          "402": {
+            "description": "Payment Required - x402 challenge with Solana mainnet USDC accept and machine-readable input_schema."
+          }
+        }
+      }
+    },
+    "/v1/data/token-entry-verdict": {
+      "post": {
+        "operationId": "token_entry_verdict",
+        "summary": "Token Entry Verdict (Solana)",
+        "description": "Combines the token-check safety analysis with fresh smart-money netflow (24h/7d from our trade tape, 30d cache) and recent-trader label context into a single ENTER/CAUTION/AVOID call for any Solana mint. The safety layer is fail-closed pre-settlement - if critical sources are down you are never charged - and non-critical layers degrade honestly with named stale sources and reduced confidence. Post-settle failures are auto-refunded.",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.500000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "mint"
+                ],
+                "properties": {
+                  "mint": {
+                    "type": "string",
+                    "description": "Solana token mint address to evaluate for entry (base58, 32-44 chars)",
+                    "pattern": "^[1-9A-HJ-NP-Za-km-z]{32,44}$"
+                  }
+                }
+              },
+              "example": {
+                "mint": "DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Verdict payload (JSON object): verdict block first, evidence and data_quality layers after."
+          },
+          "402": {
+            "description": "Payment Required - x402 challenge with Solana mainnet USDC accept and machine-readable input_schema."
+          }
+        }
+      }
+    },
+    "/v1/data/market-regime-verdict": {
+      "post": {
+        "operationId": "market_regime_verdict",
+        "summary": "Crypto Market Regime Verdict",
+        "description": "Aggregates five market drivers - fear-greed sentiment, BTC momentum, on-chain smart-money netflow, Binance perp funding, and DeFiLlama stablecoin float - into a single weighted risk_on/risk_off/chop regime verdict with per-driver attribution and evidence. Critical sources are health-proven before your payment settles; non-critical drivers degrade gracefully and lower confidence instead of failing the call. Optional detail:summary trims the raw payload. Post-settle failures are auto-refunded.",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.500000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [],
+                "properties": {
+                  "detail": {
+                    "type": "string",
+                    "description": "Response detail level (default \"full\"). \"summary\" omits the raw base-pulse payload from the raw layer.",
+                    "pattern": "^(summary|full)$"
+                  }
+                }
+              },
+              "example": {
+                "detail": "full"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Verdict payload (JSON object): verdict block first, evidence and data_quality layers after."
+          },
+          "402": {
+            "description": "Payment Required - x402 challenge with Solana mainnet USDC accept and machine-readable input_schema."
+          }
+        }
+      }
+    },
+    "/v1/data/base-token-forensics": {
+      "post": {
+        "operationId": "base_token_forensics",
+        "summary": "Base Token Forensics",
+        "description": "POST a Base token contract address and get a merged forensic dossier from Etherscan verification data, Blockscout holder distribution, and decoded on-chain activity. A single explicit rule table yields a CLEAN, WATCH, or RED-FLAG verdict with per-source data-quality disclosure. Critical sources are proven before settlement; degraded sources are flagged, never silently omitted. Post-settle failures are auto-refunded.",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.350000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "contract_address"
+                ],
+                "properties": {
+                  "contract_address": {
+                    "type": "string",
+                    "description": "Base (eip155:8453) token contract address to investigate (0x + 40 hex chars)",
+                    "pattern": "^0x[0-9a-fA-F]{40}$"
+                  }
+                }
+              },
+              "example": {
+                "contract_address": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Verdict payload (JSON object): verdict block first, evidence and data_quality layers after."
+          },
+          "402": {
+            "description": "Payment Required - x402 challenge with Solana mainnet USDC accept and machine-readable input_schema."
+          }
+        }
+      }
+    },
+    "/v1/data/x402-liveness-check": {
+      "post": {
+        "operationId": "x402_liveness_check",
+        "summary": "x402 Endpoint Liveness Check",
+        "description": "Sends one unpaid GET/POST/HEAD probe to any x402 resource URL and grades its 402 surface: ALIVE means a well-formed 402 with valid accepts and extracted minimum USD price; DEGRADED means reachable but not a clean x402 surface (non-402, redirect, malformed challenge, or slow); DEAD means network error, timeout, or 5xx. Private, loopback, link-local, CGNAT and metadata targets are blocked before settlement so you are never charged for an unprobeable request. Post-settle failures are auto-refunded.",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.250000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "resource_url"
+                ],
+                "properties": {
+                  "resource_url": {
+                    "type": "string",
+                    "description": "Full http(s) URL of the x402 resource to probe (we request it unpaid and grade its 402 challenge).",
+                    "pattern": "^https?://"
+                  },
+                  "method": {
+                    "type": "string",
+                    "description": "HTTP method for the probe: GET | POST | HEAD. Default GET.",
+                    "pattern": "^(GET|POST|HEAD)$"
+                  },
+                  "request_body": {
+                    "type": "object",
+                    "description": "Optional JSON object sent as the probe body when method is POST (many x402 endpoints only answer 402 on POST)."
+                  }
+                }
+              },
+              "example": {
+                "resource_url": "https://proxy.suverse.io/v1/data/crypto-market-pulse",
+                "method": "POST"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Verdict payload (JSON object): verdict block first, evidence and data_quality layers after."
+          },
+          "402": {
+            "description": "Payment Required - x402 challenge with Solana mainnet USDC accept and machine-readable input_schema."
+          }
+        }
+      }
+    },
+    "/v1/swap/solana/quote": {
+      "post": {
+        "operationId": "solana_swap_quote",
+        "summary": "Solana Swap Quote (Jupiter-routed)",
+        "description": "Returns a firm Jupiter-routed quote for a USDC-to-token or token-to-USDC swap on Solana mainnet: expected output, route plan, price impact, service fee, and a quote_id with an x402_pay_url for the dynamically priced execute step (POST /v1/swap/solana/execute/{quote_id}, priced per quote at quoted USDC value plus 1% service fee, so it is not listed as a fixed-price path here). One side of the pair must be USDC. Forward input is capped at 50 USDC per swap; slippage_bps accepts 10-500.",
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "input_mint",
+                  "output_mint",
+                  "input_amount",
+                  "slippage_bps"
+                ],
+                "properties": {
+                  "input_mint": {
+                    "type": "string",
+                    "description": "Input token mint (base58). Exactly one of input_mint/output_mint must be USDC (EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v)."
+                  },
+                  "output_mint": {
+                    "type": "string",
+                    "description": "Output token mint (base58)."
+                  },
+                  "input_amount": {
+                    "type": "string",
+                    "description": "Input amount in atomic units of input_mint, as a decimal string. Forward (USDC-in) swaps are capped at 50000000 (50 USDC)."
+                  },
+                  "slippage_bps": {
+                    "type": "integer",
+                    "description": "Max slippage in basis points, 10-500.",
+                    "minimum": 10,
+                    "maximum": 500
+                  }
+                }
+              },
+              "example": {
+                "input_mint": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "output_mint": "So11111111111111111111111111111111111111112",
+                "input_amount": "1000000",
+                "slippage_bps": 50
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Quote object: expected_output, route plan, price_impact, fees, quote_id and x402_pay_url for the execute step."
+          },
+          "402": {
+            "description": "Payment Required - x402 challenge with Solana mainnet USDC accept ($0.001 quote fee)."
+          }
+        }
+      }
+    }
+  }
+}

--- a/providers/suverse/data/openapi.json
+++ b/providers/suverse/data/openapi.json
@@ -172,7 +172,7 @@
       "post": {
         "operationId": "base_token_forensics",
         "summary": "Base Token Forensics",
-        "description": "POST a Base token contract address and get a merged forensic dossier from Etherscan verification data, Blockscout holder distribution, and decoded on-chain activity. A single explicit rule table yields a CLEAN, WATCH, or RED-FLAG verdict with per-source data-quality disclosure. Critical sources are proven before settlement; degraded sources are flagged, never silently omitted. Post-settle failures are auto-refunded.",
+        "description": "POST a Base token contract address and get a merged forensic dossier from Etherscan verification data, Blockscout holder distribution, and decoded on-chain activity. A single explicit rule table yields a CLEAN, WATCH, or RED_FLAG verdict with per-source data-quality disclosure. Critical sources are proven before settlement; degraded sources are flagged, never silently omitted. Post-settle failures are auto-refunded.",
         "x-payment-info": {
           "price": {
             "mode": "fixed",
@@ -310,11 +310,13 @@
                 "properties": {
                   "input_mint": {
                     "type": "string",
-                    "description": "Input token mint (base58). Exactly one of input_mint/output_mint must be USDC (EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v)."
+                    "description": "Input token mint (base58). Exactly one of input_mint/output_mint must be USDC (EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v).",
+                    "pattern": "^[1-9A-HJ-NP-Za-km-z]{32,44}$"
                   },
                   "output_mint": {
                     "type": "string",
-                    "description": "Output token mint (base58)."
+                    "description": "Output token mint (base58).",
+                    "pattern": "^[1-9A-HJ-NP-Za-km-z]{32,44}$"
                   },
                   "input_amount": {
                     "type": "string",


### PR DESCRIPTION
## What

New provider `suverse/data` — six first-party pay-per-call endpoints on `https://proxy.suverse.io`, all returning x402 challenges with **Solana mainnet USDC** accepts:

| Endpoint | Price | Returns |
|---|---|---|
| `POST /v1/data/polymarket-smart-sheet` | $0.75 | Ranked sheet of Polymarket markets where tracked smart money has an edge |
| `POST /v1/data/token-entry-verdict` | $0.50 | ENTER / CAUTION / AVOID verdict for a Solana token mint |
| `POST /v1/data/market-regime-verdict` | $0.50 | risk_on / risk_off / chop market regime call |
| `POST /v1/data/base-token-forensics` | $0.35 | CLEAN / WATCH / RED_FLAG verdict for a Base token contract |
| `POST /v1/data/x402-liveness-check` | $0.25 | ALIVE / DEGRADED / DEAD grade for any third-party x402 endpoint |
| `POST /v1/swap/solana/quote` | $0.001 | Jupiter-routed USDC↔token swap quote; response links the dynamic-priced execute step |

All endpoints answer verdict-first JSON with an evidence layer and `data_quality` disclosure; unpaid 402 responses include a machine-readable `input_schema`. Critical sources are proven before settle (fail-closed) and post-settle failures are auto-refunded.

The swap **execute** step (`POST /v1/swap/solana/execute/{quote_id}`) is intentionally not in the OpenAPI document: its price is dynamic per quote (quoted USDC value + 1% fee), so there is no fixed-price path to probe. The quote response carries its `x402_pay_url`.

## Validation

`pay catalog check providers/suverse/data/PAY.md -v` — green:
- Probe: 6/6 `OK 402 x402 USDC`
- Solana-compat verdict: **PASS (6/6)**
- `pay catalog check . --no-probe` — 874 endpoints / 71 providers, no regressions
- `pay catalog check . --changed-from upstream/main` (CI mirror) — successful

Related: #78 (separate SuVerse FMCSA provider, still open).