### PR TITLE
feat: add RelayZero DrainBrain Token Risk Scan provider

### DIFF
--- a/providers/relayzero/drainbrain-token-scan/PAY.md
+++ b/providers/relayzero/drainbrain-token-scan/PAY.md
@@ -12,12 +12,15 @@ openapi:
 DrainBrain is an in-house ML security oracle (5-model ensemble, trained on 175K+ tokens) that scores Solana token mints for rug-pull risk. One x402-paid GET returns a 0-100 risk score, a risk level, a rug-stage classification, honeypot flags, and model confidence.
 
 - **Endpoint:** `GET https://relayzero.ai/v1/intel/scan/{address}` — `{address}` is the token mint (base58)
+- **Batch:** `POST https://relayzero.ai/v1/intel/scan/batch` — up to 10 mints per call, $0.10 (50% off single-scan pricing), partial-result semantics per mint
+- **Free sample:** `GET https://relayzero.ai/v1/intel/sample-scan` — a real scan of a fixed mint with the exact paid response shape, free, so you can integrate before paying
 - **Payment:** $0.02 USDC per scan, x402 v2 `exact` scheme on Solana mainnet via the PayAI facilitator, with a sponsored fee payer — the paying wallet needs USDC only, no SOL
 - **Auth:** none. Unpaid requests return a standard x402 v2 challenge in the `payment-required` header; payment is authentication
 - **Latency:** typically a few seconds; a cold first scan of a mint can take up to ~60s
 
 ## Spend-aware usage
 
-- Flat $0.02 per call. No subscription, no minimum, no signup.
+- Flat $0.02 per call. No subscription, no minimum, no signup. Scanning several mints? One $0.10 batch call (up to 10) beats 5+ singles.
+- Integrate against the free sample first — it is the exact paid response shape and costs nothing.
 - Results are served from a short (~5 minute) server-side cache per mint; a paid re-scan of the same mint inside that window returns the cached result and still costs $0.02 — cache client-side and dedupe your retries.
 - Scan before spend: one $0.02 scan gating a swap or listing decision is cheap insurance. Avoid re-scanning the same mint inside a polling loop.

--- a/providers/relayzero/drainbrain-token-scan/PAY.md
+++ b/providers/relayzero/drainbrain-token-scan/PAY.md
@@ -1,0 +1,23 @@
+---
+name: drainbrain-token-scan
+title: "DrainBrain Token Risk Scan (RelayZero)"
+description: "ML rug-pull and honeypot risk scoring for Solana token mints — 0-100 risk score, risk level, rug-stage classification, honeypot flags, and model confidence. Pay-per-call x402: $0.02 USDC on Solana mainnet, no API key."
+use_case: "Use for pre-trade token safety: score a Solana mint for rug-pull risk before an agent buys, swaps, lists, or routes liquidity through it."
+category: security
+service_url: https://relayzero.ai
+openapi:
+  path: openapi.json
+---
+
+DrainBrain is an in-house ML security oracle (5-model ensemble, trained on 175K+ tokens) that scores Solana token mints for rug-pull risk. One x402-paid GET returns a 0-100 risk score, a risk level, a rug-stage classification, honeypot flags, and model confidence.
+
+- **Endpoint:** `GET https://relayzero.ai/v1/intel/scan/{address}` — `{address}` is the token mint (base58)
+- **Payment:** $0.02 USDC per scan, x402 v2 `exact` scheme on Solana mainnet via the PayAI facilitator, with a sponsored fee payer — the paying wallet needs USDC only, no SOL
+- **Auth:** none. Unpaid requests return a standard x402 v2 challenge in the `payment-required` header; payment is authentication
+- **Latency:** typically a few seconds; a cold first scan of a mint can take up to ~60s
+
+## Spend-aware usage
+
+- Flat $0.02 per call. No subscription, no minimum, no signup.
+- Results are served from a short (~5 minute) server-side cache per mint; a paid re-scan of the same mint inside that window returns the cached result and still costs $0.02 — cache client-side and dedupe your retries.
+- Scan before spend: one $0.02 scan gating a swap or listing decision is cheap insurance. Avoid re-scanning the same mint inside a polling loop.

