### PR TITLE
Add derivatives-pricer: Black-Scholes option pricing + IV surface (x4…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ dist/
 index.json
 skills.json
 /.DS_Store
+pay-skills/

--- a/providers/quantumwatch/derivatives-pricer/PAY.md
+++ b/providers/quantumwatch/derivatives-pricer/PAY.md
@@ -1,8 +1,8 @@
 ---
 name: derivatives-pricer
 title: "Derivatives Pricer"
-description: "x402-paid Black-Scholes European option pricing, full analytic Greeks, and implied-volatility surfaces from market premiums. JSON APIs for agents; USDC on Solana mainnet via PayAI facilitator."
-use_case: "Use for option fair value, delta/vega hedging, IV surfaces from premiums, commodity/power/equity European risk, and portfolio Greeks in agent trading workflows."
+description: "x402-paid Black-Scholes European option pricing, full analytic Greeks, single-premium IV, IV surfaces, portfolio net Greeks, and scenario reprice. JSON APIs for agents; USDC on Solana mainnet or Base mainnet via PayAI facilitator."
+use_case: "Use for option fair value, delta/vega hedging, IV from premiums, portfolio Greeks, scenario P&L, commodity/power/equity European risk in agent trading workflows."
 category: finance
 service_url: https://derivatives-pricer-production.up.railway.app
 version: v1
@@ -10,7 +10,7 @@ openapi:
   path: openapi.json
 ---
 
-x402 pay-per-request derivatives analytics. No API keys. Settlement: **Solana mainnet USDC** via facilitator `https://facilitator.payai.network`.
+x402 pay-per-request derivatives analytics. No API keys. Settlement: **Solana mainnet or Base mainnet USDC** (exact scheme) via facilitator `https://facilitator.payai.network`. Unpaid calls return HTTP 402 with accepts for **both** networks.
 
 OpenAPI: see co-located `openapi.json` (request examples are suitable for `pay catalog` probes).
 
@@ -19,7 +19,10 @@ OpenAPI: see co-located `openapi.json` (request examples are suitable for `pay c
 | Method | Path | Price (USDC) | Summary |
 |--------|------|--------------|---------|
 | `POST` | `/v1/option/price` | $0.01 | BSM fair value + full analytic Greeks |
+| `POST` | `/v1/option/implied-vol` | $0.03 | Solve IV from one market premium + Greeks |
 | `POST` | `/v1/volatility/surface` | $0.10 | IV surface + per-quote IV/Greeks from market premiums |
+| `POST` | `/v1/portfolio/greeks` | $0.15 | Net MTM + Greeks for multi-leg books |
+| `POST` | `/v1/portfolio/scenario` | $0.25 | Scenario reprice (spot/vol/time shocks) |
 | `GET` | `/` | free | Agent service card (capabilities, examples) |
 | `GET` | `/health` | free | Liveness |
 
@@ -37,6 +40,22 @@ OpenAPI: see co-located `openapi.json` (request examples are suitable for `pay c
 }
 ```
 
+### `POST /v1/option/implied-vol` — $0.03 USDC
+
+Solve Black-Scholes implied vol from a single market premium; returns σ̂, full Greeks, modelPrice, priceError, iterations.
+
+```json
+{
+  "underlying": 100,
+  "strike": 100,
+  "timeToExpiry": 1,
+  "rate": 0.05,
+  "dividendYield": 0,
+  "optionType": "call",
+  "premium": 10.45057562
+}
+```
+
 ### `POST /v1/volatility/surface` — $0.10 USDC
 
 Shared `rate` / `dividendYield`; each option has its own `underlying`.
@@ -51,14 +70,87 @@ Shared `rate` / `dividendYield`; each option has its own `underlying`.
       "strike": 90,
       "timeToExpiry": 0.25,
       "optionType": "call",
-      "premium": 12.5
+      "premium": 12.21003823
     },
     {
       "underlying": 102,
       "strike": 100,
       "timeToExpiry": 0.5,
       "optionType": "call",
-      "premium": 8.7
+      "premium": 8.67399132
+    }
+  ]
+}
+```
+
+### `POST /v1/portfolio/greeks` — $0.15 USDC
+
+Net MTM and Greeks for multi-leg European books. `quantity > 0` = long, `quantity < 0` = short.
+
+```json
+{
+  "rate": 0.05,
+  "dividendYield": 0,
+  "includeDollarGreeks": true,
+  "positions": [
+    {
+      "underlying": 100,
+      "strike": 100,
+      "timeToExpiry": 1,
+      "optionType": "call",
+      "quantity": 10,
+      "volatility": 0.2
+    },
+    {
+      "underlying": 100,
+      "strike": 110,
+      "timeToExpiry": 1,
+      "optionType": "put",
+      "quantity": -5,
+      "volatility": 0.22
+    }
+  ]
+}
+```
+
+### `POST /v1/portfolio/scenario` — $0.25 USDC
+
+Base MTM + Greeks, then reprice under relative `spotShock` / `volShock` and `timeDecayDays`.
+
+```json
+{
+  "rate": 0.05,
+  "dividendYield": 0,
+  "positions": [
+    {
+      "underlying": 100,
+      "strike": 100,
+      "timeToExpiry": 1,
+      "optionType": "call",
+      "quantity": 10,
+      "volatility": 0.2
+    },
+    {
+      "underlying": 100,
+      "strike": 110,
+      "timeToExpiry": 1,
+      "optionType": "put",
+      "quantity": -5,
+      "volatility": 0.22
+    }
+  ],
+  "scenarios": [
+    {
+      "name": "spot_down_10",
+      "spotShock": -0.1,
+      "volShock": 0,
+      "timeDecayDays": 0
+    },
+    {
+      "name": "vol_up_20pct_rel",
+      "spotShock": 0,
+      "volShock": 0.2,
+      "timeDecayDays": 1
     }
   ]
 }
@@ -67,15 +159,22 @@ Shared `rate` / `dividendYield`; each option has its own `underlying`.
 ## Payment
 
 - Protocol: **x402** (HTTP 402 → `PAYMENT-REQUIRED` header)
-- Network: **Solana mainnet** (`solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp`)
 - Asset: **USDC**
+- Scheme: **exact**
 - Facilitator: `https://facilitator.payai.network`
+- Networks (client may pay on **either**):
 
-Unpaid paid-path calls return **402**. Decode `PAYMENT-REQUIRED` (base64 JSON) for amount, asset, and payTo.
+| Network | CAIP-2 | payTo |
+|---------|--------|-------|
+| Solana mainnet | `solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp` | server `PAY_TO_ADDRESS` / `PAY_TO_SVM_ADDRESS` |
+| Base mainnet | `eip155:8453` | `0x34cfb8bdbf16e4484b7da0ed31deed5771b16c8f` (`PAY_TO_EVM_ADDRESS`) |
+
+Unpaid paid-path calls return **402**. Decode `PAYMENT-REQUIRED` (base64 JSON) for `accepts[]` — each entry has network, amount/price, asset, and payTo. Pick Solana **or** Base and settle USDC on that chain.
 
 ## Spend-aware usage
 
-- Prefer `/v1/option/price` for single contracts; use `/v1/volatility/surface` only for book-level IV grids.
-- Cap surface `options` to the smallest set that answers the task (max 200).
+- Prefer `/v1/option/price` for single contracts; `/v1/option/implied-vol` for one-premium IV; use `/v1/volatility/surface` only for book-level IV grids.
+- Use `/v1/portfolio/greeks` for net risk; `/v1/portfolio/scenario` for what-if P&L (higher price).
+- Cap surface `options` and portfolio `positions`/`scenarios` to the smallest set that answers the task.
 - Reuse `Idempotency-Key` on retries after successful payment.
 - Keep premiums and underlyings in consistent units (e.g. USD/MWh, USD/bbl, index points).

--- a/providers/quantumwatch/derivatives-pricer/PAY.md
+++ b/providers/quantumwatch/derivatives-pricer/PAY.md
@@ -1,0 +1,81 @@
+---
+name: derivatives-pricer
+title: "Derivatives Pricer"
+description: "x402-paid Black-Scholes European option pricing, full analytic Greeks, and implied-volatility surfaces from market premiums. JSON APIs for agents; USDC on Solana mainnet via PayAI facilitator."
+use_case: "Use for option fair value, delta/vega hedging, IV surfaces from premiums, commodity/power/equity European risk, and portfolio Greeks in agent trading workflows."
+category: finance
+service_url: https://derivatives-pricer-production.up.railway.app
+version: v1
+openapi:
+  path: openapi.json
+---
+
+x402 pay-per-request derivatives analytics. No API keys. Settlement: **Solana mainnet USDC** via facilitator `https://facilitator.payai.network`.
+
+OpenAPI: see co-located `openapi.json` (request examples are suitable for `pay catalog` probes).
+
+## Endpoints
+
+| Method | Path | Price (USDC) | Summary |
+|--------|------|--------------|---------|
+| `POST` | `/v1/option/price` | $0.01 | BSM fair value + full analytic Greeks |
+| `POST` | `/v1/volatility/surface` | $0.10 | IV surface + per-quote IV/Greeks from market premiums |
+| `GET` | `/` | free | Agent service card (capabilities, examples) |
+| `GET` | `/health` | free | Liveness |
+
+### `POST /v1/option/price` — $0.01 USDC
+
+```json
+{
+  "spot": 100,
+  "strike": 100,
+  "timeToExpiry": 1,
+  "rate": 0.05,
+  "volatility": 0.2,
+  "optionType": "call",
+  "dividendYield": 0
+}
+```
+
+### `POST /v1/volatility/surface` — $0.10 USDC
+
+Shared `rate` / `dividendYield`; each option has its own `underlying`.
+
+```json
+{
+  "rate": 0.05,
+  "dividendYield": 0,
+  "options": [
+    {
+      "underlying": 100,
+      "strike": 90,
+      "timeToExpiry": 0.25,
+      "optionType": "call",
+      "premium": 12.5
+    },
+    {
+      "underlying": 102,
+      "strike": 100,
+      "timeToExpiry": 0.5,
+      "optionType": "call",
+      "premium": 8.7
+    }
+  ]
+}
+```
+
+## Payment
+
+- Protocol: **x402** (HTTP 402 → `PAYMENT-REQUIRED` header)
+- Network: **Solana mainnet** (`solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp`)
+- Asset: **USDC**
+- Facilitator: `https://facilitator.payai.network`
+
+Unpaid paid-path calls return **402**. Decode `PAYMENT-REQUIRED` (base64 JSON) for amount, asset, and payTo.
+
+## Spend-aware usage
+
+- Prefer `/v1/option/price` for single contracts; use `/v1/volatility/surface` only for book-level IV grids.
+- Cap surface `options` to the smallest set that answers the task (max 200).
+- Reuse `Idempotency-Key` on retries after successful payment.
+- Keep premiums and underlyings in consistent units (e.g. USD/MWh, USD/bbl, index points).

--- a/providers/quantumwatch/derivatives-pricer/openapi.json
+++ b/providers/quantumwatch/derivatives-pricer/openapi.json
@@ -5,6 +5,7 @@
     "description": "x402-paid Black-Scholes European option pricing, analytic Greeks, single-premium IV, IV surfaces, portfolio net Greeks, and scenario reprice. USDC exact on Solana mainnet and/or Base mainnet via PayAI. No API keys.",
     "version": "1.3.0",
     "contact": {
+      "name": "Derivatives Pricer",
       "url": "https://derivatives-pricer-production.up.railway.app"
     }
   },
