### PR TITLE
Add Recompete Radar

### DIFF
--- a/providers/melchiorlabs/recompete-radar/PAY.md
+++ b/providers/melchiorlabs/recompete-radar/PAY.md
@@ -1,0 +1,44 @@
+---
+name: recompete-radar
+title: "Recompete Radar"
+description: "Source-linked USAspending evidence for federal contract awards approaching their reported period-of-performance end date, with recipient, agency, obligation, expiration, provenance, and receipt fields."
+use_case: "Use for researching federal contract award expirations by recipient name or UEI, building sourced GovCon watchlists, and retrieving current USAspending records with direct award links."
+category: data
+service_url: https://recompete.melchiorlabs.com
+version: v1
+openapi:
+  path: openapi.json
+---
+
+Recompete Radar exposes one paid operation: `POST /v1/awards/expiring`.
+Send a JSON body with the required `recipient` field and optional `windowDays`,
+`asOf`, `limit`, and `minimumAwardAmount` controls. The response returns current
+USAspending-backed award records, days until their reported end dates, direct
+USAspending links, source metadata, scan coverage, digests, and interpretation
+warnings.
+
+Each successful request costs $0.03 USDC over x402. The live payment challenge
+accepts Base and Solana mainnet. Invalid input, an incomplete broad-recipient
+scan, and upstream failures are not successful paid results.
+
+## Interpretation limits
+
+- An award's reported expiration is not proof of a recompete, renewal,
+  solicitation, or future opportunity. The API does not predict any of them.
+- Recompete Radar is an independent product and is not affiliated with or
+  endorsed by the U.S. government.
+- USAspending records can be revised. `asOf` filters the current source snapshot
+  and does not reconstruct what the source reported historically.
+- Recipient lookup can span similarly named entities. Prefer a UEI when entity
+  precision matters and review the returned recipient names and source links.
+- `totalObligation` is cumulative federal obligation from USAspending's Award
+  Amount field, not the award's potential ceiling.
+
+## Spend-aware usage
+
+- Use the smallest `windowDays` and `limit` that answer the research question.
+- Apply `minimumAwardAmount` when low-value awards are outside the task scope.
+- Reuse returned award IDs and USAspending links instead of repeating broad
+  recipient searches.
+- Treat a zero-result response as evidence for the stated query and current
+  source snapshot, not as proof that no future opportunity exists.