--- a/providers/relayzero/drainbrain-token-scan/openapi.json
+++ b/providers/relayzero/drainbrain-token-scan/openapi.json
@@ -1,0 +1,99 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "DrainBrain Token Risk Scan (RelayZero)",
+    "version": "1.0.0",
+    "description": "ML rug-pull risk scoring for Solana token mints. Pay-per-call via x402: $0.02 USDC, exact scheme, Solana mainnet (PayAI facilitator, sponsored fee payer). No API key — an unpaid request returns an x402 v2 challenge in the payment-required header; sign it with any x402 client and retry with the payment-signature header."
+  },
+  "servers": [{ "url": "https://relayzero.ai", "description": "Production" }],
+  "paths": {
+    "/v1/intel/scan/{address}": {
+      "get": {
+        "operationId": "scanTokenAddress",
+        "summary": "Score a Solana token mint for rug-pull risk (DrainBrain ML)",
+        "description": "Scores a Solana token mint for rug-pull and honeypot risk using an in-house ML ensemble. Most scans return in a few seconds; a cold first scan of a mint can take up to ~60s.",
+        "tags": ["Intel"],
+        "parameters": [
+          {
+            "name": "address",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "minLength": 32, "maxLength": 44 },
+            "description": "Solana token mint address (base58)"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Completed scan",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "scan": {
+                      "type": "object",
+                      "properties": {
+                        "type": { "type": "string", "example": "drainbrain_scan" },
+                        "address": { "type": "string" },
+                        "result": {
+                          "type": "object",
+                          "properties": {
+                            "mint": { "type": "string" },
+                            "score": { "type": "number", "description": "Rug risk 0-100 (higher = riskier)" },
+                            "riskLevel": { "type": "string", "example": "CRITICAL" },
+                            "isRug": { "type": "boolean" },
+                            "rugStage": { "type": "number" },
+                            "rugStageName": { "type": "string" },
+                            "honeypot": {
+                              "type": "object",
+                              "properties": {
+                                "isHoneypot": { "type": "boolean" },
+                                "reason": { "type": "string", "nullable": true }
+                              }
+                            },
+                            "confidence": { "type": "number" },
+                            "cached": { "type": "boolean" },
+                            "timestamp": { "type": "string", "format": "date-time" }
+                          },
+                          "additionalProperties": true
+                        },
+                        "scanned_at": { "type": "string", "format": "date-time" }
+                      }
+                    },
+                    "source": { "type": "string", "example": "DrainBrain ML Security Oracle" },
+                    "generated_at": { "type": "string", "format": "date-time" }
+                  }
+                }
+              }
+            }
+          },
+          "400": { "description": "Invalid Solana token address" },
+          "402": {
+            "description": "Payment required — x402 v2 challenge in the payment-required header (exact scheme, USDC, Solana mainnet, sponsored fee payer)"
+          },
+          "503": { "description": "Scan engine temporarily unavailable" }
+        },
+        "x-payment-info": {
+          "price": { "mode": "fixed", "currency": "USD", "amount": "0.020000" },
+          "protocols": [{ "x402": {} }]
+        },
+        "x-extensions": {
+          "bazaar": {
+            "schema": {
+              "properties": {
+                "input": {
+                  "type": "object",
+                  "properties": {
+                    "address": { "type": "string", "description": "Solana token mint address (base58)" }
+                  },
+                  "required": ["address"]
+                },
+                "output": { "type": "object" }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/providers/relayzero/drainbrain-token-scan/openapi.json
+++ b/providers/relayzero/drainbrain-token-scan/openapi.json
@@ -3,22 +3,33 @@
   "info": {
     "title": "DrainBrain Token Risk Scan (RelayZero)",
     "version": "1.0.0",
-    "description": "ML rug-pull risk scoring for Solana token mints. Pay-per-call via x402: $0.02 USDC, exact scheme, Solana mainnet (PayAI facilitator, sponsored fee payer). No API key — an unpaid request returns an x402 v2 challenge in the payment-required header; sign it with any x402 client and retry with the payment-signature header."
+    "description": "ML rug-pull risk scoring for Solana token mints. Pay-per-call via x402: $0.02 USDC, exact scheme, Solana mainnet (PayAI facilitator, sponsored fee payer). No API key \u2014 an unpaid request returns an x402 v2 challenge in the payment-required header; sign it with any x402 client and retry with the payment-signature header."
   },
-  "servers": [{ "url": "https://relayzero.ai", "description": "Production" }],
+  "servers": [
+    {
+      "url": "https://relayzero.ai",
+      "description": "Production"
+    }
+  ],
   "paths": {
     "/v1/intel/scan/{address}": {
       "get": {
         "operationId": "scanTokenAddress",
         "summary": "Score a Solana token mint for rug-pull risk (DrainBrain ML)",
         "description": "Scores a Solana token mint for rug-pull and honeypot risk using an in-house ML ensemble. Most scans return in a few seconds; a cold first scan of a mint can take up to ~60s.",
-        "tags": ["Intel"],
+        "tags": [
+          "Intel"
+        ],
         "parameters": [
           {
             "name": "address",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "minLength": 32, "maxLength": 44 },
+            "schema": {
+              "type": "string",
+              "minLength": 32,
+              "maxLength": 44
+            },
             "description": "Solana token mint address (base58)"
           }
         ],
@@ -33,49 +44,101 @@
                     "scan": {
                       "type": "object",
                       "properties": {
-                        "type": { "type": "string", "example": "drainbrain_scan" },
-                        "address": { "type": "string" },
+                        "type": {
+                          "type": "string",
+                          "example": "drainbrain_scan"
+                        },
+                        "address": {
+                          "type": "string"
+                        },
                         "result": {
                           "type": "object",
                           "properties": {
-                            "mint": { "type": "string" },
-                            "score": { "type": "number", "description": "Rug risk 0-100 (higher = riskier)" },
-                            "riskLevel": { "type": "string", "example": "CRITICAL" },
-                            "isRug": { "type": "boolean" },
-                            "rugStage": { "type": "number" },
-                            "rugStageName": { "type": "string" },
+                            "mint": {
+                              "type": "string"
+                            },
+                            "score": {
+                              "type": "number",
+                              "description": "Rug risk 0-100 (higher = riskier)"
+                            },
+                            "riskLevel": {
+                              "type": "string",
+                              "example": "CRITICAL"
+                            },
+                            "isRug": {
+                              "type": "boolean"
+                            },
+                            "rugStage": {
+                              "type": "number"
+                            },
+                            "rugStageName": {
+                              "type": "string"
+                            },
                             "honeypot": {
                               "type": "object",
                               "properties": {
-                                "isHoneypot": { "type": "boolean" },
-                                "reason": { "type": "string", "nullable": true }
+                                "isHoneypot": {
+                                  "type": "boolean"
+                                },
+                                "reason": {
+                                  "type": "string",
+                                  "nullable": true
+                                }
                               }
                             },
-                            "confidence": { "type": "number" },
-                            "cached": { "type": "boolean" },
-                            "timestamp": { "type": "string", "format": "date-time" }
+                            "confidence": {
+                              "type": "number"
+                            },
+                            "cached": {
+                              "type": "boolean"
+                            },
+                            "timestamp": {
+                              "type": "string",
+                              "format": "date-time"
+                            }
                           },
                           "additionalProperties": true
                         },
-                        "scanned_at": { "type": "string", "format": "date-time" }
+                        "scanned_at": {
+                          "type": "string",
+                          "format": "date-time"
+                        }
                       }
                     },
-                    "source": { "type": "string", "example": "DrainBrain ML Security Oracle" },
-                    "generated_at": { "type": "string", "format": "date-time" }
+                    "source": {
+                      "type": "string",
+                      "example": "DrainBrain ML Security Oracle"
+                    },
+                    "generated_at": {
+                      "type": "string",
+                      "format": "date-time"
+                    }
                   }
                 }
               }
             }
           },
-          "400": { "description": "Invalid Solana token address" },
-          "402": {
-            "description": "Payment required — x402 v2 challenge in the payment-required header (exact scheme, USDC, Solana mainnet, sponsored fee payer)"
+          "400": {
+            "description": "Invalid Solana token address"
           },
-          "503": { "description": "Scan engine temporarily unavailable" }
+          "402": {
+            "description": "Payment required \u2014 x402 v2 challenge in the payment-required header (exact scheme, USDC, Solana mainnet, sponsored fee payer)"
+          },
+          "503": {
+            "description": "Scan engine temporarily unavailable"
+          }
         },
         "x-payment-info": {
-          "price": { "mode": "fixed", "currency": "USD", "amount": "0.020000" },
-          "protocols": [{ "x402": {} }]
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.020000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
         },
         "x-extensions": {
           "bazaar": {
@@ -84,14 +147,124 @@
                 "input": {
                   "type": "object",
                   "properties": {
-                    "address": { "type": "string", "description": "Solana token mint address (base58)" }
+                    "address": {
+                      "type": "string",
+                      "description": "Solana token mint address (base58)"
+                    }
                   },
-                  "required": ["address"]
+                  "required": [
+                    "address"
+                  ]
                 },
-                "output": { "type": "object" }
+                "output": {
+                  "type": "object"
+                }
               }
             }
           }