@@ -33,6 +34,31 @@
     }
   ],
   "paths": {
+    "/": {
+      "get": {
+        "operationId": "getServiceCard",
+        "tags": [
+          "discovery"
+        ],
+        "summary": "Service card for agents",
+        "description": "Machine-readable catalog: capabilities, endpoints, examples, settlement. Free — no x402 payment.",
+        "security": [],
+        "x-free": true,
+        "responses": {
+          "200": {
+            "description": "Service discovery document",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/health": {
       "get": {
         "operationId": "getHealth",
@@ -40,7 +66,9 @@
           "discovery"
         ],
         "summary": "Liveness probe",
-        "description": "Returns service status, networks, and pricing snapshot. Free.",
+        "description": "Returns service status, networks, pricing snapshot, and payTo receivers. Free — no x402 payment.",
+        "security": [],
+        "x-free": true,
         "responses": {
           "200": {
             "description": "Service is healthy",
@@ -56,17 +84,69 @@
         }
       }
     },
-    "/": {
+    "/openapi.json": {
       "get": {
-        "operationId": "getServiceCard",
+        "operationId": "getOpenApi",
         "tags": [
           "discovery"
         ],
-        "summary": "Service card for agents",
-        "description": "Machine-readable catalog: capabilities, endpoints, examples. Free.",
+        "summary": "OpenAPI 3.1 specification",
+        "description": "Full OpenAPI document for this service. Free — no x402 payment.",
+        "security": [],
+        "x-free": true,
         "responses": {
           "200": {
-            "description": "Service discovery document",
+            "description": "OpenAPI 3.1 document",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/.well-known/x402": {
+      "get": {
+        "operationId": "getWellKnownX402",
+        "tags": [
+          "discovery"
+        ],
+        "summary": "x402 well-known discovery manifest",
+        "description": "Machine-readable x402 service discovery (resources, pricing, settlement). Free — no x402 payment. Same payload as /.well-known/x402.json.",
+        "security": [],
+        "x-free": true,
+        "responses": {
+          "200": {
+            "description": "x402 discovery document",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/.well-known/x402.json": {
+      "get": {
+        "operationId": "getWellKnownX402Json",
+        "tags": [
+          "discovery"
+        ],
+        "summary": "x402 well-known discovery manifest",
+        "description": "Machine-readable x402 service discovery (JSON alias). Free — no x402 payment.",
+        "security": [],
+        "x-free": true,
+        "responses": {
+          "200": {
+            "description": "x402 discovery document",
             "content": {
               "application/json": {
                 "schema": {
@@ -86,7 +166,7 @@
           "options"
         ],
         "summary": "Price European option + Greeks",
-        "description": "Black-Scholes-Merton fair value and full analytic Greeks (delta, gamma, vega, theta, rho). Paid via x402: $0.01 USDC per request (Solana mainnet or Base mainnet). or Base mainnet (USDC exact).",
+        "description": "Black-Scholes-Merton fair value and full analytic Greeks (delta, gamma, vega, theta, rho). Paid via x402: $0.01 USDC per request (Solana mainnet or Base mainnet).",
         "parameters": [
           {
             "name": "Idempotency-Key",
@@ -197,7 +277,143 @@
             "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
             "eip155:8453"
           ]
-        }
+        },
+        "security": [
+          {
+            "x402": []
+          }
+        ]
+      }
+    },
+    "/v1/option/implied-vol": {
+      "post": {
+        "operationId": "solveImpliedVol",
+        "tags": [
+          "options"
+        ],
+        "summary": "Implied volatility from market premium",
+        "description": "Solve Black-Scholes implied volatility from a single market premium and return full analytic Greeks at the solved σ. Paid via x402: $0.03 USDC per request (Solana mainnet or Base mainnet).",
+        "parameters": [
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "Optional key for safe retries of a paid request"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ImpliedVolRequest"
+              },
+              "example": {
+                "underlying": 100,
+                "strike": 100,
+                "timeToExpiry": 1,
+                "rate": 0.05,
+                "dividendYield": 0,
+                "optionType": "call",
+                "premium": 10.45057562
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Implied vol, Greeks, model price (after successful x402 settlement)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImpliedVolResponse"
+                },
+                "example": {
+                  "impliedVol": 0.2,
+                  "greeks": {
+                    "delta": 0.63683059,
+                    "gamma": 0.01876202,
+                    "vega": 37.52403469,
+                    "theta": -6.41402764,
+                    "rho": 53.23248343
+                  },
+                  "modelPrice": 10.45057562,
+                  "priceError": 0,
+                  "iterations": 12,
+                  "converged": true,
+                  "inputs": {
+                    "underlying": 100,
+                    "strike": 100,
+                    "timeToExpiry": 1,
+                    "rate": 0.05,
+                    "dividendYield": 0,
+                    "optionType": "call",
+                    "premium": 10.45057562
+                  },
+                  "requestId": "00000000-0000-4000-8000-000000000003",
+                  "computedAt": "2026-01-01T00:00:00.000Z"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request body",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required (x402). Decode PAYMENT-REQUIRED header (base64 JSON) for accepts[] — Solana mainnet and/or Base mainnet USDC exact, amount, and payTo.",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "Base64-encoded x402 payment requirements (v2)",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentRequiredBody"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "IV solver failed to converge or premium out of bounds",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-pricing": {
+          "currency": "USDC",
+          "price_usd": 0.03,
+          "unit": "request",
+          "scheme": "exact",
+          "networks": [
+            "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "eip155:8453"
+          ]
+        },
+        "security": [
+          {
+            "x402": []
+          }
+        ]
       }
     },
     "/v1/volatility/surface": {
@@ -207,7 +423,7 @@
           "volatility"
         ],
         "summary": "Implied volatility surface from market premiums",
-        "description": "Invert a market option book into an IV surface grid, per-quote IV and Greeks, fit metrics, and solve stats. Shared rate/yield; each option has its own underlying (multi-maturity marks). Paid via x402: $0.10 USDC per request (Solana mainnet or Base mainnet). or Base mainnet (USDC exact).",
+        "description": "Invert a market option book into an IV surface grid, per-quote IV and Greeks, fit metrics, and solve stats. Shared rate/yield; each option has its own underlying (multi-maturity marks). Paid via x402: $0.10 USDC per request (Solana mainnet or Base mainnet).",
         "parameters": [
           {
             "name": "Idempotency-Key",
@@ -415,179 +631,12 @@
             "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
             "eip155:8453"
           ]
-        }
-      }
-    },
-    "/.well-known/x402": {
-      "get": {
-        "operationId": "getWellKnownX402",
-        "tags": [
-          "discovery"
-        ],
-        "summary": "x402 well-known discovery manifest",
-        "description": "Machine-readable x402 service discovery (resources, pricing, settlement). Free. Same payload as /.well-known/x402.json.",
-        "responses": {
-          "200": {
-            "description": "x402 discovery document",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": true
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/.well-known/x402.json": {
-      "get": {
-        "operationId": "getWellKnownX402Json",
-        "tags": [
-          "discovery"
-        ],
-        "summary": "x402 well-known discovery manifest",
-        "description": "Machine-readable x402 service discovery (JSON alias). Free.",
-        "responses": {
-          "200": {
-            "description": "x402 discovery document",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": true
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/v1/option/implied-vol": {
-      "post": {
-        "operationId": "solveImpliedVol",
-        "tags": [
-          "options"
-        ],
-        "summary": "Implied volatility from market premium",
-        "description": "Solve Black-Scholes implied volatility from a single market premium and return full analytic Greeks at the solved σ. Paid via x402: $0.03 USDC per request (Solana mainnet or Base mainnet). or Base mainnet (USDC exact).",
-        "parameters": [
+        },
+        "security": [
           {
-            "name": "Idempotency-Key",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "Optional key for safe retries of a paid request"
+            "x402": []
           }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ImpliedVolRequest"
-              },
-              "example": {
-                "underlying": 100,
-                "strike": 100,
-                "timeToExpiry": 1,
-                "rate": 0.05,
-                "dividendYield": 0,
-                "optionType": "call",
-                "premium": 10.45057562
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Implied vol, Greeks, model price (after successful x402 settlement)",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ImpliedVolResponse"
-                },
-                "example": {
-                  "impliedVol": 0.2,
-                  "greeks": {
-                    "delta": 0.63683059,
-                    "gamma": 0.01876202,
-                    "vega": 37.52403469,
-                    "theta": -6.41402764,
-                    "rho": 53.23248343
-                  },
-                  "modelPrice": 10.45057562,
-                  "priceError": 0,
-                  "iterations": 12,
-                  "converged": true,
-                  "inputs": {
-                    "underlying": 100,
-                    "strike": 100,
-                    "timeToExpiry": 1,
-                    "rate": 0.05,
-                    "dividendYield": 0,
-                    "optionType": "call",
-                    "premium": 10.45057562
-                  },
-                  "requestId": "00000000-0000-4000-8000-000000000003",
-                  "computedAt": "2026-01-01T00:00:00.000Z"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid request body",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "402": {
-            "description": "Payment required (x402). Decode PAYMENT-REQUIRED header (base64 JSON) for accepts[] — Solana mainnet and/or Base mainnet USDC exact, amount, and payTo.",
-            "headers": {
-              "PAYMENT-REQUIRED": {
-                "description": "Base64-encoded x402 payment requirements (v2)",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaymentRequiredBody"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "IV solver failed to converge or premium out of bounds",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        },
-        "x-pricing": {
-          "currency": "USDC",
-          "price_usd": 0.03,
-          "unit": "request",
-          "scheme": "exact",
-          "networks": [
-            "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
-            "eip155:8453"
-          ]
-        }
+        ]
       }
     },
     "/v1/portfolio/greeks": {
@@ -597,7 +646,7 @@
           "portfolio"
         ],
         "summary": "Net portfolio Greeks and MTM",
-        "description": "Aggregate net Greeks and mark-to-model for a multi-leg European option book. quantity > 0 long, quantity < 0 short. Optional dollar Greeks. Paid via x402: $0.15 USDC per request (Solana mainnet or Base mainnet). or Base mainnet (USDC exact).",
+        "description": "Aggregate net Greeks and mark-to-model for a multi-leg European option book. quantity > 0 long, quantity < 0 short. Optional dollar Greeks. Paid via x402: $0.15 USDC per request (Solana mainnet or Base mainnet).",
         "parameters": [
           {
             "name": "Idempotency-Key",
@@ -752,7 +801,12 @@
             "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
             "eip155:8453"
           ]
-        }
+        },
+        "security": [
+          {
+            "x402": []
+          }
+        ]
       }
     },
     "/v1/portfolio/scenario": {
@@ -762,7 +816,7 @@
           "portfolio"
         ],
         "summary": "Portfolio scenario reprice",
-        "description": "Reprice a multi-leg European portfolio under relative spot/vol shocks and calendar time decay. Returns base MTM+Greeks and per-scenario shocked MTM, MTM change, and full Greeks. Paid via x402: $0.25 USDC per request (Solana mainnet or Base mainnet). or Base mainnet (USDC exact).",
+        "description": "Reprice a multi-leg European portfolio under relative spot/vol shocks and calendar time decay. Returns base MTM+Greeks and per-scenario shocked MTM, MTM change, and full Greeks. Paid via x402: $0.25 USDC per request (Solana mainnet or Base mainnet).",
         "parameters": [
           {
             "name": "Idempotency-Key",
@@ -922,7 +976,12 @@
             "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
             "eip155:8453"
           ]
-        }
+        },
+        "security": [
+          {
+            "x402": []
+          }
+        ]
       }
     }
   },
@@ -1756,6 +1815,14 @@
           }
         }
       }
+    },
+    "securitySchemes": {
+      "x402": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "x402",
+        "description": "x402 micropayment (HTTP 402). Clients settle USDC exact on Solana mainnet and/or Base mainnet, then retry with the payment proof. Free discovery endpoints override with security: []."
+      }
     }
   },
   "x-payment": {
@@ -1777,5 +1844,10 @@
       }
     ],
     "note": "Unpaid requests return HTTP 402 with accepts for each configured network. Clients may settle USDC on Solana or Base."
-  }
+  },
+  "security": [
+    {
+      "x402": []
+    }
+  ]
 }

--- a/providers/quantumwatch/derivatives-pricer/openapi.json
+++ b/providers/quantumwatch/derivatives-pricer/openapi.json
@@ -32,7 +32,9 @@
     "/health": {
       "get": {
         "operationId": "getHealth",
-        "tags": ["discovery"],
+        "tags": [
+          "discovery"
+        ],
         "summary": "Liveness probe",
         "description": "Returns service status, networks, and pricing snapshot. Free.",
         "responses": {
@@ -53,7 +55,9 @@
     "/": {
       "get": {
         "operationId": "getServiceCard",
-        "tags": ["discovery"],
+        "tags": [
+          "discovery"
+        ],
         "summary": "Service card for agents",
         "description": "Machine-readable catalog: capabilities, endpoints, examples. Free.",
         "responses": {
@@ -74,7 +78,9 @@
     "/v1/option/price": {
       "post": {
         "operationId": "priceOption",
-        "tags": ["options"],
+        "tags": [
+          "options"
+        ],
         "summary": "Price European option + Greeks",
         "description": "Black-Scholes-Merton fair value and full analytic Greeks (delta, gamma, vega, theta, rho). Paid via x402: $0.01 USDC per request on Solana mainnet.",
         "parameters": [
@@ -189,7 +195,9 @@
     "/v1/volatility/surface": {
       "post": {
         "operationId": "buildVolatilitySurface",
-        "tags": ["volatility"],
+        "tags": [
+          "volatility"
+        ],
         "summary": "Implied volatility surface from market premiums",
         "description": "Invert a market option book into an IV surface grid, per-quote IV and Greeks, fit metrics, and solve stats. Shared rate/yield; each option has its own underlying (multi-maturity marks). Paid via x402: $0.10 USDC per request on Solana mainnet.",
         "parameters": [
@@ -220,14 +228,21 @@
                     "strike": 90,
                     "timeToExpiry": 0.25,
                     "optionType": "call",
-                    "premium": 12.5
+                    "premium": 12.21003823
                   },
                   {
                     "underlying": 102,
                     "strike": 100,
                     "timeToExpiry": 0.5,
                     "optionType": "call",
-                    "premium": 8.7
+                    "premium": 8.67399132
+                  },
+                  {
+                    "underlying": 101,
+                    "strike": 110,
+                    "timeToExpiry": 1,
+                    "optionType": "put",
+                    "premium": 10.13483934
                   }
                 ]
               }
@@ -244,11 +259,32 @@
                 },
                 "example": {
                   "surface": {
-                    "strikes": [90, 100],
-                    "maturities": [0.25, 0.5],
+                    "strikes": [
+                      90,
+                      100,
+                      110
+                    ],
+                    "maturities": [
+                      0.25,
+                      0.5,
+                      1
+                    ],
                     "impliedVols": [
-                      [0.25, null],
-                      [null, 0.22]
+                      [
+                        0.25,
+                        null,
+                        null
+                      ],
+                      [
+                        null,
+                        0.22,
+                        null
+                      ],
+                      [
+                        null,
+                        null,
+                        0.2
+                      ]
                     ]
                   },
                   "market": {
@@ -262,32 +298,70 @@
                       "strike": 90,
                       "timeToExpiry": 0.25,
                       "optionType": "call",
-                      "premium": 12.5,
+                      "premium": 12.21003823,
                       "impliedVol": 0.25,
                       "greeks": {
-                        "delta": 0.75,
-                        "gamma": 0.02,
-                        "vega": 15,
-                        "theta": -8,
-                        "rho": 10
+                        "delta": 0.84264403,
+                        "gamma": 0.01925343,
+                        "vega": 12.03339684,
+                        "theta": -9.61941667,
+                        "rho": 18.01359123
                       },
-                      "modelPrice": 12.5,
+                      "modelPrice": 12.21003823,
+                      "priceError": 0,
+                      "status": "ok"
+                    },
+                    {
+                      "index": 1,
+                      "underlying": 102,
+                      "strike": 100,
+                      "timeToExpiry": 0.5,
+                      "optionType": "call",
+                      "premium": 8.67399132,
+                      "impliedVol": 0.22,
+                      "greeks": {
+                        "delta": 0.64273679,
+                        "gamma": 0.02351518,
+                        "vega": 26.91171634,
+                        "theta": -8.76483566,
+                        "rho": 28.44258072
+                      },
+                      "modelPrice": 8.67399132,
+                      "priceError": 0,
+                      "status": "ok"
+                    },
+                    {
+                      "index": 2,
+                      "underlying": 101,
+                      "strike": 110,
+                      "timeToExpiry": 1,
+                      "optionType": "put",
+                      "premium": 10.13483934,
+                      "impliedVol": 0.2,
+                      "greeks": {
+                        "delta": -0.53060844,
+                        "gamma": 0.01969146,
+                        "vega": 40.17451831,
+                        "theta": -0.83113722,
+                        "rho": -63.72629213
+                      },
+                      "modelPrice": 10.13483934,
                       "priceError": 0,
                       "status": "ok"
                     }
                   ],
                   "fit": {
-                    "okCount": 2,
+                    "okCount": 3,
                     "failedCount": 0,
-                    "meanAbsPriceError": 1e-8,
-                    "maxAbsPriceError": 2e-8,
-                    "rmsePriceError": 1.2e-8
+                    "meanAbsPriceError": 0,
+                    "maxAbsPriceError": 0,
+                    "rmsePriceError": 0
                   },
                   "stats": {
-                    "optionCount": 2,
-                    "elapsedMs": 1.2,
+                    "optionCount": 3,
+                    "elapsedMs": 2.5,
                     "solver": "fastImpliedVol",
-                    "avgIterations": 4
+                    "avgIterations": 12.3333
                   },
                   "requestId": "00000000-0000-4000-8000-000000000002",
                   "computedAt": "2026-01-01T00:00:00.000Z"
@@ -337,13 +411,22 @@
     "schemas": {
       "OptionType": {
         "type": "string",
-        "enum": ["call", "put"],
+        "enum": [
+          "call",
+          "put"
+        ],
         "description": "European call or put"
       },
       "Greeks": {
         "type": "object",
         "description": "Analytic Black-Scholes-Merton Greeks. Vega/theta/rho are raw derivatives (per 1.0 vol, per year, per 1.0 rate).",
-        "required": ["delta", "gamma", "vega", "theta", "rho"],
+        "required": [
+          "delta",
+          "gamma",
+          "vega",
+          "theta",
+          "rho"
+        ],
         "properties": {
           "delta": {
             "type": "number",
@@ -498,7 +581,10 @@
         "type": "object",
         "title": "ImpliedVolatilitySurfaceRequest",
         "description": "Shared rate/yield plus market quotes with per-row underlyings.",
-        "required": ["rate", "options"],
+        "required": [
+          "rate",
+          "options"
+        ],
         "additionalProperties": false,
         "properties": {
           "rate": {
@@ -543,7 +629,10 @@
             "type": "number"
           },
           "impliedVol": {
-            "type": ["number", "null"]
+            "type": [
+              "number",
+              "null"
+            ]
           },
           "greeks": {
             "oneOf": [
@@ -556,15 +645,24 @@
             ]
           },
           "modelPrice": {
-            "type": ["number", "null"]
+            "type": [
+              "number",
+              "null"
+            ]
           },
           "priceError": {
-            "type": ["number", "null"],
+            "type": [
+              "number",
+              "null"
+            ],
             "description": "modelPrice − premium"
           },
           "status": {
             "type": "string",
-            "enum": ["ok", "failed"]
+            "enum": [
+              "ok",
+              "failed"
+            ]
           },
           "reason": {
             "type": "string"
@@ -586,7 +684,11 @@
         "properties": {
           "surface": {
             "type": "object",
-            "required": ["strikes", "maturities", "impliedVols"],
+            "required": [
+              "strikes",
+              "maturities",
+              "impliedVols"
+            ],
             "properties": {
               "strikes": {
                 "type": "array",
@@ -606,7 +708,10 @@
                 "items": {
                   "type": "array",
                   "items": {
-                    "type": ["number", "null"]
+                    "type": [
+                      "number",
+                      "null"
+                    ]
                   }
                 }
               }
@@ -639,13 +744,22 @@
                 "type": "integer"
               },
               "meanAbsPriceError": {
-                "type": ["number", "null"]
+                "type": [
+                  "number",
+                  "null"
+                ]
               },
               "maxAbsPriceError": {
-                "type": ["number", "null"]
+                "type": [
+                  "number",
+                  "null"
+                ]
               },
               "rmsePriceError": {
-                "type": ["number", "null"]
+                "type": [
+                  "number",
+                  "null"
+                ]
               }
             }
           },

--- a/providers/quantumwatch/derivatives-pricer/openapi.json
+++ b/providers/quantumwatch/derivatives-pricer/openapi.json
@@ -307,8 +307,8 @@
                         "theta": -9.61941667,
                         "rho": 18.01359123
                       },
-                      "modelPrice": 12.21003823,
-                      "priceError": 0,
+                      "modelPrice": 12.21003824,
+                      "priceError": 1e-8,
                       "status": "ok"
                     },
                     {
@@ -326,8 +326,8 @@
                         "theta": -8.76483566,
                         "rho": 28.44258072
                       },
-                      "modelPrice": 8.67399132,
-                      "priceError": 0,
+                      "modelPrice": 8.67399129,
+                      "priceError": -3e-8,
                       "status": "ok"
                     },
                     {
@@ -345,17 +345,17 @@
                         "theta": -0.83113722,
                         "rho": -63.72629213
                       },
-                      "modelPrice": 10.13483934,
-                      "priceError": 0,
+                      "modelPrice": 10.13483936,
+                      "priceError": 2e-8,
                       "status": "ok"
                     }
                   ],
                   "fit": {
                     "okCount": 3,
                     "failedCount": 0,
-                    "meanAbsPriceError": 0,
-                    "maxAbsPriceError": 0,
-                    "rmsePriceError": 0
+                    "meanAbsPriceError": 2e-8,
+                    "maxAbsPriceError": 3e-8,
+                    "rmsePriceError": 2e-8
                   },
                   "stats": {
                     "optionCount": 3,

--- a/providers/quantumwatch/derivatives-pricer/openapi.json
+++ b/providers/quantumwatch/derivatives-pricer/openapi.json
@@ -1,0 +1,720 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Derivatives Pricer",
+    "description": "x402-paid Black-Scholes European option pricing, analytic Greeks, and implied-volatility surfaces. USDC on Solana mainnet. No API keys.",
+    "version": "1.0.0",
+    "contact": {
+      "url": "https://derivatives-pricer-production.up.railway.app"
+    }
+  },
+  "servers": [
+    {
+      "url": "https://derivatives-pricer-production.up.railway.app",
+      "description": "Production"
+    }
+  ],
+  "tags": [
+    {
+      "name": "options",
+      "description": "Single-contract European option pricing"
+    },
+    {
+      "name": "volatility",
+      "description": "Implied volatility surface from market premiums"
+    },
+    {
+      "name": "discovery",
+      "description": "Free service discovery endpoints"
+    }
+  ],
+  "paths": {
+    "/health": {
+      "get": {
+        "operationId": "getHealth",
+        "tags": ["discovery"],
+        "summary": "Liveness probe",
+        "description": "Returns service status, networks, and pricing snapshot. Free.",
+        "responses": {
+          "200": {
+            "description": "Service is healthy",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/": {
+      "get": {
+        "operationId": "getServiceCard",
+        "tags": ["discovery"],
+        "summary": "Service card for agents",
+        "description": "Machine-readable catalog: capabilities, endpoints, examples. Free.",
+        "responses": {
+          "200": {
+            "description": "Service discovery document",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/option/price": {
+      "post": {
+        "operationId": "priceOption",
+        "tags": ["options"],
+        "summary": "Price European option + Greeks",
+        "description": "Black-Scholes-Merton fair value and full analytic Greeks (delta, gamma, vega, theta, rho). Paid via x402: $0.01 USDC per request on Solana mainnet.",
+        "parameters": [
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "Optional key for safe retries of a paid request"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OptionPriceRequest"
+              },
+              "example": {
+                "spot": 100,
+                "strike": 100,
+                "timeToExpiry": 1,
+                "rate": 0.05,
+                "volatility": 0.2,
+                "optionType": "call",
+                "dividendYield": 0
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Option price and Greeks (after successful x402 settlement)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OptionPriceResponse"
+                },
+                "example": {
+                  "price": 10.45057562,
+                  "greeks": {
+                    "delta": 0.63683059,
+                    "gamma": 0.01876202,
+                    "vega": 37.52403469,
+                    "theta": -6.41402764,
+                    "rho": 53.23248343
+                  },
+                  "inputs": {
+                    "spot": 100,
+                    "strike": 100,
+                    "timeToExpiry": 1,
+                    "rate": 0.05,
+                    "volatility": 0.2,
+                    "optionType": "call",
+                    "dividendYield": 0
+                  },
+                  "model": "black-scholes-merton",
+                  "units": {
+                    "price": "option value in spot currency units",
+                    "delta": "dV/dS (share equivalent)",
+                    "gamma": "d²V/dS²",
+                    "vega": "dV/dσ per 1.0 absolute volatility (not per 1%)",
+                    "theta": "dV/dT per year (not per day)",
+                    "rho": "dV/dr per 1.0 absolute rate (not per 1%)"
+                  },
+                  "requestId": "00000000-0000-4000-8000-000000000001",
+                  "computedAt": "2026-01-01T00:00:00.000Z"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request body",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required (x402). Decode PAYMENT-REQUIRED header (base64 JSON) for amount, network, asset, payTo.",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "Base64-encoded x402 payment requirements (v2)",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentRequiredBody"
+                }
+              }
+            }
+          }
+        },
+        "x-pricing": {
+          "currency": "USDC",
+          "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+          "price_usd": 0.01,
+          "unit": "request"
+        }
+      }
+    },
+    "/v1/volatility/surface": {
+      "post": {
+        "operationId": "buildVolatilitySurface",
+        "tags": ["volatility"],
+        "summary": "Implied volatility surface from market premiums",
+        "description": "Invert a market option book into an IV surface grid, per-quote IV and Greeks, fit metrics, and solve stats. Shared rate/yield; each option has its own underlying (multi-maturity marks). Paid via x402: $0.10 USDC per request on Solana mainnet.",
+        "parameters": [
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "Optional key for safe retries of a paid request"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VolatilitySurfaceRequest"
+              },
+              "example": {
+                "rate": 0.05,
+                "dividendYield": 0,
+                "options": [
+                  {
+                    "underlying": 100,
+                    "strike": 90,
+                    "timeToExpiry": 0.25,
+                    "optionType": "call",
+                    "premium": 12.5
+                  },
+                  {
+                    "underlying": 102,
+                    "strike": 100,
+                    "timeToExpiry": 0.5,
+                    "optionType": "call",
+                    "premium": 8.7
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "IV surface, points, fit, and stats (after successful x402 settlement)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VolatilitySurfaceResponse"
+                },
+                "example": {
+                  "surface": {
+                    "strikes": [90, 100],
+                    "maturities": [0.25, 0.5],
+                    "impliedVols": [
+                      [0.25, null],
+                      [null, 0.22]
+                    ]
+                  },
+                  "market": {
+                    "rate": 0.05,
+                    "dividendYield": 0
+                  },
+                  "points": [
+                    {
+                      "index": 0,
+                      "underlying": 100,
+                      "strike": 90,
+                      "timeToExpiry": 0.25,
+                      "optionType": "call",
+                      "premium": 12.5,
+                      "impliedVol": 0.25,
+                      "greeks": {
+                        "delta": 0.75,
+                        "gamma": 0.02,
+                        "vega": 15,
+                        "theta": -8,
+                        "rho": 10
+                      },
+                      "modelPrice": 12.5,
+                      "priceError": 0,
+                      "status": "ok"
+                    }
+                  ],
+                  "fit": {
+                    "okCount": 2,
+                    "failedCount": 0,
+                    "meanAbsPriceError": 1e-8,
+                    "maxAbsPriceError": 2e-8,
+                    "rmsePriceError": 1.2e-8
+                  },
+                  "stats": {
+                    "optionCount": 2,
+                    "elapsedMs": 1.2,
+                    "solver": "fastImpliedVol",
+                    "avgIterations": 4
+                  },
+                  "requestId": "00000000-0000-4000-8000-000000000002",
+                  "computedAt": "2026-01-01T00:00:00.000Z"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request body",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required (x402). Decode PAYMENT-REQUIRED header (base64 JSON) for amount, network, asset, payTo.",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "Base64-encoded x402 payment requirements (v2)",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentRequiredBody"
+                }
+              }
+            }
+          }
+        },
+        "x-pricing": {
+          "currency": "USDC",
+          "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+          "price_usd": 0.1,
+          "unit": "request"
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "OptionType": {
+        "type": "string",
+        "enum": ["call", "put"],
+        "description": "European call or put"
+      },
+      "Greeks": {
+        "type": "object",
+        "description": "Analytic Black-Scholes-Merton Greeks. Vega/theta/rho are raw derivatives (per 1.0 vol, per year, per 1.0 rate).",
+        "required": ["delta", "gamma", "vega", "theta", "rho"],
+        "properties": {
+          "delta": {
+            "type": "number",
+            "description": "dV/dS — underlying hedge ratio"
+          },
+          "gamma": {
+            "type": "number",
+            "description": "d²V/dS² — convexity"
+          },
+          "vega": {
+            "type": "number",
+            "description": "dV/dσ per 1.0 absolute volatility (not per 1%)"
+          },
+          "theta": {
+            "type": "number",
+            "description": "dV/dT per year (not per calendar day)"
+          },
+          "rho": {
+            "type": "number",
+            "description": "dV/dr per 1.0 absolute rate (not per 1%)"
+          }
+        },
+        "additionalProperties": false
+      },
+      "OptionPriceRequest": {
+        "type": "object",
+        "title": "EuropeanOptionPriceRequest",
+        "description": "Inputs for Black-Scholes-Merton European option fair value. timeToExpiry is a year-fraction.",
+        "required": [
+          "spot",
+          "strike",
+          "timeToExpiry",
+          "rate",
+          "volatility",
+          "optionType"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "spot": {
+            "type": "number",
+            "exclusiveMinimum": 0,
+            "description": "Underlying price S (> 0)"
+          },
+          "strike": {
+            "type": "number",
+            "exclusiveMinimum": 0,
+            "description": "Strike price K (> 0)"
+          },
+          "timeToExpiry": {
+            "type": "number",
+            "minimum": 0,
+            "description": "Time to expiry T in years (≥ 0)"
+          },
+          "rate": {
+            "type": "number",
+            "description": "Continuous risk-free rate r (e.g. 0.05 = 5%)"
+          },
+          "volatility": {
+            "type": "number",
+            "exclusiveMinimum": 0,
+            "description": "Annualized volatility σ as a decimal (e.g. 0.2 = 20%)"
+          },
+          "optionType": {
+            "$ref": "#/components/schemas/OptionType"
+          },
+          "dividendYield": {
+            "type": "number",
+            "minimum": 0,
+            "default": 0,
+            "description": "Continuous dividend/convenience yield q (default 0)"
+          }
+        }
+      },
+      "OptionPriceResponse": {
+        "type": "object",
+        "title": "EuropeanOptionPriceResponse",
+        "required": [
+          "price",
+          "greeks",
+          "inputs",
+          "model",
+          "requestId",
+          "computedAt"
+        ],
+        "properties": {
+          "price": {
+            "type": "number",
+            "description": "Model option fair value"
+          },
+          "greeks": {
+            "$ref": "#/components/schemas/Greeks"
+          },
+          "inputs": {
+            "type": "object",
+            "description": "Echo of validated inputs",
+            "additionalProperties": true
+          },
+          "model": {
+            "type": "string",
+            "const": "black-scholes-merton"
+          },
+          "units": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "requestId": {
+            "type": "string"
+          },
+          "computedAt": {
+            "type": "string",
+            "description": "ISO-8601 UTC timestamp"
+          }
+        }
+      },
+      "MarketOptionQuote": {
+        "type": "object",
+        "required": [
+          "underlying",
+          "strike",
+          "timeToExpiry",
+          "optionType",
+          "premium"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "underlying": {
+            "type": "number",
+            "exclusiveMinimum": 0,
+            "description": "Underlying S for this quote; may differ by maturity"
+          },
+          "strike": {
+            "type": "number",
+            "exclusiveMinimum": 0
+          },
+          "timeToExpiry": {
+            "type": "number",
+            "minimum": 0
+          },
+          "optionType": {
+            "$ref": "#/components/schemas/OptionType"
+          },
+          "premium": {
+            "type": "number",
+            "minimum": 0,
+            "description": "Market option premium"
+          }
+        }
+      },
+      "VolatilitySurfaceRequest": {
+        "type": "object",
+        "title": "ImpliedVolatilitySurfaceRequest",
+        "description": "Shared rate/yield plus market quotes with per-row underlyings.",
+        "required": ["rate", "options"],
+        "additionalProperties": false,
+        "properties": {
+          "rate": {
+            "type": "number",
+            "description": "Shared continuous risk-free rate r"
+          },
+          "dividendYield": {
+            "type": "number",
+            "minimum": 0,
+            "default": 0,
+            "description": "Shared continuous yield q (default 0)"
+          },
+          "options": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 200,
+            "items": {
+              "$ref": "#/components/schemas/MarketOptionQuote"
+            }
+          }
+        }
+      },
+      "SurfacePoint": {
+        "type": "object",
+        "properties": {
+          "index": {
+            "type": "integer"
+          },
+          "underlying": {
+            "type": "number"
+          },
+          "strike": {
+            "type": "number"
+          },
+          "timeToExpiry": {
+            "type": "number"
+          },
+          "optionType": {
+            "$ref": "#/components/schemas/OptionType"
+          },
+          "premium": {
+            "type": "number"
+          },
+          "impliedVol": {
+            "type": ["number", "null"]
+          },
+          "greeks": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/Greeks"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "modelPrice": {
+            "type": ["number", "null"]
+          },
+          "priceError": {
+            "type": ["number", "null"],
+            "description": "modelPrice − premium"
+          },
+          "status": {
+            "type": "string",
+            "enum": ["ok", "failed"]
+          },
+          "reason": {
+            "type": "string"
+          }
+        }
+      },
+      "VolatilitySurfaceResponse": {
+        "type": "object",
+        "title": "ImpliedVolatilitySurfaceResponse",
+        "required": [
+          "surface",
+          "market",
+          "points",
+          "fit",
+          "stats",
+          "requestId",
+          "computedAt"
+        ],
+        "properties": {
+          "surface": {
+            "type": "object",
+            "required": ["strikes", "maturities", "impliedVols"],
+            "properties": {
+              "strikes": {
+                "type": "array",
+                "items": {
+                  "type": "number"
+                }
+              },
+              "maturities": {
+                "type": "array",
+                "items": {
+                  "type": "number"
+                }
+              },
+              "impliedVols": {
+                "type": "array",
+                "description": "Grid [strikeIndex][maturityIndex]; null if empty",
+                "items": {
+                  "type": "array",
+                  "items": {
+                    "type": ["number", "null"]
+                  }
+                }
+              }
+            }
+          },
+          "market": {
+            "type": "object",
+            "properties": {
+              "rate": {
+                "type": "number"
+              },
+              "dividendYield": {
+                "type": "number"
+              }
+            }
+          },
+          "points": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SurfacePoint"
+            }
+          },
+          "fit": {
+            "type": "object",
+            "properties": {
+              "okCount": {
+                "type": "integer"
+              },
+              "failedCount": {
+                "type": "integer"
+              },
+              "meanAbsPriceError": {
+                "type": ["number", "null"]
+              },
+              "maxAbsPriceError": {
+                "type": ["number", "null"]
+              },
+              "rmsePriceError": {
+                "type": ["number", "null"]
+              }
+            }
+          },
+          "stats": {
+            "type": "object",
+            "properties": {
+              "optionCount": {
+                "type": "integer"
+              },
+              "elapsedMs": {
+                "type": "number"
+              },
+              "solver": {
+                "type": "string",
+                "const": "fastImpliedVol"
+              },
+              "avgIterations": {
+                "type": "number"
+              }
+            }
+          },
+          "requestId": {
+            "type": "string"
+          },
+          "computedAt": {
+            "type": "string"
+          }
+        }
+      },
+      "PaymentRequiredBody": {
+        "type": "object",
+        "description": "Optional JSON body on unpaid requests (server may also return {}). Primary payment terms are in PAYMENT-REQUIRED.",
+        "properties": {
+          "error": {
+            "type": "string",
+            "example": "payment_required"
+          },
+          "message": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
+          },
+          "method": {
+            "type": "string"
+          }
+        }
+      },
+      "ErrorResponse": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "details": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        }
+      }
+    }
+  },
+  "x-payment": {
+    "protocol": "x402",
+    "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+    "asset": "USDC",
+    "facilitator": "https://facilitator.payai.network"
+  }
+}

--- a/providers/quantumwatch/derivatives-pricer/openapi.json
+++ b/providers/quantumwatch/derivatives-pricer/openapi.json
@@ -2,8 +2,8 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Derivatives Pricer",
-    "description": "x402-paid Black-Scholes European option pricing, analytic Greeks, and implied-volatility surfaces. USDC on Solana mainnet. No API keys.",
-    "version": "1.0.0",
+    "description": "x402-paid Black-Scholes European option pricing, analytic Greeks, single-premium IV, IV surfaces, portfolio net Greeks, and scenario reprice. USDC exact on Solana mainnet and/or Base mainnet via PayAI. No API keys.",
+    "version": "1.3.0",
     "contact": {
       "url": "https://derivatives-pricer-production.up.railway.app"
     }
@@ -17,11 +17,15 @@
   "tags": [
     {
       "name": "options",
-      "description": "Single-contract European option pricing"
+      "description": "Single-contract European option pricing and IV"
     },
     {
       "name": "volatility",
       "description": "Implied volatility surface from market premiums"
+    },
+    {
+      "name": "portfolio",
+      "description": "Multi-leg portfolio Greeks and scenario analysis"
     },
     {
       "name": "discovery",
@@ -82,7 +86,7 @@
           "options"
         ],
         "summary": "Price European option + Greeks",
-        "description": "Black-Scholes-Merton fair value and full analytic Greeks (delta, gamma, vega, theta, rho). Paid via x402: $0.01 USDC per request on Solana mainnet.",
+        "description": "Black-Scholes-Merton fair value and full analytic Greeks (delta, gamma, vega, theta, rho). Paid via x402: $0.01 USDC per request (Solana mainnet or Base mainnet). or Base mainnet (USDC exact).",
         "parameters": [
           {
             "name": "Idempotency-Key",
@@ -166,7 +170,7 @@
             }
           },
           "402": {
-            "description": "Payment required (x402). Decode PAYMENT-REQUIRED header (base64 JSON) for amount, network, asset, payTo.",
+            "description": "Payment required (x402). Decode PAYMENT-REQUIRED header (base64 JSON) for accepts[] — Solana mainnet and/or Base mainnet USDC exact, amount, and payTo.",
             "headers": {
               "PAYMENT-REQUIRED": {
                 "description": "Base64-encoded x402 payment requirements (v2)",
@@ -186,9 +190,13 @@
         },
         "x-pricing": {
           "currency": "USDC",
-          "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
           "price_usd": 0.01,
-          "unit": "request"
+          "unit": "request",
+          "scheme": "exact",
+          "networks": [
+            "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "eip155:8453"
+          ]
         }
       }
     },
@@ -199,7 +207,7 @@
           "volatility"
         ],
         "summary": "Implied volatility surface from market premiums",
-        "description": "Invert a market option book into an IV surface grid, per-quote IV and Greeks, fit metrics, and solve stats. Shared rate/yield; each option has its own underlying (multi-maturity marks). Paid via x402: $0.10 USDC per request on Solana mainnet.",
+        "description": "Invert a market option book into an IV surface grid, per-quote IV and Greeks, fit metrics, and solve stats. Shared rate/yield; each option has its own underlying (multi-maturity marks). Paid via x402: $0.10 USDC per request (Solana mainnet or Base mainnet). or Base mainnet (USDC exact).",
         "parameters": [
           {
             "name": "Idempotency-Key",
@@ -380,7 +388,7 @@
             }
           },
           "402": {
-            "description": "Payment required (x402). Decode PAYMENT-REQUIRED header (base64 JSON) for amount, network, asset, payTo.",
+            "description": "Payment required (x402). Decode PAYMENT-REQUIRED header (base64 JSON) for accepts[] — Solana mainnet and/or Base mainnet USDC exact, amount, and payTo.",
             "headers": {
               "PAYMENT-REQUIRED": {
                 "description": "Base64-encoded x402 payment requirements (v2)",
@@ -400,9 +408,520 @@
         },
         "x-pricing": {
           "currency": "USDC",
-          "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
           "price_usd": 0.1,
-          "unit": "request"
+          "unit": "request",
+          "scheme": "exact",
+          "networks": [
+            "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "eip155:8453"
+          ]
+        }
+      }
+    },
+    "/.well-known/x402": {
+      "get": {
+        "operationId": "getWellKnownX402",
+        "tags": [
+          "discovery"
+        ],
+        "summary": "x402 well-known discovery manifest",
+        "description": "Machine-readable x402 service discovery (resources, pricing, settlement). Free. Same payload as /.well-known/x402.json.",
+        "responses": {
+          "200": {
+            "description": "x402 discovery document",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/.well-known/x402.json": {
+      "get": {
+        "operationId": "getWellKnownX402Json",
+        "tags": [
+          "discovery"
+        ],
+        "summary": "x402 well-known discovery manifest",
+        "description": "Machine-readable x402 service discovery (JSON alias). Free.",
+        "responses": {
+          "200": {
+            "description": "x402 discovery document",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/option/implied-vol": {
+      "post": {
+        "operationId": "solveImpliedVol",
+        "tags": [
+          "options"
+        ],
+        "summary": "Implied volatility from market premium",
+        "description": "Solve Black-Scholes implied volatility from a single market premium and return full analytic Greeks at the solved σ. Paid via x402: $0.03 USDC per request (Solana mainnet or Base mainnet). or Base mainnet (USDC exact).",
+        "parameters": [
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "Optional key for safe retries of a paid request"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ImpliedVolRequest"
+              },
+              "example": {
+                "underlying": 100,
+                "strike": 100,
+                "timeToExpiry": 1,
+                "rate": 0.05,
+                "dividendYield": 0,
+                "optionType": "call",
+                "premium": 10.45057562
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Implied vol, Greeks, model price (after successful x402 settlement)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImpliedVolResponse"
+                },
+                "example": {
+                  "impliedVol": 0.2,
+                  "greeks": {
+                    "delta": 0.63683059,
+                    "gamma": 0.01876202,
+                    "vega": 37.52403469,
+                    "theta": -6.41402764,
+                    "rho": 53.23248343
+                  },
+                  "modelPrice": 10.45057562,
+                  "priceError": 0,
+                  "iterations": 12,
+                  "converged": true,
+                  "inputs": {
+                    "underlying": 100,
+                    "strike": 100,
+                    "timeToExpiry": 1,
+                    "rate": 0.05,
+                    "dividendYield": 0,
+                    "optionType": "call",
+                    "premium": 10.45057562
+                  },
+                  "requestId": "00000000-0000-4000-8000-000000000003",
+                  "computedAt": "2026-01-01T00:00:00.000Z"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request body",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required (x402). Decode PAYMENT-REQUIRED header (base64 JSON) for accepts[] — Solana mainnet and/or Base mainnet USDC exact, amount, and payTo.",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "Base64-encoded x402 payment requirements (v2)",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentRequiredBody"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "IV solver failed to converge or premium out of bounds",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-pricing": {
+          "currency": "USDC",
+          "price_usd": 0.03,
+          "unit": "request",
+          "scheme": "exact",
+          "networks": [
+            "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "eip155:8453"
+          ]
+        }
+      }
+    },
+    "/v1/portfolio/greeks": {
+      "post": {
+        "operationId": "portfolioGreeks",
+        "tags": [
+          "portfolio"
+        ],
+        "summary": "Net portfolio Greeks and MTM",
+        "description": "Aggregate net Greeks and mark-to-model for a multi-leg European option book. quantity > 0 long, quantity < 0 short. Optional dollar Greeks. Paid via x402: $0.15 USDC per request (Solana mainnet or Base mainnet). or Base mainnet (USDC exact).",
+        "parameters": [
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "Optional key for safe retries of a paid request"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PortfolioGreeksRequest"
+              },
+              "example": {
+                "rate": 0.05,
+                "dividendYield": 0,
+                "includeDollarGreeks": true,
+                "positions": [
+                  {
+                    "underlying": 100,
+                    "strike": 100,
+                    "timeToExpiry": 1,
+                    "optionType": "call",
+                    "quantity": 10,
+                    "volatility": 0.2
+                  },
+                  {
+                    "underlying": 100,
+                    "strike": 110,
+                    "timeToExpiry": 1,
+                    "optionType": "put",
+                    "quantity": -5,
+                    "volatility": 0.22
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Net MTM, Greeks, per-leg detail (after successful x402 settlement)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PortfolioGreeksResponse"
+                },
+                "example": {
+                  "net": {
+                    "mtm": 47.16439511,
+                    "greeks": {
+                      "delta": 9.05941615,
+                      "gamma": 0.09736793,
+                      "vega": 176.68540458,
+                      "theta": -58.62185203,
+                      "rho": 858.77721991
+                    },
+                    "dollarGreeks": {
+                      "deltaCash": 905.941615,
+                      "gammaCash": 486.8396,
+                      "vegaPerPoint": 1.76685405,
+                      "thetaPerDay": -0.16060781,
+                      "rhoPerPoint": 8.5877722
+                    }
+                  },
+                  "legs": [
+                    {
+                      "index": 0,
+                      "quantity": 10,
+                      "underlying": 100,
+                      "strike": 100,
+                      "timeToExpiry": 1,
+                      "optionType": "call",
+                      "volatility": 0.2,
+                      "price": 10.45057562,
+                      "contribution": 104.50575619,
+                      "greeks": {
+                        "delta": 6.3683059,
+                        "gamma": 0.18762017,
+                        "vega": 375.24034692,
+                        "theta": -64.1402764,
+                        "rho": 532.32483426
+                      }
+                    },
+                    {
+                      "index": 1,
+                      "quantity": -5,
+                      "underlying": 100,
+                      "strike": 110,
+                      "timeToExpiry": 1,
+                      "optionType": "put",
+                      "volatility": 0.22,
+                      "price": 11.46827222,
+                      "contribution": -57.34136108,
+                      "greeks": {
+                        "delta": 2.69111025,
+                        "gamma": -0.09025225,
+                        "vega": -198.55494233,
+                        "theta": 5.51842437,
+                        "rho": 326.45238565
+                      }
+                    }
+                  ],
+                  "positionCount": 2,
+                  "requestId": "00000000-0000-4000-8000-000000000004",
+                  "computedAt": "2026-01-01T00:00:00.000Z"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request body",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required (x402). Decode PAYMENT-REQUIRED header (base64 JSON) for accepts[] — Solana mainnet and/or Base mainnet USDC exact, amount, and payTo.",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "Base64-encoded x402 payment requirements (v2)",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentRequiredBody"
+                }
+              }
+            }
+          }
+        },
+        "x-pricing": {
+          "currency": "USDC",
+          "price_usd": 0.15,
+          "unit": "request",
+          "scheme": "exact",
+          "networks": [
+            "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "eip155:8453"
+          ]
+        }
+      }
+    },
+    "/v1/portfolio/scenario": {
+      "post": {
+        "operationId": "portfolioScenario",
+        "tags": [
+          "portfolio"
+        ],
+        "summary": "Portfolio scenario reprice",
+        "description": "Reprice a multi-leg European portfolio under relative spot/vol shocks and calendar time decay. Returns base MTM+Greeks and per-scenario shocked MTM, MTM change, and full Greeks. Paid via x402: $0.25 USDC per request (Solana mainnet or Base mainnet). or Base mainnet (USDC exact).",
+        "parameters": [
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "Optional key for safe retries of a paid request"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PortfolioScenarioRequest"
+              },
+              "example": {
+                "rate": 0.05,
+                "dividendYield": 0,
+                "positions": [
+                  {
+                    "underlying": 100,
+                    "strike": 100,
+                    "timeToExpiry": 1,
+                    "optionType": "call",
+                    "quantity": 10,
+                    "volatility": 0.2
+                  },
+                  {
+                    "underlying": 100,
+                    "strike": 110,
+                    "timeToExpiry": 1,
+                    "optionType": "put",
+                    "quantity": -5,
+                    "volatility": 0.22
+                  }
+                ],
+                "scenarios": [
+                  {
+                    "name": "spot_down_10",
+                    "spotShock": -0.1,
+                    "volShock": 0,
+                    "timeDecayDays": 0
+                  },
+                  {
+                    "name": "vol_up_20pct_rel",
+                    "spotShock": 0,
+                    "volShock": 0.2,
+                    "timeDecayDays": 1
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Base and shocked portfolio MTM/Greeks (after successful x402 settlement)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PortfolioScenarioResponse"
+                },
+                "example": {
+                  "base": {
+                    "mtm": 47.16439511,
+                    "greeks": {
+                      "delta": 9.05941615,
+                      "gamma": 0.09736793,
+                      "vega": 176.68540458,
+                      "theta": -58.62185203,
+                      "rho": 858.77721991
+                    }
+                  },
+                  "scenarios": [
+                    {
+                      "name": "spot_down_10",
+                      "shocks": {
+                        "spotShock": -0.1,
+                        "volShock": 0,
+                        "timeDecayDays": 0
+                      },
+                      "mtm": -37.85755566,
+                      "mtmChange": -85.02195077,
+                      "greeks": {
+                        "delta": 7.8848641,
+                        "gamma": 0.13279827,
+                        "vega": 201.29852574,
+                        "theta": -55.98280497,
+                        "rho": 747.49532487
+                      }
+                    },
+                    {
+                      "name": "vol_up_20pct_rel",
+                      "shocks": {
+                        "spotShock": 0,
+                        "volShock": 0.2,
+                        "timeDecayDays": 1
+                      },
+                      "mtm": 53.31386329,
+                      "mtmChange": 6.14946818,
+                      "greeks": {
+                        "delta": 8.86589449,
+                        "gamma": 0.08214409,
+                        "vega": 178.51169933,
+                        "theta": -60.74906514,
+                        "rho": 830.99263852
+                      }
+                    }
+                  ],
+                  "positionCount": 2,
+                  "scenarioCount": 2,
+                  "requestId": "00000000-0000-4000-8000-000000000005",
+                  "computedAt": "2026-01-01T00:00:00.000Z"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request body",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required (x402). Decode PAYMENT-REQUIRED header (base64 JSON) for accepts[] — Solana mainnet and/or Base mainnet USDC exact, amount, and payTo.",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "Base64-encoded x402 payment requirements (v2)",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentRequiredBody"
+                }
+              }
+            }
+          }
+        },
+        "x-pricing": {
+          "currency": "USDC",
+          "price_usd": 0.25,
+          "unit": "request",
+          "scheme": "exact",
+          "networks": [
+            "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "eip155:8453"
+          ]
         }
       }
     }
@@ -822,13 +1341,441 @@
             "additionalProperties": true
           }
         }
+      },
+      "ImpliedVolRequest": {
+        "type": "object",
+        "title": "ImpliedVolRequest",
+        "description": "Solve Black-Scholes implied volatility from a single market premium.",
+        "required": [
+          "underlying",
+          "strike",
+          "timeToExpiry",
+          "rate",
+          "optionType",
+          "premium"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "underlying": {
+            "type": "number",
+            "exclusiveMinimum": 0,
+            "description": "Underlying price S (> 0)"
+          },
+          "strike": {
+            "type": "number",
+            "exclusiveMinimum": 0,
+            "description": "Strike K (> 0)"
+          },
+          "timeToExpiry": {
+            "type": "number",
+            "minimum": 0,
+            "description": "Time to expiry T in years (≥ 0)"
+          },
+          "rate": {
+            "type": "number",
+            "description": "Continuous risk-free rate r"
+          },
+          "dividendYield": {
+            "type": "number",
+            "minimum": 0,
+            "default": 0,
+            "description": "Continuous yield q (default 0)"
+          },
+          "optionType": {
+            "$ref": "#/components/schemas/OptionType"
+          },
+          "premium": {
+            "type": "number",
+            "minimum": 0,
+            "description": "Observed market premium"
+          }
+        }
+      },
+      "ImpliedVolResponse": {
+        "type": "object",
+        "title": "ImpliedVolResponse",
+        "required": [
+          "impliedVol",
+          "greeks",
+          "modelPrice",
+          "priceError",
+          "iterations",
+          "converged",
+          "requestId",
+          "computedAt"
+        ],
+        "properties": {
+          "impliedVol": {
+            "type": "number",
+            "description": "Solved annualized volatility σ"
+          },
+          "greeks": {
+            "$ref": "#/components/schemas/Greeks"
+          },
+          "modelPrice": {
+            "type": "number",
+            "description": "BSM price at solved σ"
+          },
+          "priceError": {
+            "type": "number",
+            "description": "modelPrice − premium"
+          },
+          "iterations": {
+            "type": "integer"
+          },
+          "converged": {
+            "type": "boolean"
+          },
+          "reason": {
+            "type": "string"
+          },
+          "inputs": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "requestId": {
+            "type": "string"
+          },
+          "computedAt": {
+            "type": "string",
+            "description": "ISO-8601 UTC timestamp"
+          }
+        }
+      },
+      "PortfolioPosition": {
+        "type": "object",
+        "required": [
+          "underlying",
+          "strike",
+          "timeToExpiry",
+          "optionType",
+          "quantity",
+          "volatility"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "underlying": {
+            "type": "number",
+            "exclusiveMinimum": 0,
+            "description": "Underlying S for this leg"
+          },
+          "strike": {
+            "type": "number",
+            "exclusiveMinimum": 0
+          },
+          "timeToExpiry": {
+            "type": "number",
+            "minimum": 0
+          },
+          "optionType": {
+            "$ref": "#/components/schemas/OptionType"
+          },
+          "quantity": {
+            "type": "number",
+            "description": "Position size; >0 long, <0 short; must be non-zero"
+          },
+          "volatility": {
+            "type": "number",
+            "exclusiveMinimum": 0,
+            "description": "Annualized vol σ for this leg"
+          }
+        }
+      },
+      "DollarGreeks": {
+        "type": "object",
+        "properties": {
+          "deltaCash": {
+            "type": "number",
+            "description": "Σ delta_i * S_i"
+          },
+          "gammaCash": {
+            "type": "number",
+            "description": "Σ 0.5 * gamma_i * S_i²"
+          },
+          "vegaPerPoint": {
+            "type": "number",
+            "description": "net vega * 0.01"
+          },
+          "thetaPerDay": {
+            "type": "number",
+            "description": "net theta / 365"
+          },
+          "rhoPerPoint": {
+            "type": "number",
+            "description": "net rho * 0.01"
+          }
+        }
+      },
+      "PortfolioGreeksRequest": {
+        "type": "object",
+        "title": "PortfolioGreeksRequest",
+        "description": "Aggregate net Greeks and MTM for a multi-leg European option book.",
+        "required": [
+          "rate",
+          "positions"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "rate": {
+            "type": "number"
+          },
+          "dividendYield": {
+            "type": "number",
+            "minimum": 0,
+            "default": 0
+          },
+          "includeDollarGreeks": {
+            "type": "boolean",
+            "default": false,
+            "description": "If true, include cash delta/gamma and per-point vega/theta/rho scalings"
+          },
+          "positions": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 100,
+            "items": {
+              "$ref": "#/components/schemas/PortfolioPosition"
+            }
+          }
+        }
+      },
+      "PortfolioGreeksResponse": {
+        "type": "object",
+        "title": "PortfolioGreeksResponse",
+        "required": [
+          "net",
+          "legs",
+          "positionCount",
+          "requestId",
+          "computedAt"
+        ],
+        "properties": {
+          "net": {
+            "type": "object",
+            "required": [
+              "mtm",
+              "greeks"
+            ],
+            "properties": {
+              "mtm": {
+                "type": "number"
+              },
+              "greeks": {
+                "$ref": "#/components/schemas/Greeks"
+              },
+              "dollarGreeks": {
+                "$ref": "#/components/schemas/DollarGreeks"
+              }
+            }
+          },
+          "legs": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "index": {
+                  "type": "integer"
+                },
+                "quantity": {
+                  "type": "number"
+                },
+                "underlying": {
+                  "type": "number"
+                },
+                "strike": {
+                  "type": "number"
+                },
+                "timeToExpiry": {
+                  "type": "number"
+                },
+                "optionType": {
+                  "$ref": "#/components/schemas/OptionType"
+                },
+                "volatility": {
+                  "type": "number"
+                },
+                "price": {
+                  "type": "number"
+                },
+                "contribution": {
+                  "type": "number"
+                },
+                "greeks": {
+                  "$ref": "#/components/schemas/Greeks"
+                }
+              }
+            }
+          },
+          "positionCount": {
+            "type": "integer"
+          },
+          "requestId": {
+            "type": "string"
+          },
+          "computedAt": {
+            "type": "string"
+          }
+        }
+      },
+      "ScenarioShock": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string",
+            "maxLength": 64
+          },
+          "spotShock": {
+            "type": "number",
+            "default": 0,
+            "description": "Relative spot move; newS = S*(1+spotShock)"
+          },
+          "volShock": {
+            "type": "number",
+            "default": 0,
+            "description": "Relative vol move; newσ = σ*(1+volShock)"
+          },
+          "timeDecayDays": {
+            "type": "number",
+            "minimum": 0,
+            "default": 0,
+            "description": "Calendar days of time decay; T reduced by days/365"
+          }
+        }
+      },
+      "PortfolioScenarioRequest": {
+        "type": "object",
+        "title": "PortfolioScenarioRequest",
+        "description": "Reprice a portfolio under relative spot/vol shocks and calendar time decay.",
+        "required": [
+          "rate",
+          "positions",
+          "scenarios"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "rate": {
+            "type": "number"
+          },
+          "dividendYield": {
+            "type": "number",
+            "minimum": 0,
+            "default": 0
+          },
+          "positions": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 100,
+            "items": {
+              "$ref": "#/components/schemas/PortfolioPosition"
+            }
+          },
+          "scenarios": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 20,
+            "items": {
+              "$ref": "#/components/schemas/ScenarioShock"
+            }
+          }
+        }
+      },
+      "PortfolioScenarioResponse": {
+        "type": "object",
+        "title": "PortfolioScenarioResponse",
+        "required": [
+          "base",
+          "scenarios",
+          "positionCount",
+          "scenarioCount",
+          "requestId",
+          "computedAt"
+        ],
+        "properties": {
+          "base": {
+            "type": "object",
+            "required": [
+              "mtm",
+              "greeks"
+            ],
+            "properties": {
+              "mtm": {
+                "type": "number"
+              },
+              "greeks": {
+                "$ref": "#/components/schemas/Greeks"
+              }
+            }
+          },
+          "scenarios": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "shocks": {
+                  "type": "object",
+                  "properties": {
+                    "spotShock": {
+                      "type": "number"
+                    },
+                    "volShock": {
+                      "type": "number"
+                    },
+                    "timeDecayDays": {
+                      "type": "number"
+                    }
+                  }
+                },
+                "mtm": {
+                  "type": "number"
+                },
+                "mtmChange": {
+                  "type": "number",
+                  "description": "scenario mtm − base mtm"
+                },
+                "greeks": {
+                  "$ref": "#/components/schemas/Greeks"
+                }
+              }
+            }
+          },
+          "positionCount": {
+            "type": "integer"
+          },
+          "scenarioCount": {
+            "type": "integer"
+          },
+          "requestId": {
+            "type": "string"
+          },
+          "computedAt": {
+            "type": "string"
+          }
+        }
       }
     }
   },
   "x-payment": {
     "protocol": "x402",
-    "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
     "asset": "USDC",
-    "facilitator": "https://facilitator.payai.network"
+    "scheme": "exact",
+    "facilitator": "https://facilitator.payai.network",
+    "networks": [
+      {
+        "caip2": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+        "alias": "solana",
+        "name": "Solana mainnet"
+      },
+      {
+        "caip2": "eip155:8453",
+        "alias": "base",
+        "name": "Base mainnet",
+        "payTo": "0x34cfb8bdbf16e4484b7da0ed31deed5771b16c8f"
+      }
+    ],
+    "note": "Unpaid requests return HTTP 402 with accepts for each configured network. Clients may settle USDC on Solana or Base."
   }
 }

