### PR TITLE
Add Utilia Solana Preflight

### DIFF
--- a/providers/utilia/preflight/PAY.md
+++ b/providers/utilia/preflight/PAY.md
@@ -1,0 +1,37 @@
+---
+name: preflight
+title: "Utilia Solana Preflight"
+description: "Pay-per-call Solana transaction simulation, failure diagnostics, priority-fee estimates, and token-risk analysis. Structured results over x402 with no account, API key, or subscription."
+use_case: "Use when an AI agent needs to simulate a Solana transaction before signing or broadcasting, diagnose a failed signature, choose a priority-fee bid, or check an unfamiliar SPL or Token-2022 mint for authority and concentration risks."
+category: devtools
+service_url: https://api.utilia.ink
+version: v1
+openapi:
+  path: openapi.json
+---
+
+Utilia gives autonomous agents four narrow Solana preflight and diagnostic
+operations without requiring an account or API key. Each paid call settles in
+USDC on Solana mainnet through x402 v2 and returns structured JSON suitable for
+automated decisions.
+
+## Capabilities and pricing
+
+| Operation | Price | Use |
+|---|---:|---|
+| `GET /v1/fees/priority` | $0.002 | Estimate network-wide or writable-account-local priority fees. |
+| `GET /v1/transaction/{signature}` | $0.004 | Explain confirmation, balances, logs, compute use, and failures. |
+| `GET /v1/token/{mint}` | $0.006 | Inspect authorities, Token-2022 controls, concentration, and risk flags. |
+| `POST /v1/transaction/simulate` | $0.008 | Simulate a serialized transaction with a fresh blockhash before broadcast. |
+
+## Spend-aware usage
+
+- Use the $0.002 fee endpoint only when a transaction is close to broadcast;
+  repeat the `account` query parameter for its writable accounts to obtain a
+  localized estimate.
+- Simulate once after the transaction is fully assembled. Reuse the resulting
+  classification instead of repeatedly simulating an unchanged payload.
+- Analyze a signature only after it is confirmed or has failed; pass the exact
+  signature rather than polling the endpoint.
+- Check token risk once per mint and cache the result until the mint, freeze, or
+  Token-2022 authority state changes.