+        }
+      }
+    },
+    "/v1/intel/scan/batch": {
+      "post": {
+        "operationId": "scanTokenBatch",
+        "summary": "Score up to 10 Solana mints in one call (batch DrainBrain scan)",
+        "description": "Batch variant: up to 10 mints per paid call at $0.10 (50% off single-scan pricing). Partial-result semantics: each mint succeeds or fails independently. Try the response shape free first: GET /v1/intel/sample-scan.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "mints"
+                ],
+                "properties": {
+                  "mints": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "minLength": 32,
+                      "maxLength": 44
+                    },
+                    "minItems": 1,
+                    "maxItems": 10,
+                    "description": "1-10 unique Solana token mint addresses (base58)"
+                  }
+                }
+              },
+              "example": {
+                "mints": [
+                  "DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Batch results (per-mint ok flags; partial results possible)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "batch": {
+                      "type": "boolean"
+                    },
+                    "requested": {
+                      "type": "number"
+                    },
+                    "scanned": {
+                      "type": "number"
+                    },
+                    "failed": {
+                      "type": "number"
+                    },
+                    "results": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "mint": {
+                            "type": "string"
+                          },
+                          "ok": {
+                            "type": "boolean"
+                          },
+                          "result": {
+                            "type": "object",
+                            "additionalProperties": true
+                          },
+                          "error": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid body or mint addresses"
+          },
+          "402": {
+            "description": "x402 payment required \u2014 v2 challenge in the payment-required header"
+          }
+        },
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.100000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
         }
       }
     }


### PR DESCRIPTION
Adds `providers/relayzero/drainbrain-token-scan/` — an ML rug-pull / honeypot risk scan for Solana token mints.

- **Endpoint:** `GET https://relayzero.ai/v1/intel/scan/{address}`
- **Payment:** $0.02 USDC per call, x402 v2 `exact` scheme on **Solana mainnet** (PayAI facilitator, sponsored fee payer — payer wallet needs USDC only, no SOL). No API key; an unpaid request returns the x402 challenge in the `payment-required` header.
- **Returns:** 0-100 risk score, risk level, rug-stage classification, honeypot flags, model confidence.
- OpenAPI committed as a sidecar (`openapi.json`), one endpoint.

Local validation from the registry root:
- `catalog check . --files ... --no-probe` → passed, 0 warnings
- `catalog check . --files ... --currencies USDC,USDT --probe-timeout 15` → **"1/1 gates compatible with Solana"** (live 402 probe)

The payment path is live and settle-verified on mainnet (real USDC settlement through the PayAI facilitator earlier today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)