--- a/providers/melchiorlabs/recompete-radar/openapi.json
+++ b/providers/melchiorlabs/recompete-radar/openapi.json
@@ -1,0 +1,275 @@
+{
+    "openapi": "3.1.0",
+    "info": {
+        "title": "Recompete Radar",
+        "version": "1.0.0",
+        "description": "Pay-per-request lookups of federal contract awards approaching the end of their period of performance, backed by USAspending.gov. Independent tool; not affiliated with or endorsed by the U.S. government."
+    },
+    "servers": [
+        {
+            "url": "https://recompete.melchiorlabs.com"
+        }
+    ],
+    "paths": {
+        "/v1/awards/expiring": {
+            "post": {
+                "summary": "Find a recipient's awards expiring within a window",
+                "description": "Requires payment of $0.03 over x402 (HTTP 402).",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "additionalProperties": false,
+                                "properties": {
+                                    "recipient": {
+                                        "type": "string",
+                                        "minLength": 2,
+                                        "maxLength": 120,
+                                        "description": "Recipient name or UEI to search for in USAspending"
+                                    },
+                                    "windowDays": {
+                                        "type": "integer",
+                                        "minimum": 30,
+                                        "maximum": 1095,
+                                        "default": 365
+                                    },
+                                    "asOf": {
+                                        "type": "string",
+                                        "format": "date",
+                                        "description": "Defaults to today (UTC)"
+                                    },
+                                    "limit": {
+                                        "type": "integer",
+                                        "minimum": 1,
+                                        "maximum": 50,
+                                        "default": 20
+                                    },
+                                    "minimumAwardAmount": {
+                                        "type": "number",
+                                        "minimum": 0,
+                                        "maximum": 1000000000,
+                                        "default": 0
+                                    }
+                                },
+                                "required": [
+                                    "recipient"
+                                ]
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Expiring awards for the recipient",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "requestId": {
+                                            "type": "string"
+                                        },
+                                        "query": {
+                                            "type": "object",
+                                            "additionalProperties": false,
+                                            "required": [
+                                                "recipient",
+                                                "windowDays",
+                                                "asOf",
+                                                "limit",
+                                                "minimumAwardAmount"
+                                            ],
+                                            "properties": {
+                                                "recipient": {
+                                                    "type": "string"
+                                                },
+                                                "windowDays": {
+                                                    "type": "integer"
+                                                },
+                                                "asOf": {
+                                                    "type": "string",
+                                                    "format": "date"
+                                                },
+                                                "limit": {
+                                                    "type": "integer"
+                                                },
+                                                "minimumAwardAmount": {
+                                                    "type": "number"
+                                                }
+                                            }
+                                        },
+                                        "dataAsOf": {
+                                            "type": [
+                                                "string",
+                                                "null"
+                                            ],
+                                            "format": "date"
+                                        },
+                                        "generatedAt": {
+                                            "type": "string",
+                                            "format": "date-time"
+                                        },
+                                        "source": {
+                                            "type": "object",
+                                            "properties": {
+                                                "name": {
+                                                    "type": "string"
+                                                },
+                                                "apiUrl": {
+                                                    "type": "string"
+                                                },
+                                                "websiteUrl": {
+                                                    "type": "string"
+                                                },
+                                                "independent": {
+                                                    "type": "boolean"
+                                                }
+                                            }
+                                        },
+                                        "results": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "awardId": {
+                                                        "type": "string"
+                                                    },
+                                                    "recipientName": {
+                                                        "type": "string"
+                                                    },
+                                                    "agency": {
+                                                        "type": [
+                                                            "string",
+                                                            "null"
+                                                        ]
+                                                    },
+                                                    "subagency": {
+                                                        "type": [
+                                                            "string",
+                                                            "null"
+                                                        ]
+                                                    },
+                                                    "contractAwardType": {
+                                                        "type": [
+                                                            "string",
+                                                            "null"
+                                                        ]
+                                                    },
+                                                    "startDate": {
+                                                        "type": [
+                                                            "string",
+                                                            "null"
+                                                        ],
+                                                        "format": "date"
+                                                    },
+                                                    "endDate": {
+                                                        "type": "string",
+                                                        "format": "date"
+                                                    },
+                                                    "totalObligation": {
+                                                        "type": "number",
+                                                        "description": "USAspending's Award Amount field: cumulative federal obligation, not potential contract ceiling."
+                                                    },
+                                                    "description": {
+                                                        "type": [
+                                                            "string",
+                                                            "null"
+                                                        ]
+                                                    },
+                                                    "daysUntilExpiration": {
+                                                        "type": "integer"
+                                                    },
+                                                    "usaspendingUrl": {
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "summary": {
+                                            "type": "object",
+                                            "properties": {
+                                                "count": {
+                                                    "type": "integer"
+                                                },
+                                                "returnedTotalObligation": {
+                                                    "type": "number"
+                                                },
+                                                "earliestExpiration": {
+                                                    "type": [
+                                                        "string",
+                                                        "null"
+                                                    ],
+                                                    "format": "date"
+                                                },
+                                                "sourceRecordsScanned": {
+                                                    "type": "integer"
+                                                },
+                                                "scanCompleteThroughAsOf": {
+                                                    "type": "boolean"
+                                                }
+                                            }
+                                        },
+                                        "receipt": {
+                                            "type": "object",
+                                            "properties": {
+                                                "inputDigest": {
+                                                    "type": "string"
+                                                },
+                                                "sourceSnapshot": {
+                                                    "type": [
+                                                        "string",
+                                                        "null"
+                                                    ],
+                                                    "format": "date"
+                                                },
+                                                "resultDigest": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        },
+                                        "warnings": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request"
+                    },
+                    "402": {
+                        "description": "Payment required (x402)"
+                    },
+                    "413": {
+                        "description": "Request body too large"
+                    },
+                    "422": {
+                        "description": "Recipient search is too broad to complete within the source scan safety bound; payment is not settled"
+                    },
+                    "502": {
+                        "description": "Upstream (USAspending) connection or data error"
+                    },
+                    "504": {
+                        "description": "Upstream (USAspending) request timed out"
+                    }
+                }
+            }
+        },
+        "/health": {
+            "get": {
+                "summary": "Check Recompete Radar service health",
+                "responses": {
+                    "200": {
+                        "description": "Service is healthy"
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds `melchiorlabs/recompete-radar`, a source-linked federal award expiration evidence API backed by USAspending.gov. The provider skill documents its interpretation limits, spend-aware usage, and current request/response contract.

## Validation

- The committed OpenAPI sidecar was refetched from the deployed service and semantically matches production.
- `npx --yes @solana/pay catalog check providers/melchiorlabs/recompete-radar/PAY.md -v` passed.
- `npx --yes @solana/pay catalog check . --changed-from origin/main` passed.
- Two endpoints were tested; the paid POST returned an x402 USDC challenge and passed the Solana compatibility gate (1/1 paid gates compatible).
- The full no-probe registry check exited 0; its warnings were pre-existing elsewhere in the registry.

## Provider behavior

- Paid: `POST /v1/awards/expiring`, $0.03 USDC via x402 on Base or Solana.
- Free: `GET /health`.
- Invalid input, incomplete broad-recipient scans, and upstream failures are not successful paid results.
- The product reports current public award records and explicitly does not predict recompetes, renewals, solicitations, or future opportunities.