--- a/providers/utilia/preflight/openapi.json
+++ b/providers/utilia/preflight/openapi.json
@@ -1,0 +1,748 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Utilia Solana Preflight API",
+    "version": "0.1.0",
+    "description": "Machine-payable Solana transaction diagnostics for autonomous agents. No account, subscription, or API key is required. Paid routes use x402 v2 exact USDC payments on Solana mainnet.",
+    "contact": {
+      "url": "https://api.utilia.ink"
+    },
+    "x-guidance": "Use Utilia before a Solana transaction is signed or broadcast, and after a failed transaction needs explanation.\n\nFor unsigned or signed serialized transactions, call POST /v1/transaction/simulate before broadcast. It replaces the recent blockhash, disables signature verification, and classifies failures without submitting the transaction.\n\nFor fee bidding, call GET /v1/fees/priority. Repeat the account query parameter for writable accounts to localize the estimate; omit it for a network-wide sample.\n\nFor a confirmed signature, call GET /v1/transaction/{signature} to inspect balance deltas, logs, compute use, confirmation state, and retry-safe error guidance.\n\nBefore interacting with an unfamiliar token, call GET /v1/token/{mint} to inspect authorities, Token-2022 controls, supply, holder concentration, and risk flags.\n\nEach paid operation declares a fixed USD price and x402 support in x-payment-info. Call it normally, read the PAYMENT-REQUIRED header from HTTP 402, sign the advertised exact Solana USDC payment, then retry with PAYMENT-SIGNATURE."
+  },
+  "servers": [
+    {
+      "url": "https://api.utilia.ink"
+    }
+  ],
+  "tags": [
+    {
+      "name": "Transactions",
+      "description": "Solana transaction preflight and diagnostics"
+    },
+    {
+      "name": "Fees",
+      "description": "Recent Solana priority-fee estimates"
+    },
+    {
+      "name": "Tokens",
+      "description": "SPL token authority and concentration signals"
+    },
+    {
+      "name": "Service",
+      "description": "Free service status"
+    }
+  ],
+  "paths": {
+    "/healthz": {
+      "get": {
+        "operationId": "getServiceHealth",
+        "summary": "Check Utilia service health",
+        "tags": [
+          "Service"
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Healthy",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "status",
+                    "service",
+                    "version",
+                    "payments"
+                  ],
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "const": "ok"
+                    },
+                    "service": {
+                      "type": "string"
+                    },
+                    "version": {
+                      "type": "string"
+                    },
+                    "payments": {
+                      "type": "string",
+                      "enum": [
+                        "enabled",
+                        "disabled"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/transaction/{signature}": {
+      "get": {
+        "operationId": "analyzeSolanaTransaction",
+        "summary": "Analyze a confirmed Solana transaction",
+        "description": "Analyze a confirmed Solana transaction, including confirmation, balance changes, logs, compute usage, and a retry-safe failure classification.",
+        "tags": [
+          "Transactions"
+        ],
+        "parameters": [
+          {
+            "name": "signature",
+            "in": "path",
+            "required": true,
+            "description": "Base58 Solana transaction signature",
+            "schema": {
+              "type": "string",
+              "minLength": 64,
+              "maxLength": 88
+            }
+          }
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.004000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "x-x402-price": "$0.004",
+        "responses": {
+          "200": {
+            "description": "Transaction analysis",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "signature",
+                    "slot",
+                    "succeeded",
+                    "classification",
+                    "solBalanceChanges",
+                    "tokenBalanceChanges",
+                    "logs",
+                    "confirmation"
+                  ],
+                  "properties": {
+                    "signature": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "slot": {
+                      "type": "integer"
+                    },
+                    "blockTime": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ]
+                    },
+                    "succeeded": {
+                      "type": "boolean"
+                    },
+                    "feeLamports": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ]
+                    },
+                    "computeUnitsConsumed": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ]
+                    },
+                    "classification": {
+                      "type": "object",
+                      "required": [
+                        "category",
+                        "summary",
+                        "suggestedAction"
+                      ],
+                      "properties": {
+                        "category": {
+                          "type": "string",
+                          "enum": [
+                            "none",
+                            "slippage",
+                            "insufficient_funds",
+                            "compute_budget",
+                            "expired_blockhash",
+                            "account_conflict",
+                            "program_error",
+                            "unknown"
+                          ]
+                        },
+                        "summary": {
+                          "type": "string"
+                        },
+                        "suggestedAction": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      }
+                    },
+                    "solBalanceChanges": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "account": {
+                            "type": "string"
+                          },
+                          "lamports": {
+                            "type": "integer"
+                          }
+                        }
+                      }
+                    },
+                    "tokenBalanceChanges": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "owner": {
+                            "type": "string"
+                          },
+                          "mint": {
+                            "type": "string"
+                          },
+                          "rawAmount": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "logs": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "rawError": {},
+                    "confirmation": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "additionalProperties": true
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "x402 payment required",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "Base64-encoded x402 v2 payment requirements",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Request failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "requestId": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/transaction/simulate": {
+      "post": {
+        "operationId": "simulateSolanaTransaction",
+        "summary": "Simulate and classify a transaction",
+        "description": "Simulate a serialized Solana transaction with a fresh recent blockhash and classify any failure before broadcast.",
+        "tags": [
+          "Transactions"
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.008000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "x-x402-price": "$0.008",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "transaction"
+                ],
+                "properties": {
+                  "transaction": {
+                    "type": "string",
+                    "description": "Base64- or base58-encoded serialized transaction"
+                  },
+                  "encoding": {
+                    "type": "string",
+                    "enum": [
+                      "base64",
+                      "base58"
+                    ],
+                    "default": "base64"
+                  },
+                  "accountAddresses": {
+                    "type": "array",
+                    "maxItems": 20,
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Simulation analysis",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "slot",
+                    "succeeded",
+                    "unitsConsumed",
+                    "classification",
+                    "logs"
+                  ],
+                  "properties": {
+                    "slot": {
+                      "type": "integer"
+                    },
+                    "succeeded": {
+                      "type": "boolean"
+                    },
+                    "unitsConsumed": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ]
+                    },
+                    "classification": {
+                      "type": "object",
+                      "required": [
+                        "category",
+                        "summary",
+                        "suggestedAction"
+                      ],
+                      "properties": {
+                        "category": {
+                          "type": "string",
+                          "enum": [
+                            "none",
+                            "slippage",
+                            "insufficient_funds",
+                            "compute_budget",
+                            "expired_blockhash",
+                            "account_conflict",
+                            "program_error",
+                            "unknown"
+                          ]
+                        },
+                        "summary": {
+                          "type": "string"
+                        },
+                        "suggestedAction": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      }
+                    },
+                    "logs": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "rawError": {},
+                    "replacementBlockhash": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "additionalProperties": true
+                    },
+                    "accounts": {
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {}
+                    },
+                    "returnData": {}
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Request failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "requestId": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "x402 payment required",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "Base64-encoded x402 v2 payment requirements",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/fees/priority": {
+      "get": {
+        "operationId": "estimateSolanaPriorityFees",
+        "summary": "Estimate priority fee quantiles",
+        "description": "Return recent priority-fee quantiles in micro-lamports, optionally localized to up to 20 writable accounts.",
+        "tags": [
+          "Fees"
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.002000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "x-x402-price": "$0.002",
+        "parameters": [
+          {
+            "name": "account",
+            "in": "query",
+            "description": "Repeatable writable Solana account address",
+            "schema": {
+              "type": "array",
+              "maxItems": 20,
+              "items": {
+                "type": "string"
+              }
+            },
+            "style": "form",
+            "explode": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Priority fee quantiles",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "accounts",
+                    "sampleCount",
+                    "minMicroLamports",
+                    "lowMicroLamports",
+                    "mediumMicroLamports",
+                    "highMicroLamports",
+                    "urgentMicroLamports",
+                    "maxMicroLamports",
+                    "note"
+                  ],
+                  "properties": {
+                    "accounts": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "sampleCount": {
+                      "type": "integer"
+                    },
+                    "minMicroLamports": {
+                      "type": "integer"
+                    },
+                    "lowMicroLamports": {
+                      "type": "integer"
+                    },
+                    "mediumMicroLamports": {
+                      "type": "integer"
+                    },
+                    "highMicroLamports": {
+                      "type": "integer"
+                    },
+                    "urgentMicroLamports": {
+                      "type": "integer"
+                    },
+                    "maxMicroLamports": {
+                      "type": "integer"
+                    },
+                    "note": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Request failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "requestId": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "x402 payment required",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "Base64-encoded x402 v2 payment requirements",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/token/{mint}": {
+      "get": {
+        "operationId": "analyzeSolanaToken",
+        "summary": "Fetch Solana token mint risk signals",
+        "description": "Inspect an SPL token mint for active authorities, Token-2022 controls, supply, holder concentration, and risk flags.",
+        "tags": [
+          "Tokens"
+        ],
+        "x-payment-info": {
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.006000"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "x-x402-price": "$0.006",
+        "parameters": [
+          {
+            "name": "mint",
+            "in": "path",
+            "required": true,
+            "description": "Base58 SPL token mint address",
+            "schema": {
+              "type": "string",
+              "minLength": 32,
+              "maxLength": 44
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Mint analysis",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "mint",
+                    "program",
+                    "ownerProgram",
+                    "supplyRaw",
+                    "token2022Extensions",
+                    "largestAccounts",
+                    "riskFlags",
+                    "caution"
+                  ],
+                  "properties": {
+                    "mint": {
+                      "type": "string"
+                    },
+                    "program": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "ownerProgram": {
+                      "type": "string"
+                    },
+                    "decimals": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ]
+                    },
+                    "supplyRaw": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "initialized": {
+                      "type": [
+                        "boolean",
+                        "null"
+                      ]
+                    },
+                    "mintAuthority": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "freezeAuthority": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "token2022Extensions": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "top10HolderPercent": {
+                      "type": "number"
+                    },
+                    "largestAccounts": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "rank": {
+                            "type": "integer"
+                          },
+                          "address": {
+                            "type": "string"
+                          },
+                          "amountRaw": {
+                            "type": "string"
+                          },
+                          "supplyPercent": {
+                            "type": "number"
+                          }
+                        }
+                      }
+                    },
+                    "riskFlags": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "holderDataAvailable": {
+                      "type": "boolean"
+                    },
+                    "caution": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "x402 payment required",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "Base64-encoded x402 v2 payment requirements",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Request failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "requestId": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Add Utilia, a native Solana x402 provider for transaction simulation, confirmed-transaction diagnostics, priority-fee estimates, and SPL/Token-2022 mint risk signals.

- four paid endpoints at $0.002–$0.008 USDC per call
- Solana mainnet exact-payment challenges through x402 v2
- no account, subscription, or API key
- committed OpenAPI 3.1 document and spend-aware routing guidance

## Validation

- `npx @solana/pay@latest catalog check providers/utilia/preflight/PAY.md -v`
- 4/4 paid gates compatible with Solana
- all paid routes returned valid HTTP 402 x402 USDC challenges
- free `/healthz` correctly classified as free

The live provider is https://api.utilia.ink and its public discovery document is https://api.utilia.ink/.well-known/x402.