--- a/providers/quantumwatch/derivatives-pricer/openapi.json
+++ b/providers/quantumwatch/derivatives-pricer/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Derivatives Pricer",
     "description": "x402-paid Black-Scholes European option pricing, analytic Greeks, single-premium IV, IV surfaces, portfolio net Greeks, and scenario reprice. USDC exact on Solana mainnet and/or Base mainnet via PayAI. No API keys.",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "contact": {
       "name": "Derivatives Pricer",
       "url": "https://derivatives-pricer-production.up.railway.app"
@@ -41,7 +41,7 @@
           "discovery"
         ],
         "summary": "Service card for agents",
-        "description": "Machine-readable catalog: capabilities, endpoints, examples, settlement. Free — no x402 payment.",
+        "description": "Machine-readable catalog: capabilities, endpoints, examples, settlement. Free — no payment required.",
         "security": [],
         "x-free": true,
         "responses": {
@@ -66,7 +66,7 @@
           "discovery"
         ],
         "summary": "Liveness probe",
-        "description": "Returns service status, networks, pricing snapshot, and payTo receivers. Free — no x402 payment.",
+        "description": "Returns service status, networks, pricing snapshot, and payTo receivers. Free — no payment required.",
         "security": [],
         "x-free": true,
         "responses": {
@@ -91,7 +91,7 @@
           "discovery"
         ],
         "summary": "OpenAPI 3.1 specification",
