### PR TITLE
Add MilyPay (milysec/*) Australian data APIs

### DIFF
--- a/providers/milysec/au-address/PAY.md
+++ b/providers/milysec/au-address/PAY.md
@@ -1,0 +1,23 @@
+---
+name: au-address
+title: "MilyPay AU Address"
+description: "MilyPay Australian address API over G-NAF (16.9M addresses): validate, search/autocomplete, and geocode Australian postal addresses. Returns canonical form, GNAF PID, and coordinates as JSON over x402."
+use_case: "Use for Australian address validation, G-NAF geocoding, address autocomplete, canonical address cleanup, and property-location resolution for agents operating in Australia."
+category: maps
+service_url: https://api.milypay.xyz
+version: v1
+openapi:
+  path: openapi.json
+---
+
+MilyPay G-NAF address validation, search, and geocoding. © Geoscape Australia open G-NAF licence. Per-call lookups only.
+
+Pay per call via x402 on Solana. Accepts **USDC**, **USDT**, and **AUDD**.
+
+## Spend-aware usage
+
+- Prefer `/au-address/validate` when you have a full address string.
+- Use `/au-address/search` for autocomplete; take the top hit, then validate once.
+- Use `/au-address/geocode` only when coordinates alone are needed.
+
+Docs: https://milypay.xyz/agents.md · Demo: https://milypay.xyz/demo · Brand: **MilyPay** (Milysec)

--- a/providers/milysec/au-address/PAY.md
+++ b/providers/milysec/au-address/PAY.md
@@ -1,7 +1,7 @@
 ---
 name: au-address
-title: "MilyPay AU Address"
-description: "MilyPay Australian address API over G-NAF (16.9M addresses): validate, search/autocomplete, and geocode Australian postal addresses. Returns canonical form, GNAF PID, and coordinates as JSON over x402."
+title: "Milypay AU Address"
+description: "Milypay Australian address API over G-NAF (16.9M addresses): validate, search/autocomplete, and geocode Australian postal addresses. Returns canonical form, GNAF PID, and coordinates as JSON over x402."
 use_case: "Use for Australian address validation, G-NAF geocoding, address autocomplete, canonical address cleanup, and property-location resolution for agents operating in Australia."
 category: maps
 service_url: https://api.milypay.xyz
@@ -10,7 +10,7 @@ openapi:
   path: openapi.json
 ---
 
-MilyPay G-NAF address validation, search, and geocoding. © Geoscape Australia open G-NAF licence. Per-call lookups only.
+Milypay G-NAF address validation, search, and geocoding. © Geoscape Australia open G-NAF licence. Per-call lookups only.
 
 Pay per call via x402 on Solana. Accepts **USDC**, **USDT**, and **AUDD**.
 
@@ -20,4 +20,4 @@ Pay per call via x402 on Solana. Accepts **USDC**, **USDT**, and **AUDD**.
 - Use `/au-address/search` for autocomplete; take the top hit, then validate once.
 - Use `/au-address/geocode` only when coordinates alone are needed.
 
-Docs: https://milypay.xyz/agents.md · Demo: https://milypay.xyz/demo · Brand: **MilyPay** (Milysec)
+Docs: https://milypay.xyz/agents.md · Demo: https://milypay.xyz/demo · Brand: **Milypay** (Milysec)

--- a/providers/milysec/au-address/openapi.json
+++ b/providers/milysec/au-address/openapi.json
@@ -1,0 +1,139 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "MilyPay AU Address",
+    "description": "MilyPay Australian address API over G-NAF (16.9M addresses): validate, search/autocomplete, and geocode Australian postal addresses. Returns canonical form, GNAF PID, and coordinates as JSON over x402.",
+    "version": "1.0.0",
+    "contact": {
+      "name": "MilyPay",
+      "url": "https://milypay.xyz",
+      "email": "hello@milysec.com"
+    },
+    "x-brand": "MilyPay"
+  },
+  "servers": [
+    {
+      "url": "https://api.milypay.xyz",
+      "description": "MilyPay production API"
+    }
+  ],
+  "paths": {
+    "/au-address/validate": {
+      "get": {
+        "operationId": "validateAddress",
+        "summary": "Validate an Australian address against G-NAF",
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "1 Bligh Street Sydney NSW 2000"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Canonical address + geocode"
+          },
+          "402": {
+            "description": "Payment Required (x402)"
+          }
+        },
+        "x-pricing": {
+          "dimensions": [
+            {
+              "direction": "usage",
+              "unit": "requests",
+              "scale": 1,
+              "tiers": [
+                {
+                  "price_usd": 0.004
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "/au-address/search": {
+      "get": {
+        "operationId": "searchAddress",
+        "summary": "Search Australian addresses (autocomplete)",
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "120 collins st melbourne"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Ranked address matches"
+          },
+          "402": {
+            "description": "Payment Required (x402)"
+          }
+        },
+        "x-pricing": {
+          "dimensions": [
+            {
+              "direction": "usage",
+              "unit": "requests",
+              "scale": 1,
+              "tiers": [
+                {
+                  "price_usd": 0.004
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "/au-address/geocode": {
+      "get": {
+        "operationId": "geocodeAddress",
+        "summary": "Geocode an Australian address",
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "200 Adelaide St Brisbane"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Latitude and longitude"
+          },
+          "402": {
+            "description": "Payment Required (x402)"
+          }
+        },
+        "x-pricing": {
+          "dimensions": [
+            {
+              "direction": "usage",
+              "unit": "requests",
+              "scale": 1,
+              "tiers": [
+                {
+                  "price_usd": 0.004
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/providers/milysec/au-address/openapi.json
+++ b/providers/milysec/au-address/openapi.json
@@ -1,20 +1,20 @@
 {
   "openapi": "3.1.0",
   "info": {
-    "title": "MilyPay AU Address",
-    "description": "MilyPay Australian address API over G-NAF (16.9M addresses): validate, search/autocomplete, and geocode Australian postal addresses. Returns canonical form, GNAF PID, and coordinates as JSON over x402.",
+    "title": "Milypay AU Address",
+    "description": "Milypay Australian address API over G-NAF (16.9M addresses): validate, search/autocomplete, and geocode Australian postal addresses. Returns canonical form, GNAF PID, and coordinates as JSON over x402.",
     "version": "1.0.0",
     "contact": {
-      "name": "MilyPay",
+      "name": "Milypay",
       "url": "https://milypay.xyz",
       "email": "hello@milysec.com"
     },
-    "x-brand": "MilyPay"
+    "x-brand": "Milypay"
   },
   "servers": [
     {
       "url": "https://api.milypay.xyz",
-      "description": "MilyPay production API"
+      "description": "Milypay production API"
     }
   ],
   "paths": {

--- a/providers/milysec/au-bsb/PAY.md
+++ b/providers/milysec/au-bsb/PAY.md
@@ -1,7 +1,7 @@
 ---
 name: au-bsb
-title: "MilyPay AU BSB"
-description: "MilyPay Australian BSB lookup and search over 17,000+ AusPayNet directory entries. Returns bank name, branch, address, and supported payment methods (paper, electronic, high-value) as JSON over x402."
+title: "Milypay AU BSB"
+description: "Milypay Australian BSB lookup and search over 17,000+ AusPayNet directory entries. Returns bank name, branch, address, and supported payment methods (paper, electronic, high-value) as JSON over x402."
 use_case: "Use for Australian BSB validation, bank branch lookup, payment-rail capability checks, suburb or bank-name search, and agent banking workflows in Australia."
 category: finance
 service_url: https://api.milypay.xyz
@@ -10,7 +10,7 @@ openapi:
   path: openapi.json
 ---
 
-MilyPay BSB directory (AusPayNet). Hyphen optional (`012-002` or `012002`).
+Milypay BSB directory (AusPayNet). Hyphen optional (`012-002` or `012002`).
 
 Pay per call via x402 on Solana. Accepts **USDC**, **USDT**, and **AUDD**.
 
@@ -19,4 +19,4 @@ Pay per call via x402 on Solana. Accepts **USDC**, **USDT**, and **AUDD**.
 - Prefer exact `/au-bsb/{bsb}` when the number is known.
 - Use search once to resolve a branch, then cache the BSB.
 
-Docs: https://milypay.xyz/agents.md · Demo: https://milypay.xyz/demo · Brand: **MilyPay** (Milysec)
+Docs: https://milypay.xyz/agents.md · Demo: https://milypay.xyz/demo · Brand: **Milypay** (Milysec)

--- a/providers/milysec/au-bsb/PAY.md
+++ b/providers/milysec/au-bsb/PAY.md
@@ -1,0 +1,22 @@
+---
+name: au-bsb
+title: "MilyPay AU BSB"
+description: "MilyPay Australian BSB lookup and search over 17,000+ AusPayNet directory entries. Returns bank name, branch, address, and supported payment methods (paper, electronic, high-value) as JSON over x402."
+use_case: "Use for Australian BSB validation, bank branch lookup, payment-rail capability checks, suburb or bank-name search, and agent banking workflows in Australia."
+category: finance
+service_url: https://api.milypay.xyz
+version: v1
+openapi:
+  path: openapi.json
+---
+
+MilyPay BSB directory (AusPayNet). Hyphen optional (`012-002` or `012002`).
+
+Pay per call via x402 on Solana. Accepts **USDC**, **USDT**, and **AUDD**.
+
+## Spend-aware usage
+
+- Prefer exact `/au-bsb/{bsb}` when the number is known.
+- Use search once to resolve a branch, then cache the BSB.
+
+Docs: https://milypay.xyz/agents.md · Demo: https://milypay.xyz/demo · Brand: **MilyPay** (Milysec)

--- a/providers/milysec/au-bsb/openapi.json
+++ b/providers/milysec/au-bsb/openapi.json
@@ -1,20 +1,20 @@
 {
   "openapi": "3.1.0",
   "info": {
-    "title": "MilyPay AU BSB",
-    "description": "MilyPay Australian BSB lookup and search over 17,000+ AusPayNet directory entries. Returns bank name, branch, address, and supported payment methods (paper, electronic, high-value) as JSON over x402.",
+    "title": "Milypay AU BSB",
+    "description": "Milypay Australian BSB lookup and search over 17,000+ AusPayNet directory entries. Returns bank name, branch, address, and supported payment methods (paper, electronic, high-value) as JSON over x402.",
     "version": "1.0.0",
     "contact": {
-      "name": "MilyPay",
+      "name": "Milypay",
       "url": "https://milypay.xyz",
       "email": "hello@milysec.com"
     },
-    "x-brand": "MilyPay"
+    "x-brand": "Milypay"
   },
   "servers": [
     {
       "url": "https://api.milypay.xyz",
-      "description": "MilyPay production API"
+      "description": "Milypay production API"
     }
   ],
   "paths": {

--- a/providers/milysec/au-bsb/openapi.json
+++ b/providers/milysec/au-bsb/openapi.json
@@ -1,0 +1,101 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "MilyPay AU BSB",
+    "description": "MilyPay Australian BSB lookup and search over 17,000+ AusPayNet directory entries. Returns bank name, branch, address, and supported payment methods (paper, electronic, high-value) as JSON over x402.",
+    "version": "1.0.0",
+    "contact": {
+      "name": "MilyPay",
+      "url": "https://milypay.xyz",
+      "email": "hello@milysec.com"
+    },
+    "x-brand": "MilyPay"
+  },
+  "servers": [
+    {
+      "url": "https://api.milypay.xyz",
+      "description": "MilyPay production API"
+    }
+  ],
+  "paths": {
+    "/au-bsb/{bsb}": {
+      "get": {
+        "operationId": "lookupBsb",
+        "summary": "Look up an Australian BSB",
+        "parameters": [
+          {
+            "name": "bsb",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "012-002"
+            },
+            "description": "BSB with or without hyphen"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "BSB record"
+          },
+          "402": {
+            "description": "Payment Required (x402)"
+          }
+        },
+        "x-pricing": {
+          "dimensions": [
+            {
+              "direction": "usage",
+              "unit": "requests",
+              "scale": 1,
+              "tiers": [
+                {
+                  "price_usd": 0.002
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "/au-bsb/search": {
+      "get": {
+        "operationId": "searchBsb",
+        "summary": "Search BSBs by bank, branch, or suburb",
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "commonwealth melbourne"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Matching BSBs"
+          },
+          "402": {
+            "description": "Payment Required (x402)"
+          }
+        },
+        "x-pricing": {
+          "dimensions": [
+            {
+              "direction": "usage",
+              "unit": "requests",
+              "scale": 1,
+              "tiers": [
+                {
+                  "price_usd": 0.004
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/providers/milysec/au-business/PAY.md
+++ b/providers/milysec/au-business/PAY.md
@@ -1,7 +1,7 @@
 ---
 name: au-business
-title: "MilyPay AU Business"
-description: "MilyPay Australian business identity API: ABN and ACN lookup plus name search from the ABR (ATO). Returns entity name, status, type, GST, and location as JSON for agent KYB over x402 on Solana."
+title: "Milypay AU Business"
+description: "Milypay Australian business identity API: ABN and ACN lookup plus name search from the ABR (ATO). Returns entity name, status, type, GST, and location as JSON for agent KYB over x402 on Solana."
 use_case: "Use for Australian ABN lookup, ACN lookup, business name search, entity verification, GST status checks, and agent KYB against the Australian Business Register."
 category: identity
 service_url: https://api.milypay.xyz
@@ -10,7 +10,7 @@ openapi:
   path: openapi.json
 ---
 
-MilyPay Australian business identity endpoints. Source: Australian Business Register (ATO).
+Milypay Australian business identity endpoints. Source: Australian Business Register (ATO).
 
 Pay per call via x402 on Solana. Accepts **USDC**, **USDT**, and **AUDD**.
 No API keys. Demo (free, rate-limited): https://milypay.xyz/demo
@@ -22,4 +22,4 @@ No API keys. Demo (free, rate-limited): https://milypay.xyz/demo
 - Use `/au-business/search?name=` once to resolve a name to an ABN, then switch to exact ABN lookups.
 - Cache ABN results for the task; do not re-query the same ABN in a loop.
 
-Docs: https://milypay.xyz/agents.md · Demo: https://milypay.xyz/demo · Brand: **MilyPay** (Milysec)
+Docs: https://milypay.xyz/agents.md · Demo: https://milypay.xyz/demo · Brand: **Milypay** (Milysec)

--- a/providers/milysec/au-business/PAY.md
+++ b/providers/milysec/au-business/PAY.md
@@ -1,0 +1,25 @@
+---
+name: au-business
+title: "MilyPay AU Business"
+description: "MilyPay Australian business identity API: ABN and ACN lookup plus name search from the ABR (ATO). Returns entity name, status, type, GST, and location as JSON for agent KYB over x402 on Solana."
+use_case: "Use for Australian ABN lookup, ACN lookup, business name search, entity verification, GST status checks, and agent KYB against the Australian Business Register."
+category: identity
+service_url: https://api.milypay.xyz
+version: v1
+openapi:
+  path: openapi.json
+---
+
+MilyPay Australian business identity endpoints. Source: Australian Business Register (ATO).
+
+Pay per call via x402 on Solana. Accepts **USDC**, **USDT**, and **AUDD**.
+No API keys. Demo (free, rate-limited): https://milypay.xyz/demo
+
+## Spend-aware usage
+
+- Prefer `/au-business/abn/{abn}` when the ABN is known — cheapest exact lookup.
+- Use `/au-business/acn/{acn}` only when you have an ACN, not an ABN.
+- Use `/au-business/search?name=` once to resolve a name to an ABN, then switch to exact ABN lookups.
+- Cache ABN results for the task; do not re-query the same ABN in a loop.
+
+Docs: https://milypay.xyz/agents.md · Demo: https://milypay.xyz/demo · Brand: **MilyPay** (Milysec)

--- a/providers/milysec/au-business/openapi.json
+++ b/providers/milysec/au-business/openapi.json
@@ -1,20 +1,20 @@
 {
   "openapi": "3.1.0",
   "info": {
-    "title": "MilyPay AU Business",
-    "description": "MilyPay Australian business identity API: ABN and ACN lookup plus name search from the ABR (ATO). Returns entity name, status, type, GST, and location as JSON for agent KYB over x402 on Solana.",
+    "title": "Milypay AU Business",
+    "description": "Milypay Australian business identity API: ABN and ACN lookup plus name search from the ABR (ATO). Returns entity name, status, type, GST, and location as JSON for agent KYB over x402 on Solana.",
     "version": "1.0.0",
     "contact": {
-      "name": "MilyPay",
+      "name": "Milypay",
       "url": "https://milypay.xyz",
       "email": "hello@milysec.com"
     },
-    "x-brand": "MilyPay"
+    "x-brand": "Milypay"
   },
   "servers": [
     {
       "url": "https://api.milypay.xyz",
-      "description": "MilyPay production API"
+      "description": "Milypay production API"
     }
   ],
   "paths": {

--- a/providers/milysec/au-business/openapi.json
+++ b/providers/milysec/au-business/openapi.json
@@ -1,0 +1,141 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "MilyPay AU Business",
+    "description": "MilyPay Australian business identity API: ABN and ACN lookup plus name search from the ABR (ATO). Returns entity name, status, type, GST, and location as JSON for agent KYB over x402 on Solana.",
+    "version": "1.0.0",
+    "contact": {
+      "name": "MilyPay",
+      "url": "https://milypay.xyz",
+      "email": "hello@milysec.com"
+    },
+    "x-brand": "MilyPay"
+  },
+  "servers": [
+    {
+      "url": "https://api.milypay.xyz",
+      "description": "MilyPay production API"
+    }
+  ],
+  "paths": {
+    "/au-business/abn/{abn}": {
+      "get": {
+        "operationId": "lookupAbn",
+        "summary": "Look up an Australian business by ABN",
+        "description": "Entity name, status, type, ACN, GST, business names, location from the ABR.",
+        "parameters": [
+          {
+            "name": "abn",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "51824753556"
+            },
+            "description": "11-digit Australian Business Number"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Business entity details"
+          },
+          "402": {
+            "description": "Payment Required (x402)"
+          }
+        },
+        "x-pricing": {
+          "dimensions": [
+            {
+              "direction": "usage",
+              "unit": "requests",
+              "scale": 1,
+              "tiers": [
+                {
+                  "price_usd": 0.002
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "/au-business/acn/{acn}": {
+      "get": {
+        "operationId": "lookupAcn",
+        "summary": "Look up an Australian business by ACN",
+        "parameters": [
+          {
+            "name": "acn",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "051775556"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Business entity details"
+          },
+          "402": {
+            "description": "Payment Required (x402)"
+          }
+        },
+        "x-pricing": {
+          "dimensions": [
+            {
+              "direction": "usage",
+              "unit": "requests",
+              "scale": 1,
+              "tiers": [
+                {
+                  "price_usd": 0.002
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "/au-business/search": {
+      "get": {
+        "operationId": "searchBusiness",
+        "summary": "Search Australian businesses by name",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "woolworths"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Matching ABNs"
+          },
+          "402": {
+            "description": "Payment Required (x402)"
+          }
+        },
+        "x-pricing": {
+          "dimensions": [
+            {
+              "direction": "usage",
+              "unit": "requests",
+              "scale": 1,
+              "tiers": [
+                {
+                  "price_usd": 0.004
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/providers/milysec/au-company/PAY.md
+++ b/providers/milysec/au-company/PAY.md
@@ -1,0 +1,23 @@
+---
+name: au-company
+title: "MilyPay AU Company"
+description: "MilyPay ASIC company register API: look up Australian companies by ACN or name across 3.9M records. Returns status, type, class, registration dates, and former names as JSON over x402 on Solana."
+use_case: "Use for ASIC company lookup by ACN, company name search, former-name resolution, registration status checks, and Australian corporate identity workflows for agents."
+category: identity
+service_url: https://api.milypay.xyz
+version: v1
+openapi:
+  path: openapi.json
+---
+
+MilyPay ASIC company register endpoints (data.gov.au). ~3.9M companies.
+
+Pay per call via x402 on Solana. Accepts **USDC**, **USDT**, and **AUDD**.
+
+## Spend-aware usage
+
+- Prefer `/au-company/acn/{acn}` when the ACN is known.
+- Use name search once to resolve ACN, then exact lookups.
+- Do not paginate blindly — take the top match and verify by ACN.
+
+Docs: https://milypay.xyz/agents.md · Demo: https://milypay.xyz/demo · Brand: **MilyPay** (Milysec)

--- a/providers/milysec/au-company/PAY.md
+++ b/providers/milysec/au-company/PAY.md
@@ -1,7 +1,7 @@
 ---
 name: au-company
-title: "MilyPay AU Company"
-description: "MilyPay ASIC company register API: look up Australian companies by ACN or name across 3.9M records. Returns status, type, class, registration dates, and former names as JSON over x402 on Solana."
+title: "Milypay AU Company"
+description: "Milypay ASIC company register API: look up Australian companies by ACN or name across 3.9M records. Returns status, type, class, registration dates, and former names as JSON over x402 on Solana."
 use_case: "Use for ASIC company lookup by ACN, company name search, former-name resolution, registration status checks, and Australian corporate identity workflows for agents."
 category: identity
 service_url: https://api.milypay.xyz
@@ -10,7 +10,7 @@ openapi:
   path: openapi.json
 ---
 
-MilyPay ASIC company register endpoints (data.gov.au). ~3.9M companies.
+Milypay ASIC company register endpoints (data.gov.au). ~3.9M companies.
 
 Pay per call via x402 on Solana. Accepts **USDC**, **USDT**, and **AUDD**.
 
@@ -20,4 +20,4 @@ Pay per call via x402 on Solana. Accepts **USDC**, **USDT**, and **AUDD**.
 - Use name search once to resolve ACN, then exact lookups.
 - Do not paginate blindly — take the top match and verify by ACN.
 
-Docs: https://milypay.xyz/agents.md · Demo: https://milypay.xyz/demo · Brand: **MilyPay** (Milysec)
+Docs: https://milypay.xyz/agents.md · Demo: https://milypay.xyz/demo · Brand: **Milypay** (Milysec)

--- a/providers/milysec/au-company/openapi.json
+++ b/providers/milysec/au-company/openapi.json
@@ -1,0 +1,100 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "MilyPay AU Company",
+    "description": "MilyPay ASIC company register API: look up Australian companies by ACN or name across 3.9M records. Returns status, type, class, registration dates, and former names as JSON over x402 on Solana.",
+    "version": "1.0.0",
+    "contact": {
+      "name": "MilyPay",
+      "url": "https://milypay.xyz",
+      "email": "hello@milysec.com"
+    },
+    "x-brand": "MilyPay"
+  },
+  "servers": [
+    {
+      "url": "https://api.milypay.xyz",
+      "description": "MilyPay production API"
+    }
+  ],
+  "paths": {
+    "/au-company/acn/{acn}": {
+      "get": {
+        "operationId": "lookupCompanyAcn",
+        "summary": "Look up an ASIC company by ACN",
+        "parameters": [
+          {
+            "name": "acn",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "004085616"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Company record"
+          },
+          "402": {
+            "description": "Payment Required (x402)"
+          }
+        },
+        "x-pricing": {
+          "dimensions": [
+            {
+              "direction": "usage",
+              "unit": "requests",
+              "scale": 1,
+              "tiers": [
+                {
+                  "price_usd": 0.002
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "/au-company/search": {
+      "get": {
+        "operationId": "searchCompany",
+        "summary": "Search ASIC companies by name",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "commonwealth bank"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Matching companies"
+          },
+          "402": {
+            "description": "Payment Required (x402)"
+          }
+        },
+        "x-pricing": {
+          "dimensions": [
+            {
+              "direction": "usage",
+              "unit": "requests",
+              "scale": 1,
+              "tiers": [
+                {
+                  "price_usd": 0.004
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/providers/milysec/au-company/openapi.json
+++ b/providers/milysec/au-company/openapi.json
@@ -1,20 +1,20 @@
 {
   "openapi": "3.1.0",
   "info": {
-    "title": "MilyPay AU Company",
-    "description": "MilyPay ASIC company register API: look up Australian companies by ACN or name across 3.9M records. Returns status, type, class, registration dates, and former names as JSON over x402 on Solana.",
+    "title": "Milypay AU Company",
+    "description": "Milypay ASIC company register API: look up Australian companies by ACN or name across 3.9M records. Returns status, type, class, registration dates, and former names as JSON over x402 on Solana.",
     "version": "1.0.0",
     "contact": {
-      "name": "MilyPay",
+      "name": "Milypay",
       "url": "https://milypay.xyz",
       "email": "hello@milysec.com"
     },
-    "x-brand": "MilyPay"
+    "x-brand": "Milypay"
   },
   "servers": [
     {
       "url": "https://api.milypay.xyz",
-      "description": "MilyPay production API"
+      "description": "Milypay production API"
     }
   ],
   "paths": {

--- a/providers/milysec/au-postage/PAY.md
+++ b/providers/milysec/au-postage/PAY.md
@@ -1,0 +1,22 @@
+---
+name: au-postage
+title: "MilyPay AU Postage"
+description: "MilyPay Australia Post postage rates API: domestic and international parcel service options and prices between postcodes via the AusPost PAC. JSON over x402 on Solana for agents."
+use_case: "Use for Australia Post shipping quotes, domestic postcode-to-postcode parcel rates, international postage by country code, and agent logistics pricing in Australia."
+category: shopping
+service_url: https://api.milypay.xyz
+version: v1
+openapi:
+  path: openapi.json
+---
+
+MilyPay Australia Post PAC rates. Domestic: `from`, `to`, `weight`. International: `country`, `weight`.
+
+Pay per call via x402 on Solana. Accepts **USDC**, **USDT**, and **AUDD**.
+
+## Spend-aware usage
+
+- Quote once per lane (from/to/weight); reuse within the cart.
+- Prefer domestic postcodes when both ends are Australian.
+
+Docs: https://milypay.xyz/agents.md · Demo: https://milypay.xyz/demo · Brand: **MilyPay** (Milysec)

--- a/providers/milysec/au-postage/PAY.md
+++ b/providers/milysec/au-postage/PAY.md
@@ -1,7 +1,7 @@
 ---
 name: au-postage
-title: "MilyPay AU Postage"
-description: "MilyPay Australia Post postage rates API: domestic and international parcel service options and prices between postcodes via the AusPost PAC. JSON over x402 on Solana for agents."
+title: "Milypay AU Postage"
+description: "Milypay Australia Post postage rates API: domestic and international parcel service options and prices between postcodes via the AusPost PAC. JSON over x402 on Solana for agents."
 use_case: "Use for Australia Post shipping quotes, domestic postcode-to-postcode parcel rates, international postage by country code, and agent logistics pricing in Australia."
 category: shopping
 service_url: https://api.milypay.xyz
@@ -10,7 +10,7 @@ openapi:
   path: openapi.json
 ---
 
-MilyPay Australia Post PAC rates. Domestic: `from`, `to`, `weight`. International: `country`, `weight`.
+Milypay Australia Post PAC rates. Domestic: `from`, `to`, `weight`. International: `country`, `weight`.
 
 Pay per call via x402 on Solana. Accepts **USDC**, **USDT**, and **AUDD**.
 
@@ -19,4 +19,4 @@ Pay per call via x402 on Solana. Accepts **USDC**, **USDT**, and **AUDD**.
 - Quote once per lane (from/to/weight); reuse within the cart.
 - Prefer domestic postcodes when both ends are Australian.
 
-Docs: https://milypay.xyz/agents.md · Demo: https://milypay.xyz/demo · Brand: **MilyPay** (Milysec)
+Docs: https://milypay.xyz/agents.md · Demo: https://milypay.xyz/demo · Brand: **Milypay** (Milysec)

--- a/providers/milysec/au-postage/openapi.json
+++ b/providers/milysec/au-postage/openapi.json
@@ -1,20 +1,20 @@
 {
   "openapi": "3.1.0",
   "info": {
-    "title": "MilyPay AU Postage",
-    "description": "MilyPay Australia Post postage rates API: domestic and international parcel service options and prices between postcodes via the AusPost PAC. JSON over x402 on Solana for agents.",
+    "title": "Milypay AU Postage",
+    "description": "Milypay Australia Post postage rates API: domestic and international parcel service options and prices between postcodes via the AusPost PAC. JSON over x402 on Solana for agents.",
     "version": "1.0.0",
     "contact": {
-      "name": "MilyPay",
+      "name": "Milypay",
       "url": "https://milypay.xyz",
       "email": "hello@milysec.com"
     },
-    "x-brand": "MilyPay"
+    "x-brand": "Milypay"
   },
   "servers": [
     {
       "url": "https://api.milypay.xyz",
-      "description": "MilyPay production API"
+      "description": "Milypay production API"
     }
   ],
   "paths": {

--- a/providers/milysec/au-postage/openapi.json
+++ b/providers/milysec/au-postage/openapi.json
@@ -1,0 +1,88 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "MilyPay AU Postage",
+    "description": "MilyPay Australia Post postage rates API: domestic and international parcel service options and prices between postcodes via the AusPost PAC. JSON over x402 on Solana for agents.",
+    "version": "1.0.0",
+    "contact": {
+      "name": "MilyPay",
+      "url": "https://milypay.xyz",
+      "email": "hello@milysec.com"
+    },
+    "x-brand": "MilyPay"
+  },
+  "servers": [
+    {
+      "url": "https://api.milypay.xyz",
+      "description": "MilyPay production API"
+    }
+  ],
+  "paths": {
+    "/au-postage": {
+      "get": {
+        "operationId": "getPostage",
+        "summary": "Australia Post parcel rates",
+        "parameters": [
+          {
+            "name": "from",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "3000"
+            }
+          },
+          {
+            "name": "to",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "2000"
+            }
+          },
+          {
+            "name": "weight",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "number",
+              "example": 0.5
+            }
+          },
+          {
+            "name": "country",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "US"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Service options and prices"
+          },
+          "402": {
+            "description": "Payment Required (x402)"
+          }
+        },
+        "x-pricing": {
+          "dimensions": [
+            {
+              "direction": "usage",
+              "unit": "requests",
+              "scale": 1,
+              "tiers": [
+                {
+                  "price_usd": 0.002
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/providers/milysec/au-super/PAY.md
+++ b/providers/milysec/au-super/PAY.md
@@ -1,0 +1,22 @@
+---
+name: au-super
+title: "MilyPay AU Super"
+description: "MilyPay Australian super fund lookup by ABN from the ATO Super Fund Lookup register. Returns fund name, status, type, complying status, and USIs as JSON for agents over x402 on Solana."
+use_case: "Use for Australian super fund verification by ABN, complying-status checks, USI retrieval, and retirement-fund identity workflows for agents."
+category: finance
+service_url: https://api.milypay.xyz
+version: v1
+openapi:
+  path: openapi.json
+---
+
+MilyPay Super Fund Lookup (ATO). Verify funds by ABN.
+
+Pay per call via x402 on Solana. Accepts **USDC**, **USDT**, and **AUDD**.
+
+## Spend-aware usage
+
+- Call once per ABN and cache for the task.
+- Do not poll the same fund ABN repeatedly.
+
+Docs: https://milypay.xyz/agents.md · Demo: https://milypay.xyz/demo · Brand: **MilyPay** (Milysec)

--- a/providers/milysec/au-super/PAY.md
+++ b/providers/milysec/au-super/PAY.md
@@ -1,7 +1,7 @@
 ---
 name: au-super
-title: "MilyPay AU Super"
-description: "MilyPay Australian super fund lookup by ABN from the ATO Super Fund Lookup register. Returns fund name, status, type, complying status, and USIs as JSON for agents over x402 on Solana."
+title: "Milypay AU Super"
+description: "Milypay Australian super fund lookup by ABN from the ATO Super Fund Lookup register. Returns fund name, status, type, complying status, and USIs as JSON for agents over x402 on Solana."
 use_case: "Use for Australian super fund verification by ABN, complying-status checks, USI retrieval, and retirement-fund identity workflows for agents."
 category: finance
 service_url: https://api.milypay.xyz
@@ -10,7 +10,7 @@ openapi:
   path: openapi.json
 ---
 
-MilyPay Super Fund Lookup (ATO). Verify funds by ABN.
+Milypay Super Fund Lookup (ATO). Verify funds by ABN.
 
 Pay per call via x402 on Solana. Accepts **USDC**, **USDT**, and **AUDD**.
 
@@ -19,4 +19,4 @@ Pay per call via x402 on Solana. Accepts **USDC**, **USDT**, and **AUDD**.
 - Call once per ABN and cache for the task.
 - Do not poll the same fund ABN repeatedly.
 
-Docs: https://milypay.xyz/agents.md · Demo: https://milypay.xyz/demo · Brand: **MilyPay** (Milysec)
+Docs: https://milypay.xyz/agents.md · Demo: https://milypay.xyz/demo · Brand: **Milypay** (Milysec)

--- a/providers/milysec/au-super/openapi.json
+++ b/providers/milysec/au-super/openapi.json
@@ -1,0 +1,61 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "MilyPay AU Super",
+    "description": "MilyPay Australian super fund lookup by ABN from the ATO Super Fund Lookup register. Returns fund name, status, type, complying status, and USIs as JSON for agents over x402 on Solana.",
+    "version": "1.0.0",
+    "contact": {
+      "name": "MilyPay",
+      "url": "https://milypay.xyz",
+      "email": "hello@milysec.com"
+    },
+    "x-brand": "MilyPay"
+  },
+  "servers": [
+    {
+      "url": "https://api.milypay.xyz",
+      "description": "MilyPay production API"
+    }
+  ],
+  "paths": {
+    "/au-super/abn/{abn}": {
+      "get": {
+        "operationId": "lookupSuperFund",
+        "summary": "Look up an Australian super fund by ABN",
+        "parameters": [
+          {
+            "name": "abn",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "65714394898"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Super fund record"
+          },
+          "402": {
+            "description": "Payment Required (x402)"
+          }
+        },
+        "x-pricing": {
+          "dimensions": [
+            {
+              "direction": "usage",
+              "unit": "requests",
+              "scale": 1,
+              "tiers": [
+                {
+                  "price_usd": 0.002
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/providers/milysec/au-super/openapi.json
+++ b/providers/milysec/au-super/openapi.json
@@ -1,20 +1,20 @@
 {
   "openapi": "3.1.0",
   "info": {
-    "title": "MilyPay AU Super",
-    "description": "MilyPay Australian super fund lookup by ABN from the ATO Super Fund Lookup register. Returns fund name, status, type, complying status, and USIs as JSON for agents over x402 on Solana.",
+    "title": "Milypay AU Super",
+    "description": "Milypay Australian super fund lookup by ABN from the ATO Super Fund Lookup register. Returns fund name, status, type, complying status, and USIs as JSON for agents over x402 on Solana.",
     "version": "1.0.0",
     "contact": {
-      "name": "MilyPay",
+      "name": "Milypay",
       "url": "https://milypay.xyz",
       "email": "hello@milysec.com"
     },
-    "x-brand": "MilyPay"
+    "x-brand": "Milypay"
   },
   "servers": [
     {
       "url": "https://api.milypay.xyz",
-      "description": "MilyPay production API"
+      "description": "Milypay production API"
     }
   ],
   "paths": {

--- a/providers/milysec/au-weather/PAY.md
+++ b/providers/milysec/au-weather/PAY.md
@@ -1,7 +1,7 @@
 ---
 name: au-weather
-title: "MilyPay AU Weather"
-description: "MilyPay Australian weather API: current conditions and multi-day forecast for any Australian address or coordinate using BOM ACCESS-G via Open-Meteo. JSON over x402 on Solana."
+title: "Milypay AU Weather"
+description: "Milypay Australian weather API: current conditions and multi-day forecast for any Australian address or coordinate using BOM ACCESS-G via Open-Meteo. JSON over x402 on Solana."
 use_case: "Use for Australian weather by address, BOM-style forecasts by lat/lng, current conditions, multi-day outlooks, and location-aware agent workflows in Australia."
 category: data
 service_url: https://api.milypay.xyz
@@ -10,7 +10,7 @@ openapi:
   path: openapi.json
 ---
 
-MilyPay weather for Australia (BOM ACCESS-G via Open-Meteo). Query by address `q` or `lat`/`lng`.
+Milypay weather for Australia (BOM ACCESS-G via Open-Meteo). Query by address `q` or `lat`/`lng`.
 
 Pay per call via x402 on Solana. Accepts **USDC**, **USDT**, and **AUDD**.
 
@@ -19,4 +19,4 @@ Pay per call via x402 on Solana. Accepts **USDC**, **USDT**, and **AUDD**.
 - Prefer coordinates when already known — avoids an extra address resolve.
 - One call covers current + multi-day forecast; do not fan out per day.
 
-Docs: https://milypay.xyz/agents.md · Demo: https://milypay.xyz/demo · Brand: **MilyPay** (Milysec)
+Docs: https://milypay.xyz/agents.md · Demo: https://milypay.xyz/demo · Brand: **Milypay** (Milysec)

--- a/providers/milysec/au-weather/PAY.md
+++ b/providers/milysec/au-weather/PAY.md
@@ -1,0 +1,22 @@
+---
+name: au-weather
+title: "MilyPay AU Weather"
+description: "MilyPay Australian weather API: current conditions and multi-day forecast for any Australian address or coordinate using BOM ACCESS-G via Open-Meteo. JSON over x402 on Solana."
+use_case: "Use for Australian weather by address, BOM-style forecasts by lat/lng, current conditions, multi-day outlooks, and location-aware agent workflows in Australia."
+category: data
+service_url: https://api.milypay.xyz
+version: v1
+openapi:
+  path: openapi.json
+---
+
+MilyPay weather for Australia (BOM ACCESS-G via Open-Meteo). Query by address `q` or `lat`/`lng`.
+
+Pay per call via x402 on Solana. Accepts **USDC**, **USDT**, and **AUDD**.
+
+## Spend-aware usage
+
+- Prefer coordinates when already known — avoids an extra address resolve.
+- One call covers current + multi-day forecast; do not fan out per day.
+
+Docs: https://milypay.xyz/agents.md · Demo: https://milypay.xyz/demo · Brand: **MilyPay** (Milysec)

--- a/providers/milysec/au-weather/openapi.json
+++ b/providers/milysec/au-weather/openapi.json
@@ -1,0 +1,79 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "MilyPay AU Weather",
+    "description": "MilyPay Australian weather API: current conditions and multi-day forecast for any Australian address or coordinate using BOM ACCESS-G via Open-Meteo. JSON over x402 on Solana.",
+    "version": "1.0.0",
+    "contact": {
+      "name": "MilyPay",
+      "url": "https://milypay.xyz",
+      "email": "hello@milysec.com"
+    },
+    "x-brand": "MilyPay"
+  },
+  "servers": [
+    {
+      "url": "https://api.milypay.xyz",
+      "description": "MilyPay production API"
+    }
+  ],
+  "paths": {
+    "/au-weather": {
+      "get": {
+        "operationId": "getWeather",
+        "summary": "Current conditions and forecast for an Australian location",
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "Melbourne VIC"
+            }
+          },
+          {
+            "name": "lat",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "number",
+              "example": -37.81
+            }
+          },
+          {
+            "name": "lng",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "number",
+              "example": 144.96
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Weather payload"
+          },
+          "402": {
+            "description": "Payment Required (x402)"
+          }
+        },
+        "x-pricing": {
+          "dimensions": [
+            {
+              "direction": "usage",
+              "unit": "requests",
+              "scale": 1,
+              "tiers": [
+                {
+                  "price_usd": 0.001
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/providers/milysec/au-weather/openapi.json
+++ b/providers/milysec/au-weather/openapi.json
@@ -1,20 +1,20 @@
 {
   "openapi": "3.1.0",
   "info": {
-    "title": "MilyPay AU Weather",
-    "description": "MilyPay Australian weather API: current conditions and multi-day forecast for any Australian address or coordinate using BOM ACCESS-G via Open-Meteo. JSON over x402 on Solana.",
+    "title": "Milypay AU Weather",
+    "description": "Milypay Australian weather API: current conditions and multi-day forecast for any Australian address or coordinate using BOM ACCESS-G via Open-Meteo. JSON over x402 on Solana.",
     "version": "1.0.0",
     "contact": {
-      "name": "MilyPay",
+      "name": "Milypay",
       "url": "https://milypay.xyz",
       "email": "hello@milysec.com"
     },
-    "x-brand": "MilyPay"
+    "x-brand": "Milypay"
   },
   "servers": [
     {
       "url": "https://api.milypay.xyz",
-      "description": "MilyPay production API"
+      "description": "Milypay production API"
     }
   ],
   "paths": {


### PR DESCRIPTION
## Summary

Adds **MilyPay** Australian data providers under the `milysec/*` namespace for the pay-skills registry / pay.sh catalog.

MilyPay is the x402 service provider for Australia (a Milysec company). Agents get pay-per-call access to Australian government and commercial data — no API keys, no signup.

### Providers

| FQN | Category | What |
| --- | --- | --- |
| `milysec/au-business` | identity | ABR ABN / ACN / name search |
| `milysec/au-company` | identity | ASIC company register |
| `milysec/au-address` | maps | G-NAF validate / search / geocode |
| `milysec/au-super` | finance | ATO super fund lookup |
| `milysec/au-weather` | data | BOM ACCESS-G weather |
| `milysec/au-postage` | shopping | Australia Post PAC rates |
| `milysec/au-bsb` | finance | AusPayNet BSB directory |

### Settlement

- Network: Solana mainnet
- Stables: **USDC**, **USDT** (pay-skills required), and **AUDD** (AUD-native)
- Facilitator: PayAI
- Base URL: `https://api.milypay.xyz`

### Validation

```bash
pay catalog check providers/milysec/au-business/PAY.md
# all 7 providers: PAY.md check successful, Solana-compatible
```

### Links

- Site: https://milypay.xyz
- Agent docs: https://milypay.xyz/agents.md
- Demo: https://milypay.xyz/demo
- Manifest: https://milypay.xyz/api/x402-manifest

## Checklist

- [x] `pay catalog check` green for each provider
- [x] OpenAPI committed as `openapi.json` sidecars
- [x] `name:` matches directory
- [x] description / use_case length constraints
- [x] Brand spelling: **MilyPay** (not Milypay)
- [x] Paid endpoints return Solana 402 accepting USDC / USDT