-        "description": "Full OpenAPI document for this service. Free — no x402 payment.",
+        "description": "Full OpenAPI document for this service. Free — no payment required.",
         "security": [],
         "x-free": true,
         "responses": {
@@ -109,6 +109,30 @@
         }
       }
     },
+    "/llms.txt": {
+      "get": {
+        "operationId": "getLlmsTxt",
+        "tags": [
+          "discovery"
+        ],
+        "summary": "llms.txt agent discovery document",
+        "description": "Concise Markdown summary for AI agents (llms.txt convention): capabilities, paid endpoints, discovery links. Free — no payment required.",
+        "security": [],
+        "x-free": true,
+        "responses": {
+          "200": {
+            "description": "llms.txt Markdown as text/plain",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/.well-known/x402": {
       "get": {
         "operationId": "getWellKnownX402",
@@ -116,7 +140,7 @@
           "discovery"
         ],
         "summary": "x402 well-known discovery manifest",
-        "description": "Machine-readable x402 service discovery (resources, pricing, settlement). Free — no x402 payment. Same payload as /.well-known/x402.json.",
+        "description": "Machine-readable x402 discovery (resources, pricing, settlement). Free — no payment required. Same payload as /.well-known/x402.json.",
         "security": [],
         "x-free": true,
         "responses": {
@@ -141,7 +165,7 @@
           "discovery"
         ],
         "summary": "x402 well-known discovery manifest",
-        "description": "Machine-readable x402 service discovery (JSON alias). Free — no x402 payment.",
+        "description": "Machine-readable x402 discovery (JSON alias). Free — no payment required.",
         "security": [],
         "x-free": true,
         "responses": {
@@ -1821,7 +1845,7 @@
         "type": "http",
         "scheme": "bearer",
         "bearerFormat": "x402",
-        "description": "x402 micropayment (HTTP 402). Clients settle USDC exact on Solana mainnet and/or Base mainnet, then retry with the payment proof. Free discovery endpoints override with security: []."
+        "description": "x402 micropayment (HTTP 402). Settle USDC exact on Solana and/or Base, then retry with payment proof. Free discovery operations set security: [] and must not expect 402."
       }
     }
   },


### PR DESCRIPTION
Adds the derivatives-pricer x402 service (Black-Scholes pricing, IV option, IV surface, portfolio greeks, stress scenarios) on Solana and Base mainnets.